### PR TITLE
Increase Rust coverage for package helpers

### DIFF
--- a/src/helper/main.rs
+++ b/src/helper/main.rs
@@ -572,6 +572,40 @@ mod tests {
     }
 
     #[test]
+    fn helper_wrappers_cover_nonempty_packages_callbacks_and_sha_inputs() {
+        CALLBACK_EVENTS.lock().unwrap().clear();
+        let packages = CString::new(r#"[{"name":"rg","version":null}]"#).unwrap();
+
+        for response in [
+            nuke_helper_install(packages.as_ptr(), ptr::null_mut(), Some(capture_progress)),
+            nuke_helper_update(packages.as_ptr(), ptr::null_mut(), Some(capture_progress)),
+            nuke_helper_uninstall(packages.as_ptr(), ptr::null_mut(), Some(capture_progress)),
+            nuke_helper_make_default(packages.as_ptr(), ptr::null_mut(), Some(capture_progress)),
+            nuke_helper_update_all(ptr::null_mut(), Some(capture_progress)),
+        ] {
+            let value =
+                serde_json::from_str::<serde_json::Value>(&raw_to_string(response)).unwrap();
+            assert!(value.get("Err").is_some() || value.get("Ok").is_some());
+        }
+
+        let executable = CString::new("/usr/bin/python3").unwrap();
+        let script = CString::new("/tmp/script.py").unwrap();
+        let sha = CString::new("a".repeat(64)).unwrap();
+        let keys = CString::new(r#"["OPENAI_API_KEY","ANTHROPIC_API_KEY"]"#).unwrap();
+        let response = raw_to_string(nuke_helper_remember_isotope_always_allow(
+            executable.as_ptr(),
+            script.as_ptr(),
+            sha.as_ptr(),
+            keys.as_ptr(),
+            ptr::null_mut(),
+            Some(capture_progress),
+        ));
+        let value = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+        assert!(value.get("Err").is_some() || value.get("Ok").is_some());
+        assert!(!CALLBACK_EVENTS.lock().unwrap().is_empty());
+    }
+
+    #[test]
     fn helper_dotenv_wrappers_parse_modes_policies_and_keys() {
         let invalid_policy = CString::new("bogus").unwrap();
         let response = raw_to_string(nuke_helper_set_dotenv_approval_policy(

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -17286,11 +17286,7 @@ long_prefix = re.compile(r'/opt/python@3.12/[0-9\\._abrc]+')\n"
         configure_debug_install_environment();
 
         let value = env::var("PKG_ALLOW").unwrap();
-        if cfg!(debug_assertions) {
-            assert_eq!(value, "unsupported-formulas:relocation-failures");
-        } else {
-            assert_eq!(value, "unsupported-formulas:relocation-failures");
-        }
+        assert_eq!(value, "unsupported-formulas:relocation-failures");
     }
 
     #[test]

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -11626,6 +11626,90 @@ package or `npm:tsx` for the package that provides the `tsx` executable"
         empty_printer.begin().unwrap();
         empty_printer.finish(&empty_report).unwrap();
         assert_eq!(empty_printer.finding_count, 0);
+
+        for format in [
+            SecretScannerStreamFormat::Plain,
+            SecretScannerStreamFormat::Rich,
+        ] {
+            let mut printer = SecretScannerStreamPrinter {
+                format,
+                color: true,
+                scope: SecretScannerScope::Full,
+                finding_count: 0,
+                printed_findings_header: false,
+                printed_warnings_header: false,
+            };
+            printer.begin().unwrap();
+            printer
+                .print_event(SecretScannerEvent::Finding(&finding))
+                .unwrap();
+            printer
+                .print_event(SecretScannerEvent::Error(&error))
+                .unwrap();
+            printer.finish(&report).unwrap();
+            assert_eq!(printer.finding_count, 1);
+            assert!(printer.printed_findings_header);
+            assert!(printer.printed_warnings_header);
+
+            let mut empty_printer = SecretScannerStreamPrinter {
+                format,
+                color: true,
+                scope: SecretScannerScope::IsotopesOnly,
+                finding_count: 0,
+                printed_findings_header: false,
+                printed_warnings_header: false,
+            };
+            empty_printer.begin().unwrap();
+            empty_printer.finish(&empty_report).unwrap();
+            assert_eq!(empty_printer.finding_count, 0);
+        }
+
+        print_scan_box(
+            "Scan",
+            &[
+                "short".to_string(),
+                "a much longer scanner line that exercises clamped box width".to_string(),
+            ],
+            true,
+        );
+        assert_eq!(strip_ansi_width("\u{1b}[31mred\u{1b}[0m"), 3);
+        assert_eq!(
+            secret_scanner_file_probe_summary(&empty_report),
+            "file probes skipped"
+        );
+        assert_eq!(pluralize(1, "finding", "findings"), "1 finding");
+        assert!(matches!(
+            scan_severity_style(&SecretScannerFinding {
+                severity: "low".to_string(),
+                ..finding.clone()
+            }),
+            ScanStyle::Warning
+        ));
+        assert!(scan_paint("x", ScanStyle::Error, true).contains("\u{1b}[31;1m"));
+        assert_eq!(scan_paint("x", ScanStyle::Error, false), "x");
+
+        let _env_lock = test_env_lock().lock().unwrap();
+        let _clean_env =
+            TestEnvGuard::unset(&["NO_COLOR", "CLICOLOR_FORCE", "TERM", SCANNER_WRAPPER_UI_ENV]);
+        assert!(!scanner_wrapper_ui_enabled());
+        assert!(!output_supports_ansi(false));
+        {
+            let _env = TestEnvGuard::set(&[(SCANNER_WRAPPER_UI_ENV, "1")]);
+            assert!(scanner_wrapper_ui_enabled());
+        }
+        {
+            let _env = TestEnvGuard::set(&[("CLICOLOR_FORCE", "1")]);
+            assert!(scan_stdout_is_rich());
+            assert!(output_supports_ansi(false));
+        }
+        {
+            let _env = TestEnvGuard::set(&[("NO_COLOR", "1")]);
+            assert!(!output_supports_ansi(true));
+        }
+        {
+            let _env = TestEnvGuard::set(&[("TERM", "dumb")]);
+            assert!(!output_supports_ansi(true));
+        }
     }
 
     #[test]
@@ -13245,6 +13329,102 @@ managed_secrets = ["dep:managed-secrets"]"#,
     }
 
     #[test]
+    fn secret_file_probe_paths_cover_direct_files_defaults_and_skip_resolution() {
+        let temp = TempDir::new().unwrap();
+        let env_path = temp.path().join(".env");
+        fs::write(&env_path, "SERVICE_TOKEN=secret_secret\n").unwrap();
+
+        let mut findings = Vec::new();
+        let mut errors = Vec::new();
+        let mut seen_findings = HashSet::new();
+        let mut seen_errors = HashSet::new();
+        let (scanned_files, file_probes) = scan_secret_file_probes(
+            Some(&env_path),
+            &[],
+            &mut findings,
+            &mut errors,
+            &mut seen_findings,
+            &mut seen_errors,
+            &mut |_| Ok(()),
+        )
+        .unwrap();
+        assert_eq!((scanned_files, file_probes), (1, 1));
+        assert_eq!(findings.len(), 1);
+        assert!(errors.is_empty());
+
+        let root_file_skips = SecretScanSkips::new(Some(&env_path), &[PathBuf::from(".env")]);
+        assert!(root_file_skips.should_skip(&env_path));
+        let relative_skip = PathBuf::from("relative-secret.env");
+        let relative_skips = SecretScanSkips::new(None, std::slice::from_ref(&relative_skip));
+        assert!(relative_skips.should_skip(&relative_skip));
+        assert!(!relative_skips.should_skip(Path::new("other-secret.env")));
+
+        let mut none_findings = Vec::new();
+        let mut none_errors = Vec::new();
+        let mut none_seen_findings = HashSet::new();
+        let mut none_seen_errors = HashSet::new();
+        let skipped_defaults = default_secret_scan_paths();
+        assert_eq!(
+            scan_secret_file_probes(
+                None,
+                &skipped_defaults,
+                &mut none_findings,
+                &mut none_errors,
+                &mut none_seen_findings,
+                &mut none_seen_errors,
+                &mut |_| Ok(())
+            )
+            .unwrap(),
+            (0, 0)
+        );
+
+        assert!(
+            scan_secret_file_probes(
+                Some(&temp.path().join("missing")),
+                &[],
+                &mut Vec::new(),
+                &mut Vec::new(),
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut |_| Ok(())
+            )
+            .unwrap_err()
+            .contains("scan path does not exist")
+        );
+
+        let fifo_path = temp.path().join("secret.pipe");
+        let fifo_c_path = CString::new(fifo_path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_c_path.as_ptr(), 0o600) }, 0);
+        assert!(
+            scan_secret_file_probes(
+                Some(&fifo_path),
+                &[],
+                &mut Vec::new(),
+                &mut Vec::new(),
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut |_| Ok(())
+            )
+            .unwrap_err()
+            .contains("not a file or directory")
+        );
+
+        assert_eq!(
+            scan_secret_file_probes(
+                Some(temp.path()),
+                &[temp.path().to_path_buf()],
+                &mut Vec::new(),
+                &mut Vec::new(),
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut |_| Ok(())
+            )
+            .unwrap(),
+            (0, 0)
+        );
+    }
+
+    #[test]
     fn secret_scanner_runs_isotope_detectors_and_file_probes() {
         let _lock = test_env_lock().lock().unwrap();
         let temp = TempDir::new().unwrap();
@@ -14368,6 +14548,29 @@ managed_secrets = ["dep:managed-secrets"]"#,
     }
 
     #[test]
+    fn install_progress_helpers_cover_empty_no_callback_and_style_paths() {
+        let progress = InstallProgress::with_callback("coverage-progress", None);
+
+        progress.emit(ProgressEvent::Resolving);
+        progress.begin_download_phase();
+        progress.add_download_total(None);
+        progress.add_download_total(Some(0));
+        progress.advance_download(0);
+        progress.emit_downloading_for("missing-package");
+        progress.begin_install_phase();
+        progress.begin_install_phase();
+        progress.log("\n\r");
+        progress.log("first line\nsecond line");
+        progress.finish_with_paths(&[]);
+        progress.finish_with_paths(&["/tmp/av".to_string(), "/tmp/nuke-helper".to_string()]);
+        progress.clear();
+
+        let _ = download_progress_style();
+        let _ = install_progress_style();
+        let _ = final_progress_style();
+    }
+
+    #[test]
     fn installed_package_summary_serializes_source() {
         let summary = core::InstalledPackageSummary {
             name: "isotope:gh".to_string(),
@@ -14596,6 +14799,13 @@ managed_secrets = ["dep:managed-secrets"]"#,
             state.reasons
         );
         assert_eq!(state.error, None);
+
+        for identifier in ["node@24", "isotope:node@24", "brew:node@24"] {
+            let state = package_security_state_for_identifiers([identifier.to_string()])
+                .unwrap_or_else(|| panic!("{identifier} should map to node@24"));
+            assert_eq!(isotope_unqualified_name(&state.isotope_name), "node@24");
+            assert!(state.install_is_insecure);
+        }
     }
 
     #[test]
@@ -17069,6 +17279,21 @@ long_prefix = re.compile(r'/opt/python@3.12/[0-9\\._abrc]+')\n"
     }
 
     #[test]
+    fn configure_debug_install_environment_preserves_existing_debug_flags() {
+        let _env_lock = test_env_lock().lock().unwrap();
+        let _env = TestEnvGuard::set(&[("PKG_ALLOW", "unsupported-formulas:relocation-failures")]);
+
+        configure_debug_install_environment();
+
+        let value = env::var("PKG_ALLOW").unwrap();
+        if cfg!(debug_assertions) {
+            assert_eq!(value, "unsupported-formulas:relocation-failures");
+        } else {
+            assert_eq!(value, "unsupported-formulas:relocation-failures");
+        }
+    }
+
+    #[test]
     fn pkg_allow_runtime_override_stays_debug_only() {
         let _env_lock = test_env_lock().lock().unwrap();
         let _env = TestEnvGuard::set(&[("PKG_ALLOW", "relocation-failures")]);
@@ -19042,6 +19267,152 @@ long_prefix = re.compile(r'/opt/python@3.12/[0-9\\._abrc]+')\n"
     }
 
     #[test]
+    fn incremental_update_and_copy_helpers_cover_seed_edges() {
+        let temp = TempDir::new().unwrap();
+        let shared_file = temp.path().join("shared-file");
+        fs::write(&shared_file, b"not a directory").unwrap();
+        assert!(!shared_tmp_root_is_writable(&shared_file.join("child")));
+
+        let missing_receipt = InstallPlan {
+            mode: Mode::I,
+            package_name: "missing-receipt".to_string(),
+            root_formula: "missing-receipt".to_string(),
+            stable_root: temp.path().join("opt/missing-receipt"),
+            install_root: temp.path().join("opt/missing-receipt"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        fs::create_dir_all(&missing_receipt.install_root).unwrap();
+        assert!(!install_root_supports_incremental_update(&missing_receipt).unwrap());
+
+        let unreadable_receipts = InstallPlan {
+            package_name: "bad-receipts".to_string(),
+            root_formula: "bad-receipts".to_string(),
+            stable_root: temp.path().join("opt/bad-receipts"),
+            install_root: temp.path().join("opt/bad-receipts"),
+            ..missing_receipt.clone()
+        };
+        fs::create_dir_all(&unreadable_receipts.install_root).unwrap();
+        write_package_receipt(
+            &unreadable_receipts.root_receipt_path(),
+            &PackageReceipt {
+                package_name: unreadable_receipts.package_name.clone(),
+                version: "1.0.0".to_string(),
+                source: PackageReceiptSource::Formula {
+                    root_formula: unreadable_receipts.root_formula.clone(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        fs::write(unreadable_receipts.install_root.join(RECEIPTS_DIR), b"file").unwrap();
+        assert!(
+            formula_receipts_support_incremental_update(&unreadable_receipts)
+                .unwrap_err()
+                .contains("failed to read")
+        );
+
+        let invalid_receipts = InstallPlan {
+            package_name: "invalid-receipts".to_string(),
+            root_formula: "invalid-receipts".to_string(),
+            stable_root: temp.path().join("opt/invalid-receipts"),
+            install_root: temp.path().join("opt/invalid-receipts"),
+            ..missing_receipt.clone()
+        };
+        fs::create_dir_all(invalid_receipts.install_root.join(RECEIPTS_DIR)).unwrap();
+        write_package_receipt(
+            &invalid_receipts.root_receipt_path(),
+            &PackageReceipt {
+                package_name: invalid_receipts.package_name.clone(),
+                version: "1.0.0".to_string(),
+                source: PackageReceiptSource::Formula {
+                    root_formula: invalid_receipts.root_formula.clone(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+        fs::write(
+            invalid_receipts
+                .install_root
+                .join(RECEIPTS_DIR)
+                .join("invalid.json"),
+            b"{not-json",
+        )
+        .unwrap();
+        assert!(
+            formula_receipts_support_incremental_update(&invalid_receipts)
+                .unwrap_err()
+                .contains("failed to parse")
+        );
+
+        let seeded = InstallPlan {
+            mode: Mode::I,
+            package_name: "seeded".to_string(),
+            root_formula: "seeded".to_string(),
+            stable_root: temp.path().join("opt/seeded"),
+            install_root: temp.path().join("opt/seeded"),
+            tmp_root: temp.path().join("tmp"),
+        };
+        fs::create_dir_all(seeded.install_root.join("bin")).unwrap();
+        fs::create_dir_all(seeded.install_root.join("share/doc")).unwrap();
+        fs::write(seeded.install_root.join("bin/tool"), b"old tool").unwrap();
+        fs::write(seeded.install_root.join("share/doc/readme"), b"docs").unwrap();
+        symlink("bin/tool", seeded.install_root.join("tool-link")).unwrap();
+        fs::create_dir_all(seeded.install_root.join(RECEIPTS_DIR)).unwrap();
+        fs::write(
+            seeded.install_root.join(RECEIPTS_DIR).join("notes.txt"),
+            b"skip",
+        )
+        .unwrap();
+        write_receipt_with_owned_paths(
+            &seeded.receipt_path("seeded"),
+            &InstalledFormula {
+                spec: FormulaSpec {
+                    name: "seeded".to_string(),
+                    bottle_sha256: "sha".to_string(),
+                    bottle_url: "https://example.invalid/seeded.tar.gz".to_string(),
+                },
+                keg_dir_name: "1.0.0".to_string(),
+                archive_path: PathBuf::new(),
+            },
+            "arm64_tahoe",
+            vec!["bin/tool".to_string()],
+        )
+        .unwrap();
+        write_package_receipt(
+            &seeded.root_receipt_path(),
+            &PackageReceipt {
+                package_name: seeded.package_name.clone(),
+                version: "1.0.0".to_string(),
+                source: PackageReceiptSource::Formula {
+                    root_formula: seeded.root_formula.clone(),
+                },
+                metadata: PackageMetadata::default(),
+            },
+        )
+        .unwrap();
+
+        let prepared = prepare_i_install_plan(&seeded, InstallIntent::Update).unwrap();
+        assert_eq!(
+            fs::read(prepared.plan.install_root.join("bin/tool")).unwrap(),
+            b"old tool"
+        );
+        assert_eq!(
+            fs::read_link(prepared.plan.install_root.join("tool-link")).unwrap(),
+            PathBuf::from("bin/tool")
+        );
+        assert!(prepared.plan.install_root.join("share/doc/readme").exists());
+
+        let source_file = temp.path().join("source-file");
+        let destination_file = temp.path().join("destination-file");
+        fs::write(&source_file, b"replacement").unwrap();
+        fs::write(&destination_file, b"existing").unwrap();
+        let metadata = fs::metadata(&source_file).unwrap();
+        copy_file_preserving_metadata(&source_file, &destination_file, &metadata).unwrap();
+        assert_eq!(fs::read(&destination_file).unwrap(), b"replacement");
+    }
+
+    #[test]
     fn package_install_root_uses_iso_prefix() {
         let temp = TempDir::new().unwrap();
 
@@ -19611,10 +19982,20 @@ info: requested `imagemagick`; `brew:imagemagick-full` is recommended instead\n"
         let older_remote = test_combined_data_with_generated_at("2026-05-17T12:42:37Z");
         let same_remote = test_combined_data_with_generated_at("2026-05-17T13:12:55Z");
         let newer_remote = test_combined_data_with_generated_at("2026-05-17T13:12:56Z");
+        let invalid_remote = test_combined_data_with_generated_at("not-rfc3339");
+        let invalid_embedded = test_combined_data_with_generated_at("not-rfc3339");
 
         assert!(!combined_data_is_at_least_as_new(&older_remote, &embedded));
         assert!(combined_data_is_at_least_as_new(&same_remote, &embedded));
         assert!(combined_data_is_at_least_as_new(&newer_remote, &embedded));
+        assert!(!combined_data_is_at_least_as_new(
+            &invalid_remote,
+            &embedded
+        ));
+        assert!(combined_data_is_at_least_as_new(
+            &same_remote,
+            &invalid_embedded
+        ));
     }
 
     #[test]

--- a/src/lib/rs/ops.rs
+++ b/src/lib/rs/ops.rs
@@ -1968,6 +1968,10 @@ mod tests {
         let geiger = list_geiger_packages(0, 1).unwrap();
         assert!(geiger.total_count >= geiger.packages.len());
         assert!(geiger.packages.len() <= 1);
+
+        let recommendations = list_security_recommendation_packages(0, 1).unwrap();
+        assert!(recommendations.total_count >= recommendations.packages.len());
+        assert!(recommendations.packages.len() <= 1);
     }
 
     #[test]
@@ -2078,10 +2082,192 @@ mod tests {
     }
 
     #[test]
+    fn catalog_metadata_helpers_cover_source_variants_and_defaults() {
+        let formula = catalog_metadata_for_source(&PackageReceiptSource::Formula {
+            root_formula: "uv".to_string(),
+        });
+        assert_eq!(
+            formula.summary.as_deref(),
+            Some("Extremely fast Python package installer and resolver, written in Rust")
+        );
+        assert_eq!(
+            formula.homepage.as_deref(),
+            Some("https://docs.astral.sh/uv/")
+        );
+        assert_eq!(
+            formula.repository.as_deref(),
+            Some("https://github.com/astral-sh/uv")
+        );
+        assert_eq!(
+            formula.upstream_docs.as_deref(),
+            Some("https://docs.astral.sh/uv")
+        );
+        assert_eq!(formula.docs, vec!["https://docs.astral.sh/uv".to_string()]);
+        assert_eq!(formula.category.as_deref(), Some("developer-tools"));
+        assert!(formula.has_visible_fields());
+
+        let alias = formula_catalog_metadata("rg");
+        assert_eq!(alias.summary.as_deref(), Some("Search tool"));
+        assert!(alias.has_visible_fields());
+
+        let cask = catalog_metadata_for_source(&PackageReceiptSource::Cask {
+            cask_name: "codex".to_string(),
+        });
+        assert!(cask.summary.is_some());
+        assert!(cask.homepage.is_some());
+
+        let isotope_with_formula = catalog_metadata_for_source(&PackageReceiptSource::Isotope {
+            isotope_name: "uv".to_string(),
+        });
+        assert_eq!(
+            isotope_with_formula.repository.as_deref(),
+            Some("https://github.com/astral-sh/uv")
+        );
+
+        let versioned_isotope = catalog_metadata_for_source(&PackageReceiptSource::Isotope {
+            isotope_name: "node@24".to_string(),
+        });
+        assert_eq!(
+            versioned_isotope.summary.as_deref(),
+            Some("JavaScript runtime")
+        );
+
+        let detector_only_isotope = catalog_metadata_for_source(&PackageReceiptSource::Isotope {
+            isotope_name: "curl".to_string(),
+        });
+        assert!(detector_only_isotope.homepage.is_none());
+        assert!(!detector_only_isotope.has_visible_fields());
+
+        let npm = catalog_metadata_for_source(&PackageReceiptSource::Npm {
+            package_name: "coverage-npm".to_string(),
+        });
+        assert_eq!(npm.summary.as_deref(), Some("Coverage npm tool"));
+        assert_eq!(npm.homepage.as_deref(), Some("https://example.test/npm"));
+
+        let missing = catalog_metadata_for_source(&PackageReceiptSource::Pip {
+            package_name: "coverage-pip".to_string(),
+        });
+        assert!(!missing.has_visible_fields());
+        assert!(!formula_catalog_metadata("missing-formula").has_visible_fields());
+        assert!(!cask_catalog_metadata("missing-cask").has_visible_fields());
+        assert!(!isotope_catalog_metadata("missing-isotope").has_visible_fields());
+        assert!(!npm_catalog_metadata("missing-npm").has_visible_fields());
+    }
+
+    #[test]
+    fn search_package_summary_covers_hardened_source_and_install_name_variants() {
+        let isotope = search_package_summary(PackageSearchResult {
+            source: PackageReceiptSource::Isotope {
+                isotope_name: "gh".to_string(),
+            },
+            ..ranked_search_result("isotope:gh", None)
+        });
+        assert!(isotope.installs_hardened);
+
+        let vendor = search_package_summary(PackageSearchResult {
+            source: PackageReceiptSource::Vendor {
+                vendor_name: "terraform".to_string(),
+            },
+            ..ranked_search_result("terraform", None)
+        });
+        assert!(vendor.installs_hardened);
+
+        let plain_sources = [
+            PackageReceiptSource::Cask {
+                cask_name: "codex".to_string(),
+            },
+            PackageReceiptSource::Npm {
+                package_name: "coverage-npm".to_string(),
+            },
+            PackageReceiptSource::Pip {
+                package_name: "coverage-pip".to_string(),
+            },
+        ];
+        for source in plain_sources {
+            let summary = search_package_summary(PackageSearchResult {
+                source,
+                ..ranked_search_result("plain", None)
+            });
+            assert!(!summary.installs_hardened);
+        }
+
+        let mut names = ranked_search_result("mixed", None);
+        names.install_package_names = vec![
+            "bad/name".to_string(),
+            "cask:codex".to_string(),
+            "isotope:gh".to_string(),
+        ];
+        assert!(search_package_summary(names).installs_hardened);
+
+        for package_name in [
+            "isotope:gh",
+            "brew:node@24",
+            "terraform",
+            "cask:codex",
+            "npm:coverage-npm",
+            "pip:coverage-pip",
+            "bad/name",
+        ] {
+            let _ = install_package_name_installs_hardened(package_name);
+        }
+        assert!(install_package_name_installs_hardened("isotope:gh"));
+        assert!(install_package_name_installs_hardened("brew:node@24"));
+        assert!(install_package_name_installs_hardened("terraform"));
+        assert!(!install_package_name_installs_hardened("cask:codex"));
+        assert!(!install_package_name_installs_hardened("npm:coverage-npm"));
+        assert!(!install_package_name_installs_hardened("pip:coverage-pip"));
+        assert!(!install_package_name_installs_hardened("bad/name"));
+    }
+
+    #[test]
+    fn helper_command_routes_dotenv_approval_errors_through_progress() {
+        let commands = [
+            HelperCommand::GetDotenvApprovalPolicy,
+            HelperCommand::SetDotenvApprovalPolicy {
+                policy: dotenv::DotenvApprovalPolicy::RememberApproved,
+            },
+            HelperCommand::RememberDotenvApproval {
+                mode: dotenv::DotenvApprovalMode::Run,
+                env_file_path: "/tmp/project/.env".to_string(),
+                project_root: "/tmp/project".to_string(),
+                env_sha256: "0".repeat(64),
+                public_key_fingerprint: "f".repeat(64),
+                keys: vec!["API_TOKEN".to_string()],
+            },
+        ];
+
+        for command in commands {
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let captured = Arc::clone(&events);
+            let result = execute_helper_command(command, move |event| {
+                captured.lock().unwrap().push(event);
+            });
+            assert!(result.is_err());
+            assert!(matches!(
+                events.lock().unwrap().last(),
+                Some(ProgressEvent::Error { message }) if message.contains("root")
+            ));
+        }
+    }
+
+    #[test]
     fn validation_helpers_cover_limits_versions_and_isotope_names() {
         assert_eq!(search_page_size(0), DEFAULT_SEARCH_PAGE_SIZE);
         assert_eq!(search_page_size(1), 1);
         assert_eq!(search_page_size(usize::MAX), MAX_SEARCH_PAGE_SIZE);
+        assert_eq!(
+            normalized_requested_category(Some(" developer-tools ")),
+            Some("developer-tools")
+        );
+        assert_eq!(normalized_requested_category(Some(" ")), None);
+        assert_eq!(normalized_requested_category(None), None);
+        for (raw, expected) in [
+            (Some("security"), Some("security")),
+            (Some("\tcloud\n"), Some("cloud")),
+            (Some(""), None),
+        ] {
+            assert_eq!(normalized_requested_category(raw), expected);
+        }
 
         assert_eq!(normalized_isotope_name("isotope:gh").unwrap(), "gh");
         assert_eq!(normalized_isotope_name("aws-cli").unwrap(), "aws-cli");
@@ -2096,6 +2282,11 @@ mod tests {
             validate_optional_version(Some(" 1.2.3 ")).unwrap(),
             Some("1.2.3".to_string())
         );
+        assert_eq!(
+            validate_optional_version(Some("1.2.3")).unwrap(),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(validate_optional_version(None).unwrap(), None);
         assert!(validate_optional_version(Some(" ")).is_err());
         assert!(validate_optional_version(Some("1.2.3 beta")).is_err());
 
@@ -2216,6 +2407,21 @@ mod tests {
         assert_eq!(
             validate_isotope_always_allow_script("/bin/echo", None, None).unwrap(),
             None
+        );
+        assert!(
+            validate_isotope_always_allow_script("/usr/bin/env", Some("/tmp/script"), None)
+                .unwrap_err()
+                .contains("env always-allow")
+        );
+        assert!(
+            validate_isotope_always_allow_script("/bin/sh", Some("relative.sh"), None)
+                .unwrap_err()
+                .contains("must be absolute")
+        );
+        assert!(
+            validate_isotope_always_allow_script("/bin/sh", Some("/tmp/missing-script"), Some("z"))
+                .unwrap_err()
+                .contains("64-character")
         );
     }
 

--- a/src/web/main.rs
+++ b/src/web/main.rs
@@ -5290,6 +5290,182 @@ mod tests {
         response
     }
 
+    fn read_raw_request(raw_request: &str) -> Result<Option<Request>, String> {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept request");
+            read_request(&stream)
+        });
+        let mut client = TcpStream::connect(addr).expect("connect client");
+        client
+            .write_all(raw_request.as_bytes())
+            .expect("write request");
+        client
+            .shutdown(Shutdown::Write)
+            .expect("finish request body");
+        server.join().expect("join server")
+    }
+
+    fn serde_json_package(base: &PackageRow, full: Value) -> PackageRow {
+        let mut package = base.clone();
+        package.data.full = full;
+        package
+    }
+
+    fn markdown_agent_safety_missing_summary(base: &PackageRow) -> String {
+        let package = serde_json_package(base, serde_json::json!({"agentSafetyAnswer": {}}));
+        let mut text = String::new();
+        markdown_agent_safety_section(&mut text, &package, &LOCALES[0]);
+        text
+    }
+
+    struct EnvGuard {
+        values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn set(values: &[(&'static str, Option<&str>)]) -> Self {
+            let guard = Self {
+                values: values
+                    .iter()
+                    .map(|(key, _)| (*key, env::var_os(key)))
+                    .collect(),
+            };
+            for (key, value) in values {
+                unsafe {
+                    match value {
+                        Some(value) => env::set_var(key, value),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+            guard
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.values {
+                unsafe {
+                    match value {
+                        Some(value) => env::set_var(key, value),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn app_state_request_and_query_helpers_cover_edge_cases() {
+        let db = test_database();
+        assert_database_ready(db.path()).unwrap();
+        let empty_db = NamedTempFile::new().expect("empty database");
+        assert!(
+            assert_database_ready(empty_db.path())
+                .unwrap_err()
+                .contains("is not ready")
+        );
+
+        let _env = EnvGuard::set(&[
+            ("AV_WEB_BIND_ADDR", Some("127.0.0.1:3999")),
+            ("AV_WEB_DB_PATH", Some(db.path().to_str().unwrap())),
+            ("AV_WEB_ORIGIN_HEADER", Some("X-Coverage-Origin")),
+            ("AV_WEB_ORIGIN_SECRET", Some("")),
+        ]);
+        let state = AppState::from_env();
+        assert_eq!(state.bind_addr, "127.0.0.1:3999");
+        assert_eq!(state.db_path, db.path());
+        assert_eq!(state.origin_header, "x-coverage-origin");
+        assert_eq!(state.origin_secret, None);
+
+        {
+            let missing = db.path().with_file_name("missing-av-web.sqlite");
+            let _env = EnvGuard::set(&[
+                ("AV_WEB_BIND_ADDR", Some("127.0.0.1:0")),
+                ("AV_WEB_DB_PATH", Some(missing.to_str().unwrap())),
+                ("AV_WEB_ORIGIN_HEADER", None),
+                ("AV_WEB_ORIGIN_SECRET", None),
+            ]);
+            assert!(run().unwrap_err().contains("failed to open"));
+        }
+
+        let request = read_raw_request(
+            "get /pkg/search.json?q=aws+cli&blank=&bad=%ZZ HTTP/1.1\r\nHost: test\r\nX-Test: One\r\ncontinued\r\n\r\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.path, "/pkg/search.json");
+        assert_eq!(request.query.as_deref(), Some("q=aws+cli&blank=&bad=%ZZ"));
+        assert_eq!(
+            request.headers.get("x-test").map(String::as_str),
+            Some("One")
+        );
+
+        assert_eq!(read_raw_request("").unwrap(), None);
+        assert!(
+            read_raw_request("BROKEN\r\n")
+                .unwrap_err()
+                .contains("invalid request line")
+        );
+        assert!(
+            read_raw_request("GET /pkg/%FF HTTP/1.1\r\nHost: test\r\n\r\n")
+                .unwrap_err()
+                .contains("invalid request path encoding")
+        );
+
+        let parsed = parse_query("=ignored&q=aws+cli&bad=%ZZ&bare&limit=99");
+        assert_eq!(parsed.get("q").map(String::as_str), Some("aws cli"));
+        assert_eq!(parsed.get("bad").map(String::as_str), Some("%ZZ"));
+        assert_eq!(parsed.get("bare").map(String::as_str), Some(""));
+        assert_eq!(
+            split_target("pkg/brew/awscli#fragment").unwrap(),
+            ("/pkg/brew/awscli".to_string(), None)
+        );
+        assert_eq!(
+            slash_redirect_location("/fr/pkg", None).as_deref(),
+            Some("/fr/pkg/")
+        );
+        assert_eq!(slash_redirect_location("/not-pkg", None), None);
+        assert_eq!(normalize_response_path("/pkg"), "/pkg/index.html");
+        assert_eq!(normalize_response_path("/pkg/search.js"), "/pkg/search.js");
+        assert_eq!(
+            normalize_response_path("/pkg/brew/awscli"),
+            "/pkg/brew/awscli/index.html"
+        );
+        assert!(is_search_path("/ja/pkg/search.json"));
+        assert_eq!(
+            locale_for_search("/zh-hans/pkg/search.json", &BTreeMap::new()),
+            "zh-Hans"
+        );
+        assert_eq!(
+            locale_for_search(
+                "/pkg/search.json",
+                &BTreeMap::from([("locale".to_string(), "ja".to_string())])
+            ),
+            "ja"
+        );
+        assert_eq!(empty_as_unknown(""), "unknown");
+        assert_eq!(empty_as_unknown("1.2.3"), "1.2.3");
+        assert_eq!(non_empty("", "fallback"), "fallback");
+        assert_eq!(non_empty("value", "fallback"), "value");
+        assert!(
+            render_urlset(&[sitemap_url("/pkg/brew/awscli/", "2026-06-03")])
+                .contains("hreflang=\"x-default\"")
+        );
+        assert_eq!(canonical_pkg_route("/fr/pkg").1, "/pkg/index.html");
+        assert_eq!(
+            canonical_pkg_route("/pkg/brew/awscli").1,
+            "/pkg/brew/awscli/index.html"
+        );
+        assert_eq!(
+            dynamic_response_for_path(db.path(), "/not-pkg").unwrap(),
+            None
+        );
+    }
+
     #[test]
     fn route_lookup_handles_trailing_slash_and_index_html() {
         let db = test_database();
@@ -5430,6 +5606,585 @@ mod tests {
                 .expect("private html")
                 .contains("noindex,follow")
         );
+    }
+
+    #[test]
+    fn dynamic_package_fallback_renderers_cover_sparse_metadata() {
+        let db = test_database();
+        let connection = Connection::open(db.path()).expect("open fixture database");
+        insert_package(
+            &connection,
+            PackageFixture {
+                path: "/pkg/brew/sparse/",
+                provider: "brew",
+                slug: "sparse",
+                package_key: "brew:sparse",
+                name: "sparse",
+                display_name: "sparse",
+                summary: "",
+                provider_label: "Homebrew",
+                package_manager_url: "",
+                install_command: "",
+                native_install_command: "",
+                version: "",
+                category: "developer-tools",
+                license: "",
+                homepage: "",
+                repository: "",
+                rank: None,
+                last_updated_at: "2026-06-04",
+                indexable: true,
+                data_json: serde_json::json!({"full": {
+                    "aliases": [
+                        {"label": "sparse-label"},
+                        {"name": "sparse-name"},
+                        {"target": "sparse-target"},
+                        {"source": "sparse-source"},
+                        {"package": "sparse-package"},
+                        {"key": "sparse-key"},
+                        7,
+                        true
+                    ],
+                    "geiger": {
+                        "level": "medium",
+                        "confidence": "low",
+                        "category": "network",
+                        "reasons": [],
+                        "signals": []
+                    },
+                    "installBehavior": {"postInstallDefined": false},
+                    "bottle": {"available": false},
+                    "dependencies": ["openssl@3"],
+                    "popularity": {"downloads_per_30_days": 12345},
+                    "extra": {
+                        "registryInsights": {
+                            "apiURL": "https://example.test/api",
+                            "customMetric": 9876,
+                            "enabled": true,
+                            "emptyList": [],
+                            "nested": {"inner_id": "value"},
+                            "list": ["alpha", false, 12]
+                        }
+                    },
+                    "externalMatches": [
+                        {
+                            "manager": "apk",
+                            "packageName": "sparse",
+                            "evidence": "Alpine package index",
+                            "metadata": {
+                                "description": "Sparse package in an external index.",
+                                "homepage": "https://example.test/sparse"
+                            }
+                        },
+                        {"metadata": {}}
+                    ],
+                    "packageHubs": [
+                        {"slug": "", "label": "skip"},
+                        {"slug": "cloud", "label": "Cloud"}
+                    ],
+                    "relatedPackages": [
+                        {"provider": "brew", "name": "sparse", "label": "self", "rel": "domain_peer"},
+                        {"provider": "", "name": "bad", "rel": "domain_peer"},
+                        {"provider": "npm", "package": "left-pad", "label": "left pad", "rel": "domain_peer"},
+                        {"provider": "brew", "target": "curl", "label": "curl", "rel": "other"}
+                    ],
+                    "alsoAvailableVia": [
+                        {"provider": "pip", "name": "sparse", "label": "sparse-py"}
+                    ],
+                    "sourceNotes": [42, true, {"label": "fixture note"}]
+                }})
+                .to_string(),
+                search_text: "sparse brew fallback rendering",
+            },
+        );
+        connection
+            .execute(
+                "INSERT INTO hub_packages(hub_slug, package_key, position, reason)
+                 VALUES('cloud', 'brew:sparse', 2, '')",
+                [],
+            )
+            .expect("insert sparse hub package");
+        connection
+            .execute(
+                "INSERT INTO hubs(path, slug, title, description, group_name, data_json)
+                 VALUES('/pkg/empty-related/', 'empty-related', 'Empty related', '', 'topical', '{}')",
+                [],
+            )
+            .expect("insert empty related hub");
+        connection
+            .execute(
+                "INSERT INTO hub_packages(hub_slug, package_key, position, reason)
+                 VALUES('empty-related', 'brew:sparse', 1, '')",
+                [],
+            )
+            .expect("insert empty related hub package");
+
+        let sparse = package_by_provider_slug(&connection, "brew", "sparse")
+            .expect("query sparse")
+            .expect("sparse package");
+        let mut manifest_with_counts = metadata_json(&connection, "manifest")
+            .expect("read manifest")
+            .expect("manifest");
+        manifest_with_counts["package_count"] = serde_json::json!(99);
+        manifest_with_counts["approval_gate_count"] = serde_json::json!(11);
+        connection
+            .execute(
+                "UPDATE metadata SET value = ?1 WHERE key = 'manifest'",
+                params![serde_json::to_string(&manifest_with_counts).unwrap()],
+            )
+            .expect("update manifest counts");
+        assert!(
+            render_index_page(&connection, &LOCALES[0])
+                .expect("render counted index")
+                .contains(">99<")
+        );
+        assert_eq!(metadata_json(&connection, "missing").unwrap(), None);
+        assert!(
+            hub_signal_condition("non_low_geiger")
+                .unwrap()
+                .contains("geiger")
+        );
+        assert_eq!(hub_signal_condition("unknown"), None);
+
+        let html = render_package_page(&sparse, &LOCALES[0], "2026-06-07T00:00:00Z");
+        assert!(html.contains("Homebrew metadata was not linked in local data."));
+        assert!(html.contains("No classifier reasons were present."));
+        assert!(html.contains("No classifier signals were present."));
+        assert!(html.contains("No Homebrew post-install hook is recorded"));
+        assert!(html.contains("No Homebrew bottle metadata was recorded."));
+        assert!(html.contains("30d downloads"));
+        assert!(html.contains("12,345"));
+        assert!(html.contains("Source database details"));
+        assert!(html.contains("Custom Metric"));
+        assert!(html.contains("Sparse package in an external index."));
+
+        let markdown = render_package_markdown(&sparse, &LOCALES[0], "2026-06-07T00:00:00Z");
+        assert!(markdown.contains("Bottle: not available"));
+        assert!(markdown.contains("left pad"));
+        assert!(markdown.contains("fixture note"));
+        assert!(markdown.contains("apk - sparse"));
+
+        let dynamic = dynamic_response_for_path(db.path(), "/fr/pkg/brew/sparse/")
+            .expect("dynamic sparse query")
+            .expect("dynamic sparse response");
+        assert_eq!(dynamic.content_type, "text/html; charset=utf-8");
+        assert!(
+            String::from_utf8(dynamic.body)
+                .expect("localized sparse html")
+                .contains("sparse")
+        );
+        assert!(
+            dynamic_response_for_path(db.path(), "/pkg/missing-hub/")
+                .expect("missing hub query")
+                .is_none()
+        );
+
+        let hub_row = hub_package_row(&sparse, "", &LOCALES[0]);
+        assert!(hub_row.contains("Executable aliases include"));
+        assert!(hub_row.contains("sparse-label"));
+        let hub = hub_by_slug(&connection, "cloud")
+            .expect("query cloud hub")
+            .expect("cloud hub");
+        let hub_markdown = render_hub_markdown(&connection, &hub, &LOCALES[0])
+            .expect("render sparse hub markdown");
+        assert!(hub_markdown.contains("Executable aliases include"));
+        let related_hubs = related_hub_links(&connection, &hub, &LOCALES[0]).expect("related hubs");
+        assert!(related_hubs.join("").contains("package graph"));
+        let hub_schema = schema_for_hub(
+            &hub,
+            vec![&sparse],
+            "Sparse hub description",
+            "2026-06-07",
+            &LOCALES[0],
+        );
+        assert_eq!(
+            hub_schema["@graph"][1]["@type"],
+            serde_json::Value::String("Organization".to_string())
+        );
+
+        let mut isotope_only = sparse.clone();
+        isotope_only.summary.clear();
+        isotope_only.install_command.clear();
+        isotope_only.data.full = serde_json::json!({"isotope": {}});
+        assert!(hero_sentence(&isotope_only).contains("secret handling"));
+        let isotope_security = render_security(&isotope_only, &LOCALES[0]);
+        assert!(isotope_security.contains("Protected-tool coverage"));
+        assert!(isotope_security.contains("No caveats were listed"));
+
+        let mut gate_only = sparse.clone();
+        gate_only.summary.clear();
+        gate_only.install_command.clear();
+        gate_only.data.full = serde_json::json!({
+            "approvalGate": {"rule_count": "7", "rules": [], "coverage_status": "draft"}
+        });
+        assert!(hero_sentence(&gate_only).contains("approval-gate metadata"));
+        assert!(render_gate(&gate_only, &LOCALES[0]).contains("No rule descriptions"));
+        let mut security_markdown = String::new();
+        markdown_security_section(&mut security_markdown, &gate_only, &LOCALES[0]);
+        assert!(security_markdown.contains("Approval gate rules"));
+
+        let mut bare = sparse.clone();
+        bare.summary.clear();
+        bare.install_command.clear();
+        bare.version.clear();
+        bare.last_updated_at.clear();
+        bare.data.full = serde_json::json!({});
+        assert!(hero_sentence(&bare).contains("local Automic Vault package sources"));
+        assert!(render_executables(&bare, &LOCALES[0]).contains("No executable data"));
+        assert!(render_agent_safety_answer(&bare, &LOCALES[0]).is_empty());
+        assert!(render_registry_insights(&bare, &LOCALES[0]).is_empty());
+        assert!(render_external_package_manager_matches(&bare, &LOCALES[0]).is_empty());
+        assert!(security_heading(&bare, &LOCALES[0]).contains("No protected-tool"));
+        assert!(related_article("Empty", Vec::new()).is_empty());
+
+        let mut summary_only = bare.clone();
+        summary_only.summary = "Sparse summary without an install command".to_string();
+        assert!(hero_sentence(&summary_only).contains("Nucleus can resolve"));
+
+        let mut dependency_fallback = sparse.clone();
+        dependency_fallback.data.full = serde_json::json!({"dependencies": ["zlib"]});
+        let dependency_links = related_links(
+            &dependency_fallback,
+            &LOCALES[0],
+            "relatedPackages",
+            4,
+            false,
+        );
+        assert!(dependency_links.join("").contains("zlib"));
+
+        assert_eq!(
+            install_command_manager_label(&serde_json::json!({"manager": "apk"})),
+            "Alpine Linux apk"
+        );
+        assert_eq!(
+            install_command_manager_label(&serde_json::json!({"manager": "dnf"})),
+            "Fedora dnf"
+        );
+        assert_eq!(
+            install_command_manager_label(&serde_json::json!({"manager": "npm"})),
+            "npm"
+        );
+        assert_eq!(
+            install_command_manager_label(
+                &serde_json::json!({"manager": "shell", "source": {"manager": "winget"}})
+            ),
+            "Windows Package Manager"
+        );
+        assert_eq!(
+            native_command_provider("brew install --cask visual-studio-code"),
+            Some("cask")
+        );
+        assert_eq!(native_command_provider("npm i sparse"), Some("npm"));
+        assert_eq!(
+            native_command_provider("python3 -m pip install sparse"),
+            Some("pip")
+        );
+        assert_eq!(native_command_provider("curl https://example.test"), None);
+        assert_eq!(fmt_int(-12345), "-12,345");
+        assert_eq!(short_text("superlong", 1), "…");
+        assert_eq!(slugify("Example++"), "example");
+        assert_eq!(html_hreflang_links("https://example.test/pkg/"), "");
+        assert_eq!(metadata_value_html(&serde_json::Value::Null), "");
+        assert_eq!(metadata_value_html(&serde_json::json!([])), "");
+        assert_eq!(metadata_value_html(&serde_json::json!({})), "");
+        assert_eq!(metadata_value_text(&serde_json::json!({"empty": ""})), "");
+        assert!(metadata_value_present(&serde_json::json!(false)));
+        assert_eq!(
+            value_string(&serde_json::json!(false)),
+            Some("false".to_string())
+        );
+        assert_eq!(
+            value_i64_key(&serde_json::json!({"n": "42"}), "n"),
+            Some(42)
+        );
+        assert_eq!(
+            value_f64_key(&serde_json::json!({"n": "0.75"}), "n"),
+            Some(0.75)
+        );
+        assert_eq!(parse_query("&&a=b").get("a").map(String::as_str), Some("b"));
+
+        let mut empty_metadata = sparse.clone();
+        empty_metadata.package_key.clear();
+        empty_metadata.provider_label.clear();
+        empty_metadata.last_updated_at.clear();
+        empty_metadata.data.full = serde_json::json!({});
+        assert!(
+            render_install_metadata(&empty_metadata, &LOCALES[0])
+                .contains("No resolver details were present.")
+        );
+
+        let mut npm_behavior = sparse.clone();
+        npm_behavior.provider = "npm".to_string();
+        npm_behavior.data.full = serde_json::json!({
+            "installBehavior": {"postInstallDefined": true},
+            "bottle": {"available": true}
+        });
+        assert!(
+            render_install_behavior_signals(&npm_behavior)
+                .contains("npm package metadata declares a postinstall script.")
+        );
+        assert!(
+            render_install_behavior_signals(&serde_json_package(
+                &sparse,
+                serde_json::json!({"installBehavior": {}})
+            ))
+            .is_empty()
+        );
+
+        let mut executable_edges = sparse.clone();
+        executable_edges.data.full = serde_json::json!({
+            "executablesDetailed": [
+                {"name": ""},
+                {"name": "dup"},
+                {"name": "dup"}
+            ],
+            "binaries": [
+                {"target": "dup"},
+                {"source": "binary-source"}
+            ],
+            "extra": {"stub_exclusions": ["alias-skip"]},
+            "aliases": ["alias-skip", "dup"]
+        });
+        let executable_html = render_executables(&executable_edges, &LOCALES[0]);
+        assert!(executable_html.contains("Automic Vault stub excluded"));
+        assert!(executable_html.contains("binary-source"));
+
+        let mut freshness_edges = sparse.clone();
+        freshness_edges.data.full = serde_json::json!({
+            "versionFreshness": {
+                "packageManager": {"version": "1.0.0"},
+                "siteData": {},
+                "upstream": {}
+            }
+        });
+        assert!(
+            render_freshness(&freshness_edges, "", &LOCALES[0])
+                .contains("No freshness warnings were generated.")
+        );
+
+        let empty_registry = serde_json_package(
+            &sparse,
+            serde_json::json!({"registryInsights": {"empty": [], "blank": ""}}),
+        );
+        assert!(render_registry_insights(&empty_registry, &LOCALES[0]).is_empty());
+
+        let manager_card = external_package_match_card(&serde_json::json!({
+            "displayName": "Chocolatey",
+            "packageId": "Sparse.Tool",
+            "confidence": "manual",
+            "command": "choco install sparse",
+            "matchedBy": "package_id",
+            "source": {"sourceLabel": "Chocolatey", "sourceUrl": "https://community.chocolatey.org/packages/sparse"},
+            "metadata": {
+                "version": "1.2.3",
+                "license": "MIT",
+                "dependencies": ["dep"],
+                "optionalDependencies": ["optional"],
+                "provides": ["sparse"],
+                "sourcePackage": "sparse-src"
+            }
+        }));
+        assert!(manager_card.contains("choco install sparse"));
+        assert!(manager_card.contains("Matched by: Package ID"));
+        assert!(
+            external_package_match_card(&serde_json::json!({"displayName": "Empty"}))
+                .contains("Empty")
+        );
+
+        assert!(markdown_agent_safety_missing_summary(&sparse).is_empty());
+        assert!(
+            render_agent_safety_answer(
+                &serde_json_package(&sparse, serde_json::json!({"agentSafetyAnswer": {}})),
+                &LOCALES[0]
+            )
+            .is_empty()
+        );
+        assert!(install_command_source_html(&serde_json::json!({"source": {}})).is_empty());
+
+        let command_edges = serde_json_package(
+            &sparse,
+            serde_json::json!({
+                "dependencies": ["zlib"],
+                "installCommands": [
+                    {"platform": "portable", "manager": "Automic Vault", "command": "sudo av install sparse"},
+                    {"platform": "macos", "manager": "Homebrew", "command": "", "confidence": 0.2},
+                    {"platform": "linux", "manager": "apt", "command": "sudo apt install sparse"}
+                ]
+            }),
+        );
+        assert!(schema_for_package(&command_edges, "Install sparse.", "2026-06-07", &LOCALES[0])
+            ["@graph"][6]["step"]
+            .as_array()
+            .unwrap()
+            .len()
+            >= 2);
+        let mut install_groups = String::new();
+        markdown_install_groups(&mut install_groups, &command_edges);
+        assert!(install_groups.contains("unknown confidence"));
+
+        assert!(hub_package_reason(&gate_only, &LOCALES[0]).contains("approval-gate"));
+        let geiger_reason = serde_json_package(
+            &sparse,
+            serde_json::json!({
+                "geiger": {"reasons": ["This package reads credentials from many user paths and may mutate remote state when automation runs without review."]}
+            }),
+        );
+        assert!(hub_package_reason(&geiger_reason, &LOCALES[0]).contains("reads credentials"));
+        let mut summary_reason = bare.clone();
+        summary_reason.summary = "Summary reason for a sparse package.".to_string();
+        assert!(hub_package_reason(&summary_reason, &LOCALES[0]).contains("Summary reason"));
+        assert!(
+            hub_package_reason(&bare, &LOCALES[0])
+                .contains("Matched package metadata for this hub.")
+        );
+        assert!(
+            hub_package_row(&bare, "", &LOCALES[0])
+                .contains("Matched package metadata for this hub.")
+        );
+
+        assert_eq!(sentence_text(""), "");
+        assert_eq!(metadata_value_present(&serde_json::Value::Null), false);
+        assert_eq!(metadata_value_present(&serde_json::json!("  ")), false);
+        assert_eq!(
+            metadata_number_text(&serde_json::Number::from(u64::MAX)),
+            u64::MAX.to_string()
+        );
+        assert_eq!(
+            alternate_install_sentence(&serde_json_package(
+                &sparse,
+                serde_json::json!({"installCommands": [
+                    {"manager": "Automic Vault", "command": "sudo av install sparse"},
+                    {"manager": "brew", "command": ""}
+                ]})
+            )),
+            ""
+        );
+        let mut default_command_package = serde_json_package(&sparse, serde_json::json!({}));
+        default_command_package.install_command = "sudo av install sparse".to_string();
+        let default_command = install_command_entries(&default_command_package);
+        assert_eq!(
+            default_command[0]["command"],
+            serde_json::json!("sudo av install sparse")
+        );
+
+        let behavior_items = markdown_install_behavior_items(&serde_json_package(
+            &sparse,
+            serde_json::json!({
+                "installBehavior": {
+                    "postInstallDefined": true,
+                    "service": "com.example.sparse",
+                    "caveats": "Review shell completions.",
+                    "lifecycleScripts": ["prepare"],
+                    "pythonRequires": ">=3.12",
+                    "requiresDistCount": 3
+                },
+                "bottle": {"available": true, "platforms": ["arm64_tahoe"]}
+            }),
+        ));
+        assert!(behavior_items.join("\n").contains("com.example.sparse"));
+        let freshness_items = markdown_freshness_items(
+            &serde_json_package(
+                &sparse,
+                serde_json::json!({
+                    "versionFreshness": {
+                        "upstream": {
+                            "repository": "https://example.test/sparse",
+                            "latestVersion": "2.0.0",
+                            "comparison": "behind"
+                        },
+                        "warnings": [
+                            {"severity": "warning", "message": ""},
+                            {"message": "Manual review needed."}
+                        ]
+                    }
+                }),
+            ),
+            "not-a-date",
+        );
+        assert!(freshness_items.join("\n").contains("Manual review needed."));
+
+        let mut registry_markdown = String::new();
+        markdown_registry_insights(&mut registry_markdown, &bare, &LOCALES[0]);
+        assert!(registry_markdown.is_empty());
+        markdown_registry_insights(&mut registry_markdown, &empty_registry, &LOCALES[0]);
+        assert!(registry_markdown.is_empty());
+
+        let mut external_markdown = String::new();
+        markdown_external_package_manager_matches(&mut external_markdown, &bare, &LOCALES[0]);
+        assert!(external_markdown.is_empty());
+        let external_edges = serde_json_package(
+            &sparse,
+            serde_json::json!({
+                "externalPackageManagerMatches": [
+                    {},
+                    {"displayName": "OnlyName"},
+                    {"packageId": "NoDetails"}
+                ]
+            }),
+        );
+        markdown_external_package_manager_matches(
+            &mut external_markdown,
+            &external_edges,
+            &LOCALES[0],
+        );
+        assert!(external_markdown.contains("OnlyName"));
+
+        let mut related_markdown = String::new();
+        markdown_related(
+            &mut related_markdown,
+            &serde_json_package(
+                &sparse,
+                serde_json::json!({
+                    "packageHubs": [{"slug": ""}, {"slug": "cloud"}],
+                    "relatedPackages": [
+                        {"provider": "", "name": "skip", "label": "skip"},
+                        {"provider": "brew", "name": "curl", "label": "curl"}
+                    ]
+                }),
+            ),
+            &LOCALES[0],
+        );
+        assert!(related_markdown.contains("[curl]"));
+
+        assert!(hub_cluster_block("Empty", &[], &LOCALES[0]).is_empty());
+        assert!(hub_related_block("Empty", &[]).is_empty());
+        assert!(
+            core_security_guides(
+                &serde_json_package(&sparse, serde_json::json!({"aliases": ["gh"]})),
+                &LOCALES[0]
+            )
+            .join("")
+            .contains("GitHub CLI token security")
+        );
+        assert_eq!(
+            SearchResult {
+                title: "Exact".to_string(),
+                url: "/pkg/brew/exact/".to_string(),
+                summary: String::new(),
+                provider: "brew".to_string(),
+                package_key: "brew:exact".to_string(),
+                rank: None,
+                search_text: "exact".to_string(),
+            }
+            .search_rank("exact"),
+            Some(0)
+        );
+        let ranked = SearchResult {
+            title: "Exact".to_string(),
+            url: "/pkg/brew/exact-tool/".to_string(),
+            summary: String::new(),
+            provider: "brew".to_string(),
+            package_key: "brew:exact-tool".to_string(),
+            rank: Some(9),
+            search_text: "body match text".to_string(),
+        };
+        assert_eq!(ranked.search_rank("exa"), Some(1));
+        assert_eq!(ranked.search_rank("tool"), Some(2));
+        assert_eq!(ranked.search_rank("body"), Some(3));
+        assert_eq!(ranked.search_rank("absent"), None);
+        assert_eq!(ranked.match_distance("exact"), 0);
+        assert!(ranked.match_distance("match") < usize::MAX);
+        assert_eq!(ranked.match_distance("absent"), usize::MAX);
     }
 
     #[test]

--- a/src/web/main.rs
+++ b/src/web/main.rs
@@ -4771,6 +4771,7 @@ mod tests {
     use rusqlite::params;
     use std::io::{Read, Write};
     use std::net::Shutdown;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
     use std::thread;
     use tempfile::NamedTempFile;
 
@@ -5320,13 +5321,21 @@ mod tests {
         text
     }
 
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
     struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
         values: Vec<(&'static str, Option<std::ffi::OsString>)>,
     }
 
     impl EnvGuard {
         fn set(values: &[(&'static str, Option<&str>)]) -> Self {
+            let lock = env_lock().lock().unwrap();
             let guard = Self {
+                _lock: lock,
                 values: values
                     .iter()
                     .map(|(key, _)| (*key, env::var_os(key)))
@@ -5368,17 +5377,19 @@ mod tests {
                 .contains("is not ready")
         );
 
-        let _env = EnvGuard::set(&[
-            ("AV_WEB_BIND_ADDR", Some("127.0.0.1:3999")),
-            ("AV_WEB_DB_PATH", Some(db.path().to_str().unwrap())),
-            ("AV_WEB_ORIGIN_HEADER", Some("X-Coverage-Origin")),
-            ("AV_WEB_ORIGIN_SECRET", Some("")),
-        ]);
-        let state = AppState::from_env();
-        assert_eq!(state.bind_addr, "127.0.0.1:3999");
-        assert_eq!(state.db_path, db.path());
-        assert_eq!(state.origin_header, "x-coverage-origin");
-        assert_eq!(state.origin_secret, None);
+        {
+            let _env = EnvGuard::set(&[
+                ("AV_WEB_BIND_ADDR", Some("127.0.0.1:3999")),
+                ("AV_WEB_DB_PATH", Some(db.path().to_str().unwrap())),
+                ("AV_WEB_ORIGIN_HEADER", Some("X-Coverage-Origin")),
+                ("AV_WEB_ORIGIN_SECRET", Some("")),
+            ]);
+            let state = AppState::from_env();
+            assert_eq!(state.bind_addr, "127.0.0.1:3999");
+            assert_eq!(state.db_path, db.path());
+            assert_eq!(state.origin_header, "x-coverage-origin");
+            assert_eq!(state.origin_secret, None);
+        }
 
         {
             let missing = db.path().with_file_name("missing-av-web.sqlite");


### PR DESCRIPTION
## Summary
- Adds coverage-focused Rust tests for package search/validation helpers, helper FFI wrappers, secret scanner/progress helpers, incremental update edge cases, and package-origin web renderers.
- Leaves public `/db.json` schema untouched and does not modify isotope/radioisotope data repos.

## Coverage
- Baseline: `92.6129%` (`83033/89656`)
- Required target: `93.1129%`
- Final: `93.1163%` (`84517/90765`)
- Coverage command: `AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1`
- Confirmed `lcov.info` includes both `data/isotopes` and `data/radioisotopes` Rust sources.

## Validation
- `cargo fmt --all`
- `cargo test -p av-web -- --test-threads=1`
- `cargo test -p nucleus --lib -- --test-threads=1`
- `cargo test --bin nuke-helper -- --test-threads=1`
- `/usr/bin/python3 scripts/generate-coverage-fixtures.py && git diff --exit-code -- data/combined.json src/lib/rs/fixtures/coverage-combined.json`
- `git diff --check`
