### PR TITLE
[codex] Raise coverage to 87.35%

### DIFF
--- a/src/lib/rs/info.rs
+++ b/src/lib/rs/info.rs
@@ -2674,6 +2674,105 @@ mod tests {
     }
 
     #[test]
+    fn security_recommendation_results_require_homebrew_without_vault_install() {
+        let temp = TempDir::new().unwrap();
+        let cellar = temp.path().join("Cellar");
+        let opt_root = temp.path().join("opt");
+        for formula in ["awscli", "gh"] {
+            let version_root = cellar.join(formula).join("1.0.0");
+            fs::create_dir_all(&version_root).unwrap();
+            fs::write(version_root.join(HOMEBREW_INSTALL_RECEIPT), "{}").unwrap();
+        }
+
+        let results =
+            resolve_security_recommendation_package_results_at(&cellar, &opt_root).unwrap();
+        assert_eq!(results.len(), 2);
+        let awscli = results
+            .iter()
+            .find(|result| result.package_name == "brew:awscli")
+            .unwrap();
+        assert_eq!(awscli.install_package_names, vec!["brew:awscli"]);
+        assert!(awscli.summary.as_deref().unwrap().contains("AWS"));
+        assert!(awscli.security_state.is_some());
+
+        let gh = results
+            .iter()
+            .find(|result| result.package_name == "brew:gh")
+            .unwrap();
+        let gh_summary = gh.summary.as_deref().unwrap();
+        assert!(gh_summary.contains("GitHub CLI"));
+        assert!(gh_summary.contains("Geiger: orange."));
+        assert!(gh_summary.contains("Confidence: high."));
+        assert!(gh_summary.contains("Category: infrastructure."));
+
+        let isotope_root = package_install_root(&opt_root, "isotope:gh").unwrap();
+        fs::create_dir_all(&isotope_root).unwrap();
+        write_package_receipt(
+            &isotope_root.join(ROOT_RECEIPT),
+            &PackageReceipt {
+                package_name: "isotope:gh".to_string(),
+                version: "1.0.0".to_string(),
+                source: PackageReceiptSource::Isotope {
+                    isotope_name: "gh".to_string(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+
+        let filtered =
+            resolve_security_recommendation_package_results_at(&cellar, &opt_root).unwrap();
+        assert!(
+            filtered
+                .iter()
+                .all(|result| result.package_name != "brew:gh")
+        );
+        assert!(
+            filtered
+                .iter()
+                .any(|result| result.package_name == "brew:awscli")
+        );
+    }
+
+    #[test]
+    fn security_recommendation_result_falls_back_without_formula_index_match() {
+        let recommendation = SecurityRecommendationPackage {
+            install_package_name: "brew:tap/tool/tool".to_string(),
+            reasons: vec!["  ".to_string()],
+            approval_gate: true,
+            signals: vec!["isotope".to_string()],
+            ..SecurityRecommendationPackage::default()
+        };
+
+        let result =
+            security_recommendation_package_result("brew:tap/tool/tool", &recommendation, &[])
+                .unwrap();
+
+        assert_eq!(result.package_name, "brew:tap/tool/tool");
+        assert_eq!(
+            result.source,
+            PackageReceiptSource::Formula {
+                root_formula: "tap/tool/tool".to_string()
+            }
+        );
+        assert_eq!(result.install_package_names, vec!["brew:tap/tool/tool"]);
+        assert_eq!(
+            result.summary.as_deref(),
+            Some(
+                "Root-owned Automic Vault install recommended. Approval gate metadata is available."
+            )
+        );
+        assert_eq!(homebrew_formula_cellar_name("tap/tool/tool"), "tool");
+        assert_eq!(
+            compare_security_recommendation_rank_order(
+                &search_result("ranked", result.source.clone(), None, Some(1)),
+                &search_result("unranked", result.source, None, None),
+            ),
+            std::cmp::Ordering::Less
+        );
+    }
+
+    #[test]
     fn search_ranking_helpers_cover_names_summaries_sources_and_popularity() {
         let exact = search_result(
             "ripgrep",

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -10263,7 +10263,7 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
             .formulas
             .get("node")
             .and_then(|metadata| string_or_none(&metadata.summary))
-            .unwrap();
+            .expect("expected embedded DB to include a non-empty summary for formula `node`");
         let formula_homebrew_info = formula.homebrew_info.unwrap();
         assert!(!formula.installed);
         assert_eq!(formula.latest_version, Some("22.0.0".to_string()));

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -10259,7 +10259,7 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
         )
         .unwrap();
         let expected_node_summary = crate::cli::load_db()
-            .unwrap()
+            .expect("embedded DB fixture must be available")
             .formulas
             .get("node")
             .and_then(|metadata| string_or_none(&metadata.summary))

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -10258,11 +10258,23 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
             &RequestedPackage::HomebrewFormula("node".to_string()),
         )
         .unwrap();
+        let expected_node_summary = crate::cli::load_db()
+            .unwrap()
+            .formulas
+            .get("node")
+            .and_then(|metadata| string_or_none(&metadata.summary))
+            .unwrap();
+        let formula_homebrew_info = formula.homebrew_info.unwrap();
         assert!(!formula.installed);
         assert_eq!(formula.latest_version, Some("22.0.0".to_string()));
         assert_eq!(
-            formula.homebrew_info.unwrap().description,
-            Some("Node runtime".to_string())
+            formula_homebrew_info.description,
+            Some(expected_node_summary)
+        );
+        assert_eq!(formula_homebrew_info.license, Some("MIT".to_string()));
+        assert_eq!(
+            formula_homebrew_info.dependencies,
+            vec!["openssl@3".to_string()]
         );
 
         let cask = resolve_package_info(
@@ -11942,6 +11954,7 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
         let home = temp.path().join("home");
         let xdg_config = temp.path().join("xdg-config");
         let xdg_cache = temp.path().join("xdg-cache");
+        let xdg_data = temp.path().join("xdg-data");
         let xdg_state = temp.path().join("xdg-state");
         let xdg_runtime = temp.path().join("xdg-runtime");
         let missing = temp.path().join("missing");
@@ -11980,6 +11993,16 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
         write_fixture(
             &home.join(".config/acli/jira_config.yaml"),
             "token: atlassian\n",
+        );
+        write_fixture(&xdg_data.join("atuin/key"), "atuin-secret\n");
+        write_fixture(
+            &xdg_config.join("atuin/config.toml"),
+            "session_path = \"~/atuin-session\"\n",
+        );
+        write_fixture(&home.join("atuin-session"), "atuin-session-secret\n");
+        write_fixture(
+            &home.join(".config/letsencrypt/live/example/privkey.pem"),
+            "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----\n",
         );
         write_fixture(
             &akamai_edgerc,
@@ -12022,8 +12045,28 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
             r#"{"auths":{"registry.example":{"auth":"dXNlcjpwYXNz"}},"credsStore":"osxkeychain","credHelpers":{"ghcr.io":"desktop"}}"#,
         );
         write_fixture(
+            &home.join(".docker/machine/machines/default/id_rsa"),
+            "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----\n",
+        );
+        write_fixture(
+            &home.join(".fastlane/spaceship/default/cookie"),
+            "---\n- !ruby/object:HTTP::Cookie\n  name: myacinfo\n  value: secret\n",
+        );
+        write_fixture(
             &xdg_config.join("fastly/config.toml"),
             "token = \"fastly\"\n",
+        );
+        write_fixture(
+            &home.join(".cloudflared/cert.pem"),
+            "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----\n",
+        );
+        write_fixture(
+            &xdg_config.join("cloudflared/credentials.json"),
+            r#"{"TunnelSecret":"cloudflared-secret"}"#,
+        );
+        write_fixture(
+            &xdg_config.join(".wrangler/config/default.toml"),
+            "oauth_token = \"wrangler-oauth\"\nrefresh_token = \"wrangler-refresh\"\n",
         );
         write_fixture(&home.join(".fly/config.yml"), "access_token: FlyV1 token\n");
         write_fixture(
@@ -12056,6 +12099,14 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
         write_fixture(
             &home.join(".nuget/NuGet/NuGet.Config"),
             r#"<configuration></configuration>"#,
+        );
+        write_fixture(
+            &xdg_config.join("openvpn/prod.auth"),
+            "openvpn-user\nopenvpn-password\n",
+        );
+        write_fixture(
+            &xdg_config.join("openvpn/prod.ovpn"),
+            "auth-user-pass prod.auth\n<tls-crypt>\nline1\nline2\n</tls-crypt>\n",
         );
         write_fixture(&npmrc, "_authToken=npm-token\n");
         write_fixture(
@@ -12101,6 +12152,10 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
             &vagrant_home.join("data/vagrant_login_token"),
             "vagrant-token\n",
         );
+        write_fixture(
+            &xdg_data.join("com.vercel.cli/auth.json"),
+            r#"{"token":"vercel-token","refreshToken":"vercel-refresh"}"#,
+        );
         write_fixture(&home.join(".vault-token"), "hvs.secret\n");
         write_fixture(&home.join(".vt.toml"), "apikey=\"vt-key\"\n");
         write_fixture(&home.join(".vultr-cli.yaml"), "api-key: vultr-key\n");
@@ -12126,6 +12181,7 @@ machine example.com login user password netrc-token
             ("HOME", home.to_str().unwrap()),
             ("XDG_CONFIG_HOME", xdg_config.to_str().unwrap()),
             ("XDG_CACHE_HOME", xdg_cache.to_str().unwrap()),
+            ("XDG_DATA_HOME", xdg_data.to_str().unwrap()),
             ("XDG_STATE_HOME", xdg_state.to_str().unwrap()),
             ("XDG_RUNTIME_DIR", xdg_runtime.to_str().unwrap()),
             ("AKAMAI_EDGERC", akamai_edgerc.to_str().unwrap()),
@@ -12190,12 +12246,20 @@ machine example.com login user password netrc-token
             "akamai",
             "algolia",
             "argocd",
+            "atuin",
             "bitwarden-cli",
+            "certbot",
+            "cloudflare-wrangler",
+            "cloudflared",
             "docker",
+            "docker-machine",
+            "fastlane",
             "gh",
             "kubernetes-cli",
+            "openvpn",
             "supabase",
             "terraform",
+            "vercel-cli",
         ] {
             assert!(
                 triggered.contains(&expected),


### PR DESCRIPTION
## What changed

- Added focused security recommendation coverage for Homebrew fallback and vault-isotope filtering behavior.
- Expanded the generated detector fixture test to exercise additional isotope/radioisotope detector paths without modifying the checked-out `data/` repositories.
- Made the `node` package info assertion derive the expected summary from the embedded DB fixture, while still asserting license and dependency metadata.

## Coverage

- Passing baseline after fixing fixture drift: `86.8163%` (`73266/84392`)
- Final coverage: `87.3499%` (`73815/84505`)
- Delta: `+0.5336` percentage points

## Validation

- `cargo test resolve_uninstalled_package_info_populates_all_source_metadata -- --test-threads=1`
- `cargo test security_recommendation -- --test-threads=1`
- `cargo test generated_isotope_detectors_report_seeded_secret_files -- --test-threads=1`
- `AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1`
- `/usr/bin/python3 scripts/generate-coverage-fixtures.py` plus clean fixture diff
- `git diff --check`