### PR TITLE
Increase coverage for stub and gate flows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucleus"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2024"
 autobins = false
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -110,6 +110,7 @@ fn generate_isotope_integrations() {
         "pub(crate) struct IsotopeIntegration {\n",
         "  pub(crate) name: &'static str,\n",
         "  pub(crate) detect: Option<fn() -> Result<bool, String>>,\n",
+        "  pub(crate) detect_reasons: Option<fn() -> Result<Vec<String>, String>>,\n",
         "  pub(crate) migrate: Option<fn() -> Result<(), String>>,\n",
         "  pub(crate) post_install: Option<fn() -> Result<(), String>>,\n",
         "}\n\n",
@@ -145,6 +146,14 @@ fn generate_isotope_integrations() {
         } else {
             "None".to_string()
         };
+        let detect_reasons = if entry.has_detect_reasons {
+            format!(
+                "Some({}::detect::install_insecurity_reasons)",
+                entry.module_name
+            )
+        } else {
+            "None".to_string()
+        };
         let migrate = if entry.migrate_path.is_some() {
             format!("Some({}::migrate::migrate_credentials)", entry.module_name)
         } else {
@@ -157,10 +166,10 @@ fn generate_isotope_integrations() {
         };
         output.push_str(&format!(
             concat!(
-                "  IsotopeIntegration {{ name: {:?}, detect: {}, migrate: {}, ",
-                "post_install: {} }},\n"
+                "  IsotopeIntegration {{ name: {:?}, detect: {}, detect_reasons: {}, ",
+                "migrate: {}, post_install: {} }},\n"
             ),
-            entry.isotope_name, detect, migrate, post_install
+            entry.isotope_name, detect, detect_reasons, migrate, post_install
         ));
     }
     output.push_str("];\n");
@@ -213,10 +222,16 @@ fn collect_isotope_integrations(
         if post_install_path.exists() {
             println!("cargo:rerun-if-changed={}", post_install_path.display());
         }
+        let has_detect_reasons = detect_path
+            .exists()
+            .then(|| std::fs::read_to_string(&detect_path).unwrap_or_default())
+            .is_some_and(|contents| contents.contains("pub fn install_insecurity_reasons"));
+
         entries.push(IsotopeIntegrationInput {
             module_name: rust_module_name(&isotope_name),
             isotope_name,
             detect_path: detect_path.exists().then_some(detect_path),
+            has_detect_reasons,
             migrate_path: migrate_path.exists().then_some(migrate_path),
             post_install_path: post_install_path.exists().then_some(post_install_path),
         });
@@ -227,6 +242,7 @@ struct IsotopeIntegrationInput {
     module_name: String,
     isotope_name: String,
     detect_path: Option<std::path::PathBuf>,
+    has_detect_reasons: bool,
     migrate_path: Option<std::path::PathBuf>,
     post_install_path: Option<std::path::PathBuf>,
 }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -24,6 +24,10 @@ load_build_env() {
   done <"$env_file"
 }
 
+rust_protocol_version() {
+  awk -F'"' '/PROTOCOL_VERSION[[:space:]]*:/ { print $2; exit }' "$ROOT_DIR/src/lib/rs/core.rs"
+}
+
 usage() {
   cat <<'EOF'
 Usage: scripts/build-app.sh [--debug|--release]
@@ -93,7 +97,8 @@ ICON_NAME="gui-icon"
 ICONSET_DIR="$BUILD_DIR/$ICON_NAME.iconset"
 ICON_ICNS="$BUILD_DIR/$ICON_NAME.icns"
 [[ -n "${MIN_MACOS_VERSION:-}" ]] || cli_die "Set MIN_MACOS_VERSION in .env"
-[[ -n "${NUKE_PROTOCOL_VERSION:-}" ]] || cli_die "Set NUKE_PROTOCOL_VERSION in .env"
+NUKE_PROTOCOL_VERSION="$(rust_protocol_version)"
+[[ -n "$NUKE_PROTOCOL_VERSION" ]] || cli_die "Could not read PROTOCOL_VERSION from src/lib/rs/core.rs"
 [[ -n "${NUKE_HELPER_VERSION:-}" ]] || cli_die "Set NUKE_HELPER_VERSION in .env"
 NUKE_BUILD_ID="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || printf 'unknown')"
 APP_VERSION="$(awk -F'\"' '/^version = / { print $2; exit }' "$ROOT_DIR/Cargo.toml")"

--- a/src/gui/DossierView.swift
+++ b/src/gui/DossierView.swift
@@ -109,9 +109,9 @@ final class DossierView: NSView {
         static let securityNoticeIconWidth: CGFloat = 34
         static let securityNoticeIconHeight: CGFloat = 40
         static let securityNoticeHeadlineTopInset: CGFloat = 6
-        static let securityNoticeCaveatsTopGap: CGFloat = 8
-        static let securityNoticeCaveatsHeaderHeight: CGFloat = 12
-        static let securityNoticeCaveatsBodyTopGap: CGFloat = 7
+        static let securityNoticeDetailTopGap: CGFloat = 8
+        static let securityNoticeDetailHeaderHeight: CGFloat = 12
+        static let securityNoticeDetailBodyTopGap: CGFloat = 7
         static let securityNoticeButtonTopGap: CGFloat = 10
         static let securityNoticeButtonHeight: CGFloat = 28
         static let securityNoticeButtonGap: CGFloat = 10
@@ -169,6 +169,8 @@ final class DossierView: NSView {
     private let securityNoticeIconLayer = CATextLayer()
     private let securityNoticeHeadlineLayer = CATextLayer()
     private let securityNoticeBodyLayer = CATextLayer()
+    private let securityNoticeReasonsHeaderLayer = CATextLayer()
+    private let securityNoticeReasonsBodyLayer = CATextLayer()
     private let securityNoticeCaveatsHeaderLayer = CATextLayer()
     private let securityNoticeCaveatsBodyLayer = CATextLayer()
     private let popularityHeaderLayer = CATextLayer()
@@ -268,6 +270,8 @@ final class DossierView: NSView {
             securityNoticeIconLayer,
             securityNoticeHeadlineLayer,
             securityNoticeBodyLayer,
+            securityNoticeReasonsHeaderLayer,
+            securityNoticeReasonsBodyLayer,
             securityNoticeCaveatsHeaderLayer,
             securityNoticeCaveatsBodyLayer,
             popularityHeaderLayer,
@@ -620,16 +624,44 @@ final class DossierView: NSView {
             )
             noticeCursorY = securityNoticeBodyLayer.frame.maxY
 
+            if securityNoticeReasonsBodyLayer.string != nil {
+                noticeCursorY += Metrics.securityNoticeDetailTopGap
+                securityNoticeReasonsHeaderLayer.frame = CGRect(
+                    x: noticeContentMinX,
+                    y: noticeCursorY,
+                    width: noticeContentWidth,
+                    height: Metrics.securityNoticeDetailHeaderHeight
+                )
+                noticeCursorY = securityNoticeReasonsHeaderLayer.frame.maxY
+                    + Metrics.securityNoticeDetailBodyTopGap
+
+                let reasonsHeight = heightForNoticeText(
+                    in: securityNoticeReasonsBodyLayer,
+                    width: noticeContentWidth,
+                    minimumHeight: 16
+                )
+                securityNoticeReasonsBodyLayer.frame = CGRect(
+                    x: noticeContentMinX,
+                    y: noticeCursorY,
+                    width: noticeContentWidth,
+                    height: reasonsHeight
+                )
+                noticeCursorY = securityNoticeReasonsBodyLayer.frame.maxY
+            } else {
+                securityNoticeReasonsHeaderLayer.frame = .zero
+                securityNoticeReasonsBodyLayer.frame = .zero
+            }
+
             if securityNoticeCaveatsBodyLayer.string != nil {
-                noticeCursorY += Metrics.securityNoticeCaveatsTopGap
+                noticeCursorY += Metrics.securityNoticeDetailTopGap
                 securityNoticeCaveatsHeaderLayer.frame = CGRect(
                     x: noticeContentMinX,
                     y: noticeCursorY,
                     width: noticeContentWidth,
-                    height: Metrics.securityNoticeCaveatsHeaderHeight
+                    height: Metrics.securityNoticeDetailHeaderHeight
                 )
                 noticeCursorY = securityNoticeCaveatsHeaderLayer.frame.maxY
-                    + Metrics.securityNoticeCaveatsBodyTopGap
+                    + Metrics.securityNoticeDetailBodyTopGap
 
                 let caveatsHeight = heightForNoticeText(
                     in: securityNoticeCaveatsBodyLayer,
@@ -704,6 +736,8 @@ final class DossierView: NSView {
             securityNoticeIconLayer.frame = .zero
             securityNoticeHeadlineLayer.frame = .zero
             securityNoticeBodyLayer.frame = .zero
+            securityNoticeReasonsHeaderLayer.frame = .zero
+            securityNoticeReasonsBodyLayer.frame = .zero
             securityNoticeCaveatsHeaderLayer.frame = .zero
             securityNoticeCaveatsBodyLayer.frame = .zero
             securityLearnMoreButton.frame = .zero
@@ -1018,6 +1052,8 @@ final class DossierView: NSView {
             securityNoticeIconLayer.string = nil
             securityNoticeHeadlineLayer.string = nil
             securityNoticeBodyLayer.string = nil
+            securityNoticeReasonsHeaderLayer.string = nil
+            securityNoticeReasonsBodyLayer.string = nil
             securityNoticeCaveatsHeaderLayer.string = nil
             securityNoticeCaveatsBodyLayer.string = nil
             popularityHeaderLayer.string = nil
@@ -1120,6 +1156,8 @@ final class DossierView: NSView {
             securityNoticeIconLayer.string = nil
             securityNoticeHeadlineLayer.string = nil
             securityNoticeBodyLayer.string = nil
+            securityNoticeReasonsHeaderLayer.string = nil
+            securityNoticeReasonsBodyLayer.string = nil
             securityNoticeCaveatsHeaderLayer.string = nil
             securityNoticeCaveatsBodyLayer.string = nil
             securityLearnMoreButton.isHidden = true
@@ -1142,6 +1180,10 @@ final class DossierView: NSView {
             tracking: 0.2
         )
         securityNoticeBodyLayer.string = securityNoticeBodyText(from: notice.body)
+        securityNoticeReasonsHeaderLayer.string = notice.reasons.isEmpty
+            ? nil
+            : UIStyle.sectionHeaderText("Detection")
+        securityNoticeReasonsBodyLayer.string = securityNoticeReasonsText(notice.reasons)
         securityNoticeCaveatsHeaderLayer.string = notice.caveats == nil
             ? nil
             : UIStyle.sectionHeaderText("Caveats")
@@ -1239,6 +1281,16 @@ final class DossierView: NSView {
                 .joined(separator: "\n")
             return securityNoticeBodyText(from: markdown)
         }
+    }
+
+    private func securityNoticeReasonsText(_ reasons: [String]) -> NSAttributedString? {
+        guard reasons.isEmpty == false else {
+            return nil
+        }
+        let markdown = reasons
+            .map { "- \(normalizedCaveatBullet($0))" }
+            .joined(separator: "\n")
+        return securityNoticeBodyText(from: markdown)
     }
 
     private func normalizedCaveatBullet(_ caveat: String) -> String {
@@ -1826,6 +1878,8 @@ final class DossierView: NSView {
                 securityNoticeIconLayer,
                 securityNoticeHeadlineLayer,
                 securityNoticeBodyLayer,
+                securityNoticeReasonsHeaderLayer,
+                securityNoticeReasonsBodyLayer,
                 securityNoticeCaveatsHeaderLayer,
                 securityNoticeCaveatsBodyLayer
             ])

--- a/src/gui/NukeHelperBridge.swift
+++ b/src/gui/NukeHelperBridge.swift
@@ -197,12 +197,12 @@ final class NukeHelperBridge {
         }
 
         var cursor = 0.45
-        cursor = appendDownload(package: "brew:sqlite", start: cursor, speed: 1_240_000)
-        events.append((0.60, .downloading(package: "brew:zstd", bytesPerSecond: 680_000, progress: 0.32)))
-        events.append((0.70, .log(package: "brew:zstd", message: "dependency already current")))
+        cursor = appendDownload(package: "sqlite", start: cursor, speed: 1_240_000)
+        events.append((0.60, .downloading(package: "zstd", bytesPerSecond: 680_000, progress: 0.32)))
+        events.append((0.70, .log(package: "zstd", message: "dependency already current")))
         cursor = appendDownload(package: "npm:tsx", start: cursor, speed: 910_000)
         cursor = appendDownload(package: "pypi:uv", start: cursor, speed: 1_450_000)
-        cursor = appendDownload(package: "cask:keepingyouawake", start: cursor, speed: 840_000)
+        cursor = appendDownload(package: "keepingyouawake", start: cursor, speed: 840_000)
         cursor = appendDownload(package: "isotope:gh", start: cursor, speed: 1_320_000)
         for (delay, event) in events {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {

--- a/src/gui/PackageModels.swift
+++ b/src/gui/PackageModels.swift
@@ -548,14 +548,21 @@ struct PackageDetail: Decodable, Equatable {
     }
 
     var securityNotice: PackageSecurityNotice? {
-        if isHomebrewInstall, !securityStateNeedsReview {
+        let notice = SecurityCatalog.shared.notice(for: self)
+        if installed,
+           !isIsotopeInstall,
+           notice?.source == .isotope,
+           !securityStateNeedsReview {
             return nil
         }
-        return SecurityCatalog.shared.notice(for: self)
+        return notice
     }
 
-    private var isHomebrewInstall: Bool {
-        isHomebrewMigrationCandidate || isUnsupportedHomebrewInstall
+    private var isIsotopeInstall: Bool {
+        if case .isotope = source {
+            return true
+        }
+        return false
     }
 
     private var securityStateNeedsReview: Bool {

--- a/src/gui/PackageModels.swift
+++ b/src/gui/PackageModels.swift
@@ -174,7 +174,23 @@ struct PackageRecord: Decodable, Equatable {
 struct PackageSecurityState: Decodable, Equatable {
     let isotopeName: String
     let installIsInsecure: Bool
+    let reasons: [String]
     let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case isotopeName
+        case installIsInsecure
+        case reasons
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        isotopeName = try container.decode(String.self, forKey: .isotopeName)
+        installIsInsecure = try container.decode(Bool.self, forKey: .installIsInsecure)
+        reasons = try container.decodeIfPresent([String].self, forKey: .reasons) ?? []
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
 }
 
 struct OutdatedPackageRecord: Codable, Equatable {
@@ -660,7 +676,23 @@ struct HomebrewMigrationPackage: Decodable, Equatable {
 struct HomebrewMigrationHazard: Decodable, Equatable {
     let packageName: String
     let isotopeName: String
+    let reasons: [String]
     let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case packageName
+        case isotopeName
+        case reasons
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        packageName = try container.decode(String.self, forKey: .packageName)
+        isotopeName = try container.decode(String.self, forKey: .isotopeName)
+        reasons = try container.decodeIfPresent([String].self, forKey: .reasons) ?? []
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
 
     var radioisotopeReadmeURL: URL? {
         var pathAllowed = CharacterSet.urlPathAllowed

--- a/src/gui/PackageModels.swift
+++ b/src/gui/PackageModels.swift
@@ -458,7 +458,22 @@ struct PackageDetail: Decodable, Equatable {
     }
 
     var securityNotice: PackageSecurityNotice? {
+        if isHomebrewInstall, !securityStateNeedsReview {
+            return nil
+        }
         return SecurityCatalog.shared.notice(for: self)
+    }
+
+    private var isHomebrewInstall: Bool {
+        isHomebrewMigrationCandidate || isUnsupportedHomebrewInstall
+    }
+
+    private var securityStateNeedsReview: Bool {
+        guard let securityState else {
+            return false
+        }
+        return securityState.installIsInsecure
+            || securityState.error?.isEmpty == false
     }
 }
 

--- a/src/gui/PackageModels.swift
+++ b/src/gui/PackageModels.swift
@@ -208,6 +208,32 @@ struct PackageDetail: Decodable, Equatable {
     let homebrewMigration: HomebrewMigrationRecommendation?
     let versionOptions: [PackageVersionOption]
 
+    enum CodingKeys: String, CodingKey {
+        case packageName
+        case qualifiedName
+        case installRoot
+        case installed
+        case source
+        case sourceError
+        case aliases
+        case aliasesError
+        case installedVersion
+        case latestVersion
+        case latestVersionError
+        case executablePaths
+        case executablePathsError
+        case popularity
+        case lastUpdatedAt
+        case homebrewInfo
+        case homebrewInfoError
+        case npmHomepage
+        case npmPackageInfoError
+        case securityState
+        case installPackageNames
+        case homebrewMigration
+        case versionOptions
+    }
+
     init(
         packageName: String,
         qualifiedName: String,
@@ -256,6 +282,54 @@ struct PackageDetail: Decodable, Equatable {
         self.installPackageNames = installPackageNames
         self.homebrewMigration = homebrewMigration
         self.versionOptions = versionOptions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        packageName = try container.decode(String.self, forKey: .packageName)
+        qualifiedName = try container.decode(String.self, forKey: .qualifiedName)
+        installRoot = try container.decode(String.self, forKey: .installRoot)
+        installed = try container.decode(Bool.self, forKey: .installed)
+        source = try container.decodeIfPresent(PackageSource.self, forKey: .source)
+        sourceError = try container.decodeIfPresent(String.self, forKey: .sourceError)
+        aliases = try container.decode([String].self, forKey: .aliases)
+        aliasesError = try container.decodeIfPresent(String.self, forKey: .aliasesError)
+        installedVersion = try container.decodeIfPresent(String.self, forKey: .installedVersion)
+        latestVersion = try container.decodeIfPresent(String.self, forKey: .latestVersion)
+        latestVersionError = try container.decodeIfPresent(String.self, forKey: .latestVersionError)
+        executablePaths = try container.decode([String].self, forKey: .executablePaths)
+        executablePathsError = try container.decodeIfPresent(
+            String.self,
+            forKey: .executablePathsError
+        )
+        popularity = try container.decodeIfPresent(PackagePopularity.self, forKey: .popularity)
+        lastUpdatedAt = try container.decodeIfPresent(String.self, forKey: .lastUpdatedAt)
+        homebrewInfo = try container.decodeIfPresent(
+            HomebrewPackageInfo.self,
+            forKey: .homebrewInfo
+        )
+        homebrewInfoError = try container.decodeIfPresent(String.self, forKey: .homebrewInfoError)
+        npmHomepage = try container.decodeIfPresent(String.self, forKey: .npmHomepage)
+        npmPackageInfoError = try container.decodeIfPresent(
+            String.self,
+            forKey: .npmPackageInfoError
+        )
+        securityState = try container.decodeIfPresent(
+            PackageSecurityState.self,
+            forKey: .securityState
+        )
+        installPackageNames = try container.decodeIfPresent(
+            [String].self,
+            forKey: .installPackageNames
+        )
+        homebrewMigration = try container.decodeIfPresent(
+            HomebrewMigrationRecommendation.self,
+            forKey: .homebrewMigration
+        )
+        versionOptions = try container.decodeIfPresent(
+            [PackageVersionOption].self,
+            forKey: .versionOptions
+        ) ?? []
     }
 
     var primaryDescription: String {

--- a/src/gui/SecurityCatalog.swift
+++ b/src/gui/SecurityCatalog.swift
@@ -15,6 +15,7 @@ struct PackageSecurityNotice: Equatable {
     let applyPackageName: String?
     let headline: String
     let body: String
+    let reasons: [String]
     let caveats: Caveats?
     let learnMoreURL: URL
 
@@ -25,6 +26,7 @@ struct PackageSecurityNotice: Equatable {
         applyPackageName: String?,
         headline: String = Self.defaultHeadline,
         body: String = Self.defaultBody,
+        reasons: [String] = [],
         caveats: Caveats? = nil,
         learnMoreURL: URL = Self.defaultLearnMoreURL
     ) {
@@ -32,6 +34,7 @@ struct PackageSecurityNotice: Equatable {
         self.applyPackageName = applyPackageName
         self.headline = headline
         self.body = body
+        self.reasons = reasons
         self.caveats = caveats
         self.learnMoreURL = learnMoreURL
     }
@@ -86,6 +89,7 @@ final class SecurityCatalog {
                     ?? PackageSecurityNotice.defaultHeadline,
                 body: matchedIsotope.justification?.detail
                     ?? PackageSecurityNotice.defaultBody,
+                reasons: detail.securityState?.reasons ?? [],
                 caveats: matchedIsotope.caveats?.noticeCaveats,
                 learnMoreURL: matchedIsotope.learnMoreURL
                     ?? PackageSecurityNotice.defaultLearnMoreURL
@@ -95,7 +99,8 @@ final class SecurityCatalog {
            securityState.installIsInsecure {
             return PackageSecurityNotice(
                 source: .isotope,
-                applyPackageName: "isotope:\(securityState.isotopeName)"
+                applyPackageName: "isotope:\(securityState.isotopeName)",
+                reasons: securityState.reasons
             )
         }
         return nil

--- a/src/gui/UpdateProgressViewController.swift
+++ b/src/gui/UpdateProgressViewController.swift
@@ -572,7 +572,9 @@ final class UpdateProgressViewController: NSViewController {
                 )
             }
         case .downloading(let package, let bytesPerSecond, let progress):
-            let isVisiblePackage = track(package)
+            let visiblePackage = visiblePackageName(forProgressPackage: package)
+            let isVisiblePackage = visiblePackage != nil
+            let rowPackage = visiblePackage ?? package
             let speedText = Self.format(speed: bytesPerSecond)
             setOperation("Updating \(package)")
             if shouldLogDownloadStart(for: package) {
@@ -583,20 +585,22 @@ final class UpdateProgressViewController: NSViewController {
                 return
             }
             updateRow(
-                package: package,
+                package: rowPackage,
                 stage: .downloading,
                 progress: downloadProgress(for: CGFloat(progress)),
                 speed: speedText
             )
         case .installing(let package):
-            let isVisiblePackage = track(package)
-            let state = packageStates[package] ?? PackageRuntimeState()
+            let visiblePackage = visiblePackageName(forProgressPackage: package)
+            let isVisiblePackage = visiblePackage != nil
+            let rowPackage = visiblePackage ?? package
+            let state = packageStates[rowPackage] ?? packageStates[package] ?? PackageRuntimeState()
             if state.observedDownload {
                 setOperation("Extracting \(package)")
                 appendLog("Extracting \(package)")
                 guard isVisiblePackage else { return }
                 updateRow(
-                    package: package,
+                    package: rowPackage,
                     stage: .extracting,
                     progress: extractProgress(from: state.lastRenderedProgress),
                     speed: nil
@@ -606,7 +610,7 @@ final class UpdateProgressViewController: NSViewController {
                 appendLog("Installing \(package)")
                 guard isVisiblePackage else { return }
                 updateRow(
-                    package: package,
+                    package: rowPackage,
                     stage: .installing,
                     progress: ProgressLayout.installFloor,
                     speed: nil
@@ -617,11 +621,13 @@ final class UpdateProgressViewController: NSViewController {
             setOperation(Self.sentenceCase(message))
             appendLog("\(package): \(message)")
         case .completed(let package):
-            let isVisiblePackage = track(package)
+            let visiblePackage = visiblePackageName(forProgressPackage: package)
+            let isVisiblePackage = visiblePackage != nil
+            let rowPackage = visiblePackage ?? package
             setOperation("Sealing \(package)")
             appendLog("Completed \(package)")
             guard isVisiblePackage else { return }
-            updateRow(package: package, stage: .completed, progress: 1, speed: nil)
+            updateRow(package: rowPackage, stage: .completed, progress: 1, speed: nil)
         case .error(let message):
             fail(message: message)
         }
@@ -629,7 +635,7 @@ final class UpdateProgressViewController: NSViewController {
 
     func succeed(message: String, packages: [String]) {
         packages
-            .filter { acceptsNewVisiblePackages || visiblePackages.contains($0) }
+            .compactMap(visiblePackageName(forProgressPackage:))
             .forEach { updateRow(package: $0, stage: .completed, progress: 1, speed: nil) }
         isTerminalState = true
         operationAnimator?.stop()
@@ -666,6 +672,28 @@ final class UpdateProgressViewController: NSViewController {
         packageStates[package] = packageStates[package] ?? PackageRuntimeState()
         rebuildRows()
         return true
+    }
+
+    private func visiblePackageName(forProgressPackage package: String) -> String? {
+        if acceptsNewVisiblePackages {
+            visiblePackages.insert(package)
+        }
+        if visiblePackages.contains(package) {
+            return package
+        }
+        let qualifiedCandidates = [
+            "brew:\(package)",
+            "cask:\(package)"
+        ].filter { visiblePackages.contains($0) }
+        guard qualifiedCandidates.count == 1 else {
+            packageStates[package] = packageStates[package] ?? PackageRuntimeState()
+            return nil
+        }
+        let visiblePackage = qualifiedCandidates[0]
+        packageStates[visiblePackage] = packageStates[visiblePackage]
+            ?? packageStates[package]
+            ?? PackageRuntimeState()
+        return visiblePackage
     }
 
     private func rebuildRows() {

--- a/src/lib/rs/core.rs
+++ b/src/lib/rs/core.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) const PROTOCOL_VERSION: &str = "1.5";
+pub(crate) const PROTOCOL_VERSION: &str = "1.6";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProtocolMethod {
@@ -131,6 +131,7 @@ pub(crate) struct HomebrewMigrationHazardSummary {
     pub(crate) package_name: String,
     #[serde(rename = "isotopeName")]
     pub(crate) isotope_name: String,
+    pub(crate) reasons: Vec<String>,
     pub(crate) error: Option<String>,
 }
 

--- a/src/lib/rs/gate.rs
+++ b/src/lib/rs/gate.rs
@@ -77,6 +77,18 @@ where
 }
 
 fn request_gate_approval(options: &GateOptions) -> Result<(), String> {
+    request_gate_approval_with(options, ping_gate_approval_app, wait_for_gate_decision)
+}
+
+fn request_gate_approval_with<P, W>(
+    options: &GateOptions,
+    ping_gate_approval_app: P,
+    wait_for_gate_decision: W,
+) -> Result<(), String>
+where
+    P: FnOnce() -> Result<(), String>,
+    W: FnOnce(&str) -> Result<(), String>,
+{
     let request_id = format!(
         "{}-{}",
         process::id(),
@@ -269,6 +281,7 @@ mod tests {
     use super::*;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
+    use std::sync::{Arc, Mutex};
 
     struct EnvGuard {
         key: &'static str,
@@ -534,5 +547,58 @@ mod tests {
                 .unwrap_err()
                 .contains("failed to decode gate approval decision")
         );
+    }
+
+    #[test]
+    fn gate_request_flow_writes_snapshot_and_removes_pending_on_ping_failure() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvGuard::set("HOME", temp.path().to_str().unwrap());
+
+        let err = request_gate_approval_with(
+            &GateOptions {
+                message: "approve".to_string(),
+            },
+            || Err("ping failed".to_string()),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "ping failed");
+        assert!(!pending_approval_path().unwrap().exists());
+    }
+
+    #[test]
+    fn gate_request_flow_persists_snapshot_and_waits_with_generated_id() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvGuard::set("HOME", temp.path().to_str().unwrap());
+        let seen_request_id = Arc::new(Mutex::new(None::<String>));
+        let seen_request_id_for_wait = Arc::clone(&seen_request_id);
+
+        request_gate_approval_with(
+            &GateOptions {
+                message: "approve access".to_string(),
+            },
+            || Ok(()),
+            move |request_id| {
+                let pending = pending_approval_path().unwrap();
+                let snapshot: GateApprovalRequestSnapshot =
+                    serde_json::from_slice(&fs::read(&pending).unwrap()).unwrap();
+                assert_eq!(snapshot.message, "approve access");
+                assert_eq!(
+                    snapshot.cwd,
+                    env::current_dir().unwrap().display().to_string()
+                );
+                assert_eq!(snapshot.id, request_id);
+                *seen_request_id_for_wait.lock().unwrap() = Some(request_id.to_string());
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        let request_id = seen_request_id.lock().unwrap().clone().unwrap();
+        assert!(request_id.starts_with(&format!("{}-", process::id())));
+        assert!(pending_approval_path().unwrap().exists());
     }
 }

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -584,6 +584,7 @@ struct PackageSecurityState {
     isotope_name: String,
     #[serde(rename = "installIsInsecure")]
     install_is_insecure: bool,
+    reasons: Vec<String>,
     error: Option<String>,
 }
 
@@ -2286,9 +2287,19 @@ fn run_generated_isotope_post_install(name: &str) -> Option<Result<(), String>> 
     Some(post_install())
 }
 
-fn detect_isotope_install_is_insecure(name: &str) -> Option<Result<bool, String>> {
-    let detect = isotope_integration(name)?.detect?;
-    Some(detect())
+fn detect_isotope_install_reasons(name: &str) -> Option<Result<Vec<String>, String>> {
+    let integration = isotope_integration(name)?;
+    if let Some(detect_reasons) = integration.detect_reasons {
+        return Some(detect_reasons());
+    }
+    let detect = integration.detect?;
+    Some(detect().map(|install_is_insecure| {
+        if install_is_insecure {
+            vec![format!("isotope:{name} detector triggered")]
+        } else {
+            Vec::new()
+        }
+    }))
 }
 
 fn package_security_state(info: &PackageInfo) -> Option<PackageSecurityState> {
@@ -2333,16 +2344,18 @@ where
 }
 
 fn package_security_state_for_isotope(isotope_name: &str) -> Option<PackageSecurityState> {
-    let result = detect_isotope_install_is_insecure(isotope_name)?;
+    let result = detect_isotope_install_reasons(isotope_name)?;
     Some(match result {
-        Ok(install_is_insecure) => PackageSecurityState {
+        Ok(reasons) => PackageSecurityState {
             isotope_name: isotope_name.to_string(),
-            install_is_insecure,
+            install_is_insecure: !reasons.is_empty(),
+            reasons,
             error: None,
         },
         Err(err) => PackageSecurityState {
             isotope_name: isotope_name.to_string(),
             install_is_insecure: false,
+            reasons: Vec::new(),
             error: Some(err),
         },
     })
@@ -8606,15 +8619,19 @@ or `npm:clawhub` for the aliased package"
 
         let state = package_security_state_for_identifiers(["awscli".to_string()]);
 
-        if detect_isotope_install_is_insecure("aws-cli").is_some() {
-            assert_eq!(
-                state,
-                Some(PackageSecurityState {
-                    isotope_name: "aws-cli".to_string(),
-                    install_is_insecure: true,
-                    error: None,
-                })
+        if detect_isotope_install_reasons("aws-cli").is_some() {
+            let state = state.expect("aws-cli should have security state");
+            assert_eq!(state.isotope_name, "aws-cli");
+            assert!(state.install_is_insecure);
+            assert!(
+                state
+                    .reasons
+                    .iter()
+                    .any(|reason| reason.contains("AWS shared credentials file")),
+                "expected credentials reason, got {:?}",
+                state.reasons
             );
+            assert_eq!(state.error, None);
         } else {
             assert_eq!(state, None);
         }
@@ -8661,15 +8678,19 @@ or `npm:clawhub` for the aliased package"
 
         let state = package_security_state(&info);
 
-        if detect_isotope_install_is_insecure("aws-cli").is_some() {
-            assert_eq!(
-                state,
-                Some(PackageSecurityState {
-                    isotope_name: "aws-cli".to_string(),
-                    install_is_insecure: true,
-                    error: None,
-                })
+        if detect_isotope_install_reasons("aws-cli").is_some() {
+            let state = state.expect("aws-cli should have security state");
+            assert_eq!(state.isotope_name, "aws-cli");
+            assert!(state.install_is_insecure);
+            assert!(
+                state
+                    .reasons
+                    .iter()
+                    .any(|reason| reason.contains("AWS shared credentials file")),
+                "expected credentials reason, got {:?}",
+                state.reasons
             );
+            assert_eq!(state.error, None);
         } else {
             assert_eq!(state, None);
         }

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -10512,6 +10512,235 @@ long_prefix = re.compile(r'/opt/python@3.12/[0-9\\._abrc]+')\n"
     }
 
     #[test]
+    fn sync_stubs_writes_root_executables_and_removes_stale_entries() {
+        let _package_lock = acquire_package_mutation_lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let package_name = "coverage-sync-stubs";
+        let bin_root = managed_bin_root();
+        let stale_stub = bin_root.join("coverage-stale");
+        let foo_stub = bin_root.join("coverage-sync-foo");
+        let bar_stub = bin_root.join("coverage-sync-bar");
+
+        for path in [&stale_stub, &foo_stub, &bar_stub] {
+            if fs::symlink_metadata(path).is_ok() {
+                remove_path(path).unwrap();
+            }
+        }
+
+        let plan = InstallPlan {
+            mode: Mode::I,
+            package_name: package_name.to_string(),
+            root_formula: package_name.to_string(),
+            stable_root: temp.path().join("stable"),
+            install_root: temp.path().join(package_name),
+            tmp_root: temp.path().join("tmp"),
+        };
+        fs::create_dir_all(plan.install_root.join("bin")).unwrap();
+        fs::create_dir_all(plan.install_root.join("sbin")).unwrap();
+        write_executable(&plan.install_root.join("bin/coverage-sync-foo"));
+        write_executable(&plan.install_root.join("sbin/coverage-sync-bar"));
+        write_executable(&stale_stub);
+
+        sync_stubs(&plan, &[], &["coverage-stale".to_string()]).unwrap();
+
+        assert!(is_executable(&foo_stub));
+        assert!(is_executable(&bar_stub));
+        assert!(fs::symlink_metadata(&stale_stub).is_err());
+        assert_eq!(
+            load_stub_manifest(&plan.package_manifest_path())
+                .unwrap()
+                .stubs,
+            vec![
+                "coverage-sync-bar".to_string(),
+                "coverage-sync-foo".to_string(),
+            ]
+        );
+
+        for path in [&foo_stub, &bar_stub] {
+            remove_path(path).unwrap();
+        }
+    }
+
+    #[test]
+    fn sync_stubs_respects_declared_root_executable_manifest() {
+        let _package_lock = acquire_package_mutation_lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let package_name = "coverage-sync-manifest";
+        let bin_root = managed_bin_root();
+        let kept_stub = bin_root.join("coverage-keep");
+        let skipped_stub = bin_root.join("coverage-skip");
+
+        for path in [&kept_stub, &skipped_stub] {
+            if fs::symlink_metadata(path).is_ok() {
+                remove_path(path).unwrap();
+            }
+        }
+
+        let plan = InstallPlan {
+            mode: Mode::I,
+            package_name: package_name.to_string(),
+            root_formula: package_name.to_string(),
+            stable_root: temp.path().join("stable"),
+            install_root: temp.path().join(package_name),
+            tmp_root: temp.path().join("tmp"),
+        };
+        fs::create_dir_all(plan.install_root.join("bin")).unwrap();
+        write_executable(&plan.install_root.join("bin/coverage-keep"));
+        write_executable(&plan.install_root.join("bin/coverage-skip"));
+        write_root_executable_manifest(
+            &plan.root_executables_manifest_path(),
+            &["coverage-keep".to_string()],
+        )
+        .unwrap();
+
+        sync_stubs(&plan, &[], &[]).unwrap();
+
+        assert!(is_executable(&kept_stub));
+        assert!(fs::symlink_metadata(&skipped_stub).is_err());
+        assert_eq!(
+            load_stub_manifest(&plan.package_manifest_path())
+                .unwrap()
+                .stubs,
+            vec!["coverage-keep".to_string()]
+        );
+
+        remove_path(&kept_stub).unwrap();
+    }
+
+    #[test]
+    fn stub_helpers_cover_missing_and_invalid_manifest_cases() {
+        let temp = TempDir::new().unwrap();
+        let manifest_path = temp.path().join("stub-manifest.json");
+        fs::write(&manifest_path, b"{not json").unwrap();
+        assert!(
+            load_stub_manifest(&manifest_path)
+                .unwrap_err()
+                .contains("failed to parse")
+        );
+
+        assert!(!stub_belongs_to_package(&temp.path().join("missing-stub"), "coverage").unwrap());
+
+        let empty_bin_dir = temp.path().join("missing-bin");
+        refresh_post_uninstall_stubs(temp.path(), &empty_bin_dir).unwrap();
+
+        let parent = temp.path().join("nested");
+        fs::create_dir_all(&parent).unwrap();
+        fs::write(parent.join("keep"), b"keep").unwrap();
+        remove_empty_parent_dirs(&parent.join("missing/child"), temp.path()).unwrap();
+        assert!(parent.exists());
+    }
+
+    #[test]
+    fn stub_helpers_cover_non_not_found_io_errors() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("bin"), b"not a directory").unwrap();
+        assert!(
+            collect_root_executables(&root)
+                .unwrap_err()
+                .contains("failed to read")
+        );
+
+        let manifest_dir = temp.path().join("manifest-dir");
+        fs::create_dir_all(&manifest_dir).unwrap();
+        assert!(
+            load_stub_manifest(&manifest_dir)
+                .unwrap_err()
+                .contains("failed to read")
+        );
+        assert!(
+            stub_belongs_to_package(&manifest_dir, "coverage")
+                .unwrap_err()
+                .contains("failed to read")
+        );
+
+        let blocking_file = temp.path().join("blocking-file");
+        fs::write(&blocking_file, b"file").unwrap();
+        assert!(
+            remove_empty_parent_dirs(&blocking_file.join("child"), temp.path())
+                .unwrap_err()
+                .contains("failed to remove")
+        );
+
+        let opt_root = temp.path().join("opt");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        remove_existing_package_install(&opt_root, "missing", &bin_dir).unwrap();
+    }
+
+    #[test]
+    fn sync_declared_stubs_filters_exclusions_and_removes_stale_entries() {
+        let _package_lock = acquire_package_mutation_lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let package_name = "coverage-declared-stubs";
+        let bin_root = managed_bin_root();
+        let kept_stub = bin_root.join("coverage-declared-keep");
+        let stale_stub = bin_root.join("coverage-declared-stale");
+        let excluded_stub = bin_root.join("coverage-declared-skip");
+
+        for path in [&kept_stub, &stale_stub, &excluded_stub] {
+            if fs::symlink_metadata(path).is_ok() {
+                remove_path(path).unwrap();
+            }
+        }
+
+        let plan = InstallPlan {
+            mode: Mode::I,
+            package_name: package_name.to_string(),
+            root_formula: package_name.to_string(),
+            stable_root: temp.path().join("stable"),
+            install_root: temp.path().join(package_name),
+            tmp_root: temp.path().join("tmp"),
+        };
+        fs::create_dir_all(plan.install_root.join("bin")).unwrap();
+        write_executable(&plan.install_root.join("bin/coverage-declared-keep"));
+        write_executable(&plan.install_root.join("bin/coverage-declared-skip"));
+        write_executable(&stale_stub);
+
+        let excluded = HashSet::from(["coverage-declared-skip".to_string()]);
+        sync_declared_stubs(
+            &plan,
+            &[],
+            ["coverage-declared-keep", "coverage-declared-skip"],
+            &excluded,
+            &["coverage-declared-stale".to_string()],
+        )
+        .unwrap();
+
+        assert!(is_executable(&kept_stub));
+        assert!(fs::symlink_metadata(&stale_stub).is_err());
+        assert!(fs::symlink_metadata(&excluded_stub).is_err());
+        assert_eq!(
+            load_stub_manifest(&plan.package_manifest_path())
+                .unwrap()
+                .stubs,
+            vec!["coverage-declared-keep".to_string()]
+        );
+
+        remove_path(&kept_stub).unwrap();
+    }
+
+    #[test]
+    fn run_package_post_install_returns_early_without_supported_formulas() {
+        let temp = TempDir::new().unwrap();
+        let plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "coverage-no-post-install".to_string(),
+            root_formula: "coverage-no-post-install".to_string(),
+            stable_root: temp.path().join("stable"),
+            install_root: temp.path().join("coverage-no-post-install"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        run_package_post_install(&plan, &[], &bin_dir).unwrap();
+
+        assert!(fs::symlink_metadata(plan.package_manifest_path()).is_err());
+    }
+
+    #[test]
     fn run_package_post_install_creates_python_dispatchers_and_openssl_cert_path() {
         let temp = TempDir::new().unwrap();
         let opt_root = temp.path().join("opt");

--- a/src/lib/rs/ops.rs
+++ b/src/lib/rs/ops.rs
@@ -519,6 +519,7 @@ fn homebrew_migration_hazard_for_package(
     Some(core::HomebrewMigrationHazardSummary {
         package_name: package_name.to_string(),
         isotope_name: state.isotope_name,
+        reasons: state.reasons,
         error: state.error,
     })
 }


### PR DESCRIPTION
## Summary
- add targeted tests for gate approval request persistence and failure cleanup
- add stub sync and stub helper tests for stale entry cleanup and IO edge cases
- raise cargo llvm-cov line coverage from 82.14% to 82.65%

## Verification
- cargo test
- cargo llvm-cov --workspace --summary-only