### PR TITLE
[codex] Restore radioisotope coverage tracking

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -41,9 +41,16 @@ jobs:
             src/lib/rs/fixtures/coverage-combined.json
 
       - name: Generate Rust coverage
+        env:
+          AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS: "1"
         run: >
           cargo llvm-cov --workspace --lcov --output-path lcov.info
           -- --test-threads=1
+
+      - name: Verify isotope coverage paths
+        run: |
+          grep -Eq '^SF:.*/data/isotopes/.+\.rs$' lcov.info
+          grep -Eq '^SF:.*/data/radioisotopes/.+\.rs$' lcov.info
 
       - name: Upload Rust coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/build.rs
+++ b/build.rs
@@ -94,6 +94,7 @@ fn generate_isotope_integrations() {
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_REPO_CACHE");
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_RADIOISOTOPES_REPO");
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_COVERAGE");
     let isotope_roots = [
         path_env_or_default("AUTOMIC_VAULT_REPO_CACHE", repo_root.join("data/isotopes")),
         path_env_or_default(

--- a/build.rs
+++ b/build.rs
@@ -250,10 +250,21 @@ fn generate_isotope_integrations() {
 }
 
 fn path_env_or_default(key: &str, default: std::path::PathBuf) -> std::path::PathBuf {
-    std::env::var_os(key)
+    let path = std::env::var_os(key)
         .filter(|value| !value.is_empty())
         .map(std::path::PathBuf::from)
-        .unwrap_or(default)
+        .unwrap_or(default);
+    absolute_path(path)
+}
+
+fn absolute_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+
+    std::env::current_dir()
+        .unwrap_or_else(|err| panic!("failed to resolve current directory: {err}"))
+        .join(path)
 }
 
 fn include_isotope_tests_for_coverage() -> bool {

--- a/build.rs
+++ b/build.rs
@@ -93,6 +93,7 @@ fn generate_isotope_integrations() {
     let repo_root = std::path::Path::new(&manifest_dir);
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_REPO_CACHE");
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_RADIOISOTOPES_REPO");
+    println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS");
     let isotope_roots = [
         path_env_or_default("AUTOMIC_VAULT_REPO_CACHE", repo_root.join("data/isotopes")),
         path_env_or_default(
@@ -103,6 +104,7 @@ fn generate_isotope_integrations() {
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let generated_sources_dir = std::path::Path::new(&out_dir).join("isotope-generated");
     let output_path = std::path::Path::new(&out_dir).join("isotope_integrations.rs");
+    let include_isotope_tests = include_isotope_tests_for_coverage();
 
     let mut entries = Vec::new();
     for root in isotope_roots {
@@ -130,7 +132,8 @@ fn generate_isotope_integrations() {
     for entry in &entries {
         output.push_str(&format!("mod {} {{\n", entry.module_name));
         if let Some(path) = &entry.detect_path {
-            let include_path = sanitized_isotope_source(
+            let include_path = isotope_include_path(
+                include_isotope_tests,
                 &generated_sources_dir,
                 &entry.module_name,
                 "detect",
@@ -142,7 +145,8 @@ fn generate_isotope_integrations() {
             ));
         }
         if let Some(path) = &entry.migrate_path {
-            let include_path = sanitized_isotope_source(
+            let include_path = isotope_include_path(
+                include_isotope_tests,
                 &generated_sources_dir,
                 &entry.module_name,
                 "migrate",
@@ -154,7 +158,8 @@ fn generate_isotope_integrations() {
             ));
         }
         if let Some(path) = &entry.post_install_path {
-            let include_path = sanitized_isotope_source(
+            let include_path = isotope_include_path(
+                include_isotope_tests,
                 &generated_sources_dir,
                 &entry.module_name,
                 "post_install",
@@ -166,7 +171,8 @@ fn generate_isotope_integrations() {
             ));
         }
         if let Some(path) = &entry.credential_helper_path {
-            let include_path = sanitized_isotope_source(
+            let include_path = isotope_include_path(
+                include_isotope_tests,
                 &generated_sources_dir,
                 &entry.module_name,
                 "credential_helper",
@@ -247,6 +253,34 @@ fn path_env_or_default(key: &str, default: std::path::PathBuf) -> std::path::Pat
         .filter(|value| !value.is_empty())
         .map(std::path::PathBuf::from)
         .unwrap_or(default)
+}
+
+fn include_isotope_tests_for_coverage() -> bool {
+    // cargo-llvm-cov sets cfg(coverage). The explicit env var keeps CI and
+    // automation runs readable while preserving the cargo-llvm-cov default.
+    std::env::var_os("CARGO_CFG_COVERAGE").is_some()
+        || env_flag("AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS")
+}
+
+fn env_flag(key: &str) -> bool {
+    std::env::var_os(key).is_some_and(|value| {
+        let value = value.to_string_lossy();
+        !value.is_empty() && value != "0" && value != "false"
+    })
+}
+
+fn isotope_include_path(
+    include_isotope_tests: bool,
+    generated_sources_dir: &std::path::Path,
+    module_name: &str,
+    suffix: &str,
+    source_path: &std::path::Path,
+) -> std::path::PathBuf {
+    if include_isotope_tests {
+        return source_path.to_path_buf();
+    }
+
+    sanitized_isotope_source(generated_sources_dir, module_name, suffix, source_path)
 }
 
 fn sanitized_isotope_source(


### PR DESCRIPTION
## Summary
- include original isotope and radioisotope Rust source files during coverage builds so LCOV keeps data/... paths
- keep the sanitized OUT_DIR copies for normal builds
- fail the coverage workflow if LCOV stops containing isotope or radioisotope source paths

## Why
The coverage workflow still checked out data/radioisotopes, but build.rs copied snippets into OUT_DIR and stripped #[cfg(test)] modules before inclusion. That made Coveralls and the automation stop seeing data/radioisotopes entirely.

## Dependency
Depends on https://github.com/automic-vault/radioisotopes/pull/5. With radioisotope tests restored, that PR fixes the AWS, Kubernetes, and NuGet failures exposed by this harness change. The current PR check is expected to fail until radioisotopes#5 is merged because CI checks out radioisotopes@main.

## Validation
- focused AWS credential-helper radioisotope tests passed
- focused Kubernetes radioisotope migration tests passed
- focused NuGet radioisotope migration tests passed
- AUTOMIC_VAULT_REPO_CACHE=/Users/mxcl/src/automic-vault/data/isotopes AUTOMIC_VAULT_RADIOISOTOPES_REPO=/Users/mxcl/src/automic-vault/data/radioisotopes AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1
- LCOV contains 2 data/isotopes source entries and 313 data/radioisotopes source entries
- total line coverage with restored isotope sources: 81.13%