### PR TITLE
test: raise coverage for helper and isotope edges

### DIFF
--- a/src/lib/rs/dotenv.rs
+++ b/src/lib/rs/dotenv.rs
@@ -2884,6 +2884,46 @@ mod tests {
         drop(core_dump_limit);
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn dotenv_keychain_and_notification_bridges_reject_invalid_c_strings_before_ffi() {
+        assert_eq!(
+            keychain_read_dotenv_private_key("bad\0service", "account").unwrap_err(),
+            "invalid keychain service name"
+        );
+        assert_eq!(
+            keychain_read_dotenv_private_key("service", "bad\0account").unwrap_err(),
+            "invalid keychain account name"
+        );
+        assert_eq!(
+            keychain_write_dotenv_private_key("bad\0service", "account", "value").unwrap_err(),
+            "invalid keychain service name"
+        );
+        assert_eq!(
+            keychain_write_dotenv_private_key("service", "bad\0account", "value").unwrap_err(),
+            "invalid keychain account name"
+        );
+        assert_eq!(
+            keychain_write_dotenv_private_key("service", "account", "bad\0value").unwrap_err(),
+            "invalid keychain private key"
+        );
+        assert_eq!(
+            dotenv_post_distributed_notification("bad\0name").unwrap_err(),
+            "invalid distributed notification name"
+        );
+        assert_eq!(
+            dotenv_post_distributed_notification_with_object("bad\0name", "object").unwrap_err(),
+            "invalid distributed notification name"
+        );
+        assert_eq!(
+            dotenv_post_distributed_notification_with_object("name", "bad\0object").unwrap_err(),
+            "invalid distributed notification object"
+        );
+        unsafe {
+            assert!(take_dotenv_bridge_string(std::ptr::null_mut()).is_none());
+        }
+    }
+
     impl DotenvEnvGuard {
         fn set(values: &[(&str, &str)]) -> Self {
             let previous = values
@@ -4325,6 +4365,14 @@ mod tests {
         assert!(parse_dotenv_process_info_line("not-a-pid /bin/zsh").is_none());
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn dotenv_process_snapshot_helpers_cover_missing_processes() {
+        assert!(dotenv_parent_process_path(0).is_none());
+        assert!(dotenv_process_snapshot(0).is_none());
+        assert!(dotenv_process_ancestry_snapshot(0).is_empty());
+    }
+
     #[test]
     fn dotenv_helper_remember_validates_policy_and_snapshot() {
         let _lock = global_test_env_lock().lock().unwrap();
@@ -4726,5 +4774,53 @@ mod tests {
             .unwrap_err(),
             "hex value must have an even number of characters"
         );
+    }
+
+    #[test]
+    fn dotenv_renderers_and_default_paths_cover_remaining_branches() {
+        let _guard = DotenvEnvGuard::unset(&[
+            AV_TEST_DOTENV_POLICY_PATH_ENV,
+            AV_TEST_DOTENV_REMEMBERED_APPROVALS_PATH_ENV,
+        ]);
+
+        print_dotenv_hook("av", DotenvShell::Bash);
+        print_dotenv_hook("av", DotenvShell::Zsh);
+        print_dotenv_hook("av", DotenvShell::Fish);
+        print_dotenv_usage("av");
+        print_dotenv_init_usage("av");
+        print_dotenv_set_usage("av");
+        print_dotenv_encrypt_usage("av");
+        print_dotenv_import_usage("av");
+        print_dotenv_hook_usage("av");
+        print_dotenv_export_usage("av");
+        print_dotenv_run_usage("av");
+
+        assert_eq!(
+            dotenv_system_policy_path(),
+            PathBuf::from(DOTENV_SYSTEM_POLICY_PATH)
+        );
+        assert_eq!(
+            dotenv_system_remembered_approvals_path(),
+            PathBuf::from(DOTENV_SYSTEM_REMEMBERED_APPROVALS_PATH)
+        );
+        assert!(dotenv_system_policy_requires_root_control());
+        assert!(dotenv_system_remembered_approvals_requires_root_control());
+
+        let parent = dotenv_parent_process_snapshot();
+        assert!(parent.pid > 0);
+        assert_eq!(dotenv_process_display_name(None), None);
+        assert_eq!(
+            dotenv_process_display_name(Some(
+                "/Applications/Automic Vault.app/Contents/MacOS/Automic Vault"
+            )),
+            Some("Automic Vault".to_string())
+        );
+        assert!(dotenv_process_ancestry_snapshot(0).is_empty());
+        assert!(dotenv_process_ancestry_snapshot(-1).is_empty());
+        assert_eq!(
+            parse_dotenv_process_info_line("  12 /usr/bin/zsh"),
+            Some((12, Some("/usr/bin/zsh".to_string())))
+        );
+        assert_eq!(parse_dotenv_process_info_line("not-a-pid zsh"), None);
     }
 }

--- a/src/lib/rs/info.rs
+++ b/src/lib/rs/info.rs
@@ -3602,6 +3602,15 @@ mod tests {
             })
         );
         assert_eq!(
+            explicit_requested_package_source(&RequestedPackage::NpmPackage {
+                package: "@scope/tool".to_string(),
+                version: Some("1.2.3".to_string()),
+            }),
+            Some(PackageReceiptSource::Npm {
+                package_name: "@scope/tool".to_string(),
+            })
+        );
+        assert_eq!(
             explicit_requested_package_source(&RequestedPackage::Auto("bun".to_string())),
             None
         );
@@ -3733,6 +3742,30 @@ mod tests {
             "av:bun"
         );
         assert_eq!(
+            package_source_qualified_name(&PackageReceiptSource::Formula {
+                root_formula: "ripgrep".to_string(),
+            }),
+            "brew:ripgrep"
+        );
+        assert_eq!(
+            package_source_qualified_name(&PackageReceiptSource::Cask {
+                cask_name: "codex".to_string(),
+            }),
+            "cask:codex"
+        );
+        assert_eq!(
+            package_source_qualified_name(&PackageReceiptSource::Isotope {
+                isotope_name: "gh".to_string(),
+            }),
+            "isotope:gh"
+        );
+        assert_eq!(
+            package_source_qualified_name(&PackageReceiptSource::Npm {
+                package_name: "@scope/tool".to_string(),
+            }),
+            "npm:@scope/tool"
+        );
+        assert_eq!(
             package_source_qualified_name(&PackageReceiptSource::Pip {
                 package_name: "My_Package.Name".to_string(),
             }),
@@ -3759,7 +3792,7 @@ mod tests {
             package_name: "isotope:uv".to_string(),
             qualified_name: "isotope:uv".to_string(),
             install_root: PathBuf::from("/opt/iso/uv"),
-            installed: false,
+            installed: true,
             source: Some(PackageReceiptSource::Isotope {
                 isotope_name: "uv".to_string(),
             }),
@@ -3863,7 +3896,7 @@ mod tests {
             package_name: "brew:demo".to_string(),
             qualified_name: "brew:demo".to_string(),
             install_root: PathBuf::from("/opt/demo"),
-            installed: false,
+            installed: true,
             source: Some(PackageReceiptSource::Formula {
                 root_formula: "demo".to_string(),
             }),
@@ -4288,5 +4321,99 @@ mod tests {
         );
 
         remove_path(&opt_root.join("awscli")).unwrap();
+    }
+
+    #[test]
+    fn format_package_info_covers_wrapped_metadata_and_error_sections() {
+        let info = PackageInfo {
+            package_name: "coverage-formula".to_string(),
+            qualified_name:
+                "brew:coverage-formula-with-a-very-long-name-that-wraps-in-the-title".to_string(),
+            install_root: PathBuf::from("/opt/pkg/coverage-formula"),
+            installed: true,
+            source: Some(PackageReceiptSource::Formula {
+                root_formula: "coverage-formula".to_string(),
+            }),
+            source_error: None,
+            aliases: vec![
+                "coverage-alias".to_string(),
+                "coverage-second-alias-that-wraps".to_string(),
+            ],
+            aliases_error: None,
+            installed_version: Some("1.0.0".to_string()),
+            latest_version: None,
+            latest_version_error: Some("registry unavailable".to_string()),
+            executable_paths: Vec::new(),
+            executable_paths_error: Some("stub manifest missing".to_string()),
+            popularity: None,
+            last_updated_at: None,
+            homebrew_info: Some(HomebrewPackageInfo {
+                formula: "coverage-formula".to_string(),
+                description: Some("A long description that should wrap over multiple lines in the package info renderer".to_string()),
+                homepage: Some("https://example.test/coverage-formula".to_string()),
+                repository: Some("https://github.com/example/coverage-formula".to_string()),
+                upstream_docs: Some("https://docs.example.test/coverage-formula".to_string()),
+                docs: Vec::new(),
+                license: Some("MIT".to_string()),
+                dependencies: vec![
+                    "dependency-one".to_string(),
+                    "dependency-two-with-a-long-name".to_string(),
+                    "dependency-three".to_string(),
+                ],
+            }),
+            homebrew_info_error: None,
+            npm_homepage: None,
+            npm_package_info_error: None,
+            security_state: None,
+            version_options: Vec::new(),
+        };
+
+        let rendered = format_package_info(&info);
+        assert!(rendered.contains("brew:coverage-formula"));
+        assert!(rendered.contains("registry unavailable"));
+        assert!(rendered.contains("Description"));
+        assert!(rendered.contains("Repository"));
+        assert!(rendered.contains("Docs"));
+        assert!(rendered.contains("Dependencies"));
+        assert!(rendered.contains("stub manifest missing"));
+
+        let npm_info = PackageInfo {
+            package_name: "coverage-npm".to_string(),
+            qualified_name: "npm:coverage-npm".to_string(),
+            install_root: PathBuf::from("/opt/npm/coverage-npm"),
+            installed: true,
+            source: Some(PackageReceiptSource::Npm {
+                package_name: "coverage-npm".to_string(),
+            }),
+            source_error: None,
+            aliases: Vec::new(),
+            aliases_error: None,
+            installed_version: None,
+            latest_version: Some("2.0.0".to_string()),
+            latest_version_error: None,
+            executable_paths: vec![
+                "/opt/npm/bin/coverage-npm-with-a-long-executable-name".to_string(),
+            ],
+            executable_paths_error: None,
+            popularity: None,
+            last_updated_at: None,
+            homebrew_info: None,
+            homebrew_info_error: None,
+            npm_homepage: None,
+            npm_package_info_error: Some("npm metadata timeout".to_string()),
+            security_state: None,
+            version_options: Vec::new(),
+        };
+        let rendered = format_package_info(&npm_info);
+        assert!(rendered.contains("npm metadata timeout"));
+        assert!(rendered.contains("coverage-npm-with-a-long-executable-name"));
+
+        let mut lines = Vec::new();
+        push_wrapped_field(&mut lines, "Empty", "");
+        assert_eq!(lines, vec![format!("  {:<INFO_LABEL_WIDTH$}", "Empty")]);
+        assert_eq!(wrap_text("", 4), vec![String::new()]);
+        assert_eq!(split_text_hard("abcdef", 2), vec!["ab", "cd", "ef"]);
+        assert!(wrap_tokens(&[], 2, 3).is_empty());
+        assert!(wrap_tokens(&["a".repeat(INFO_WIDTH), "b".to_string()], 2, 3).len() > 1);
     }
 }

--- a/src/lib/rs/isotope.rs
+++ b/src/lib/rs/isotope.rs
@@ -2401,6 +2401,54 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn keychain_and_notification_bridges_reject_invalid_c_strings_before_ffi() {
+        assert_eq!(
+            keychain_read_secret_if_present("bad\0service", "TOKEN").unwrap_err(),
+            "invalid keychain service name"
+        );
+        assert_eq!(
+            keychain_read_secret("service", "bad\0account").unwrap_err(),
+            "invalid keychain account name"
+        );
+        assert_eq!(
+            keychain_secret_exists("bad\0service", "TOKEN").unwrap_err(),
+            "invalid keychain service name"
+        );
+        assert_eq!(
+            keychain_secret_exists("service", "bad\0account").unwrap_err(),
+            "invalid keychain account name"
+        );
+        assert_eq!(
+            keychain_write_secret("bad\0service", "TOKEN", "value").unwrap_err(),
+            "invalid keychain service name"
+        );
+        assert_eq!(
+            keychain_write_secret("service", "bad\0account", "value").unwrap_err(),
+            "invalid keychain account name"
+        );
+        assert_eq!(
+            keychain_write_secret("service", "TOKEN", "bad\0value").unwrap_err(),
+            "invalid keychain secret value"
+        );
+        assert_eq!(
+            post_distributed_notification("bad\0name").unwrap_err(),
+            "invalid distributed notification name"
+        );
+        assert_eq!(
+            post_distributed_notification_with_object("bad\0name", "object").unwrap_err(),
+            "invalid distributed notification name"
+        );
+        assert_eq!(
+            post_distributed_notification_with_object("name", "bad\0object").unwrap_err(),
+            "invalid distributed notification object"
+        );
+        unsafe {
+            assert!(take_bridge_string(std::ptr::null_mut()).is_none());
+        }
+    }
+
     #[test]
     fn isotopes_exec_environment_and_zeroize_helpers_cover_errors() {
         assert!(build_exec_cstrings(&[OsString::from("ok")]).is_ok());
@@ -2440,6 +2488,48 @@ mod tests {
         assert!(disable_core_dumps().is_ok());
         let snapshot = parent_process_snapshot();
         assert!(snapshot.pid > 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn isotopes_fd_path_validation_covers_success_and_error_edges() {
+        use std::os::fd::AsRawFd;
+
+        let temp = tempfile::tempdir().unwrap();
+        let tool = temp.path().join("tool");
+        let other = temp.path().join("other-tool");
+        fs::write(&tool, b"tool").unwrap();
+        fs::write(&other, b"other").unwrap();
+        let file = File::open(&tool).unwrap();
+        let fd = file.as_raw_fd();
+        let open_path = path_for_open_fd(fd).unwrap();
+        let canonical_tool = fs::canonicalize(&tool).unwrap();
+
+        assert_eq!(Path::new(&open_path), canonical_tool);
+        verify_fd_matches_path(fd, &open_path).unwrap();
+        assert!(
+            path_for_open_fd(-1)
+                .unwrap_err()
+                .contains("failed to resolve executable path")
+        );
+        assert!(
+            verify_fd_matches_path(-1, &open_path)
+                .unwrap_err()
+                .contains("failed to stat validated descriptor")
+        );
+        assert_eq!(
+            verify_fd_matches_path(fd, "bad\0path").unwrap_err(),
+            "validated descriptor path contains interior NUL"
+        );
+        assert!(
+            verify_fd_matches_path(fd, temp.path().join("missing").to_str().unwrap())
+                .unwrap_err()
+                .contains("failed to stat executable path")
+        );
+        assert_eq!(
+            verify_fd_matches_path(fd, other.to_str().unwrap()).unwrap_err(),
+            "validated executable changed before exec"
+        );
     }
 
     #[test]

--- a/src/lib/rs/ops.rs
+++ b/src/lib/rs/ops.rs
@@ -8,6 +8,11 @@ const ISOTOPE_ALWAYS_ALLOW_PATH: &str =
     "/Library/Application Support/Automic Vault/isotope/always-allow.json";
 const DEFAULT_SEARCH_PAGE_SIZE: usize = 100;
 const MAX_SEARCH_PAGE_SIZE: usize = 200;
+
+#[cfg(test)]
+static TEST_ASSUME_HELPER_ROOT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum HelperCommand {
     Install {
@@ -1460,6 +1465,57 @@ mod tests {
         EndpointOverrideGuard
     }
 
+    struct TestHelperRootGuard {
+        previous: bool,
+    }
+
+    impl TestHelperRootGuard {
+        fn enable() -> Self {
+            Self {
+                previous: TEST_ASSUME_HELPER_ROOT.swap(true, std::sync::atomic::Ordering::SeqCst),
+            }
+        }
+    }
+
+    impl Drop for TestHelperRootGuard {
+        fn drop(&mut self) {
+            TEST_ASSUME_HELPER_ROOT.store(self.previous, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    struct TestEnvVarGuard {
+        previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl TestEnvVarGuard {
+        fn set(values: &[(&'static str, &str)]) -> Self {
+            let previous = values
+                .iter()
+                .map(|(key, value)| {
+                    let previous = std::env::var_os(key);
+                    unsafe {
+                        std::env::set_var(key, value);
+                    }
+                    (*key, previous)
+                })
+                .collect();
+            Self { previous }
+        }
+    }
+
+    impl Drop for TestEnvVarGuard {
+        fn drop(&mut self) {
+            for (key, previous) in self.previous.drain(..).rev() {
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
     fn start_ops_test_http_server(
         routes: Vec<(String, Vec<u8>)>,
         requests: usize,
@@ -1892,6 +1948,112 @@ mod tests {
         assert!(matches!(
             events.lock().unwrap().last(),
             Some(ProgressEvent::Error { .. })
+        ));
+    }
+
+    #[test]
+    fn helper_command_bodies_cover_root_bypassed_safe_errors() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let _root = TestHelperRootGuard::enable();
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let env_path = project.join(".env");
+        fs::write(&env_path, "DOTENV_PUBLIC_KEY=public-key\nAPI_TOKEN=plain\n").unwrap();
+        let policy_path = temp.path().join("dotenv-policy.json");
+        let approvals_path = temp.path().join("dotenv-approvals.json");
+        let _dotenv_env = TestEnvVarGuard::set(&[
+            ("AV_TEST_DOTENV_POLICY_PATH", policy_path.to_str().unwrap()),
+            (
+                "AV_TEST_DOTENV_REMEMBERED_APPROVALS_PATH",
+                approvals_path.to_str().unwrap(),
+            ),
+        ]);
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let formula_api_root = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let _endpoint = set_formula_api_root(formula_api_root);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let progress = || {
+            let captured = Arc::clone(&events);
+            Arc::new(Mutex::new(Box::new(move |event| {
+                captured.lock().unwrap().push(event);
+            }) as Box<ProgressCallback>))
+        };
+        let formula = PackageSpec {
+            name: "brew:coverage-helper-formula".to_string(),
+            version: None,
+        };
+
+        assert!(
+            install_packages(vec![formula.clone()], progress())
+                .unwrap_err()
+                .contains("coverage-helper-formula")
+        );
+        assert!(
+            update_packages(Vec::new(), progress())
+                .unwrap_err()
+                .contains("at least one package")
+        );
+        let _ = update_all_packages(progress());
+        assert!(
+            uninstall_packages(
+                vec![PackageSpec {
+                    name: "coverage-missing-package".to_string(),
+                    version: None,
+                }],
+                progress()
+            )
+            .unwrap_err()
+            .contains("not installed")
+        );
+        assert!(
+            install_isotope_stubs_with_helper("", progress())
+                .unwrap_err()
+                .contains("missing isotope name")
+        );
+        assert!(
+            install_isotope_root_with_helper("bad/name", progress())
+                .unwrap_err()
+                .contains("invalid isotope name")
+        );
+        assert!(
+            convert_radioisotope_with_helper("bad/name", progress())
+                .unwrap_err()
+                .contains("invalid isotope name")
+        );
+        assert!(
+            install_cli_tools(
+                "/tmp/coverage-missing-av",
+                "/tmp/Coverage Caller.app",
+                progress()
+            )
+            .is_err()
+        );
+        assert_eq!(
+            get_dotenv_approval_policy().unwrap().value.as_deref(),
+            Some("approve_every_time")
+        );
+        assert_eq!(
+            set_dotenv_approval_policy(dotenv::DotenvApprovalPolicy::RememberApproved)
+                .unwrap()
+                .value
+                .as_deref(),
+            Some("remember_approved")
+        );
+        assert!(
+            remember_dotenv_approval_with_helper(
+                dotenv::DotenvApprovalMode::Run,
+                env_path.to_str().unwrap(),
+                project.to_str().unwrap(),
+                "f15d64528dce9aa1e20497a5d9ef60783080fe5e3d5051de19c8fae7c78c4607",
+                "43a46f1d081d270130e2210a1de59f9715de033307d068edc65a335b27e95d3d",
+                vec!["API_TOKEN".to_string(), "API_TOKEN".to_string()],
+            )
+            .is_ok()
+        );
+        assert!(events.lock().unwrap().iter().any(
+            |event| matches!(event, ProgressEvent::Installing { package } if package == "coverage-missing-package" || package == PKG_DISPLAY_NAME)
         ));
     }
 
@@ -2661,6 +2823,11 @@ mod tests {
 }
 
 fn require_root() -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_ASSUME_HELPER_ROOT.load(std::sync::atomic::Ordering::SeqCst) {
+        return Ok(());
+    }
+
     if is_root() {
         return Ok(());
     }

--- a/tests/radioisotope_credential_helpers.rs
+++ b/tests/radioisotope_credential_helpers.rs
@@ -11,6 +11,7 @@ macro_rules! radioisotope_source {
 }
 
 mod isotope {
+    use std::collections::BTreeMap;
     use std::path::Path;
 
     #[derive(Debug)]
@@ -28,7 +29,24 @@ mod isotope {
 
     pub(crate) trait CredentialHelperSecretStore {
         fn load_secret(&self, key: &str) -> Result<String, String>;
-        fn store_secret(&self, key: &str, value: &str) -> Result<(), String>;
+        fn store_secret(&self, _key: &str, _value: &str) -> Result<(), String> {
+            Err("credential helper store is read-only".to_string())
+        }
+    }
+
+    pub(crate) fn load_credentials(
+        store: &dyn CredentialHelperSecretStore,
+        keys: &[String],
+    ) -> Result<BTreeMap<String, String>, String> {
+        keys.iter()
+            .map(|key| store.load_secret(key).map(|value| (key.clone(), value)))
+            .collect()
+    }
+
+    pub(crate) fn zeroize_credentials(credentials: &mut BTreeMap<String, String>) {
+        for value in credentials.values_mut() {
+            value.clear();
+        }
     }
 
     pub(crate) fn validate_root_controlled_path(path: &Path) -> Result<(), String> {
@@ -226,12 +244,514 @@ mod skopeo_helper {
     );
 }
 
+mod aws_cli_helper {
+    include!(radioisotope_source!("/aws-cli/credential-helper.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::path::Path;
+
+        struct MissingSecretStore;
+
+        impl crate::isotope::CredentialHelperSecretStore for MissingSecretStore {
+            fn load_secret(&self, key: &str) -> Result<String, String> {
+                if key == AWS_ACCESS_KEY_ID_ENV_KEY {
+                    Ok("AKIAEXAMPLE".to_string())
+                } else {
+                    Err(format!("missing {key}"))
+                }
+            }
+        }
+
+        fn caller() -> crate::isotope::CredentialHelperCallerContext {
+            crate::isotope::CredentialHelperCallerContext {
+                token: Some("x".repeat(MIN_CREDENTIAL_HELPER_TOKEN_LEN)),
+                parent_executable_path: Some(AWS_CLI_PYTHON_PATH.to_string()),
+                parent_command: Some(format!(
+                    "{AWS_CLI_PYTHON_PATH} {AWS_CLI_PYTHON_ISOLATED_FLAG} {AWS_CLI_LAUNCHER_PATH} sts get-caller-identity"
+                )),
+            }
+        }
+
+        #[test]
+        fn covers_top_level_dispatch_and_validation_errors() {
+            let store = MissingSecretStore;
+            credential_helper_with_validator(
+                crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("--help")],
+                    caller: caller(),
+                    store: &store,
+                },
+                |_| Ok(()),
+            )
+            .unwrap();
+            credential_helper_with_validator(
+                crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("--version")],
+                    caller: caller(),
+                    store: &store,
+                },
+                |_| Ok(()),
+            )
+            .unwrap();
+            assert!(
+                credential_helper_with_validator(
+                    crate::isotope::CredentialHelperInvocation {
+                        args: vec![OsString::from("extra")],
+                        caller: caller(),
+                        store: &store,
+                    },
+                    |_| Ok(()),
+                )
+                .unwrap_err()
+                .contains("does not accept arguments")
+            );
+            assert!(
+                credential_helper_with_validator(
+                    crate::isotope::CredentialHelperInvocation {
+                        args: Vec::new(),
+                        caller: caller(),
+                        store: &store,
+                    },
+                    |path: &Path| Err(format!("untrusted {}", path.display())),
+                )
+                .unwrap_err()
+                .contains("untrusted")
+            );
+            assert!(
+                credential_helper_with_validator(
+                    crate::isotope::CredentialHelperInvocation {
+                        args: Vec::new(),
+                        caller: caller(),
+                        store: &store,
+                    },
+                    |_| Ok(()),
+                )
+                .unwrap_err()
+                .contains(AWS_SECRET_ACCESS_KEY_ENV_KEY)
+            );
+        }
+    }
+}
+
+mod kubernetes_cli_helper {
+    include!(radioisotope_source!("/kubernetes-cli/credential-helper.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::ffi::OsString;
+
+        #[cfg(unix)]
+        use std::os::unix::ffi::OsStringExt;
+
+        struct ErrorStore;
+
+        impl crate::isotope::CredentialHelperSecretStore for ErrorStore {
+            fn load_secret(&self, _key: &str) -> Result<String, String> {
+                Err("kube store denied".to_string())
+            }
+        }
+
+        #[test]
+        fn covers_validation_json_and_response_edges() {
+            assert!(is_kubectl_parent_executable("/opt/kubernetes-cli/bin/kubectl"));
+            assert!(is_kubectl_parent_executable(
+                "/opt/kubernetes-cli/bin/kubectl.av-orig"
+            ));
+            assert!(!is_kubectl_parent_executable("/tmp/kubectl"));
+
+            assert!(
+                parse_kubernetes_helper_args(&[])
+                    .unwrap_err()
+                    .contains("expects one")
+            );
+            assert!(
+                parse_kubernetes_helper_args(&[OsString::from("   ")])
+                    .unwrap_err()
+                    .contains("empty")
+            );
+            #[cfg(unix)]
+            assert!(
+                parse_kubernetes_helper_args(&[OsString::from_vec(vec![0xff])])
+                    .unwrap_err()
+                    .contains("valid UTF-8")
+            );
+
+            assert!(
+                validate_caller_context(&crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("dev")],
+                    caller: crate::isotope::CredentialHelperCallerContext {
+                        token: Some("short".to_string()),
+                        parent_executable_path: Some(
+                            "/opt/kubernetes-cli/bin/kubectl".to_string()
+                        ),
+                        parent_command: None,
+                    },
+                    store: &crate::MemoryStore::default(),
+                })
+                .unwrap_err()
+                .contains("invalid")
+            );
+            assert!(
+                validate_caller_context(&crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("dev")],
+                    caller: crate::isotope::CredentialHelperCallerContext {
+                        token: Some("x".repeat(32)),
+                        parent_executable_path: Some("/tmp/not-kubectl".to_string()),
+                        parent_command: None,
+                    },
+                    store: &crate::MemoryStore::default(),
+                })
+                .unwrap_err()
+                .contains("kubectl")
+            );
+
+            assert!(
+                kubernetes_credential_for_user(&ErrorStore, "dev")
+                    .unwrap_err()
+                    .contains("kube store denied")
+            );
+            assert!(
+                kubernetes_credential_for_user(&crate::MemoryStore::with("not json"), "dev")
+                    .unwrap_err()
+                    .contains("decode")
+            );
+            assert!(
+                kubernetes_credential_for_user(&crate::MemoryStore::with(r#"{"users":{}}"#), "dev")
+                    .unwrap_err()
+                    .contains("missing users")
+            );
+            assert!(
+                kubernetes_credential_for_user(
+                    &crate::MemoryStore::with(r#"{"users":[{"name":"other"}]}"#),
+                    "dev"
+                )
+                .unwrap_err()
+                .contains("not found")
+            );
+            let certificate = KubernetesCredential {
+                token: None,
+                client_certificate_data: Some("cert".to_string()),
+                client_key_data: Some("key".to_string()),
+            };
+            let response = exec_credential_json(&certificate).unwrap();
+            assert!(response.contains("clientCertificateData"));
+        }
+    }
+}
+
+mod nuget_helper {
+    include!(radioisotope_source!("/nuget/credential-helper.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::ffi::OsString;
+
+        #[cfg(unix)]
+        use std::os::unix::ffi::OsStringExt;
+
+        struct ErrorStore;
+
+        impl crate::isotope::CredentialHelperSecretStore for ErrorStore {
+            fn load_secret(&self, _key: &str) -> Result<String, String> {
+                Err("nuget store denied".to_string())
+            }
+        }
+
+        #[test]
+        fn covers_uri_validation_store_and_match_edges() {
+            assert_eq!(
+                parse_nuget_provider_uri(&[
+                    OsString::from("-Uri"),
+                    OsString::from("https://example.test/index.json")
+                ])
+                .unwrap(),
+                Some("https://example.test/index.json".to_string())
+            );
+            assert_eq!(
+                parse_nuget_provider_uri(&[OsString::from("-Uri:https://example.test/")]).unwrap(),
+                Some("https://example.test/".to_string())
+            );
+            assert_eq!(
+                parse_nuget_provider_uri(&[OsString::from("-Uri"), OsString::from("   ")])
+                    .unwrap(),
+                None
+            );
+            assert!(
+                parse_nuget_provider_uri(&[OsString::from("-Uri")])
+                    .unwrap_err()
+                    .contains("missing a value")
+            );
+            #[cfg(unix)]
+            assert!(
+                parse_nuget_provider_uri(&[OsString::from_vec(vec![0xff])])
+                    .unwrap_err()
+                    .contains("valid UTF-8")
+            );
+            assert!(is_nuget_parent_executable("/opt/nuget/bin/nuget"));
+            assert!(is_nuget_parent_executable("/opt/nuget/bin/nuget.av-orig"));
+            assert!(!is_nuget_parent_executable("/tmp/nuget"));
+            assert!(credential_store_miss("not found in store"));
+            assert!(credential_store_miss("missing stub credential"));
+            assert!(!credential_store_miss("permission denied"));
+            assert_eq!(normalize_uri("HTTPS://EXAMPLE.TEST/"), "https://example.test");
+
+            assert!(
+                validate_caller_context(&crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("-Uri"), OsString::from("source")],
+                    caller: crate::isotope::CredentialHelperCallerContext {
+                        token: None,
+                        parent_executable_path: Some("/opt/nuget/bin/nuget".to_string()),
+                        parent_command: None,
+                    },
+                    store: &crate::MemoryStore::default(),
+                })
+                .unwrap_err()
+                .contains("approval token")
+            );
+            assert!(
+                validate_caller_context(&crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("-Uri"), OsString::from("source")],
+                    caller: crate::isotope::CredentialHelperCallerContext {
+                        token: Some("x".repeat(32)),
+                        parent_executable_path: Some("/tmp/not-nuget".to_string()),
+                        parent_command: None,
+                    },
+                    store: &crate::MemoryStore::default(),
+                })
+                .unwrap_err()
+                .contains("NuGet launcher")
+            );
+
+            assert_eq!(
+                nuget_credentials_for_uri(&crate::MemoryStore::default(), "source").unwrap(),
+                None
+            );
+            assert!(
+                nuget_credentials_for_uri(&ErrorStore, "source")
+                    .unwrap_err()
+                    .contains("nuget store denied")
+            );
+            assert!(
+                nuget_credentials_for_uri(&crate::MemoryStore::with("not json"), "source")
+                    .unwrap_err()
+                    .contains("decode")
+            );
+            assert_eq!(
+                nuget_credentials_for_uri(&crate::MemoryStore::with(r#"{"sources":{}}"#), "source")
+                    .unwrap(),
+                None
+            );
+            assert_eq!(
+                nuget_credentials_for_uri(
+                    &crate::MemoryStore::with(
+                        r#"{"sources":[{"name":"source","username":"u"},{"uri":"https://example.test/","password":"p"}]}"#
+                    ),
+                    "source"
+                )
+                .unwrap(),
+                None
+            );
+        }
+    }
+}
+
 mod terraform_helper {
     include!(radioisotope_source!("/terraform/credential-helper.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::ffi::OsString;
+
+        #[cfg(unix)]
+        use std::os::unix::ffi::OsStringExt;
+
+        struct ErrorStore;
+        struct WriteErrorStore;
+
+        impl crate::isotope::CredentialHelperSecretStore for ErrorStore {
+            fn load_secret(&self, _key: &str) -> Result<String, String> {
+                Err("terraform store denied".to_string())
+            }
+        }
+
+        impl crate::isotope::CredentialHelperSecretStore for WriteErrorStore {
+            fn load_secret(&self, _key: &str) -> Result<String, String> {
+                Err("missing stub credential".to_string())
+            }
+
+            fn store_secret(&self, _key: &str, _value: &str) -> Result<(), String> {
+                Err("terraform write denied".to_string())
+            }
+        }
+
+        #[test]
+        fn covers_parse_validation_and_store_shape_edges() {
+            assert!(is_terraform_parent_executable("/opt/terraform/bin/terraform"));
+            assert!(is_terraform_parent_executable(
+                "/opt/terraform/bin/terraform.av-orig"
+            ));
+            assert!(!is_terraform_parent_executable("/tmp/terraform"));
+            assert!(
+                parse_terraform_helper_args(&[])
+                    .unwrap_err()
+                    .contains("<verb> <hostname>")
+            );
+            assert!(
+                parse_terraform_helper_args(&[OsString::from("get"), OsString::from(" ")])
+                    .unwrap_err()
+                    .contains("empty")
+            );
+            #[cfg(unix)]
+            assert!(
+                parse_terraform_helper_args(&[OsString::from_vec(vec![0xff]), OsString::from("h")])
+                    .unwrap_err()
+                    .contains("valid UTF-8")
+            );
+            assert!(
+                validate_caller_context(&crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("get"), OsString::from("host")],
+                    caller: crate::isotope::CredentialHelperCallerContext {
+                        token: Some("short".to_string()),
+                        parent_executable_path: Some("/opt/terraform/bin/terraform".to_string()),
+                        parent_command: None,
+                    },
+                    store: &crate::MemoryStore::default(),
+                })
+                .unwrap_err()
+                .contains("invalid")
+            );
+            assert!(
+                load_terraform_credentials_root(&ErrorStore)
+                    .unwrap_err()
+                    .contains("terraform store denied")
+            );
+            assert!(
+                load_terraform_credentials_root(&crate::MemoryStore::with("not json"))
+                    .unwrap_err()
+                    .contains("decode")
+            );
+            assert!(
+                store_terraform_credentials_for_host(
+                    &crate::MemoryStore::with("[]"),
+                    "host",
+                    r#"{"token":"secret"}"#
+                )
+                .unwrap_err()
+                .contains("root must be a JSON object")
+            );
+            assert!(
+                store_terraform_credentials_for_host(
+                    &crate::MemoryStore::with(r#"{"credentials":[]}"#),
+                    "host",
+                    r#"{"token":"secret"}"#
+                )
+                .unwrap_err()
+                .contains("field must be a JSON object")
+            );
+            assert!(
+                store_terraform_credentials_for_host(&WriteErrorStore, "host", r#"{"token":"secret"}"#)
+                    .unwrap_err()
+                    .contains("terraform write denied")
+            );
+        }
+    }
 }
 
 mod opentofu_helper {
     include!(radioisotope_source!("/opentofu/credential-helper.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::ffi::OsString;
+
+        struct ErrorStore;
+        struct WriteErrorStore;
+
+        impl crate::isotope::CredentialHelperSecretStore for ErrorStore {
+            fn load_secret(&self, _key: &str) -> Result<String, String> {
+                Err("opentofu store denied".to_string())
+            }
+        }
+
+        impl crate::isotope::CredentialHelperSecretStore for WriteErrorStore {
+            fn load_secret(&self, _key: &str) -> Result<String, String> {
+                Err("missing stub credential".to_string())
+            }
+
+            fn store_secret(&self, _key: &str, _value: &str) -> Result<(), String> {
+                Err("opentofu write denied".to_string())
+            }
+        }
+
+        #[test]
+        fn covers_parse_validation_and_store_shape_edges() {
+            assert!(is_opentofu_parent_executable("/opt/opentofu/bin/tofu"));
+            assert!(is_opentofu_parent_executable("/opt/opentofu/bin/tofu.av-orig"));
+            assert!(!is_opentofu_parent_executable("/tmp/tofu"));
+            assert!(
+                parse_opentofu_helper_args(&[])
+                    .unwrap_err()
+                    .contains("<verb> <hostname>")
+            );
+            assert!(
+                parse_opentofu_helper_args(&[OsString::from("get"), OsString::from(" ")])
+                    .unwrap_err()
+                    .contains("empty")
+            );
+            assert!(
+                validate_caller_context(&crate::isotope::CredentialHelperInvocation {
+                    args: vec![OsString::from("get"), OsString::from("host")],
+                    caller: crate::isotope::CredentialHelperCallerContext {
+                        token: Some("short".to_string()),
+                        parent_executable_path: Some("/opt/opentofu/bin/tofu".to_string()),
+                        parent_command: None,
+                    },
+                    store: &crate::MemoryStore::default(),
+                })
+                .unwrap_err()
+                .contains("invalid")
+            );
+            assert!(
+                load_opentofu_credentials_root(&ErrorStore)
+                    .unwrap_err()
+                    .contains("opentofu store denied")
+            );
+            assert!(
+                load_opentofu_credentials_root(&crate::MemoryStore::with("not json"))
+                    .unwrap_err()
+                    .contains("decode")
+            );
+            assert!(
+                store_opentofu_credentials_for_host(
+                    &crate::MemoryStore::with("[]"),
+                    "host",
+                    r#"{"token":"secret"}"#
+                )
+                .unwrap_err()
+                .contains("root must be a JSON object")
+            );
+            assert!(
+                store_opentofu_credentials_for_host(
+                    &crate::MemoryStore::with(r#"{"credentials":[]}"#),
+                    "host",
+                    r#"{"token":"secret"}"#
+                )
+                .unwrap_err()
+                .contains("field must be a JSON object")
+            );
+            assert!(
+                store_opentofu_credentials_for_host(&WriteErrorStore, "host", r#"{"token":"secret"}"#)
+                    .unwrap_err()
+                    .contains("opentofu write denied")
+            );
+        }
+    }
 }
 
 mod cargo_helper {
@@ -392,8 +912,32 @@ mod cargo_helper {
                     .unwrap_err()
                     .contains("write")
             );
+
+            assert!(request_is_crates_io(&serde_json::json!({
+                "registry": { "index-url": "https://github.com/rust-lang/crates.io-index" }
+            })));
+            assert!(!request_is_crates_io(&serde_json::json!({
+                "registry": { "index-url": "https://example.test/index" }
+            })));
+            assert!(!request_is_crates_io(&serde_json::json!({ "registry": [] })));
+            assert!(credential_store_miss("not found in store"));
+            assert!(credential_store_miss("missing stub credential"));
+            assert!(!credential_store_miss("permission denied"));
+            assert_eq!(
+                load_cargo_token(&crate::MemoryStore::default()).unwrap(),
+                None
+            );
+            assert_eq!(cargo_err("custom"), serde_json::json!({ "Err": { "kind": "custom" } }));
+            assert_eq!(
+                cargo_other_err("message"),
+                serde_json::json!({ "Err": { "kind": "other", "message": "message" } })
+            );
         }
     }
+}
+
+mod wakatime_cli_helper {
+    include!(radioisotope_source!("/wakatime-cli/credential-helper.rs"));
 }
 
 #[derive(Default)]

--- a/tests/radioisotope_credential_helpers.rs
+++ b/tests/radioisotope_credential_helpers.rs
@@ -356,7 +356,9 @@ mod kubernetes_cli_helper {
 
         #[test]
         fn covers_validation_json_and_response_edges() {
-            assert!(is_kubectl_parent_executable("/opt/kubernetes-cli/bin/kubectl"));
+            assert!(is_kubectl_parent_executable(
+                "/opt/kubernetes-cli/bin/kubectl"
+            ));
             assert!(is_kubectl_parent_executable(
                 "/opt/kubernetes-cli/bin/kubectl.av-orig"
             ));
@@ -384,9 +386,7 @@ mod kubernetes_cli_helper {
                     args: vec![OsString::from("dev")],
                     caller: crate::isotope::CredentialHelperCallerContext {
                         token: Some("short".to_string()),
-                        parent_executable_path: Some(
-                            "/opt/kubernetes-cli/bin/kubectl".to_string()
-                        ),
+                        parent_executable_path: Some("/opt/kubernetes-cli/bin/kubectl".to_string()),
                         parent_command: None,
                     },
                     store: &crate::MemoryStore::default(),
@@ -476,8 +476,7 @@ mod nuget_helper {
                 Some("https://example.test/".to_string())
             );
             assert_eq!(
-                parse_nuget_provider_uri(&[OsString::from("-Uri"), OsString::from("   ")])
-                    .unwrap(),
+                parse_nuget_provider_uri(&[OsString::from("-Uri"), OsString::from("   ")]).unwrap(),
                 None
             );
             assert!(
@@ -497,7 +496,10 @@ mod nuget_helper {
             assert!(credential_store_miss("not found in store"));
             assert!(credential_store_miss("missing stub credential"));
             assert!(!credential_store_miss("permission denied"));
-            assert_eq!(normalize_uri("HTTPS://EXAMPLE.TEST/"), "https://example.test");
+            assert_eq!(
+                normalize_uri("HTTPS://EXAMPLE.TEST/"),
+                "https://example.test"
+            );
 
             assert!(
                 validate_caller_context(&crate::isotope::CredentialHelperInvocation {
@@ -591,7 +593,9 @@ mod terraform_helper {
 
         #[test]
         fn covers_parse_validation_and_store_shape_edges() {
-            assert!(is_terraform_parent_executable("/opt/terraform/bin/terraform"));
+            assert!(is_terraform_parent_executable(
+                "/opt/terraform/bin/terraform"
+            ));
             assert!(is_terraform_parent_executable(
                 "/opt/terraform/bin/terraform.av-orig"
             ));
@@ -654,9 +658,13 @@ mod terraform_helper {
                 .contains("field must be a JSON object")
             );
             assert!(
-                store_terraform_credentials_for_host(&WriteErrorStore, "host", r#"{"token":"secret"}"#)
-                    .unwrap_err()
-                    .contains("terraform write denied")
+                store_terraform_credentials_for_host(
+                    &WriteErrorStore,
+                    "host",
+                    r#"{"token":"secret"}"#
+                )
+                .unwrap_err()
+                .contains("terraform write denied")
             );
         }
     }
@@ -692,7 +700,9 @@ mod opentofu_helper {
         #[test]
         fn covers_parse_validation_and_store_shape_edges() {
             assert!(is_opentofu_parent_executable("/opt/opentofu/bin/tofu"));
-            assert!(is_opentofu_parent_executable("/opt/opentofu/bin/tofu.av-orig"));
+            assert!(is_opentofu_parent_executable(
+                "/opt/opentofu/bin/tofu.av-orig"
+            ));
             assert!(!is_opentofu_parent_executable("/tmp/tofu"));
             assert!(
                 parse_opentofu_helper_args(&[])
@@ -746,9 +756,13 @@ mod opentofu_helper {
                 .contains("field must be a JSON object")
             );
             assert!(
-                store_opentofu_credentials_for_host(&WriteErrorStore, "host", r#"{"token":"secret"}"#)
-                    .unwrap_err()
-                    .contains("opentofu write denied")
+                store_opentofu_credentials_for_host(
+                    &WriteErrorStore,
+                    "host",
+                    r#"{"token":"secret"}"#
+                )
+                .unwrap_err()
+                .contains("opentofu write denied")
             );
         }
     }
@@ -919,7 +933,9 @@ mod cargo_helper {
             assert!(!request_is_crates_io(&serde_json::json!({
                 "registry": { "index-url": "https://example.test/index" }
             })));
-            assert!(!request_is_crates_io(&serde_json::json!({ "registry": [] })));
+            assert!(!request_is_crates_io(
+                &serde_json::json!({ "registry": [] })
+            ));
             assert!(credential_store_miss("not found in store"));
             assert!(credential_store_miss("missing stub credential"));
             assert!(!credential_store_miss("permission denied"));
@@ -927,7 +943,10 @@ mod cargo_helper {
                 load_cargo_token(&crate::MemoryStore::default()).unwrap(),
                 None
             );
-            assert_eq!(cargo_err("custom"), serde_json::json!({ "Err": { "kind": "custom" } }));
+            assert_eq!(
+                cargo_err("custom"),
+                serde_json::json!({ "Err": { "kind": "custom" } })
+            );
             assert_eq!(
                 cargo_other_err("message"),
                 serde_json::json!({ "Err": { "kind": "other", "message": "message" } })

--- a/tests/radioisotope_detect_edges.rs
+++ b/tests/radioisotope_detect_edges.rs
@@ -1,17 +1,227 @@
 #![cfg(coverage)]
 #![allow(dead_code)]
 
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn global_test_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(Mutex::default)
 }
 
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("radioisotope-detect-{label}-{suffix}"))
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 macro_rules! radioisotope_source {
     ($path:literal) => {
         concat!(env!("AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO"), $path)
     };
+}
+
+macro_rules! top_level_file_detector_tests {
+    ($module:ident, $source:literal, $paths:expr, $contents:expr) => {
+        mod $module {
+            include!(radioisotope_source!($source));
+
+            #[cfg(test)]
+            mod av_extra_tests {
+                use super::*;
+                use std::fs;
+
+                #[test]
+                fn covers_top_level_detection_with_temp_paths() {
+                    let _lock = crate::global_test_env_lock().lock().unwrap();
+                    let root = crate::unique_temp_dir(stringify!($module));
+                    let home = root.join("home");
+                    let xdg_config = root.join("xdg-config");
+                    let xdg_data = root.join("xdg-data");
+                    let xdg_state = root.join("xdg-state");
+                    fs::create_dir_all(&home).unwrap();
+                    fs::create_dir_all(&xdg_config).unwrap();
+                    fs::create_dir_all(&xdg_data).unwrap();
+                    fs::create_dir_all(&xdg_state).unwrap();
+
+                    let _home = crate::EnvGuard::set("HOME", &home);
+                    let _xdg_config = crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg_config);
+                    let _xdg_data = crate::EnvGuard::set("XDG_DATA_HOME", &xdg_data);
+                    let _xdg_state = crate::EnvGuard::set("XDG_STATE_HOME", &xdg_state);
+                    let _custom_guards = [
+                        crate::EnvGuard::remove("ARGOCD_CONFIG_DIR"),
+                        crate::EnvGuard::remove("AZURE_CONFIG_DIR"),
+                        crate::EnvGuard::remove("CIVO_CONFIG"),
+                        crate::EnvGuard::remove("COMPOSER_HOME"),
+                        crate::EnvGuard::remove("CX_CONFIG_FILE_PATH"),
+                        crate::EnvGuard::remove("DIGITALOCEAN_CONFIG"),
+                        crate::EnvGuard::remove("HELM_CONFIG_HOME"),
+                        crate::EnvGuard::remove("HELM_REPOSITORY_CONFIG"),
+                        crate::EnvGuard::remove("LUAROCKS_CONFIG"),
+                        crate::EnvGuard::remove("LUAROCKS_CONFIG_SYSTEM"),
+                        crate::EnvGuard::remove("LUAROCKS_CONFIG_USER"),
+                    ];
+
+                    let paths: Vec<std::path::PathBuf> = $paths;
+                    assert!(!paths.is_empty());
+                    for path in &paths {
+                        fs::create_dir_all(path.parent().unwrap()).unwrap();
+                        fs::write(path, $contents).unwrap();
+                    }
+
+                    let reasons = install_insecurity_reasons().unwrap();
+                    assert!(
+                        !reasons.is_empty(),
+                        "expected detector reason for {paths:?}"
+                    );
+
+                    fs::remove_dir_all(root).unwrap();
+                }
+            }
+        }
+    };
+}
+
+top_level_file_detector_tests!(
+    acli_detect,
+    "/acli/detect.rs",
+    acli_configs()
+        .unwrap()
+        .into_iter()
+        .map(|config| config.path)
+        .collect::<Vec<_>>(),
+    "profiles:\n  - token: fake-atlassian-token\n"
+);
+
+top_level_file_detector_tests!(
+    algolia_detect,
+    "/algolia/detect.rs",
+    vec![algolia_config_path().unwrap()],
+    "api_key = \"fake-algolia-key\"\n"
+);
+
+top_level_file_detector_tests!(
+    aliyun_cli_detect,
+    "/aliyun-cli/detect.rs",
+    vec![aliyun_config_path().unwrap()],
+    r#"{"profiles":[{"access_key_secret":"secret","oauth_refresh_token":"refresh"}]}"#
+);
+
+top_level_file_detector_tests!(
+    argocd_detect,
+    "/argocd/detect.rs",
+    candidate_config_paths().unwrap(),
+    "users:\n- name: prod\n  auth-token: token\n"
+);
+
+top_level_file_detector_tests!(
+    ast_cli_detect,
+    "/ast-cli/detect.rs",
+    vec![checkmarx_config_path().unwrap()],
+    "cx_apikey: ast_secret\n"
+);
+
+top_level_file_detector_tests!(
+    astra_detect,
+    "/astra/detect.rs",
+    vec![astra_config_path().unwrap()],
+    "token=AstraCS:fake-test-token\n"
+);
+
+top_level_file_detector_tests!(
+    azure_cli_detect,
+    "/azure-cli/detect.rs",
+    candidate_cache_files()
+        .unwrap()
+        .into_iter()
+        .map(|file| file.path)
+        .collect::<Vec<_>>(),
+    r#"{"secret":"access-token","client_secret":"client-secret"}"#
+);
+
+top_level_file_detector_tests!(
+    civo_detect,
+    "/civo/detect.rs",
+    vec![civo_config_path().unwrap()],
+    r#"{"apikey":"fake-civo-key","region":"NYC1"}"#
+);
+
+top_level_file_detector_tests!(
+    composer_detect,
+    "/composer/detect.rs",
+    candidate_auth_paths().unwrap(),
+    r#"{"github-oauth":{"github.com":"token"}}"#
+);
+
+top_level_file_detector_tests!(
+    doctl_detect,
+    "/doctl/detect.rs",
+    vec![doctl_config_path().unwrap()],
+    "access-token: do_secret\n"
+);
+
+top_level_file_detector_tests!(
+    helm_detect,
+    "/helm/detect.rs",
+    vec![helm_repository_config_path().unwrap()],
+    "repositories:\n- name: private\n  password: secret\n"
+);
+
+top_level_file_detector_tests!(
+    luarocks_detect,
+    "/luarocks/detect.rs",
+    upload_config_paths().unwrap(),
+    "return {\n  key = \"lr_secret\",\n}\n"
+);
+
+mod httpie_detect {
+    include!(radioisotope_source!("/httpie/detect.rs"));
+}
+
+mod openssh_detect {
+    include!(radioisotope_source!("/openssh/detect.rs"));
+}
+
+mod openvpn_detect {
+    include!(radioisotope_source!("/openvpn/detect.rs"));
 }
 
 mod docker_detect {
@@ -367,6 +577,405 @@ mod pulumi_detect {
                 Some((r#"a"b"#.to_string(), 6))
             );
             assert!(parse_json_string("unterminated", 0).is_none());
+        }
+    }
+}
+
+mod ansible_detect {
+    include!(radioisotope_source!("/ansible/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_env_path_detection_and_file_errors() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("ansible");
+            let home = root.join("home");
+            let token = root.join("galaxy-token");
+            fs::create_dir_all(&home).unwrap();
+            fs::write(&token, "token: galaxy-token-value\n").unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let _token = crate::EnvGuard::set("ANSIBLE_GALAXY_TOKEN_PATH", &token);
+
+            let paths = candidate_token_paths().unwrap();
+            assert!(paths.contains(&token));
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("galaxy-token"));
+            assert!(
+                read_to_string(&root)
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod certbot_detect {
+    include!(radioisotope_source!("/certbot/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_recursive_scan_and_top_level_reasons() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("certbot");
+            let home = root.join("home");
+            let live = home.join(".config/letsencrypt/live/example.test");
+            fs::create_dir_all(&live).unwrap();
+            fs::write(
+                live.join("privkey.pem"),
+                "-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----\n",
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("privkey.pem"));
+
+            let mut skipped = Vec::new();
+            scan_dir(&live, MAX_SCAN_DEPTH + 1, &mut skipped).unwrap();
+            assert!(skipped.is_empty());
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod opencode_detect {
+    include!(radioisotope_source!("/opencode/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_xdg_auth_path_and_json_errors() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("opencode");
+            let home = root.join("home");
+            let xdg = root.join("xdg");
+            let opencode = xdg.join("opencode");
+            fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&opencode).unwrap();
+            let auth = opencode.join("auth.json");
+            fs::write(
+                &auth,
+                r#"{"accounts":{"main":{"credential":{"access":"opencode-access-token"}}}}"#,
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let _xdg = crate::EnvGuard::set("XDG_DATA_HOME", &xdg);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("auth.json"));
+
+            fs::write(&auth, "{not json").unwrap();
+            assert!(
+                install_insecurity_reasons()
+                    .unwrap_err()
+                    .contains("opencode auth JSON")
+            );
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod mongodb_atlas_cli_detect {
+    include!(radioisotope_source!("/mongodb-atlas-cli/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_xdg_config_path_and_read_error() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("atlas");
+            let home = root.join("home");
+            let xdg = root.join("xdg");
+            let config_dir = xdg.join("atlascli");
+            fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&config_dir).unwrap();
+            fs::write(
+                config_dir.join("config.toml"),
+                "client_secret = 'atlas-client-secret'\n",
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let _xdg = crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("atlascli"));
+            assert!(
+                read_to_string(&root)
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod pianobar_detect {
+    include!(radioisotope_source!("/pianobar/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_xdg_config_path_and_space_assignment() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("pianobar");
+            let home = root.join("home");
+            let xdg = root.join("xdg");
+            let config_dir = xdg.join("pianobar");
+            fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&config_dir).unwrap();
+            fs::write(config_dir.join("config"), "password supersecret\n").unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let _xdg = crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("pianobar"));
+            assert_eq!(
+                parse_assignment("password supersecret"),
+                Some(("password", "supersecret"))
+            );
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod stripe_cli_detect {
+    include!(radioisotope_source!("/stripe-cli/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_xdg_config_path_and_home_errors() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("stripe");
+            let home = root.join("home");
+            let xdg = root.join("xdg");
+            let config_dir = xdg.join("stripe");
+            fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&config_dir).unwrap();
+            fs::write(
+                config_dir.join("config.toml"),
+                "secret_key = 'sk_test_123456789'\n",
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let _xdg = crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("stripe"));
+            assert!(
+                read_to_string(&root)
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod skopeo_detect {
+    include!(radioisotope_source!("/skopeo/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_auth_file_detection_and_home_error() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("skopeo");
+            let home = root.join("home");
+            let auth_dir = home.join(".config/containers");
+            fs::create_dir_all(&auth_dir).unwrap();
+            fs::write(
+                auth_dir.join("auth.json"),
+                r#"{"auths":{"registry.example":{"auth":"dXNlcjpwYXNz"}}}"#,
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("auth.json"));
+            drop(_home);
+            let _no_home = crate::EnvGuard::remove("HOME");
+            assert!(install_insecurity_reasons().unwrap_err().contains("HOME"));
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod maestro_detect {
+    include!(radioisotope_source!("/maestro/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_both_token_files_and_home_error() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("maestro");
+            let home = root.join("home");
+            let mobiledev = home.join(".mobiledev");
+            fs::create_dir_all(&mobiledev).unwrap();
+            fs::write(mobiledev.join("authtoken"), "maestro-cloud-token\n").unwrap();
+            fs::write(mobiledev.join("openaitoken"), "sk-test-openai-token\n").unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 2);
+            assert!(reasons.iter().any(|reason| reason.contains("Cloud")));
+            assert!(reasons.iter().any(|reason| reason.contains("OpenAI")));
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod kubernetes_cli_detect {
+    include!(radioisotope_source!("/kubernetes-cli/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_explicit_kubeconfig_path_and_list_marker_values() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("kube");
+            fs::create_dir_all(&root).unwrap();
+            let config = root.join("kubeconfig");
+            fs::write(&config, "users:\n- password: kube-password\n").unwrap();
+
+            let _kubeconfig = crate::EnvGuard::set("KUBECONFIG", &config);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("kubeconfig"));
+            assert_eq!(trim_yaml_list_marker("- token: abc"), "token: abc");
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod fauna_shell_detect {
+    include!(radioisotope_source!("/fauna-shell/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_secret_and_account_key_files() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("fauna");
+            let home = root.join("home");
+            let credentials = home.join(".fauna/credentials");
+            fs::create_dir_all(&credentials).unwrap();
+            fs::write(
+                credentials.join("account_keys"),
+                r#"{"default":{"accountKey":"fake-fauna-account-key"}}"#,
+            )
+            .unwrap();
+            fs::write(
+                credentials.join("secret_keys"),
+                r#"{"db":{"accessToken":"fake-fauna-access-token"}}"#,
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 2);
+            assert!(json_string_key_has_nonempty_value(
+                r#"{"refreshToken":"fake-refresh"}"#,
+                "refreshToken"
+            ));
+
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+mod git_detect {
+    include!(radioisotope_source!("/git/detect.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::fs;
+
+        #[test]
+        fn covers_store_helper_paths_and_top_level_detection() {
+            let _lock = crate::global_test_env_lock().lock().unwrap();
+            let root = crate::unique_temp_dir("git");
+            let home = root.join("home");
+            fs::create_dir_all(&home).unwrap();
+            fs::write(
+                home.join(".gitconfig"),
+                "[credential]\nhelper = store --file ~/.custom-git-credentials\n",
+            )
+            .unwrap();
+            fs::write(
+                home.join(".custom-git-credentials"),
+                "https://user:secret@example.com/repo.git\n",
+            )
+            .unwrap();
+
+            let _home = crate::EnvGuard::set("HOME", &home);
+            let _xdg = crate::EnvGuard::remove("XDG_CONFIG_HOME");
+            let _disable_probe =
+                crate::EnvGuard::remove("AUTOMIC_VAULT_TEST_GIT_CREDENTIAL_FILL_DETECTOR");
+            let reasons = install_insecurity_reasons().unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert!(reasons[0].contains("custom-git-credentials"));
+            assert_eq!(
+                store_helper_file_path("store --file ~/.custom-git-credentials")
+                    .unwrap()
+                    .unwrap(),
+                home.join(".custom-git-credentials")
+            );
+            assert_eq!(expand_home_path("~/tokens").unwrap(), home.join("tokens"));
+
+            fs::remove_dir_all(root).unwrap();
         }
     }
 }

--- a/tests/radioisotope_migration_edges.rs
+++ b/tests/radioisotope_migration_edges.rs
@@ -1,11 +1,46 @@
 #![cfg(coverage)]
 #![allow(dead_code)]
 
+use std::ffi::{OsStr, OsString};
 use std::sync::{Mutex, OnceLock};
 
 fn global_test_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(Mutex::default)
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 }
 
 macro_rules! radioisotope_source {
@@ -429,11 +464,10 @@ mod snowflake_cli_migrate {
         #[test]
         fn covers_default_directory_selection_and_multi_match_error() {
             let _lock = crate::global_test_env_lock().lock().unwrap();
-            let previous_home = std::env::var_os("HOME");
-            unsafe {
-                std::env::remove_var("HOME");
+            {
+                let _home = crate::EnvGuard::remove("HOME");
+                assert!(candidate_directories().unwrap_err().contains("HOME"));
             }
-            assert!(candidate_directories().unwrap_err().contains("HOME"));
 
             let home = std::env::temp_dir().join(format!("snowflake-home-{}", std::process::id()));
             let _ = fs::remove_dir_all(&home);
@@ -449,21 +483,13 @@ mod snowflake_cli_migrate {
                 "[prod]\npassword = 'two'\n",
             )
             .unwrap();
-            unsafe {
-                std::env::set_var("HOME", &home);
-            }
+            let _home = crate::EnvGuard::set("HOME", &home);
             assert_eq!(candidate_directories().unwrap().len(), 3);
             assert!(
                 migrate_default_configs(&Store::default())
                     .unwrap_err()
                     .contains("multiple Snowflake")
             );
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-            }
             fs::remove_dir_all(home).unwrap();
         }
     }
@@ -564,24 +590,23 @@ mod grafanactl_migrate {
         #[test]
         fn covers_config_paths_and_file_errors() {
             let _lock = crate::global_test_env_lock().lock().unwrap();
-            let previous_home = std::env::var_os("HOME");
-            let previous_xdg = std::env::var_os("XDG_CONFIG_HOME");
             let root = std::env::temp_dir().join(format!("grafanactl-home-{}", std::process::id()));
             let xdg = root.join("xdg");
             let _ = fs::remove_dir_all(&root);
             fs::create_dir_all(&xdg).unwrap();
-            unsafe {
-                std::env::set_var("XDG_CONFIG_HOME", &xdg);
-                std::env::remove_var("HOME");
+            {
+                let _xdg = crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg);
+                let _home = crate::EnvGuard::remove("HOME");
+                assert_eq!(
+                    grafanactl_config_path().unwrap(),
+                    xdg.join("grafanactl/config.yaml")
+                );
             }
-            assert_eq!(
-                grafanactl_config_path().unwrap(),
-                xdg.join("grafanactl/config.yaml")
-            );
-            unsafe {
-                std::env::remove_var("XDG_CONFIG_HOME");
+            {
+                let _xdg = crate::EnvGuard::remove("XDG_CONFIG_HOME");
+                let _home = crate::EnvGuard::remove("HOME");
+                assert!(grafanactl_config_path().unwrap_err().contains("HOME"));
             }
-            assert!(grafanactl_config_path().unwrap_err().contains("HOME"));
 
             let path = root.join("config.yaml");
             fs::write(
@@ -606,16 +631,6 @@ mod grafanactl_migrate {
                     .contains("failed to read")
             );
 
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-                match previous_xdg {
-                    Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
-                    None => std::env::remove_var("XDG_CONFIG_HOME"),
-                }
-            }
             fs::remove_dir_all(root).unwrap();
         }
     }
@@ -722,22 +737,18 @@ mod nuget_migrate {
         #[test]
         fn covers_env_paths_and_migration_error_edges() {
             let _lock = crate::global_test_env_lock().lock().unwrap();
-            let previous_home = std::env::var_os("HOME");
-            let previous_xdg = std::env::var_os("XDG_CONFIG_HOME");
-            unsafe {
-                std::env::remove_var("HOME");
-                std::env::remove_var("XDG_CONFIG_HOME");
+            {
+                let _home = crate::EnvGuard::remove("HOME");
+                let _xdg = crate::EnvGuard::remove("XDG_CONFIG_HOME");
+                assert!(user_home().unwrap_err().contains("HOME"));
             }
-            assert!(user_home().unwrap_err().contains("HOME"));
 
             let root = std::env::temp_dir().join(format!("nuget-home-{}", std::process::id()));
             let xdg = root.join("xdg");
             let _ = fs::remove_dir_all(&root);
             fs::create_dir_all(&xdg).unwrap();
-            unsafe {
-                std::env::set_var("HOME", &root);
-                std::env::set_var("XDG_CONFIG_HOME", &xdg);
-            }
+            let _home = crate::EnvGuard::set("HOME", &root);
+            let _xdg = crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg);
             let configs = nuget_configs().unwrap();
             assert_eq!(configs[0].path, xdg.join("NuGet/NuGet.Config"));
 
@@ -780,16 +791,6 @@ mod nuget_migrate {
                 .contains("failed to read")
             );
 
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-                match previous_xdg {
-                    Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
-                    None => std::env::remove_var("XDG_CONFIG_HOME"),
-                }
-            }
             fs::remove_dir_all(root).unwrap();
         }
     }
@@ -906,11 +907,10 @@ mod aws_cli_migrate {
         #[test]
         fn covers_store_home_login_cache_and_file_errors() {
             let _lock = crate::global_test_env_lock().lock().unwrap();
-            let previous_home = std::env::var_os("HOME");
-            unsafe {
-                std::env::remove_var("HOME");
+            {
+                let _home = crate::EnvGuard::remove("HOME");
+                assert!(home_path().unwrap_err().contains("HOME"));
             }
-            assert!(home_path().unwrap_err().contains("HOME"));
 
             let credentials = AwsCredentials {
                 access_key_id: "AKIA".to_string(),
@@ -958,12 +958,6 @@ mod aws_cli_migrate {
                     .contains("failed to read")
             );
 
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-            }
             fs::remove_dir_all(root).unwrap();
         }
     }
@@ -1071,7 +1065,11 @@ mod openstack_migrate {
             let _ = std::fs::remove_dir_all(&home);
             let config_dir = home.join(".config/openstack");
             std::fs::create_dir_all(&config_dir).unwrap();
-            assert!(load_file_state(&config_dir.join("missing.yaml")).unwrap().is_none());
+            assert!(
+                load_file_state(&config_dir.join("missing.yaml"))
+                    .unwrap()
+                    .is_none()
+            );
             assert!(
                 load_file_state(&config_dir)
                     .unwrap_err()
@@ -1080,23 +1078,18 @@ mod openstack_migrate {
 
             let secure = config_dir.join("secure.yaml");
             std::fs::write(&secure, "clouds:\n  prod:\n    password: secret\n").unwrap();
-            let previous_home = std::env::var_os("HOME");
-            unsafe { std::env::set_var("HOME", &home) };
+            let _home = crate::EnvGuard::set("HOME", &home);
 
             let store = Store::default();
             assert!(migrate_default_configs(&store).unwrap());
 
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-            }
             assert_eq!(store.values.borrow()[0].0, "OPENSTACK_SECURE_YAML");
             assert!(store.values.borrow()[0].1.contains("password: secret"));
-            assert!(std::fs::read_to_string(&secure)
-                .unwrap()
-                .contains("password: \"\""));
+            assert!(
+                std::fs::read_to_string(&secure)
+                    .unwrap()
+                    .contains("password: \"\"")
+            );
             std::fs::remove_dir_all(home).unwrap();
         }
     }
@@ -1134,23 +1127,26 @@ mod ansible_migrate {
             ));
             let _ = std::fs::remove_dir_all(&temp);
             std::fs::create_dir_all(&temp).unwrap();
-            let previous_home = std::env::var_os("HOME");
-            let previous_token_path = std::env::var_os("ANSIBLE_GALAXY_TOKEN_PATH");
 
-            unsafe {
-                std::env::set_var("HOME", temp.join("home"));
-                std::env::set_var("ANSIBLE_GALAXY_TOKEN_PATH", temp.join("custom-token"));
+            {
+                let _home = crate::EnvGuard::set("HOME", temp.join("home"));
+                let _token_path =
+                    crate::EnvGuard::set("ANSIBLE_GALAXY_TOKEN_PATH", temp.join("custom-token"));
+                let paths = candidate_token_paths().unwrap();
+                assert!(paths.contains(&temp.join("custom-token")));
+                assert!(
+                    paths
+                        .iter()
+                        .any(|path| path.ends_with(".ansible/galaxy_token"))
+                );
             }
-            let paths = candidate_token_paths().unwrap();
-            assert!(paths.contains(&temp.join("custom-token")));
-            assert!(paths.iter().any(|path| path.ends_with(".ansible/galaxy_token")));
 
-            unsafe {
-                std::env::remove_var("HOME");
-                std::env::remove_var("ANSIBLE_GALAXY_TOKEN_PATH");
+            {
+                let _home = crate::EnvGuard::remove("HOME");
+                let _token_path = crate::EnvGuard::remove("ANSIBLE_GALAXY_TOKEN_PATH");
+                assert_eq!(home_dir().unwrap_err(), "HOME is not set");
+                assert_eq!(candidate_token_paths().unwrap_err(), "HOME is not set");
             }
-            assert_eq!(home_dir().unwrap_err(), "HOME is not set");
-            assert_eq!(candidate_token_paths().unwrap_err(), "HOME is not set");
 
             assert_eq!(keys(), &["ANSIBLE_GALAXY_TOKEN"]);
             assert_eq!(
@@ -1162,32 +1158,30 @@ mod ansible_migrate {
                 galaxy_token_value("token: 'abc123'\n").unwrap().as_deref(),
                 Some("abc123")
             );
-            assert!(reject_env_line_breaks("a\nb")
-                .unwrap_err()
-                .contains("line breaks"));
+            assert!(
+                reject_env_line_breaks("a\nb")
+                    .unwrap_err()
+                    .contains("line breaks")
+            );
 
             let dir = temp.join("dir");
             std::fs::create_dir_all(&dir).unwrap();
-            assert!(migrate_token_files(&[dir], &Store::default())
-                .unwrap_err()
-                .contains("failed to read"));
+            assert!(
+                migrate_token_files(&[dir], &Store::default())
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
             let empty = temp.join("empty-token");
             std::fs::write(&empty, "token: null\n").unwrap();
-            assert!(!migrate_token_files(&[temp.join("missing"), empty], &Store::default()).unwrap());
-            assert!(keychain_store_secret("service", "account", "value")
-                .unwrap_err()
-                .contains("keychain integration"));
+            assert!(
+                !migrate_token_files(&[temp.join("missing"), empty], &Store::default()).unwrap()
+            );
+            assert!(
+                keychain_store_secret("service", "account", "value")
+                    .unwrap_err()
+                    .contains("keychain integration")
+            );
 
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-                match previous_token_path {
-                    Some(value) => std::env::set_var("ANSIBLE_GALAXY_TOKEN_PATH", value),
-                    None => std::env::remove_var("ANSIBLE_GALAXY_TOKEN_PATH"),
-                }
-            }
             std::fs::remove_dir_all(temp).unwrap();
         }
     }
@@ -1233,29 +1227,26 @@ mod glab_migrate {
             ));
             let _ = std::fs::remove_dir_all(&temp);
             std::fs::create_dir_all(&temp).unwrap();
-            let previous = [
-                ("GLAB_CONFIG_DIR", std::env::var_os("GLAB_CONFIG_DIR")),
-                ("XDG_CONFIG_HOME", std::env::var_os("XDG_CONFIG_HOME")),
-                ("HOME", std::env::var_os("HOME")),
-            ];
 
-            unsafe {
-                std::env::set_var("GLAB_CONFIG_DIR", temp.join("glab"));
+            {
+                let _glab_config_dir = crate::EnvGuard::set("GLAB_CONFIG_DIR", temp.join("glab"));
+                assert_eq!(
+                    candidate_config_paths().unwrap(),
+                    vec![temp.join("glab/config.yml")]
+                );
             }
-            assert_eq!(
-                candidate_config_paths().unwrap(),
-                vec![temp.join("glab/config.yml")]
-            );
 
-            unsafe {
-                std::env::remove_var("GLAB_CONFIG_DIR");
-                std::env::set_var("HOME", temp.join("home"));
-                std::env::set_var("XDG_CONFIG_HOME", temp.join("xdg"));
+            {
+                let _glab_config_dir = crate::EnvGuard::remove("GLAB_CONFIG_DIR");
+                let _home = crate::EnvGuard::set("HOME", temp.join("home"));
+                let _xdg_config_home = crate::EnvGuard::set("XDG_CONFIG_HOME", temp.join("xdg"));
+                let paths = candidate_config_paths().unwrap();
+                assert_eq!(paths.len(), 3);
             }
-            let paths = candidate_config_paths().unwrap();
-            assert_eq!(paths.len(), 3);
 
-            assert!(glab_config_contains_token("hosts:\n  gitlab.com:\n    token: abc\n"));
+            assert!(glab_config_contains_token(
+                "hosts:\n  gitlab.com:\n    token: abc\n"
+            ));
             assert!(glab_config_contains_oauth_refresh_token(
                 "oauth2_refresh_token: refresh\n"
             ));
@@ -1286,18 +1277,12 @@ mod glab_migrate {
             let store = Store::default();
             assert!(migrate_credentials_file(&config, &store).unwrap());
             assert_eq!(store.values.borrow()[0].0, "GLAB_ENV_ASSIGNMENTS");
-            assert!(std::fs::read_to_string(&config)
-                .unwrap()
-                .contains("token: \"\""));
+            assert!(
+                std::fs::read_to_string(&config)
+                    .unwrap()
+                    .contains("token: \"\"")
+            );
 
-            unsafe {
-                for (key, value) in previous {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
             std::fs::remove_dir_all(temp).unwrap();
         }
     }
@@ -1351,38 +1336,42 @@ mod podman_migrate {
             ));
             let _ = std::fs::remove_dir_all(&temp);
             std::fs::create_dir_all(&temp).unwrap();
-            let previous = [
-                ("REGISTRY_AUTH_FILE", std::env::var_os("REGISTRY_AUTH_FILE")),
-                ("XDG_RUNTIME_DIR", std::env::var_os("XDG_RUNTIME_DIR")),
-                ("XDG_CONFIG_HOME", std::env::var_os("XDG_CONFIG_HOME")),
-                ("HOME", std::env::var_os("HOME")),
-            ];
 
-            unsafe {
-                std::env::set_var("REGISTRY_AUTH_FILE", temp.join("auth.json"));
+            {
+                let _registry_auth_file =
+                    crate::EnvGuard::set("REGISTRY_AUTH_FILE", temp.join("auth.json"));
+                assert_eq!(
+                    candidate_auth_paths().unwrap(),
+                    vec![temp.join("auth.json")]
+                );
             }
-            assert_eq!(candidate_auth_paths().unwrap(), vec![temp.join("auth.json")]);
 
-            unsafe {
-                std::env::remove_var("REGISTRY_AUTH_FILE");
-                std::env::set_var("XDG_RUNTIME_DIR", temp.join("runtime"));
-                std::env::set_var("XDG_CONFIG_HOME", temp.join("xdg"));
-                std::env::set_var("HOME", temp.join("home"));
+            {
+                let _registry_auth_file = crate::EnvGuard::remove("REGISTRY_AUTH_FILE");
+                let _runtime = crate::EnvGuard::set("XDG_RUNTIME_DIR", temp.join("runtime"));
+                let _config = crate::EnvGuard::set("XDG_CONFIG_HOME", temp.join("xdg"));
+                let _home = crate::EnvGuard::set("HOME", temp.join("home"));
+                assert_eq!(candidate_auth_paths().unwrap().len(), 3);
             }
-            assert_eq!(candidate_auth_paths().unwrap().len(), 3);
 
             assert!(!auth_json_contains_secret("not json"));
-            assert!(!auth_entry_contains_secret(&serde_json::json!("not object")));
+            assert!(!auth_entry_contains_secret(&serde_json::json!(
+                "not object"
+            )));
             assert_eq!(
                 auth_json_with_credential_helpers(r#"{"auths":{}}"#).unwrap(),
                 r#"{"auths":{}}"#
             );
-            assert!(auth_json_with_credential_helpers("[]")
-                .unwrap_err()
-                .contains("root must be an object"));
-            assert!(auth_json_with_credential_helpers(r#"{"auths":[]}"#)
-                .unwrap_err()
-                .contains("auths field must be an object"));
+            assert!(
+                auth_json_with_credential_helpers("[]")
+                    .unwrap_err()
+                    .contains("root must be an object")
+            );
+            assert!(
+                auth_json_with_credential_helpers(r#"{"auths":[]}"#)
+                    .unwrap_err()
+                    .contains("auths field must be an object")
+            );
             assert!(auth_json_with_credential_helpers(
                 r#"{"auths":{"registry.example":{"auth":"base64"}},"credHelpers":{"registry.example":"other"}}"#
             )
@@ -1392,23 +1381,20 @@ mod podman_migrate {
             let missing = temp.join("missing.json");
             assert!(!migrate_credentials_file(&missing, &Store::default()).unwrap());
             let auth = temp.join("auth.json");
-            std::fs::write(&auth, r#"{"auths":{"registry.example":{"identityToken":"token"}}}"#)
-                .unwrap();
+            std::fs::write(
+                &auth,
+                r#"{"auths":{"registry.example":{"identityToken":"token"}}}"#,
+            )
+            .unwrap();
             let store = Store::default();
             assert!(migrate_credentials_file(&auth, &store).unwrap());
             assert_eq!(store.values.borrow()[0].0, "PODMAN_AUTH_JSON");
-            assert!(std::fs::read_to_string(&auth)
-                .unwrap()
-                .contains("av-podman"));
+            assert!(
+                std::fs::read_to_string(&auth)
+                    .unwrap()
+                    .contains("av-podman")
+            );
 
-            unsafe {
-                for (key, value) in previous {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
             std::fs::remove_dir_all(temp).unwrap();
         }
     }
@@ -1454,16 +1440,15 @@ mod s3cmd_migrate {
             ));
             let _ = std::fs::remove_dir_all(&temp);
             std::fs::create_dir_all(&temp).unwrap();
-            let previous_home = std::env::var_os("HOME");
 
-            unsafe {
-                std::env::remove_var("HOME");
+            {
+                let _home = crate::EnvGuard::remove("HOME");
+                assert_eq!(s3cmd_config_path().unwrap_err(), "HOME is not set");
             }
-            assert_eq!(s3cmd_config_path().unwrap_err(), "HOME is not set");
-            unsafe {
-                std::env::set_var("HOME", &temp);
+            {
+                let _home = crate::EnvGuard::set("HOME", &temp);
+                assert_eq!(s3cmd_config_path().unwrap(), temp.join(".s3cfg"));
             }
-            assert_eq!(s3cmd_config_path().unwrap(), temp.join(".s3cfg"));
 
             assert_eq!(keys(), &["S3CMD_ENV_ASSIGNMENTS"]);
             assert_eq!(sanitized_config("# comment\n"), "# comment\n");
@@ -1472,18 +1457,32 @@ mod s3cmd_migrate {
                 "gpg_passphrase = $S3CMD_GPG_PASSPHRASE\n"
             );
             let mut changed = false;
-            assert_eq!(sanitize_line("missing equals", &mut changed), "missing equals");
-            assert_eq!(sanitize_line("access_key = ", &mut changed), "access_key = ");
-            assert!(s3cmd_env_assignments("# comment\nmissing equals\nunknown = value\naccess_key = \n")
+            assert_eq!(
+                sanitize_line("missing equals", &mut changed),
+                "missing equals"
+            );
+            assert_eq!(
+                sanitize_line("access_key = ", &mut changed),
+                "access_key = "
+            );
+            assert!(
+                s3cmd_env_assignments(
+                    "# comment\nmissing equals\nunknown = value\naccess_key = \n"
+                )
                 .unwrap()
-                .is_empty());
+                .is_empty()
+            );
             assert_eq!(unquote_config_value("\"quoted\""), "quoted");
-            assert!(s3cmd_env_assignments("access_key = only\n")
-                .unwrap_err()
-                .contains("both be present"));
-            assert!(s3cmd_env_assignments("session_token = token\n")
-                .unwrap_err()
-                .contains("without access_key"));
+            assert!(
+                s3cmd_env_assignments("access_key = only\n")
+                    .unwrap_err()
+                    .contains("both be present")
+            );
+            assert!(
+                s3cmd_env_assignments("session_token = token\n")
+                    .unwrap_err()
+                    .contains("without access_key")
+            );
             assert!(
                 s3cmd_env_assignments("access_key = one\naccess_key = two\n")
                     .unwrap_err()
@@ -1502,16 +1501,12 @@ mod s3cmd_migrate {
             let store = Store::default();
             assert!(migrate_config_file(&config, &store).unwrap());
             assert_eq!(store.values.borrow()[0].0, "S3CMD_ENV_ASSIGNMENTS");
-            assert!(std::fs::read_to_string(&config)
-                .unwrap()
-                .contains("access_key = "));
+            assert!(
+                std::fs::read_to_string(&config)
+                    .unwrap()
+                    .contains("access_key = ")
+            );
 
-            unsafe {
-                match previous_home {
-                    Some(value) => std::env::set_var("HOME", value),
-                    None => std::env::remove_var("HOME"),
-                }
-            }
             std::fs::remove_dir_all(temp).unwrap();
         }
     }

--- a/tests/radioisotope_migration_edges.rs
+++ b/tests/radioisotope_migration_edges.rs
@@ -975,7 +975,22 @@ mod openstack_migrate {
     #[cfg(test)]
     mod av_extra_tests {
         use super::*;
+        use std::cell::RefCell;
         use std::path::PathBuf;
+
+        #[derive(Default)]
+        struct Store {
+            values: RefCell<Vec<(String, String)>>,
+        }
+
+        impl CredentialStore for Store {
+            fn store_secret(&self, key: &str, value: &str) -> Result<(), String> {
+                self.values
+                    .borrow_mut()
+                    .push((key.to_string(), value.to_string()));
+                Ok(())
+            }
+        }
 
         fn state(original: &str) -> FileState {
             FileState {
@@ -1044,5 +1059,476 @@ mod openstack_migrate {
                     .contains("line breaks")
             );
         }
+
+        #[test]
+        fn covers_file_state_errors_and_secure_payload_fallback() {
+            let _guard = crate::global_test_env_lock().lock().unwrap();
+            let home = std::env::temp_dir().join(format!(
+                "openstack-extra-{}-{}",
+                module_path!().replace("::", "_"),
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&home);
+            let config_dir = home.join(".config/openstack");
+            std::fs::create_dir_all(&config_dir).unwrap();
+            assert!(load_file_state(&config_dir.join("missing.yaml")).unwrap().is_none());
+            assert!(
+                load_file_state(&config_dir)
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
+
+            let secure = config_dir.join("secure.yaml");
+            std::fs::write(&secure, "clouds:\n  prod:\n    password: secret\n").unwrap();
+            let previous_home = std::env::var_os("HOME");
+            unsafe { std::env::set_var("HOME", &home) };
+
+            let store = Store::default();
+            assert!(migrate_default_configs(&store).unwrap());
+
+            unsafe {
+                match previous_home {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+            assert_eq!(store.values.borrow()[0].0, "OPENSTACK_SECURE_YAML");
+            assert!(store.values.borrow()[0].1.contains("password: secret"));
+            assert!(std::fs::read_to_string(&secure)
+                .unwrap()
+                .contains("password: \"\""));
+            std::fs::remove_dir_all(home).unwrap();
+        }
     }
+}
+
+mod ansible_migrate {
+    include!(radioisotope_source!("/ansible/migrate.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::cell::RefCell;
+
+        #[derive(Default)]
+        struct Store {
+            values: RefCell<Vec<(String, String)>>,
+        }
+
+        impl CredentialStore for Store {
+            fn store_secret(&self, key: &str, value: &str) -> Result<(), String> {
+                self.values
+                    .borrow_mut()
+                    .push((key.to_string(), value.to_string()));
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn covers_path_parser_no_token_and_fallback_edges() {
+            let _guard = crate::global_test_env_lock().lock().unwrap();
+            let temp = std::env::temp_dir().join(format!(
+                "ansible-extra-{}-{}",
+                module_path!().replace("::", "_"),
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&temp);
+            std::fs::create_dir_all(&temp).unwrap();
+            let previous_home = std::env::var_os("HOME");
+            let previous_token_path = std::env::var_os("ANSIBLE_GALAXY_TOKEN_PATH");
+
+            unsafe {
+                std::env::set_var("HOME", temp.join("home"));
+                std::env::set_var("ANSIBLE_GALAXY_TOKEN_PATH", temp.join("custom-token"));
+            }
+            let paths = candidate_token_paths().unwrap();
+            assert!(paths.contains(&temp.join("custom-token")));
+            assert!(paths.iter().any(|path| path.ends_with(".ansible/galaxy_token")));
+
+            unsafe {
+                std::env::remove_var("HOME");
+                std::env::remove_var("ANSIBLE_GALAXY_TOKEN_PATH");
+            }
+            assert_eq!(home_dir().unwrap_err(), "HOME is not set");
+            assert_eq!(candidate_token_paths().unwrap_err(), "HOME is not set");
+
+            assert_eq!(keys(), &["ANSIBLE_GALAXY_TOKEN"]);
+            assert_eq!(
+                galaxy_token_value("\n# comment\nnot-token\nserver: ignored\ntoken: #comment\ntoken: null\ntoken: ~\n")
+                    .unwrap(),
+                None
+            );
+            assert_eq!(
+                galaxy_token_value("token: 'abc123'\n").unwrap().as_deref(),
+                Some("abc123")
+            );
+            assert!(reject_env_line_breaks("a\nb")
+                .unwrap_err()
+                .contains("line breaks"));
+
+            let dir = temp.join("dir");
+            std::fs::create_dir_all(&dir).unwrap();
+            assert!(migrate_token_files(&[dir], &Store::default())
+                .unwrap_err()
+                .contains("failed to read"));
+            let empty = temp.join("empty-token");
+            std::fs::write(&empty, "token: null\n").unwrap();
+            assert!(!migrate_token_files(&[temp.join("missing"), empty], &Store::default()).unwrap());
+            assert!(keychain_store_secret("service", "account", "value")
+                .unwrap_err()
+                .contains("keychain integration"));
+
+            unsafe {
+                match previous_home {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+                match previous_token_path {
+                    Some(value) => std::env::set_var("ANSIBLE_GALAXY_TOKEN_PATH", value),
+                    None => std::env::remove_var("ANSIBLE_GALAXY_TOKEN_PATH"),
+                }
+            }
+            std::fs::remove_dir_all(temp).unwrap();
+        }
+    }
+}
+
+mod argocd_migrate {
+    include!(radioisotope_source!("/argocd/migrate.rs"));
+}
+
+mod doctl_migrate {
+    include!(radioisotope_source!("/doctl/migrate.rs"));
+}
+
+mod glab_migrate {
+    include!(radioisotope_source!("/glab/migrate.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::cell::RefCell;
+
+        #[derive(Default)]
+        struct Store {
+            values: RefCell<Vec<(String, String)>>,
+        }
+
+        impl CredentialStore for Store {
+            fn store_secret(&self, key: &str, value: &str) -> Result<(), String> {
+                self.values
+                    .borrow_mut()
+                    .push((key.to_string(), value.to_string()));
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn covers_config_paths_file_edges_and_host_token_parser() {
+            let _guard = crate::global_test_env_lock().lock().unwrap();
+            let temp = std::env::temp_dir().join(format!(
+                "glab-extra-{}-{}",
+                module_path!().replace("::", "_"),
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&temp);
+            std::fs::create_dir_all(&temp).unwrap();
+            let previous = [
+                ("GLAB_CONFIG_DIR", std::env::var_os("GLAB_CONFIG_DIR")),
+                ("XDG_CONFIG_HOME", std::env::var_os("XDG_CONFIG_HOME")),
+                ("HOME", std::env::var_os("HOME")),
+            ];
+
+            unsafe {
+                std::env::set_var("GLAB_CONFIG_DIR", temp.join("glab"));
+            }
+            assert_eq!(
+                candidate_config_paths().unwrap(),
+                vec![temp.join("glab/config.yml")]
+            );
+
+            unsafe {
+                std::env::remove_var("GLAB_CONFIG_DIR");
+                std::env::set_var("HOME", temp.join("home"));
+                std::env::set_var("XDG_CONFIG_HOME", temp.join("xdg"));
+            }
+            let paths = candidate_config_paths().unwrap();
+            assert_eq!(paths.len(), 3);
+
+            assert!(glab_config_contains_token("hosts:\n  gitlab.com:\n    token: abc\n"));
+            assert!(glab_config_contains_oauth_refresh_token(
+                "oauth2_refresh_token: refresh\n"
+            ));
+            assert_eq!(unquote_yaml_scalar("'quoted'"), "quoted");
+            assert_eq!(
+                glab_env_assignments("hosts:\n  gitlab.com:\n    token: abc\n").unwrap(),
+                vec![
+                    "GITLAB_TOKEN=abc".to_string(),
+                    "GITLAB_HOST=gitlab.com".to_string()
+                ]
+            );
+            assert!(
+                glab_env_assignments(
+                    "hosts:\n  one.example:\n    token: one\n  two.example:\n    token: two\n"
+                )
+                .unwrap_err()
+                .contains("multiple host tokens")
+            );
+            assert_eq!(
+                sanitized_glab_config("hosts:\n  gitlab.com:\n    token: abc\n"),
+                "hosts:\n  gitlab.com:\n    token: \"\"\n"
+            );
+
+            let missing = temp.join("missing.yml");
+            assert!(!migrate_credentials_file(&missing, &Store::default()).unwrap());
+            let config = temp.join("config.yml");
+            std::fs::write(&config, "hosts:\n  gitlab.com:\n    token: abc\n").unwrap();
+            let store = Store::default();
+            assert!(migrate_credentials_file(&config, &store).unwrap());
+            assert_eq!(store.values.borrow()[0].0, "GLAB_ENV_ASSIGNMENTS");
+            assert!(std::fs::read_to_string(&config)
+                .unwrap()
+                .contains("token: \"\""));
+
+            unsafe {
+                for (key, value) in previous {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+            std::fs::remove_dir_all(temp).unwrap();
+        }
+    }
+}
+
+mod jfrog_cli_migrate {
+    include!(radioisotope_source!("/jfrog-cli/migrate.rs"));
+}
+
+mod maestro_migrate {
+    include!(radioisotope_source!("/maestro/migrate.rs"));
+}
+
+mod minio_mc_migrate {
+    include!(radioisotope_source!("/minio-mc/migrate.rs"));
+}
+
+mod opentofu_migrate {
+    include!(radioisotope_source!("/opentofu/migrate.rs"));
+}
+
+mod podman_migrate {
+    include!(radioisotope_source!("/podman/migrate.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::cell::RefCell;
+
+        #[derive(Default)]
+        struct Store {
+            values: RefCell<Vec<(String, String)>>,
+        }
+
+        impl CredentialStore for Store {
+            fn store_secret(&self, key: &str, value: &str) -> Result<(), String> {
+                self.values
+                    .borrow_mut()
+                    .push((key.to_string(), value.to_string()));
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn covers_candidate_paths_and_auth_json_error_shapes() {
+            let _guard = crate::global_test_env_lock().lock().unwrap();
+            let temp = std::env::temp_dir().join(format!(
+                "podman-extra-{}-{}",
+                module_path!().replace("::", "_"),
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&temp);
+            std::fs::create_dir_all(&temp).unwrap();
+            let previous = [
+                ("REGISTRY_AUTH_FILE", std::env::var_os("REGISTRY_AUTH_FILE")),
+                ("XDG_RUNTIME_DIR", std::env::var_os("XDG_RUNTIME_DIR")),
+                ("XDG_CONFIG_HOME", std::env::var_os("XDG_CONFIG_HOME")),
+                ("HOME", std::env::var_os("HOME")),
+            ];
+
+            unsafe {
+                std::env::set_var("REGISTRY_AUTH_FILE", temp.join("auth.json"));
+            }
+            assert_eq!(candidate_auth_paths().unwrap(), vec![temp.join("auth.json")]);
+
+            unsafe {
+                std::env::remove_var("REGISTRY_AUTH_FILE");
+                std::env::set_var("XDG_RUNTIME_DIR", temp.join("runtime"));
+                std::env::set_var("XDG_CONFIG_HOME", temp.join("xdg"));
+                std::env::set_var("HOME", temp.join("home"));
+            }
+            assert_eq!(candidate_auth_paths().unwrap().len(), 3);
+
+            assert!(!auth_json_contains_secret("not json"));
+            assert!(!auth_entry_contains_secret(&serde_json::json!("not object")));
+            assert_eq!(
+                auth_json_with_credential_helpers(r#"{"auths":{}}"#).unwrap(),
+                r#"{"auths":{}}"#
+            );
+            assert!(auth_json_with_credential_helpers("[]")
+                .unwrap_err()
+                .contains("root must be an object"));
+            assert!(auth_json_with_credential_helpers(r#"{"auths":[]}"#)
+                .unwrap_err()
+                .contains("auths field must be an object"));
+            assert!(auth_json_with_credential_helpers(
+                r#"{"auths":{"registry.example":{"auth":"base64"}},"credHelpers":{"registry.example":"other"}}"#
+            )
+            .unwrap_err()
+            .contains("refusing to overwrite"));
+
+            let missing = temp.join("missing.json");
+            assert!(!migrate_credentials_file(&missing, &Store::default()).unwrap());
+            let auth = temp.join("auth.json");
+            std::fs::write(&auth, r#"{"auths":{"registry.example":{"identityToken":"token"}}}"#)
+                .unwrap();
+            let store = Store::default();
+            assert!(migrate_credentials_file(&auth, &store).unwrap());
+            assert_eq!(store.values.borrow()[0].0, "PODMAN_AUTH_JSON");
+            assert!(std::fs::read_to_string(&auth)
+                .unwrap()
+                .contains("av-podman"));
+
+            unsafe {
+                for (key, value) in previous {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+            std::fs::remove_dir_all(temp).unwrap();
+        }
+    }
+}
+
+mod qwen_code_migrate {
+    include!(radioisotope_source!("/qwen-code/migrate.rs"));
+}
+
+mod rust_migrate {
+    include!(radioisotope_source!("/rust/migrate.rs"));
+}
+
+mod s3cmd_migrate {
+    include!(radioisotope_source!("/s3cmd/migrate.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::cell::RefCell;
+
+        #[derive(Default)]
+        struct Store {
+            values: RefCell<Vec<(String, String)>>,
+        }
+
+        impl CredentialStore for Store {
+            fn store_secret(&self, key: &str, value: &str) -> Result<(), String> {
+                self.values
+                    .borrow_mut()
+                    .push((key.to_string(), value.to_string()));
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn covers_config_path_parser_validation_and_file_migration_edges() {
+            let _guard = crate::global_test_env_lock().lock().unwrap();
+            let temp = std::env::temp_dir().join(format!(
+                "s3cmd-extra-{}-{}",
+                module_path!().replace("::", "_"),
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&temp);
+            std::fs::create_dir_all(&temp).unwrap();
+            let previous_home = std::env::var_os("HOME");
+
+            unsafe {
+                std::env::remove_var("HOME");
+            }
+            assert_eq!(s3cmd_config_path().unwrap_err(), "HOME is not set");
+            unsafe {
+                std::env::set_var("HOME", &temp);
+            }
+            assert_eq!(s3cmd_config_path().unwrap(), temp.join(".s3cfg"));
+
+            assert_eq!(keys(), &["S3CMD_ENV_ASSIGNMENTS"]);
+            assert_eq!(sanitized_config("# comment\n"), "# comment\n");
+            assert_eq!(
+                sanitized_config("gpg_passphrase = pass\n"),
+                "gpg_passphrase = $S3CMD_GPG_PASSPHRASE\n"
+            );
+            let mut changed = false;
+            assert_eq!(sanitize_line("missing equals", &mut changed), "missing equals");
+            assert_eq!(sanitize_line("access_key = ", &mut changed), "access_key = ");
+            assert!(s3cmd_env_assignments("# comment\nmissing equals\nunknown = value\naccess_key = \n")
+                .unwrap()
+                .is_empty());
+            assert_eq!(unquote_config_value("\"quoted\""), "quoted");
+            assert!(s3cmd_env_assignments("access_key = only\n")
+                .unwrap_err()
+                .contains("both be present"));
+            assert!(s3cmd_env_assignments("session_token = token\n")
+                .unwrap_err()
+                .contains("without access_key"));
+            assert!(
+                s3cmd_env_assignments("access_key = one\naccess_key = two\n")
+                    .unwrap_err()
+                    .contains("multiple s3cmd values")
+            );
+            assert!(reject_env_line_breaks("AWS_ACCESS_KEY_ID", "a\nb").is_err());
+
+            let missing = temp.join("missing");
+            assert!(!migrate_config_file(&missing, &Store::default()).unwrap());
+            let config = temp.join("config");
+            std::fs::write(
+                &config,
+                "access_key = key\nsecret_key = secret\nsession_token = token\n",
+            )
+            .unwrap();
+            let store = Store::default();
+            assert!(migrate_config_file(&config, &store).unwrap());
+            assert_eq!(store.values.borrow()[0].0, "S3CMD_ENV_ASSIGNMENTS");
+            assert!(std::fs::read_to_string(&config)
+                .unwrap()
+                .contains("access_key = "));
+
+            unsafe {
+                match previous_home {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+            std::fs::remove_dir_all(temp).unwrap();
+        }
+    }
+}
+
+mod skopeo_migrate {
+    include!(radioisotope_source!("/skopeo/migrate.rs"));
+}
+
+mod terraform_migrate {
+    include!(radioisotope_source!("/terraform/migrate.rs"));
+}
+
+mod transifex_cli_migrate {
+    include!(radioisotope_source!("/transifex-cli/migrate.rs"));
+}
+
+mod wakatime_cli_migrate {
+    include!(radioisotope_source!("/wakatime-cli/migrate.rs"));
 }

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -107,6 +107,173 @@ macro_rules! launcher_post_install_extra_tests {
     };
 }
 
+macro_rules! two_stage_launcher_post_install_extra_tests {
+    ($module:ident, $path:literal, $wrap:ident, $script:ident) => {
+        mod $module {
+            include!(radioisotope_source!($path));
+
+            #[cfg(test)]
+            mod av_extra_tests {
+                use super::*;
+                use std::fs;
+                use std::path::{Path, PathBuf};
+                use std::time::{SystemTime, UNIX_EPOCH};
+
+                #[cfg(unix)]
+                use std::os::unix::fs::PermissionsExt;
+
+                fn temp_dir(label: &str) -> PathBuf {
+                    let suffix = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos();
+                    std::env::temp_dir().join(format!(
+                        "{}-{}-{}",
+                        module_path!().replace("::", "_"),
+                        label,
+                        suffix
+                    ))
+                }
+
+                fn write_executable(path: &Path, contents: &[u8]) {
+                    fs::write(path, contents).unwrap();
+                    let mut permissions = fs::metadata(path).unwrap().permissions();
+                    permissions.set_mode(0o755);
+                    fs::set_permissions(path, permissions).unwrap();
+                }
+
+                #[test]
+                fn covers_existing_original_invalid_data_and_quoting_edges() {
+                    let temp = temp_dir("existing-original");
+                    fs::create_dir_all(&temp).unwrap();
+                    let launcher = temp.join("launcher");
+                    write_executable(&launcher, b"#!/bin/sh\nprintf launcher\n");
+                    let original = original_launcher_path(&launcher).unwrap();
+                    write_executable(&original, b"#!/bin/sh\nprintf existing\n");
+
+                    let _ = $wrap(&launcher).unwrap();
+
+                    let original_contents = fs::read_to_string(&original).unwrap();
+                    assert!(
+                        original_contents == "#!/bin/sh\nprintf existing\n"
+                            || original_contents == "#!/bin/sh\nprintf launcher\n"
+                    );
+                    assert!(launcher_is_wrapped(&launcher).unwrap());
+
+                    let invalid = temp.join("invalid");
+                    fs::write(&invalid, [0xff, 0xfe]).unwrap();
+                    assert!(!launcher_is_wrapped(&invalid).unwrap());
+                    assert!(
+                        launcher_is_wrapped(&temp.join("missing-launcher"))
+                            .unwrap_err()
+                            .contains("failed to read")
+                    );
+                    assert!(
+                        original_launcher_path(Path::new("/"))
+                            .unwrap_err()
+                            .contains("failed to resolve")
+                    );
+
+                    let script = $script(Path::new("/tmp/it isn't"), Path::new("/tmp/inject isn't"));
+                    assert!(script.contains(r#"'\''"#));
+
+                    fs::remove_dir_all(temp).unwrap();
+                }
+
+                #[cfg(unix)]
+                #[test]
+                fn covers_relative_symlink_original_resolution() {
+                    let temp = temp_dir("relative-symlink");
+                    fs::create_dir_all(&temp).unwrap();
+                    let target = temp.join("target-launcher");
+                    write_executable(&target, b"#!/bin/sh\nprintf target\n");
+                    let launcher = temp.join("launcher");
+                    std::os::unix::fs::symlink("target-launcher", &launcher).unwrap();
+
+                    assert_eq!(original_launcher_path(&launcher).unwrap(), target);
+
+                    let _ = $wrap(&launcher).unwrap();
+
+                    assert_eq!(
+                        fs::read_to_string(temp.join("target-launcher")).unwrap(),
+                        "#!/bin/sh\nprintf target\n"
+                    );
+                    assert!(launcher_is_wrapped(&launcher).unwrap());
+
+                    fs::remove_dir_all(temp).unwrap();
+                }
+            }
+        }
+    };
+}
+
+mod aws_cli_post_install {
+    include!(radioisotope_source!("/aws-cli/post-install.rs"));
+
+    #[cfg(test)]
+    mod av_extra_tests {
+        use super::*;
+        use std::path::PathBuf;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        fn temp_path(name: &str) -> PathBuf {
+            let suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            std::env::temp_dir().join(format!(
+                "{}-{name}-{suffix}",
+                module_path!().replace("::", "_")
+            ))
+        }
+
+        #[test]
+        fn covers_post_install_and_patch_error_edges() {
+            let root = temp_path("post-install-errors");
+            let launcher = root.join("aws");
+            let lib = root.join("lib");
+            assert!(
+                prefix_aws_launcher(&launcher, ENTRYPOINT_PREFIX)
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
+            std::fs::create_dir_all(&root).unwrap();
+            std::fs::write(&launcher, format!("{ENTRYPOINT_PREFIX}print('aws')\n")).unwrap();
+            prefix_aws_launcher(&launcher, ENTRYPOINT_PREFIX).unwrap();
+            assert_eq!(
+                std::fs::read_to_string(&launcher).unwrap(),
+                format!("{ENTRYPOINT_PREFIX}print('aws')\n")
+            );
+
+            assert!(
+                patch_aws_plugin_loaders(&lib)
+                    .unwrap_err()
+                    .contains("failed to read")
+            );
+            std::fs::create_dir_all(&lib).unwrap();
+            assert!(
+                patch_aws_plugin_loaders(&lib)
+                    .unwrap_err()
+                    .contains("failed to find")
+            );
+            assert!(
+                patch_aws_plugin_loader(&launcher)
+                    .unwrap_err()
+                    .contains("failed to patch")
+            );
+            assert!(
+                patch_aws_plugin_loader_contents(
+                    "def load_plugins():\n    _load_plugins(BUILTIN_PLUGINS, event_hooks)\n"
+                )
+                .unwrap_err()
+                .contains("legacy external plugin")
+            );
+
+            std::fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
 launcher_post_install_extra_tests!(
     censys_post_install,
     "/censys/post-install.rs",
@@ -616,4 +783,88 @@ launcher_post_install_extra_tests!(
     "/plumber/post-install.rs",
     wrap_plumber_launcher,
     plumber_wrapper_script
+);
+two_stage_launcher_post_install_extra_tests!(
+    imap_backup_post_install,
+    "/imap-backup/post-install.rs",
+    wrap_imap_backup_launcher,
+    imap_backup_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    kubernetes_cli_post_install,
+    "/kubernetes-cli/post-install.rs",
+    wrap_kubectl_launcher,
+    kubectl_wrapper_script
+);
+two_stage_launcher_post_install_extra_tests!(
+    luarocks_post_install,
+    "/luarocks/post-install.rs",
+    wrap_luarocks_launcher,
+    luarocks_wrapper_script
+);
+two_stage_launcher_post_install_extra_tests!(
+    node_post_install,
+    "/node/post-install.rs",
+    wrap_npm_launcher,
+    npm_wrapper_script
+);
+two_stage_launcher_post_install_extra_tests!(
+    node_18_post_install,
+    "/node@18/post-install.rs",
+    wrap_npm_launcher,
+    npm_wrapper_script
+);
+two_stage_launcher_post_install_extra_tests!(
+    openhue_cli_post_install,
+    "/openhue-cli/post-install.rs",
+    wrap_openhue_launcher,
+    openhue_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    opentofu_post_install,
+    "/opentofu/post-install.rs",
+    wrap_opentofu_launcher,
+    opentofu_wrapper_script
+);
+two_stage_launcher_post_install_extra_tests!(
+    pnpm_post_install,
+    "/pnpm/post-install.rs",
+    wrap_pnpm_launcher,
+    pnpm_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    podman_post_install,
+    "/podman/post-install.rs",
+    wrap_podman_launcher,
+    podman_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    rclone_post_install,
+    "/rclone/post-install.rs",
+    wrap_rclone_launcher,
+    rclone_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    terraform_core_post_install,
+    "/terraform-core/post-install.rs",
+    wrap_terraform_launcher,
+    terraform_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    uv_post_install,
+    "/uv/post-install.rs",
+    wrap_uv_launcher,
+    uv_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    vagrant_post_install,
+    "/vagrant/post-install.rs",
+    wrap_vagrant_launcher,
+    vagrant_wrapper_script
+);
+launcher_post_install_extra_tests!(
+    wakatime_cli_post_install,
+    "/wakatime-cli/post-install.rs",
+    wrap_wakatime_launcher,
+    wakatime_wrapper_script
 );

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -174,7 +174,8 @@ macro_rules! two_stage_launcher_post_install_extra_tests {
                             .contains("failed to resolve")
                     );
 
-                    let script = $script(Path::new("/tmp/it isn't"), Path::new("/tmp/inject isn't"));
+                    let script =
+                        $script(Path::new("/tmp/it isn't"), Path::new("/tmp/inject isn't"));
                     assert!(script.contains(r#"'\''"#));
 
                     fs::remove_dir_all(temp).unwrap();


### PR DESCRIPTION
## Summary
- add radioisotope detect/migration/post-install and credential-helper edge coverage
- cover dotenv/isotope bridge validation and helper command error branches
- keep public db fixtures unchanged after regeneration check

## Verification
- AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1
- final coverage: LH=88609 LF=95919 coverage=92.3790%
- /usr/bin/python3 scripts/generate-coverage-fixtures.py && git diff --exit-code -- data/combined.json src/lib/rs/fixtures/coverage-combined.json