### PR TITLE
Raise Rust coverage above 80%

### DIFF
--- a/src/helper/main.rs
+++ b/src/helper/main.rs
@@ -387,6 +387,18 @@ mod tests {
                 .get("Err")
                 .is_some()
         );
+
+        let response = raw_to_string(nuke_helper_make_default(
+            packages.as_ptr(),
+            ptr::null_mut(),
+            Some(capture_progress),
+        ));
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&response)
+                .unwrap()
+                .get("Err")
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/lib/rs/gate.rs
+++ b/src/lib/rs/gate.rs
@@ -352,6 +352,20 @@ mod tests {
     }
 
     #[test]
+    fn gate_parent_snapshot_covers_display_name_derivation() {
+        let snapshot = parent_process_snapshot();
+        assert!(snapshot.pid > 0);
+        assert_eq!(
+            snapshot.display_name.as_deref(),
+            snapshot
+                .executable_path
+                .as_deref()
+                .and_then(|path| Path::new(path).file_name())
+                .and_then(|name| name.to_str())
+        );
+    }
+
+    #[test]
     fn gate_wait_for_decision_wrapper_uses_default_paths() {
         let _lock = crate::global_test_env_lock().lock().unwrap();
         let temp = TempDir::new().unwrap();

--- a/src/lib/rs/info.rs
+++ b/src/lib/rs/info.rs
@@ -1944,3 +1944,108 @@ pub(crate) fn extract_semver_from_text(text: &str) -> Option<semver::Version> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_test_receipt(
+        package_name: &str,
+        version: &str,
+        source: PackageReceiptSource,
+    ) -> PathBuf {
+        let install_root = opt_pkg_root().join(package_name);
+        if fs::symlink_metadata(&install_root).is_ok() {
+            remove_path(&install_root).unwrap();
+        }
+        fs::create_dir_all(&install_root).unwrap();
+        write_package_receipt(
+            &install_root.join(ROOT_RECEIPT),
+            &PackageReceipt {
+                package_name: package_name.to_string(),
+                version: version.to_string(),
+                source,
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        install_root
+    }
+
+    #[test]
+    fn status_and_record_wrappers_cover_all_installed_and_requested_paths() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let record_root = write_test_receipt(
+            "coverage-all-record",
+            "1.0.0",
+            PackageReceiptSource::Formula {
+                root_formula: "coverage-all-record".to_string(),
+            },
+        );
+        let status_root = write_test_receipt(
+            "coverage-all-status",
+            "0.0.1",
+            PackageReceiptSource::Isotope {
+                isotope_name: "gh".to_string(),
+            },
+        );
+        let config = Config {
+            bottle_tag: "all".to_string(),
+        };
+
+        let all_statuses = resolve_package_statuses(&config, &PackageSelection::AllInstalled).unwrap();
+        assert!(all_statuses.iter().any(|status| {
+            status.package_name == "coverage-all-status"
+                && status.installed_version == "0.0.1"
+                && status.latest_version != "0.0.1"
+        }));
+
+        let requested_statuses = resolve_package_statuses(
+            &config,
+            &PackageSelection::Requested(vec![RequestedPackage::Auto(
+                "coverage-all-status".to_string(),
+            )]),
+        )
+        .unwrap();
+        assert_eq!(requested_statuses.len(), 1);
+        assert_eq!(requested_statuses[0].package_name, "coverage-all-status");
+
+        let all_records = resolve_installed_package_records(&PackageSelection::AllInstalled).unwrap();
+        assert!(all_records.iter().any(|record| {
+            record.package_name == "coverage-all-record" && record.installed_version == "1.0.0"
+        }));
+
+        let requested_records = resolve_installed_package_records(&PackageSelection::Requested(vec![
+            RequestedPackage::Auto("coverage-all-record".to_string()),
+        ]))
+        .unwrap();
+        assert_eq!(requested_records.len(), 1);
+        assert_eq!(requested_records[0].package_name, "coverage-all-record");
+
+        remove_path(&record_root).unwrap();
+        remove_path(&status_root).unwrap();
+    }
+
+    #[test]
+    fn package_status_at_rejects_missing_and_non_directory_roots() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let config = Config {
+            bottle_tag: "all".to_string(),
+        };
+        let missing = temp.path().join("missing");
+        assert!(
+            resolve_package_status_at(&config, "missing", &missing)
+                .unwrap_err()
+                .contains("is not installed")
+        );
+
+        let file = temp.path().join("not-a-directory");
+        fs::write(&file, b"hi").unwrap();
+        assert!(
+            resolve_package_status_at(&config, "file", &file)
+                .unwrap_err()
+                .contains("is not a directory")
+        );
+    }
+}

--- a/src/lib/rs/ops.rs
+++ b/src/lib/rs/ops.rs
@@ -1221,6 +1221,29 @@ fn write_isotope_always_allow_store(
 mod tests {
     use super::*;
 
+    fn write_test_receipt(
+        package_name: &str,
+        version: &str,
+        source: PackageReceiptSource,
+    ) -> PathBuf {
+        let install_root = opt_pkg_root().join(package_name);
+        if fs::symlink_metadata(&install_root).is_ok() {
+            remove_path(&install_root).unwrap();
+        }
+        fs::create_dir_all(&install_root).unwrap();
+        write_package_receipt(
+            &install_root.join(ROOT_RECEIPT),
+            &PackageReceipt {
+                package_name: package_name.to_string(),
+                version: version.to_string(),
+                source,
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        install_root
+    }
+
     #[test]
     fn homebrew_info_formula_reads_nested_on_request_flag() {
         let report: HomebrewInfoReport = serde_json::from_value(serde_json::json!({
@@ -1494,6 +1517,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn list_installed_packages_groups_versioned_formulae_and_keeps_other_sources() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let roots = [
+            write_test_receipt(
+                "coverage-python@3.13",
+                "3.13.9",
+                PackageReceiptSource::Formula {
+                    root_formula: "coverage-python@3.13".to_string(),
+                },
+            ),
+            write_test_receipt(
+                "coverage-python@3.14",
+                "3.14.1",
+                PackageReceiptSource::Formula {
+                    root_formula: "coverage-python@3.14".to_string(),
+                },
+            ),
+            write_test_receipt(
+                "coverage-cask",
+                "1.0.0",
+                PackageReceiptSource::Cask {
+                    cask_name: "coverage-cask".to_string(),
+                },
+            ),
+        ];
+
+        let packages = list_installed_packages().unwrap().packages;
+        let grouped = packages
+            .iter()
+            .find(|package| package.name == "coverage-python")
+            .unwrap();
+        assert_eq!(grouped.installed_versions, ["3.14.1", "3.13.9"]);
+        assert_eq!(
+            grouped.install_package_names,
+            ["coverage-python@3.14", "coverage-python@3.13"]
+        );
+
+        let cask = packages
+            .iter()
+            .find(|package| package.name == "coverage-cask")
+            .unwrap();
+        assert_eq!(
+            cask.source,
+            PackageReceiptSource::Cask {
+                cask_name: "coverage-cask".to_string()
+            }
+        );
+
+        for root in roots {
+            remove_path(&root).unwrap();
+        }
+    }
+
     fn installed_formula_summary(name: &str, version: &str) -> core::InstalledPackageSummary {
         core::InstalledPackageSummary {
             name: name.to_string(),
@@ -1536,6 +1613,12 @@ mod tests {
                 }],
             },
             HelperCommand::Uninstall {
+                packages: vec![PackageSpec {
+                    name: "rg".to_string(),
+                    version: None,
+                }],
+            },
+            HelperCommand::MakeDefault {
                 packages: vec![PackageSpec {
                     name: "rg".to_string(),
                     version: None,
@@ -1729,6 +1812,65 @@ mod tests {
             validate_isotope_always_allow_script("/bin/echo", None).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn package_info_and_outdated_wrappers_cover_installed_formula_receipts() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let install_root = write_test_receipt(
+            "ripgrep",
+            "0.0.1",
+            PackageReceiptSource::Formula {
+                root_formula: "ripgrep".to_string(),
+            },
+        );
+
+        let info = package_info("ripgrep").unwrap();
+        assert!(info.installed);
+        assert_eq!(info.package_name, "ripgrep");
+        assert_eq!(info.installed_version, Some("0.0.1".to_string()));
+
+        let outdated = list_outdated_packages().unwrap();
+        assert!(outdated.packages.iter().any(|package| {
+            package.name == "ripgrep"
+                && package.current_version == "0.0.1"
+                && package.latest_version != "0.0.1"
+        }));
+
+        remove_path(&install_root).unwrap();
+    }
+
+    #[test]
+    fn make_package_default_root_rejects_non_formula_and_python_receipts() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let cask_root = write_test_receipt(
+            "coverage-default-cask",
+            "1.0.0",
+            PackageReceiptSource::Cask {
+                cask_name: "coverage-default-cask".to_string(),
+            },
+        );
+        assert!(
+            make_package_default_root("coverage-default-cask", None)
+                .unwrap_err()
+                .contains("is not a Homebrew formula")
+        );
+
+        let python_root = write_test_receipt(
+            "python@3.14",
+            "3.14.1",
+            PackageReceiptSource::Formula {
+                root_formula: "python@3.14".to_string(),
+            },
+        );
+        assert!(
+            make_package_default_root("python@3.14", None)
+                .unwrap_err()
+                .contains("Python uses side-by-side stubs")
+        );
+
+        remove_path(&cask_root).unwrap();
+        remove_path(&python_root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add direct Rust tests for info/ops wrapper paths and installed-package grouping
- cover make-default helper routing plus additional helper and gate wrapper assertions
- lift cargo-llvm-cov total region coverage from 79.19% to 80.01%

## Verification
- cargo test
- cargo llvm-cov --summary-only