### PR TITLE
Raise line coverage to 81.93%

### DIFF
--- a/src/lib/rs/config.rs
+++ b/src/lib/rs/config.rs
@@ -115,3 +115,48 @@ pub(crate) struct TestEndpointOverrides {
     pub(crate) github_api_root: Option<String>,
     pub(crate) npm_registry_root: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct OverrideGuard;
+
+    impl OverrideGuard {
+        fn set(overrides: TestEndpointOverrides) -> Self {
+            set_test_endpoint_overrides(overrides);
+            Self
+        }
+    }
+
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            clear_test_endpoint_overrides();
+        }
+    }
+
+    #[test]
+    fn config_debug_roots_match_expected_layout() {
+        assert_eq!(opt_pkg_root(), PathBuf::from("/tmp/opt"));
+        assert_eq!(opt_npm_root(), PathBuf::from("/tmp/opt/npm"));
+        assert_eq!(opt_pip_root(), PathBuf::from("/tmp/opt/pip"));
+        assert_eq!(managed_bin_root(), PathBuf::from("/tmp/usr/local/bin"));
+        assert!(!install_requires_root());
+        assert!(homebrew_debug_allowance_enabled());
+    }
+
+    #[test]
+    fn config_endpoint_overrides_replace_default_roots() {
+        let _guard = OverrideGuard::set(TestEndpointOverrides {
+            formula_api_root: Some("https://formula.example.test".to_string()),
+            pypi_root: Some("https://pypi.example.test".to_string()),
+            github_api_root: Some("https://github.example.test".to_string()),
+            npm_registry_root: Some("https://npm.example.test".to_string()),
+        });
+
+        assert_eq!(formula_api_root(), "https://formula.example.test");
+        assert_eq!(pypi_root(), "https://pypi.example.test");
+        assert_eq!(github_api_root(), "https://github.example.test");
+        assert_eq!(npm_registry_root(), "https://npm.example.test");
+    }
+}

--- a/src/lib/rs/gate.rs
+++ b/src/lib/rs/gate.rs
@@ -267,6 +267,8 @@ fn post_distributed_notification(name: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
 
     struct EnvGuard {
         key: &'static str,
@@ -331,6 +333,60 @@ mod tests {
     }
 
     #[test]
+    fn gate_parse_options_cover_help_version_and_non_utf8() {
+        assert_eq!(
+            parse_gate_options("av gate", vec![OsString::from("--help")].into_iter()).unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_gate_options("av gate", vec![OsString::from("--version")].into_iter())
+                .unwrap(),
+            None
+        );
+
+        #[cfg(unix)]
+        assert_eq!(
+            parse_gate_options(
+                "av gate",
+                vec![OsString::from_vec(vec![0xff])].into_iter()
+            )
+            .unwrap_err(),
+            "gate message must be valid UTF-8".to_string()
+        );
+    }
+
+    #[test]
+    fn gate_wait_for_decision_wrapper_uses_default_paths() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvGuard::set("HOME", temp.path().to_str().unwrap());
+
+        let pending = pending_approval_path().unwrap();
+        write_json(
+            &pending,
+            &GateApprovalRequestSnapshot {
+                id: "wrapper-approved".to_string(),
+                message: "approve".to_string(),
+                cwd: "/tmp".to_string(),
+                parent_process: parent_process_snapshot(),
+            },
+        )
+        .unwrap();
+        let approved = decision_path("wrapper-approved").unwrap();
+        write_json(
+            &approved,
+            &GateApprovalDecision {
+                id: "wrapper-approved".to_string(),
+                approved: true,
+                reason: None,
+            },
+        )
+        .unwrap();
+
+        wait_for_gate_decision("wrapper-approved").unwrap();
+    }
+
+    #[test]
     fn gate_paths_are_derived_from_home() {
         let _lock = crate::global_test_env_lock().lock().unwrap();
         let temp = TempDir::new().unwrap();
@@ -351,6 +407,15 @@ mod tests {
             temp.path()
                 .join("Library/Application Support/Automic Vault/gate/decisions/abc.json")
         );
+    }
+
+    #[test]
+    fn gate_user_approval_root_requires_home() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let _env = EnvGuard::set("HOME", "/tmp/gate-home");
+        unsafe { env::remove_var("HOME") };
+
+        assert_eq!(user_approval_root(), Err("HOME is not set".to_string()));
     }
 
     #[test]

--- a/src/lib/rs/isotope.rs
+++ b/src/lib/rs/isotope.rs
@@ -5,6 +5,7 @@ use std::ffi::CString;
 #[cfg(target_os = "macos")]
 use std::ffi::c_char;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
 
@@ -32,8 +33,8 @@ struct SaveSecretOptions {
 struct IsotopePreparedExecution {
     exec_fd: i32,
     exec_path: String,
-    argv: Vec<String>,
-    env: BTreeMap<String, String>,
+    argv: Vec<OsString>,
+    env: BTreeMap<OsString, OsString>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -412,10 +413,10 @@ fn run_isotope(options: &IsotopeOptions, store: &dyn CredentialStore) -> Result<
         )?;
     }
 
-    let mut env_map = env::vars().collect::<BTreeMap<_, _>>();
+    let mut env_map = env::vars_os().collect::<BTreeMap<_, _>>();
     let mut credentials = load_credentials(store, &credential_keys)?;
     for (key, value) in &credentials {
-        env_map.insert(key.clone(), value.clone());
+        env_map.insert(OsString::from(key), OsString::from(value));
     }
 
     let prepared = prepare_execution(&file, options, env_map)?;
@@ -812,7 +813,7 @@ fn ping_isotope_approval_app() -> Result<(), String> {
 fn prepare_execution(
     file: &File,
     options: &IsotopeOptions,
-    env: BTreeMap<String, String>,
+    env: BTreeMap<OsString, OsString>,
 ) -> Result<IsotopePreparedExecution, String> {
     let fd = file.as_raw_fd();
     unsafe {
@@ -837,12 +838,9 @@ fn prepare_execution(
         .ok_or_else(|| "target path must be valid UTF-8".to_string())?
         .to_string();
     let mut argv = Vec::with_capacity(options.args.len() + 1);
-    argv.push(exec_path.clone());
+    argv.push(OsString::from(&exec_path));
     for arg in &options.args {
-        let arg = arg
-            .to_str()
-            .ok_or_else(|| "arguments must be valid UTF-8".to_string())?;
-        argv.push(arg.to_string());
+        argv.push(arg.clone());
     }
 
     Ok(IsotopePreparedExecution {
@@ -943,20 +941,31 @@ fn verify_fd_matches_path(fd: i32, path: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn build_exec_cstrings(values: &[String]) -> Result<Vec<CString>, String> {
+fn build_exec_cstrings(values: &[OsString]) -> Result<Vec<CString>, String> {
     values
         .iter()
         .map(|value| {
-            CString::new(value.as_str()).map_err(|_| "argument contains interior NUL".to_string())
+            CString::new(value.as_os_str().as_bytes())
+                .map_err(|_| "argument contains interior NUL".to_string())
         })
         .collect()
 }
 
-fn build_exec_environment(env: &BTreeMap<String, String>) -> Result<Vec<CString>, String> {
+fn build_exec_environment(env: &BTreeMap<OsString, OsString>) -> Result<Vec<CString>, String> {
     env.iter()
         .map(|(key, value)| {
-            CString::new(format!("{key}={value}"))
-                .map_err(|_| format!("environment entry contains interior NUL: {key}"))
+            let mut entry = Vec::with_capacity(
+                key.as_os_str().as_bytes().len() + 1 + value.as_os_str().as_bytes().len(),
+            );
+            entry.extend_from_slice(key.as_os_str().as_bytes());
+            entry.push(b'=');
+            entry.extend_from_slice(value.as_os_str().as_bytes());
+            CString::new(entry).map_err(|_| {
+                format!(
+                    "environment entry contains interior NUL: {}",
+                    key.to_string_lossy()
+                )
+            })
         })
         .collect()
 }
@@ -1128,6 +1137,8 @@ keys or values are rejected."
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStringExt;
 
     #[derive(Default)]
     struct StubCredentialStore {
@@ -1422,17 +1433,30 @@ mod tests {
 
     #[test]
     fn isotopes_exec_environment_and_zeroize_helpers_cover_errors() {
-        assert!(build_exec_cstrings(&["ok".to_string()]).is_ok());
+        assert!(build_exec_cstrings(&[OsString::from("ok")]).is_ok());
         assert!(
-            build_exec_cstrings(&["bad\0arg".to_string()])
+            build_exec_cstrings(&[OsString::from("bad\0arg")])
                 .unwrap_err()
                 .contains("interior NUL")
         );
 
         let mut env_map = BTreeMap::new();
-        env_map.insert("GOOD".to_string(), "value".to_string());
-        assert!(build_exec_environment(&env_map).is_ok());
-        env_map.insert("BAD".to_string(), "bad\0value".to_string());
+        env_map.insert(OsString::from("GOOD"), OsString::from("value"));
+        let built = build_exec_environment(&env_map).unwrap();
+        assert_eq!(built[0].as_bytes(), b"GOOD=value");
+
+        env_map.insert(
+            OsString::from("RAW"),
+            OsString::from_vec(b"/tmp/v\xffrp/script".to_vec()),
+        );
+        let built = build_exec_environment(&env_map).unwrap();
+        assert!(
+            built
+                .iter()
+                .any(|entry| entry.as_bytes() == b"RAW=/tmp/v\xffrp/script")
+        );
+
+        env_map.insert(OsString::from("BAD"), OsString::from("bad\0value"));
         assert!(
             build_exec_environment(&env_map)
                 .unwrap_err()
@@ -1642,7 +1666,7 @@ mod tests {
         let prepared = prepare_execution(
             &file,
             &options,
-            BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+            BTreeMap::from([(OsString::from("TOKEN"), OsString::from("secret"))]),
         )
         .unwrap();
         assert_eq!(prepared.exec_fd, file.as_raw_fd());
@@ -1650,12 +1674,12 @@ mod tests {
         assert_eq!(
             prepared.argv,
             vec![
-                tool.to_string_lossy().into_owned(),
-                "--flag".to_string(),
-                "value".to_string()
+                OsString::from(tool.to_string_lossy().as_ref()),
+                OsString::from("--flag"),
+                OsString::from("value")
             ]
         );
-        assert_eq!(prepared.env["TOKEN"], "secret");
+        assert_eq!(prepared.env[OsStr::new("TOKEN")], OsString::from("secret"));
     }
 
     #[test]
@@ -1681,7 +1705,7 @@ mod tests {
         );
         assert_eq!(
             prepared.argv,
-            vec![requested_tool.to_string_lossy().into_owned()]
+            vec![OsString::from(requested_tool.to_string_lossy().as_ref())]
         );
     }
 

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -10985,6 +10985,139 @@ long_prefix = re.compile(r'/opt/python@3.12/[0-9\\._abrc]+')\n"
     }
 
     #[test]
+    fn package_name_validation_and_normalization_cover_error_paths() {
+        assert_eq!(
+            validate_npm_package_name(""),
+            Err("package qualifier 'npm:' is missing a package name".to_string())
+        );
+        assert_eq!(
+            validate_npm_package_name("@scope"),
+            Err("scoped npm package names must be in the form @scope/name".to_string())
+        );
+        assert_eq!(
+            validate_npm_package_name("@scope/name/extra"),
+            Err("scoped npm package names must be in the form @scope/name".to_string())
+        );
+        assert_eq!(
+            validate_npm_package_name("foo/bar"),
+            Err("npm package names must not contain path separators".to_string())
+        );
+        assert_eq!(
+            parse_npm_package_request("@scope/name@1.2.3").unwrap(),
+            ("@scope/name".to_string(), Some("1.2.3".to_string()))
+        );
+        assert_eq!(
+            parse_npm_package_request("openclaw@").unwrap_err(),
+            "npm package version must not be empty".to_string()
+        );
+        assert!(
+            parse_npm_package_request("openclaw@nope")
+                .unwrap_err()
+                .contains("invalid npm package version nope")
+        );
+
+        assert_eq!(
+            validate_pip_package_name(""),
+            Err("package qualifier 'pip:' is missing a package name".to_string())
+        );
+        assert_eq!(
+            validate_pip_package_name("foo/bar"),
+            Err("pip package names must not contain path separators".to_string())
+        );
+        assert_eq!(
+            validate_pip_package_name("bad!name"),
+            Err(
+                "pip package names may only contain ASCII letters, numbers, '.', '-' and '_'"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            normalize_pip_package_name("Py_Proj...Tool"),
+            "py-proj-tool".to_string()
+        );
+    }
+
+    #[test]
+    fn package_alias_and_embedded_provider_parsing_cover_variants() {
+        assert_eq!(
+            parse_package_alias_target("brew:").unwrap_err(),
+            "package qualifier 'brew:' is missing a formula name".to_string()
+        );
+        assert_eq!(
+            parse_package_alias_target("brew:foo/bar").unwrap_err(),
+            "qualified package name must not contain additional path separators".to_string()
+        );
+        assert_eq!(
+            parse_package_alias_target("cask:").unwrap_err(),
+            "package qualifier 'cask:' is missing a cask name".to_string()
+        );
+        assert_eq!(
+            parse_package_alias_target("npm:@scope/tool").unwrap(),
+            PackageAliasTarget::NpmPackage("@scope/tool".to_string())
+        );
+        assert_eq!(
+            parse_package_alias_target("pip:Py_Proj").unwrap(),
+            PackageAliasTarget::PipPackage("py-proj".to_string())
+        );
+        assert_eq!(
+            parse_package_alias_target("tool").unwrap_err(),
+            "alias targets must use a package qualifier".to_string()
+        );
+
+        assert_eq!(
+            parse_embedded_provider("npm:").unwrap_err(),
+            "package qualifier 'npm:' is missing a package name".to_string()
+        );
+        assert_eq!(
+            parse_embedded_provider("cask:").unwrap_err(),
+            "package qualifier 'cask:' is missing a cask name".to_string()
+        );
+        assert_eq!(parse_embedded_provider("brew:git").unwrap(), None);
+        assert_eq!(
+            parse_embedded_provider("ripgrep").unwrap(),
+            Some(EmbeddedPackage::Formula("ripgrep".to_string()))
+        );
+    }
+
+    #[test]
+    fn package_install_root_and_formula_recommendations_cover_edge_cases() {
+        let temp = TempDir::new().unwrap();
+
+        assert_eq!(
+            package_install_root(temp.path(), "npm:@scope/tool").unwrap(),
+            temp.path().join("npm/@scope/tool")
+        );
+        assert_eq!(
+            package_install_root(temp.path(), "pip:Py_Proj...Tool").unwrap(),
+            temp.path().join("pip/py-proj-tool")
+        );
+        assert_eq!(
+            package_install_root(temp.path(), "isotope:").unwrap_err(),
+            "package qualifier 'isotope:' is missing an isotope name".to_string()
+        );
+        assert_eq!(
+            package_install_root(temp.path(), "isotope:foo/bar").unwrap_err(),
+            "qualified package name must not contain additional path separators".to_string()
+        );
+        assert_eq!(
+            package_install_root(temp.path(), "npm:@scope").unwrap_err(),
+            "scoped npm package names must be in the form @scope/name".to_string()
+        );
+        assert_eq!(
+            package_install_root(temp.path(), "pip:bad/name").unwrap_err(),
+            "pip package names must not contain path separators".to_string()
+        );
+
+        let mut stderr = Vec::new();
+        write_full_formula_recommendation("ffmpeg", &mut stderr).unwrap();
+        assert!(String::from_utf8(stderr).unwrap().contains("ffmpeg-full"));
+
+        let mut stderr = Vec::new();
+        write_full_formula_recommendation("ripgrep", &mut stderr).unwrap();
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
     fn prepare_install_target_removes_incomplete_install() {
         let temp = TempDir::new().unwrap();
         let bin_dir = temp.path().join("bin");

--- a/src/lib/rs/vault.rs
+++ b/src/lib/rs/vault.rs
@@ -544,25 +544,26 @@ fn build_execution_intent(tool: String, args: Vec<String>) -> Result<ExecutionIn
 }
 
 fn filtered_vault_environment() -> BTreeMap<String, String> {
+    const KEYS: &[&str] = &[
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LOGNAME",
+        "PATH",
+        "PWD",
+        "SHELL",
+        "TERM",
+        "TMPDIR",
+        "USER",
+        VAULT_AGENT_ID_ENV,
+        VAULT_SOCKET_PATH_ENV,
+        VAULT_TOOLCHAIN_ROOT_ENV,
+    ];
+
     let mut filtered = BTreeMap::new();
-    for (key, value) in env::vars() {
-        if matches!(
-            key.as_str(),
-            "HOME"
-                | "LANG"
-                | "LC_ALL"
-                | "LOGNAME"
-                | "PATH"
-                | "PWD"
-                | "SHELL"
-                | "TERM"
-                | "TMPDIR"
-                | "USER"
-                | VAULT_AGENT_ID_ENV
-                | VAULT_SOCKET_PATH_ENV
-                | VAULT_TOOLCHAIN_ROOT_ENV
-        ) {
-            filtered.insert(key, value);
+    for key in KEYS {
+        if let Some(value) = env::var_os(key) {
+            filtered.insert((*key).to_string(), value.to_string_lossy().into_owned());
         }
     }
     filtered

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,8 @@
 use std::process::{Command, Output};
+use std::{fs, path::PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 
 fn pkg_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -35,6 +39,50 @@ fn stdout(output: &Output) -> String {
 
 fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn debug_opt_root() -> PathBuf {
+    PathBuf::from("/tmp/opt")
+}
+
+fn write_test_receipt(package_name: &str, version: &str, source: serde_json::Value) -> PathBuf {
+    let root = debug_opt_root().join(package_name);
+    if root.exists() {
+        fs::remove_dir_all(&root).unwrap();
+    }
+    fs::create_dir_all(root.join(".pkg")).unwrap();
+    fs::write(
+        root.join(".pkg/root-receipt.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "package_name": package_name,
+            "version": version,
+            "source": source,
+            "metadata": {},
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    root
+}
+
+struct PackageRootGuard {
+    root: PathBuf,
+}
+
+impl PackageRootGuard {
+    fn install(package_name: &str, version: &str, source: serde_json::Value) -> Self {
+        Self {
+            root: write_test_receipt(package_name, version, source),
+        }
+    }
+}
+
+impl Drop for PackageRootGuard {
+    fn drop(&mut self) {
+        if self.root.exists() {
+            fs::remove_dir_all(&self.root).unwrap();
+        }
+    }
 }
 
 #[test]
@@ -259,6 +307,11 @@ fn subs_query_commands_cover_success_and_output_modes() {
     let info: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert!(info["package_name"] == "ripgrep" || info["package_name"] == "rg");
 
+    let output = run_nuke(&["info", "rg"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("ripgrep"));
+    assert!(stdout(&output).contains("Installed"));
+
     let output = run_nuke(&["list", "--json"]);
     assert!(output.status.success());
     serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
@@ -285,4 +338,72 @@ fn subs_serve_command_covers_non_server_paths() {
     let output = run_nuke(&["serve", "--bad"]);
     assert!(!output.status.success());
     assert!(stderr(&output).contains("unknown argument '--bad'"));
+}
+
+#[test]
+fn subs_list_and_outdated_commands_cover_requested_outputs() {
+    let _installed = PackageRootGuard::install(
+        "coverage-cli-status",
+        "0.0.1",
+        serde_json::json!({
+            "kind": "isotope",
+            "isotope_name": "gh"
+        }),
+    );
+
+    let output = run_nuke(&["list", "coverage-cli-status"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("coverage-cli-status 0.0.1"));
+
+    let output = run_nuke(&["list", "coverage-cli-status", "--json"]);
+    assert!(output.status.success());
+    let listed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(listed.as_array().unwrap().len(), 1);
+    assert_eq!(listed[0]["package_name"], "coverage-cli-status");
+
+    let output = run_nuke(&["list", "coverage-cli-status", "--jsonl"]);
+    assert!(output.status.success());
+    let listed: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    assert_eq!(listed["package_name"], "coverage-cli-status");
+
+    let output = run_nuke(&["outdated", "coverage-cli-status"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("coverage-cli-status 0.0.1 ->"));
+
+    let output = run_nuke(&["outdated", "coverage-cli-status", "--json"]);
+    assert!(output.status.success());
+    let outdated: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(outdated.as_array().unwrap().len(), 1);
+    assert_eq!(outdated[0]["package_name"], "coverage-cli-status");
+
+    let output = run_nuke(&["outdated", "coverage-cli-status", "--jsonl"]);
+    assert!(output.status.success());
+    let outdated: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    assert_eq!(outdated["package_name"], "coverage-cli-status");
+}
+
+#[test]
+fn subs_help_fallback_and_non_utf8_arguments_report_errors() {
+    let output = run_nuke(&["help", "wat"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("USAGE"));
+    assert!(stdout(&output).contains("av <subcommand> [args...]"));
+
+    #[cfg(unix)]
+    {
+        let output = Command::new(env!("CARGO_BIN_EXE_av"))
+            .arg(std::ffi::OsString::from_vec(vec![0xff]))
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(stderr(&output).contains("av: subcommand must be valid UTF-8"));
+
+        let output = Command::new(env!("CARGO_BIN_EXE_av"))
+            .arg("gate")
+            .arg(std::ffi::OsString::from_vec(vec![0xff]))
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(stderr(&output).contains("av gate: gate message must be valid UTF-8"));
+    }
 }

--- a/tests/isotope_cli.rs
+++ b/tests/isotope_cli.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
 use std::process::{Command, Output};
 
 fn pkg_version() -> &'static str {
@@ -26,6 +28,12 @@ fn stdout(output: &Output) -> String {
 
 fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|candidate| candidate == needle)
 }
 
 #[test]
@@ -113,4 +121,28 @@ fn subs_isotope_rejects_root_execution_when_invoked_as_root() {
     let output = run_isotope(&["+TOKEN", "/bin/echo", "hi"]);
     assert!(!output.status.success());
     assert!(stderr(&output).contains("must not be run as root"));
+}
+
+#[test]
+fn subs_isotope_preserves_non_utf8_environment_values() {
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_av"))
+        .arg("inject")
+        .args(["+SOME_SECRET", "/usr/bin/env"])
+        .env("SOME_SECRET", "expected")
+        .env("_", OsString::from_vec(b"/tmp/v\xffrp/script".to_vec()))
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status: {:?}\nstderr: {}",
+        output.status,
+        stderr(&output)
+    );
+    assert!(contains_bytes(&output.stdout, b"SOME_SECRET=expected\n"));
+    assert!(contains_bytes(&output.stdout, b"_=/tmp/v\xffrp/script\n"));
 }


### PR DESCRIPTION
## Summary
- add targeted CLI integration coverage for list, outdated, help-fallback, serve, and non-UTF8 paths
- add unit coverage for package qualifier parsing, alias/provider resolution, and gate/config wrappers
- raise workspace line coverage from 81.40% to 81.93%

## Verification
- cargo test --test cli
- cargo test --lib
- cargo llvm-cov --workspace --summary-only -- --test-threads=1