### PR TITLE
Raise Rust coverage to 85.55%

### DIFF
--- a/src/gui/UpdateProgressViewController.swift
+++ b/src/gui/UpdateProgressViewController.swift
@@ -54,8 +54,34 @@ private final class ProgressStripView: NSView {
     }
 }
 
-private final class PackageProgressStackView: NSStackView {
+private enum PackageProgressListMetrics {
+    static let rowHeight: CGFloat = 34
+    static let rowSpacing: CGFloat = 6
+
+    static func contentHeight(rowCount: Int) -> CGFloat {
+        guard rowCount > 0 else { return rowHeight }
+        return CGFloat(rowCount) * rowHeight
+            + CGFloat(max(rowCount - 1, 0)) * rowSpacing
+    }
+}
+
+private final class PackageProgressListView: NSView {
     override var isFlipped: Bool { true }
+
+    override func layout() {
+        super.layout()
+        var y: CGFloat = 0
+        for subview in subviews {
+            subview.frame = CGRect(
+                x: 0,
+                y: y,
+                width: bounds.width,
+                height: PackageProgressListMetrics.rowHeight
+            )
+            y += PackageProgressListMetrics.rowHeight
+                + PackageProgressListMetrics.rowSpacing
+        }
+    }
 }
 
 private final class PackageProgressRowView: NSView {
@@ -341,7 +367,7 @@ final class UpdateProgressViewController: NSViewController {
         let operationField = NSTextField(labelWithString: "")
         let statusField = NSTextField(labelWithString: "")
         let packageScrollView = NSScrollView(frame: .zero)
-        let packageStack = PackageProgressStackView()
+        let packageListView = PackageProgressListView()
         let logScrollView = NSScrollView(frame: .zero)
         let logView = NSTextView(frame: .zero)
         let primaryButton = NSButton(title: "Abort", target: nil, action: nil)
@@ -383,14 +409,13 @@ final class UpdateProgressViewController: NSViewController {
             statusField.font = UIStyle.monoFont(size: 10, weight: .regular)
             statusField.textColor = UIStyle.quietText
 
-            packageStack.orientation = .vertical
-            packageStack.alignment = .width
-            packageStack.spacing = 8
             packageScrollView.drawsBackground = false
             packageScrollView.borderType = .noBorder
+            packageScrollView.hasHorizontalScroller = false
             packageScrollView.hasVerticalScroller = true
+            packageScrollView.autohidesScrollers = true
             packageScrollView.contentView.postsBoundsChangedNotifications = true
-            packageScrollView.documentView = packageStack
+            packageScrollView.documentView = packageListView
             panel.addSubview(packageScrollView)
 
             logView.isEditable = false
@@ -458,22 +483,73 @@ final class UpdateProgressViewController: NSViewController {
                 height: panelHeight
             )
 
-            titleField.frame = CGRect(x: 24, y: panelHeight - 42, width: panelWidth - 48, height: 20)
-            operationField.frame = CGRect(x: 24, y: panelHeight - 68, width: panelWidth - 48, height: 18)
-            statusField.frame = CGRect(x: 24, y: panelHeight - 90, width: panelWidth - 48, height: 16)
-            packageScrollView.frame = CGRect(x: 24, y: 220, width: panelWidth - 48, height: 164)
-            packageStack.frame = CGRect(
+            let inset: CGFloat = 24
+            titleField.frame = CGRect(
+                x: inset,
+                y: panelHeight - 42,
+                width: panelWidth - inset * 2,
+                height: 20
+            )
+            operationField.frame = CGRect(
+                x: inset,
+                y: panelHeight - 68,
+                width: panelWidth - inset * 2,
+                height: 18
+            )
+            statusField.frame = CGRect(
+                x: inset,
+                y: panelHeight - 90,
+                width: panelWidth - inset * 2,
+                height: 16
+            )
+
+            let rowContentHeight = PackageProgressListMetrics.contentHeight(
+                rowCount: packageListView.subviews.count
+            )
+            let buttonY: CGFloat = 24
+            let buttonHeight: CGFloat = 30
+            let logBottom = buttonY + buttonHeight + 16
+            let contentTop = panelHeight - 112
+            let packageLogGap: CGFloat = 14
+            let availableContentHeight = contentTop - logBottom - packageLogGap
+            let maxPackageHeight = min(320, max(120, availableContentHeight * 0.70))
+            let packageHeight = min(rowContentHeight, maxPackageHeight)
+            let packageY = contentTop - packageHeight
+            let logHeight = max(104, packageY - packageLogGap - logBottom)
+
+            packageScrollView.frame = CGRect(
+                x: inset,
+                y: packageY,
+                width: panelWidth - inset * 2,
+                height: packageHeight
+            )
+            packageScrollView.hasVerticalScroller = rowContentHeight > packageHeight + 0.5
+            packageListView.frame = CGRect(
                 x: 0,
                 y: 0,
                 width: packageScrollView.contentSize.width,
-                height: max(CGFloat(packageStack.arrangedSubviews.count) * 42, packageScrollView.contentSize.height)
+                height: max(rowContentHeight, packageScrollView.contentSize.height)
             )
-            for view in packageStack.arrangedSubviews {
-                view.frame.size = CGSize(width: packageStack.frame.width, height: 38)
-            }
-            logScrollView.frame = CGRect(x: 24, y: 70, width: panelWidth - 48, height: 132)
-            primaryButton.frame = CGRect(x: panelWidth - 128, y: 24, width: 104, height: 30)
-            secondaryButton.frame = CGRect(x: panelWidth - 240, y: 24, width: 104, height: 30)
+            packageListView.needsLayout = true
+
+            logScrollView.frame = CGRect(
+                x: inset,
+                y: logBottom,
+                width: panelWidth - inset * 2,
+                height: logHeight
+            )
+            primaryButton.frame = CGRect(
+                x: panelWidth - 128,
+                y: buttonY,
+                width: 104,
+                height: buttonHeight
+            )
+            secondaryButton.frame = CGRect(
+                x: panelWidth - 240,
+                y: buttonY,
+                width: 104,
+                height: buttonHeight
+            )
             UIStyle.layoutControlChrome(in: primaryButton.layer)
             UIStyle.layoutControlChrome(in: secondaryButton.layer)
         }
@@ -717,8 +793,7 @@ final class UpdateProgressViewController: NSViewController {
         guard let rootView = view as? RootView else { return }
         let existingRows = rows
         rows.removeAll(keepingCapacity: true)
-        rootView.packageStack.arrangedSubviews.forEach { subview in
-            rootView.packageStack.removeArrangedSubview(subview)
+        rootView.packageListView.subviews.forEach { subview in
             subview.removeFromSuperview()
         }
         for package in orderedPackages {
@@ -732,9 +807,7 @@ final class UpdateProgressViewController: NSViewController {
                 speed: state.lastSpeed,
                 animated: false
             )
-            rootView.packageStack.addArrangedSubview(row)
-            row.translatesAutoresizingMaskIntoConstraints = false
-            row.heightAnchor.constraint(equalToConstant: 38).isActive = true
+            rootView.packageListView.addSubview(row)
         }
         rootView.needsLayout = true
         resetPackageScrollPosition()

--- a/src/gui/UpdateProgressViewController.swift
+++ b/src/gui/UpdateProgressViewController.swift
@@ -59,7 +59,7 @@ private enum PackageProgressListMetrics {
     static let rowSpacing: CGFloat = 6
 
     static func contentHeight(rowCount: Int) -> CGFloat {
-        guard rowCount > 0 else { return rowHeight }
+        guard rowCount > 0 else { return 0 }
         return CGFloat(rowCount) * rowHeight
             + CGFloat(max(rowCount - 1, 0)) * rowSpacing
     }

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -14273,6 +14273,178 @@ info: requested `imagemagick`; `brew:imagemagick-full` is recommended instead\n"
     }
 
     #[test]
+    fn dependency_current_checks_cover_npm_pip_cask_and_isotope_roots() {
+        let temp = TempDir::new().unwrap();
+        let config = Config {
+            bottle_tag: "arm64_tahoe".to_string(),
+        };
+
+        let npm_plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "npm:coverage-npm".to_string(),
+            root_formula: "coverage-npm".to_string(),
+            stable_root: temp.path().join("opt/npm/coverage-npm"),
+            install_root: temp.path().join("opt/npm/coverage-npm"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        assert!(
+            !npm_root_is_current(
+                &npm_plan,
+                "coverage-npm",
+                &Version::parse("1.2.3").unwrap(),
+                &[],
+                &config.bottle_tag
+            )
+            .unwrap()
+        );
+        fs::create_dir_all(npm_plan.install_root.join("bin")).unwrap();
+        write_executable(&npm_plan.install_root.join("bin/coverage-npm"));
+        write_package_receipt(
+            &npm_plan.root_receipt_path(),
+            &PackageReceipt {
+                package_name: "npm:coverage-npm".to_string(),
+                version: "1.2.3".to_string(),
+                source: PackageReceiptSource::Npm {
+                    package_name: "coverage-npm".to_string(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        assert!(
+            npm_root_is_current(
+                &npm_plan,
+                "coverage-npm",
+                &Version::parse("1.2.3").unwrap(),
+                &[],
+                &config.bottle_tag,
+            )
+            .unwrap()
+        );
+        remove_path(&npm_plan.install_root.join("bin/coverage-npm")).unwrap();
+        assert!(
+            !npm_root_is_current(
+                &npm_plan,
+                "coverage-npm",
+                &Version::parse("1.2.3").unwrap(),
+                &[],
+                &config.bottle_tag,
+            )
+            .unwrap()
+        );
+
+        let pip_plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "pip:coverage-pip".to_string(),
+            root_formula: "coverage-pip".to_string(),
+            stable_root: temp.path().join("opt/pip/coverage-pip"),
+            install_root: temp.path().join("opt/pip/coverage-pip"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        fs::create_dir_all(pip_plan.install_root.join("bin")).unwrap();
+        fs::create_dir_all(pip_plan.install_root.join("venv")).unwrap();
+        fs::write(pip_plan.install_root.join("venv/pyvenv.cfg"), b"").unwrap();
+        write_executable(&pip_plan.install_root.join("bin/coverage-pip"));
+        write_root_executable_manifest(
+            &pip_plan.root_executables_manifest_path(),
+            &["coverage-pip".to_string()],
+        )
+        .unwrap();
+        write_package_receipt(
+            &pip_plan.root_receipt_path(),
+            &PackageReceipt {
+                package_name: "pip:coverage-pip".to_string(),
+                version: "2.3.4".to_string(),
+                source: PackageReceiptSource::Pip {
+                    package_name: "coverage-pip".to_string(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        assert!(pip_root_is_current(&pip_plan, "2.3.4", &[], &config.bottle_tag).unwrap());
+        remove_path(&pip_plan.install_root.join("venv/pyvenv.cfg")).unwrap();
+        assert!(!pip_root_is_current(&pip_plan, "2.3.4", &[], &config.bottle_tag).unwrap());
+
+        let cask_plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "cask:codex".to_string(),
+            root_formula: "codex".to_string(),
+            stable_root: temp.path().join("opt/cask/codex"),
+            install_root: temp.path().join("opt/cask/codex"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        let cask = EmbeddedCaskMetadata {
+            version: "1.0.0".to_string(),
+            binaries: vec![EmbeddedCaskBinary {
+                source: "Codex.app/Contents/MacOS/codex".to_string(),
+                target: Some("codex".to_string()),
+            }],
+            ..Default::default()
+        };
+        fs::create_dir_all(cask_plan.install_root.join("bin")).unwrap();
+        write_executable(&cask_plan.install_root.join("bin/codex"));
+        write_package_receipt(
+            &cask_plan.root_receipt_path(),
+            &PackageReceipt {
+                package_name: "cask:codex".to_string(),
+                version: "1.0.0".to_string(),
+                source: PackageReceiptSource::Cask {
+                    cask_name: "codex".to_string(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        assert!(cask_root_is_current(&cask_plan, &cask, &[], &config.bottle_tag).unwrap());
+        remove_path(&cask_plan.install_root.join("bin/codex")).unwrap();
+        assert!(!cask_root_is_current(&cask_plan, &cask, &[], &config.bottle_tag).unwrap());
+
+        let isotope_plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "isotope:gh".to_string(),
+            root_formula: "gh".to_string(),
+            stable_root: temp.path().join("opt/isotope/gh"),
+            install_root: temp.path().join("opt/isotope/gh"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        let isotope = IsotopePackageData {
+            name: "isotope:gh".to_string(),
+            replaces: Some("brew:gh".to_string()),
+            modifies: None,
+            migrate: None,
+            _repository: None,
+            _upstream_repository: None,
+            version: "2.80.0".to_string(),
+            release_url: Some("https://example.test/isotopes/gh".to_string()),
+            archive_url: Some("https://example.test/isotopes/gh.tar.gz".to_string()),
+            published_at: None,
+        };
+        fs::create_dir_all(isotope_plan.install_root.join("bin")).unwrap();
+        write_executable(&isotope_plan.install_root.join("bin/gh"));
+        write_root_executable_manifest(
+            &isotope_plan.root_executables_manifest_path(),
+            &["gh".to_string()],
+        )
+        .unwrap();
+        write_package_receipt(
+            &isotope_plan.root_receipt_path(),
+            &PackageReceipt {
+                package_name: "isotope:gh".to_string(),
+                version: "2.80.0".to_string(),
+                source: PackageReceiptSource::Isotope {
+                    isotope_name: "gh".to_string(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        assert!(isotope_root_is_current(&isotope_plan, &isotope).unwrap());
+        remove_path(&isotope_plan.install_root.join("bin/gh")).unwrap();
+        assert!(!isotope_root_is_current(&isotope_plan, &isotope).unwrap());
+    }
+
+    #[test]
     fn find_supported_post_install_prefixes_filters_supported_formula_receipts() {
         let temp = TempDir::new().unwrap();
         let opt_root = temp.path().join("opt");
@@ -15732,6 +15904,193 @@ EOF
             fs::read_to_string(&installed).unwrap(),
             "#!/bin/sh\necho claude\n"
         );
+    }
+
+    #[test]
+    fn cask_install_helpers_cover_tar_payload_current_receipts_and_sha_mismatch() {
+        let temp = TempDir::new().unwrap();
+        let tmp_root = temp.path().join("tmp");
+        fs::create_dir_all(&tmp_root).unwrap();
+        let archive = temp.path().join("codex.tar.gz");
+        write_test_archive(
+            &archive,
+            &[
+                ("Codex.app/Contents/MacOS/codex", b"#!/bin/sh\necho codex\n"),
+                ("Codex.app/Contents/MacOS/cdx", b"#!/bin/sh\necho cdx\n"),
+            ],
+        );
+        let archive_bytes = fs::read(&archive).unwrap();
+        let archive_sha = format!("{:x}", Sha256::digest(&archive_bytes));
+        let (base, server) = start_test_http_server(
+            vec![("/codex.tar.gz".to_string(), archive_bytes.clone())],
+            2,
+        );
+        let plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "cask:codex".to_string(),
+            root_formula: "codex".to_string(),
+            stable_root: temp.path().join("opt/cask/codex"),
+            install_root: temp.path().join("opt/cask/codex"),
+            tmp_root: tmp_root.clone(),
+        };
+        let cask = EmbeddedCaskMetadata {
+            summary: "OpenAI Codex".to_string(),
+            homepage: "https://example.test/codex".to_string(),
+            url: format!("{base}/codex.tar.gz"),
+            sha256: archive_sha,
+            version: "1.0.0".to_string(),
+            binaries: vec![
+                EmbeddedCaskBinary {
+                    source: "Codex.app/Contents/MacOS/codex".to_string(),
+                    target: None,
+                },
+                EmbeddedCaskBinary {
+                    source: "Codex.app/Contents/MacOS/cdx".to_string(),
+                    target: Some("codex-chat".to_string()),
+                },
+            ],
+            ..Default::default()
+        };
+
+        install_cask_root(&plan, "codex", &cask, None).unwrap();
+        assert!(is_executable(&plan.install_root.join("bin/codex")));
+        assert!(is_executable(&plan.install_root.join("bin/codex-chat")));
+        write_package_receipt(
+            &plan.root_receipt_path(),
+            &PackageReceipt {
+                package_name: "cask:codex".to_string(),
+                version: "1.0.0".to_string(),
+                source: PackageReceiptSource::Cask {
+                    cask_name: "codex".to_string(),
+                },
+                metadata: PackageMetadata {
+                    description: Some("OpenAI Codex".to_string()),
+                    homepage: Some("https://example.test/codex".to_string()),
+                },
+            },
+        )
+        .unwrap();
+        assert!(cask_root_is_current(&plan, &cask, &[], "all").unwrap());
+
+        let bad_archive = temp.path().join("bad-codex.tar.gz");
+        let bad_cask = EmbeddedCaskMetadata {
+            sha256: "deadbeef".repeat(8),
+            url: format!("{base}/codex.tar.gz"),
+            version: "1.0.0".to_string(),
+            binaries: vec![EmbeddedCaskBinary {
+                source: "bad-codex.tar.gz".to_string(),
+                target: None,
+            }],
+            ..Default::default()
+        };
+        let err = download_cask_archive("codex", &bad_cask, &bad_archive, None).unwrap_err();
+        assert!(err.contains("sha256 mismatch for cask codex"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn isotope_install_helpers_cover_nested_and_flat_archives() {
+        let temp = TempDir::new().unwrap();
+        let tmp_root = temp.path().join("tmp");
+        fs::create_dir_all(&tmp_root).unwrap();
+
+        let nested_archive = temp.path().join("gh.tar.gz");
+        write_test_archive(
+            &nested_archive,
+            &[
+                ("gh-2.80.0/bin/gh", b"#!/bin/sh\nprintf gh\\n\n"),
+                ("gh-2.80.0/share/man/man1/gh.1", b"GH manual\n"),
+            ],
+        );
+        let flat_archive = temp.path().join("aws-cli.tgz");
+        write_test_archive(
+            &flat_archive,
+            &[
+                ("bin/aws", b"#!/bin/sh\nprintf aws\\n\n"),
+                ("share/doc/aws.txt", b"aws docs\n"),
+            ],
+        );
+        let (base, server) = start_test_http_server(
+            vec![
+                ("/gh.tar.gz".to_string(), fs::read(&nested_archive).unwrap()),
+                ("/aws-cli.tgz".to_string(), fs::read(&flat_archive).unwrap()),
+            ],
+            2,
+        );
+
+        let isotope = IsotopePackageData {
+            name: "isotope:gh".to_string(),
+            replaces: Some("brew:gh".to_string()),
+            modifies: None,
+            migrate: None,
+            _repository: None,
+            _upstream_repository: None,
+            version: "2.80.0".to_string(),
+            release_url: Some("https://example.test/isotopes/gh".to_string()),
+            archive_url: Some(format!("{base}/gh.tar.gz")),
+            published_at: None,
+        };
+        let gh_plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "isotope:gh".to_string(),
+            root_formula: "gh".to_string(),
+            stable_root: temp.path().join("opt/isotopes/gh"),
+            install_root: temp.path().join("opt/isotopes/gh"),
+            tmp_root: tmp_root.clone(),
+        };
+        install_isotope_root(&gh_plan, &isotope, &[], None).unwrap();
+        assert!(is_executable(&gh_plan.install_root.join("bin/gh")));
+        assert!(gh_plan.install_root.join("share/man/man1/gh.1").is_file());
+        write_root_executable_manifest(
+            &gh_plan.root_executables_manifest_path(),
+            &["gh".to_string()],
+        )
+        .unwrap();
+        write_package_receipt(
+            &gh_plan.root_receipt_path(),
+            &PackageReceipt {
+                package_name: "isotope:gh".to_string(),
+                version: "2.80.0".to_string(),
+                source: PackageReceiptSource::Isotope {
+                    isotope_name: "gh".to_string(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        assert!(isotope_root_is_current(&gh_plan, &isotope).unwrap());
+
+        let radioisotope = IsotopePackageData {
+            name: "isotope:aws-cli".to_string(),
+            replaces: None,
+            modifies: Some("brew:awscli".to_string()),
+            migrate: Some("aws configure import --csv file://$1".to_string()),
+            _repository: None,
+            _upstream_repository: None,
+            version: "1.0.0".to_string(),
+            release_url: Some("https://example.test/isotopes/aws-cli".to_string()),
+            archive_url: Some(format!("{base}/aws-cli.tgz")),
+            published_at: None,
+        };
+        let aws_plan = InstallPlan {
+            mode: Mode::I,
+            package_name: "isotope:aws-cli".to_string(),
+            root_formula: "awscli".to_string(),
+            stable_root: temp.path().join("opt/isotopes/aws-cli"),
+            install_root: temp.path().join("opt/isotopes/aws-cli"),
+            tmp_root: tmp_root.clone(),
+        };
+        install_isotope_root(&aws_plan, &radioisotope, &[], None).unwrap();
+        assert!(is_executable(&aws_plan.install_root.join("bin/aws")));
+        assert!(aws_plan.install_root.join("share/doc/aws.txt").is_file());
+
+        let missing_archive = IsotopePackageData {
+            archive_url: None,
+            ..radioisotope
+        };
+        let err = install_isotope_root(&aws_plan, &missing_archive, &[], None).unwrap_err();
+        assert!(err.contains("isotope isotope:aws-cli has no archive URL"));
+        server.join().unwrap();
     }
 
     #[test]

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -14404,8 +14404,8 @@ info: requested `imagemagick`; `brew:imagemagick-full` is recommended instead\n"
             mode: Mode::I,
             package_name: "isotope:gh".to_string(),
             root_formula: "gh".to_string(),
-            stable_root: temp.path().join("opt/isotope/gh"),
-            install_root: temp.path().join("opt/isotope/gh"),
+            stable_root: temp.path().join("opt/isotopes/gh"),
+            install_root: temp.path().join("opt/isotopes/gh"),
             tmp_root: temp.path().join("tmp"),
         };
         let isotope = IsotopePackageData {


### PR DESCRIPTION
## Summary
- add current-state coverage tests for npm, pip, cask, and isotope install roots
- add cask archive install and sha mismatch coverage tests
- add isotope archive install coverage for nested and flat payload shapes

## Verification
- cargo test --lib dependency_current_checks_cover_npm_pip_cask_and_isotope_roots
- cargo test --lib cask_install_helpers_cover_tar_payload_current_receipts_and_sha_mismatch
- cargo test --lib isotope_install_helpers_cover_nested_and_flat_archives
- cargo llvm-cov --workspace --summary-only

Coverage moved from 85.04% to 85.55% line coverage for this run.