### PR TITLE
Expand coverage tests for transfer and radioisotopes

### DIFF
--- a/src/lib/rs/dotenv.rs
+++ b/src/lib/rs/dotenv.rs
@@ -3734,6 +3734,75 @@ mod tests {
         }
     }
 
+    struct VerifyFailingDotenvKeychainBackend {
+        account: String,
+        legacy_value: String,
+        new_value_after_write: Option<String>,
+        wrote: Mutex<bool>,
+    }
+
+    impl VerifyFailingDotenvKeychainBackend {
+        fn new(account: &str, legacy_value: &str, new_value_after_write: Option<String>) -> Self {
+            Self {
+                account: account.to_string(),
+                legacy_value: legacy_value.to_string(),
+                new_value_after_write,
+                wrote: Mutex::new(false),
+            }
+        }
+    }
+
+    impl DotenvKeychainBackend for VerifyFailingDotenvKeychainBackend {
+        fn read_new_if_present(
+            &self,
+            _service: &str,
+            _account: &str,
+            _access_group: &str,
+        ) -> Result<Option<String>, String> {
+            if *self.wrote.lock().unwrap() {
+                Ok(self.new_value_after_write.clone())
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn write_new(
+            &self,
+            _service: &str,
+            _account: &str,
+            _access_group: &str,
+            _value: &str,
+        ) -> Result<(), String> {
+            *self.wrote.lock().unwrap() = true;
+            Ok(())
+        }
+
+        fn delete_new(
+            &self,
+            _service: &str,
+            _account: &str,
+            _access_group: &str,
+        ) -> Result<bool, String> {
+            Ok(false)
+        }
+
+        fn read_legacy_if_present(
+            &self,
+            _service: &str,
+            account: &str,
+        ) -> Result<Option<String>, String> {
+            Ok((account == self.account).then(|| self.legacy_value.clone()))
+        }
+
+        fn enumerate_legacy_accounts(&self, _service: &str) -> Result<Vec<String>, String> {
+            Ok(vec![self.account.clone()])
+        }
+
+        fn delete_legacy(&self, _service: &str, _account: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+    }
+
     fn dotenv_test_private_key(byte: u8) -> String {
         format!("{byte:064x}")
     }
@@ -3958,6 +4027,44 @@ mod tests {
         );
         assert!(!backend.legacy_values.lock().unwrap().contains_key(account));
         assert_eq!(backend.legacy_deletes.lock().unwrap().as_slice(), [account]);
+    }
+
+    #[test]
+    fn dotenv_keychain_migration_reports_verify_failures() {
+        assert_eq!(
+            dotenv_keychain_access_group(),
+            DOTENV_DEFAULT_KEYCHAIN_ACCESS_GROUP
+        );
+        let account =
+            "DOTENV_PRIVATE_KEY:1111111111111111111111111111111111111111111111111111111111111111";
+        let legacy_value = dotenv_test_private_key(10);
+        let mismatch_backend = VerifyFailingDotenvKeychainBackend::new(
+            account,
+            &legacy_value,
+            Some(dotenv_test_private_key(11)),
+        );
+        assert!(
+            migrate_dotenv_keychain(
+                &mismatch_backend,
+                "service",
+                "TEAM.group",
+                &DotenvKeychainMigrateOptions::default(),
+            )
+            .unwrap_err()
+            .contains("new keychain value differed")
+        );
+
+        let missing_backend = VerifyFailingDotenvKeychainBackend::new(account, &legacy_value, None);
+        assert!(
+            migrate_dotenv_keychain(
+                &missing_backend,
+                "service",
+                "TEAM.group",
+                &DotenvKeychainMigrateOptions::default(),
+            )
+            .unwrap_err()
+            .contains("new keychain item was not found")
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -5093,6 +5200,22 @@ mod tests {
                 .unwrap_err(),
             "missing dotenv keychain command"
         );
+        assert!(
+            parse_dotenv_command(
+                "av dotenv",
+                [OsString::from("keychain"), OsString::from("--help")].into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            parse_dotenv_command(
+                "av dotenv",
+                [OsString::from("keychain"), OsString::from("--version")].into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
         assert_eq!(
             parse_dotenv_command(
                 "av dotenv",
@@ -5113,6 +5236,32 @@ mod tests {
             )
             .unwrap_err(),
             "unknown dotenv keychain migrate argument '--bogus'"
+        );
+        assert!(
+            parse_dotenv_command(
+                "av dotenv",
+                [
+                    OsString::from("keychain"),
+                    OsString::from("migrate"),
+                    OsString::from("--help"),
+                ]
+                .into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            parse_dotenv_command(
+                "av dotenv",
+                [
+                    OsString::from("keychain"),
+                    OsString::from("migrate"),
+                    OsString::from("--version"),
+                ]
+                .into_iter()
+            )
+            .unwrap()
+            .is_none()
         );
 
         assert!(
@@ -6010,6 +6159,19 @@ mod tests {
             &["BAR", "FOO"],
         ))
         .unwrap();
+        assert!(
+            run_dotenv_run(
+                &DotenvRunOptions {
+                    file: env_path.clone(),
+                    command: OsString::from("/definitely/missing-av-dotenv-command"),
+                    args: Vec::new(),
+                },
+                &store,
+            )
+            .unwrap_err()
+            .contains("failed to execute")
+        );
+
         run_dotenv_run(
             &DotenvRunOptions {
                 file: env_path,
@@ -6197,6 +6359,58 @@ mod tests {
                 &store,
             )
             .unwrap_err(),
+            "hex value must have an even number of characters"
+        );
+    }
+
+    #[test]
+    fn dotenv_transfer_helpers_validate_error_edges() {
+        let temp = TempDir::new().unwrap();
+        let missing_public = temp.path().join("missing-public.env");
+        fs::write(&missing_public, "FOO=bar\n").unwrap();
+        assert!(
+            load_dotenv_private_key_for_transfer(&missing_public)
+                .unwrap_err()
+                .contains("is missing DOTENV_PUBLIC_KEY")
+        );
+
+        let invalid_public = temp.path().join("invalid-public.env");
+        fs::write(&invalid_public, "DOTENV_PUBLIC_KEY=abc\n").unwrap();
+        assert!(
+            load_dotenv_private_key_for_transfer(&invalid_public)
+                .unwrap_err()
+                .contains("hex value")
+        );
+
+        assert_eq!(
+            validate_dotenv_public_key_name_for_transfer("PRIVATE_KEY").unwrap_err(),
+            "invalid dotenv public key name: PRIVATE_KEY"
+        );
+        assert_eq!(
+            validate_dotenv_public_key_for_transfer("aa").unwrap_err(),
+            "dotenv public key must be 33 bytes"
+        );
+        assert_eq!(
+            validate_dotenv_private_key_for_transfer("abc").unwrap_err(),
+            "hex value must have an even number of characters"
+        );
+        let public_key = format!("02{}", "11".repeat(32));
+        assert_eq!(
+            dotenv_public_key_fingerprint_for_transfer(&public_key).len(),
+            64
+        );
+        assert!(
+            load_existing_dotenv_private_key_for_transfer("abc")
+                .unwrap_err()
+                .contains("hex value")
+        );
+        assert!(
+            store_dotenv_private_key_for_transfer("abc", &dotenv_test_private_key(12))
+                .unwrap_err()
+                .contains("hex value")
+        );
+        assert_eq!(
+            store_dotenv_private_key_for_transfer(&public_key, "abc").unwrap_err(),
             "hex value must have an even number of characters"
         );
     }

--- a/src/lib/rs/transfer.rs
+++ b/src/lib/rs/transfer.rs
@@ -844,6 +844,98 @@ mod tests {
     }
 
     #[test]
+    fn transfer_parse_error_edges_cover_remaining_branches() {
+        assert!(
+            parse_transfer_command("av transfer", [OsString::from("--help")].into_iter())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            parse_transfer_command("av transfer", [OsString::from("--version")].into_iter())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            parse_transfer_command(
+                "av transfer",
+                [
+                    OsString::from("--no-dotenv"),
+                    OsString::from("--ssh-option"),
+                    OsString::from("-A"),
+                    OsString::from("host"),
+                ]
+                .into_iter()
+            )
+            .unwrap()
+            .is_some()
+        );
+        assert_eq!(
+            parse_transfer_command(
+                "av transfer",
+                [
+                    OsString::from("--key"),
+                    OsString::from("TOKEN"),
+                    OsString::from("--key"),
+                    OsString::from("TOKEN"),
+                    OsString::from("host"),
+                ]
+                .into_iter()
+            )
+            .unwrap_err(),
+            "duplicate key requested: TOKEN"
+        );
+        assert_eq!(
+            parse_transfer_command(
+                "av transfer",
+                [
+                    OsString::from("--remote-av"),
+                    OsString::from(""),
+                    OsString::from("host"),
+                ]
+                .into_iter()
+            )
+            .unwrap_err(),
+            "--remote-av must not be empty"
+        );
+        assert_eq!(
+            parse_transfer_command(
+                "av transfer",
+                [OsString::from("one"), OsString::from("two")].into_iter()
+            )
+            .unwrap_err(),
+            "transfer supports one ssh target"
+        );
+        assert_eq!(
+            parse_transfer_command("av transfer", [OsString::from(" ")].into_iter()).unwrap_err(),
+            "empty ssh target"
+        );
+        assert!(
+            parse_transfer_command(
+                "av transfer",
+                [OsString::from("receive"), OsString::from("--help")].into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            parse_transfer_command(
+                "av transfer",
+                [OsString::from("receive"), OsString::from("--version")].into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert_eq!(
+            parse_transfer_command(
+                "av transfer",
+                [OsString::from("receive"), OsString::from("--bogus")].into_iter()
+            )
+            .unwrap_err(),
+            "unknown transfer receive argument '--bogus'"
+        );
+    }
+
+    #[test]
     fn transfer_parse_receive_requires_stdin() {
         assert_eq!(
             parse_transfer_command(
@@ -869,6 +961,47 @@ mod tests {
         };
         assert!(options.stdin);
         assert!(options.replace);
+    }
+
+    #[test]
+    fn transfer_keychain_store_wrappers_reject_invalid_inputs_before_keychain() {
+        let store = KeychainTransferSecretStore;
+        assert!(
+            !store
+                .export_dotenv_private_key(Path::new("/definitely/missing/.env"))
+                .unwrap_err()
+                .is_empty()
+        );
+        assert!(
+            store
+                .load_isotope_secret("BAD-NAME")
+                .unwrap_err()
+                .contains("invalid isotope key name")
+        );
+        assert!(
+            store
+                .load_existing_dotenv_private_key("abc")
+                .unwrap_err()
+                .contains("hex value")
+        );
+        assert!(
+            store
+                .store_dotenv_private_key("abc", "value")
+                .unwrap_err()
+                .contains("hex value")
+        );
+        assert!(
+            store
+                .load_existing_isotope_secret("BAD-NAME")
+                .unwrap_err()
+                .contains("invalid isotope key name")
+        );
+        assert!(
+            store
+                .store_isotope_secret("BAD-NAME", "value")
+                .unwrap_err()
+                .contains("invalid isotope key name")
+        );
     }
 
     #[test]
@@ -927,6 +1060,58 @@ mod tests {
                 .unwrap_err()
                 .contains("nothing to transfer")
         );
+    }
+
+    #[test]
+    fn transfer_run_send_receive_and_zeroize_edges() {
+        let store = StubTransferStore::default();
+        let options = TransferSendOptions {
+            ssh_target: "me@mac".to_string(),
+            file: PathBuf::from(".env"),
+            include_dotenv: false,
+            keys: Vec::new(),
+            replace: false,
+            ssh_options: Vec::new(),
+            remote_av: DEFAULT_REMOTE_AV.to_string(),
+            remote_av_explicit: false,
+        };
+        assert!(
+            run_transfer_send(&options, &store)
+                .unwrap_err()
+                .contains("nothing to transfer")
+        );
+        assert_eq!(
+            run_transfer_receive(
+                &TransferReceiveOptions {
+                    stdin: false,
+                    replace: false,
+                },
+                |_| unreachable!("stdin=false returns before import")
+            )
+            .unwrap_err(),
+            "transfer receive requires --stdin"
+        );
+        assert_eq!(shell_quote(""), "''");
+        assert_eq!(pluralize(1, "key", "keys"), "1 key");
+        assert_eq!(pluralize(2, "key", "keys"), "2 keys");
+
+        let (public_key, private_key) = transfer_keypair();
+        let mut transfer_bundle = bundle(vec![
+            dotenv_item(public_key, private_key),
+            TransferBundleItem::IsotopeSecret {
+                key: "TOKEN".to_string(),
+                value: "secret".to_string(),
+            },
+        ]);
+        zeroize_transfer_bundle(&mut transfer_bundle);
+        assert!(matches!(
+            &transfer_bundle.items[0],
+            TransferBundleItem::DotenvPrivateKey { private_key, .. } if private_key.is_empty()
+        ));
+        assert!(matches!(
+            &transfer_bundle.items[1],
+            TransferBundleItem::IsotopeSecret { value, .. } if value.is_empty()
+        ));
     }
 
     #[test]
@@ -1077,6 +1262,11 @@ mod tests {
     #[test]
     fn transfer_validates_bundle_schema_duplicates_and_fingerprints() {
         let (public_key, private_key) = transfer_keypair();
+        assert_eq!(
+            validate_transfer_bundle(&bundle(Vec::new())).unwrap_err(),
+            "transfer bundle contains no keys"
+        );
+
         let mut wrong_schema = bundle(vec![dotenv_item(public_key.clone(), private_key.clone())]);
         wrong_schema.schema_version = 999;
         assert!(
@@ -1113,6 +1303,14 @@ mod tests {
             ]))
             .unwrap_err()
             .contains("duplicate isotope key")
+        );
+        assert!(
+            validate_transfer_bundle(&bundle(vec![
+                dotenv_item(public_key.clone(), private_key.clone()),
+                dotenv_item(public_key, private_key),
+            ]))
+            .unwrap_err()
+            .contains("duplicate dotenv private key")
         );
     }
 

--- a/tests/radioisotope_migration_edges.rs
+++ b/tests/radioisotope_migration_edges.rs
@@ -49,6 +49,194 @@ macro_rules! radioisotope_source {
     };
 }
 
+macro_rules! migration_keychain_extra_tests {
+    () => {
+        #[cfg(test)]
+        mod av_keychain_extra_tests {
+            use super::*;
+            use std::fs;
+            use std::time::{SystemTime, UNIX_EPOCH};
+
+            fn temp_root(label: &str) -> std::path::PathBuf {
+                let suffix = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos();
+                std::env::temp_dir().join(format!(
+                    "radioisotope-migrate-{label}-{}-{suffix}",
+                    module_path!().replace("::", "_")
+                ))
+            }
+
+            #[test]
+            fn covers_keys_and_coverage_keychain_stub() {
+                let declared_keys = keys();
+                assert!(!declared_keys.is_empty());
+
+                let store = KeychainCredentialStore;
+                let err = store.store_secret(declared_keys[0], "value").unwrap_err();
+                assert!(err.contains("keychain"));
+            }
+
+            #[test]
+            fn covers_top_level_missing_default_locations() {
+                let _lock = crate::global_test_env_lock().lock().unwrap();
+                let root = temp_root("empty-defaults");
+                let home = root.join("home");
+                let xdg_cache = root.join("xdg-cache");
+                let xdg_config = root.join("xdg-config");
+                let xdg_runtime = root.join("xdg-runtime");
+                let xdg_state = root.join("xdg-state");
+                fs::create_dir_all(&home).unwrap();
+                fs::create_dir_all(&xdg_cache).unwrap();
+                fs::create_dir_all(&xdg_config).unwrap();
+                fs::create_dir_all(&xdg_runtime).unwrap();
+                fs::create_dir_all(&xdg_state).unwrap();
+
+                let _env_guards = [
+                    crate::EnvGuard::set("HOME", &home),
+                    crate::EnvGuard::set("XDG_CACHE_HOME", &xdg_cache),
+                    crate::EnvGuard::set("XDG_CONFIG_HOME", &xdg_config),
+                    crate::EnvGuard::set("XDG_RUNTIME_DIR", &xdg_runtime),
+                    crate::EnvGuard::set("XDG_STATE_HOME", &xdg_state),
+                    crate::EnvGuard::remove("AKAMAI_EDGERC"),
+                    crate::EnvGuard::remove("ANSIBLE_GALAXY_TOKEN_PATH"),
+                    crate::EnvGuard::remove("ARGOCD_CONFIG_DIR"),
+                    crate::EnvGuard::remove("BITWARDENCLI_APPDATA_DIR"),
+                    crate::EnvGuard::remove("CARGO_HOME"),
+                    crate::EnvGuard::remove("CAROOT"),
+                    crate::EnvGuard::remove("CIVO_CONFIG"),
+                    crate::EnvGuard::remove("COMPOSER_HOME"),
+                    crate::EnvGuard::remove("CX_CONFIG_FILE_PATH"),
+                    crate::EnvGuard::remove("DCOS_DIR"),
+                    crate::EnvGuard::remove("DIGITALOCEAN_CONFIG"),
+                    crate::EnvGuard::remove("GLAB_CONFIG_DIR"),
+                    crate::EnvGuard::remove("HCLOUD_CONFIG"),
+                    crate::EnvGuard::remove("HELM_CONFIG_HOME"),
+                    crate::EnvGuard::remove("HELM_REPOSITORY_CONFIG"),
+                    crate::EnvGuard::remove("KUBECONFIG"),
+                    crate::EnvGuard::remove("MCP_REMOTE_CONFIG_DIR"),
+                    crate::EnvGuard::remove("NETRC"),
+                    crate::EnvGuard::remove("NPM_CONFIG_USERCONFIG"),
+                    crate::EnvGuard::remove("OCI_CLI_CONFIG_FILE"),
+                    crate::EnvGuard::remove("PULUMI_CREDENTIALS_PATH"),
+                    crate::EnvGuard::remove("PULUMI_HOME"),
+                    crate::EnvGuard::remove("RCLONE_CONFIG"),
+                    crate::EnvGuard::remove("REGISTRY_AUTH_FILE"),
+                    crate::EnvGuard::remove("TALOSCONFIG"),
+                    crate::EnvGuard::remove("TALOS_HOME"),
+                    crate::EnvGuard::remove("UV_CREDENTIALS_DIR"),
+                    crate::EnvGuard::remove("VAGRANT_HOME"),
+                ];
+
+                migrate_credentials().unwrap();
+                fs::remove_dir_all(root).unwrap();
+            }
+        }
+    };
+}
+
+macro_rules! migration_keychain_module_extra_tests {
+    ($module:ident, $path:literal) => {
+        mod $module {
+            include!(radioisotope_source!($path));
+            migration_keychain_extra_tests!();
+        }
+    };
+}
+
+migration_keychain_module_extra_tests!(acli_migrate_keychain, "/acli/migrate.rs");
+migration_keychain_module_extra_tests!(aliyun_cli_migrate_keychain, "/aliyun-cli/migrate.rs");
+migration_keychain_module_extra_tests!(ast_cli_migrate_keychain, "/ast-cli/migrate.rs");
+migration_keychain_module_extra_tests!(astra_migrate_keychain, "/astra/migrate.rs");
+migration_keychain_module_extra_tests!(bitwarden_cli_migrate_keychain, "/bitwarden-cli/migrate.rs");
+migration_keychain_module_extra_tests!(buf_migrate_keychain, "/buf/migrate.rs");
+migration_keychain_module_extra_tests!(censys_migrate_keychain, "/censys/migrate.rs");
+migration_keychain_module_extra_tests!(checkov_migrate_keychain, "/checkov/migrate.rs");
+migration_keychain_module_extra_tests!(circleci_migrate_keychain, "/circleci/migrate.rs");
+migration_keychain_module_extra_tests!(civo_migrate_keychain, "/civo/migrate.rs");
+migration_keychain_module_extra_tests!(
+    cloudsmith_cli_migrate_keychain,
+    "/cloudsmith-cli/migrate.rs"
+);
+migration_keychain_module_extra_tests!(composer_migrate_keychain, "/composer/migrate.rs");
+migration_keychain_module_extra_tests!(dcos_cli_migrate_keychain, "/dcos-cli/migrate.rs");
+migration_keychain_module_extra_tests!(
+    dropbox_uploader_migrate_keychain,
+    "/dropbox-uploader/migrate.rs"
+);
+migration_keychain_module_extra_tests!(fastly_migrate_keychain, "/fastly/migrate.rs");
+migration_keychain_module_extra_tests!(fauna_shell_migrate_keychain, "/fauna-shell/migrate.rs");
+migration_keychain_module_extra_tests!(firebase_cli_migrate_keychain, "/firebase-cli/migrate.rs");
+migration_keychain_module_extra_tests!(flyctl_migrate_keychain, "/flyctl/migrate.rs");
+migration_keychain_module_extra_tests!(gcli_migrate_keychain, "/gcli/migrate.rs");
+migration_keychain_module_extra_tests!(gallery_dl_migrate_keychain, "/gallery-dl/migrate.rs");
+migration_keychain_module_extra_tests!(goat_migrate_keychain, "/goat/migrate.rs");
+migration_keychain_module_extra_tests!(gotify_migrate_keychain, "/gotify/migrate.rs");
+migration_keychain_module_extra_tests!(gptcommit_migrate_keychain, "/gptcommit/migrate.rs");
+migration_keychain_module_extra_tests!(graphite_migrate_keychain, "/graphite/migrate.rs");
+migration_keychain_module_extra_tests!(hcloud_migrate_keychain, "/hcloud/migrate.rs");
+migration_keychain_module_extra_tests!(helm_migrate_keychain, "/helm/migrate.rs");
+migration_keychain_module_extra_tests!(heroku_migrate_keychain, "/heroku/migrate.rs");
+migration_keychain_module_extra_tests!(
+    huggingface_cli_migrate_keychain,
+    "/huggingface-cli/migrate.rs"
+);
+migration_keychain_module_extra_tests!(imap_backup_migrate_keychain, "/imap-backup/migrate.rs");
+migration_keychain_module_extra_tests!(k6_migrate_keychain, "/k6/migrate.rs");
+migration_keychain_module_extra_tests!(
+    kubernetes_cli_migrate_keychain,
+    "/kubernetes-cli/migrate.rs"
+);
+migration_keychain_module_extra_tests!(mariadb_migrate_keychain, "/mariadb/migrate.rs");
+migration_keychain_module_extra_tests!(maven_migrate_keychain, "/maven/migrate.rs");
+migration_keychain_module_extra_tests!(mcp_remote_migrate_keychain, "/mcp-remote/migrate.rs");
+migration_keychain_module_extra_tests!(mercurial_migrate_keychain, "/mercurial/migrate.rs");
+migration_keychain_module_extra_tests!(mkcert_migrate_keychain, "/mkcert/migrate.rs");
+migration_keychain_module_extra_tests!(mycli_migrate_keychain, "/mycli/migrate.rs");
+migration_keychain_module_extra_tests!(mysql_client_migrate_keychain, "/mysql-client/migrate.rs");
+migration_keychain_module_extra_tests!(mysql_migrate_keychain, "/mysql/migrate.rs");
+migration_keychain_module_extra_tests!(mysql_8_0_migrate_keychain, "/mysql@8.0/migrate.rs");
+migration_keychain_module_extra_tests!(mysql_8_4_migrate_keychain, "/mysql@8.4/migrate.rs");
+migration_keychain_module_extra_tests!(netlify_cli_migrate_keychain, "/netlify-cli/migrate.rs");
+migration_keychain_module_extra_tests!(node_migrate_keychain, "/node/migrate.rs");
+migration_keychain_module_extra_tests!(node_18_migrate_keychain, "/node@18/migrate.rs");
+migration_keychain_module_extra_tests!(oci_cli_migrate_keychain, "/oci-cli/migrate.rs");
+migration_keychain_module_extra_tests!(openhue_cli_migrate_keychain, "/openhue-cli/migrate.rs");
+migration_keychain_module_extra_tests!(ordercli_migrate_keychain, "/ordercli/migrate.rs");
+migration_keychain_module_extra_tests!(ossutil_migrate_keychain, "/ossutil/migrate.rs");
+migration_keychain_module_extra_tests!(oxide_cli_migrate_keychain, "/oxide-cli/migrate.rs");
+migration_keychain_module_extra_tests!(phylum_cli_migrate_keychain, "/phylum-cli/migrate.rs");
+migration_keychain_module_extra_tests!(plumber_migrate_keychain, "/plumber/migrate.rs");
+migration_keychain_module_extra_tests!(pnpm_migrate_keychain, "/pnpm/migrate.rs");
+migration_keychain_module_extra_tests!(pulumi_migrate_keychain, "/pulumi/migrate.rs");
+migration_keychain_module_extra_tests!(railway_migrate_keychain, "/railway/migrate.rs");
+migration_keychain_module_extra_tests!(rclone_migrate_keychain, "/rclone/migrate.rs");
+migration_keychain_module_extra_tests!(runpodctl_migrate_keychain, "/runpodctl/migrate.rs");
+migration_keychain_module_extra_tests!(sbt_migrate_keychain, "/sbt/migrate.rs");
+migration_keychain_module_extra_tests!(sentry_cli_migrate_keychain, "/sentry-cli/migrate.rs");
+migration_keychain_module_extra_tests!(shodan_migrate_keychain, "/shodan/migrate.rs");
+migration_keychain_module_extra_tests!(soracom_cli_migrate_keychain, "/soracom-cli/migrate.rs");
+migration_keychain_module_extra_tests!(sqlcmd_migrate_keychain, "/sqlcmd/migrate.rs");
+migration_keychain_module_extra_tests!(sslmate_migrate_keychain, "/sslmate/migrate.rs");
+migration_keychain_module_extra_tests!(talosctl_migrate_keychain, "/talosctl/migrate.rs");
+migration_keychain_module_extra_tests!(
+    terraform_core_migrate_keychain,
+    "/terraform-core/migrate.rs"
+);
+migration_keychain_module_extra_tests!(todoist_cli_migrate_keychain, "/todoist-cli/migrate.rs");
+migration_keychain_module_extra_tests!(travis_migrate_keychain, "/travis/migrate.rs");
+migration_keychain_module_extra_tests!(uaa_cli_migrate_keychain, "/uaa-cli/migrate.rs");
+migration_keychain_module_extra_tests!(uv_migrate_keychain, "/uv/migrate.rs");
+migration_keychain_module_extra_tests!(vagrant_migrate_keychain, "/vagrant/migrate.rs");
+migration_keychain_module_extra_tests!(vault_migrate_keychain, "/vault/migrate.rs");
+migration_keychain_module_extra_tests!(
+    virustotal_cli_migrate_keychain,
+    "/virustotal-cli/migrate.rs"
+);
+migration_keychain_module_extra_tests!(vultr_migrate_keychain, "/vultr/migrate.rs");
+migration_keychain_module_extra_tests!(wsk_migrate_keychain, "/wsk/migrate.rs");
+
 mod snyk_migrate {
     include!(radioisotope_source!("/snyk/migrate.rs"));
 
@@ -1189,6 +1377,7 @@ mod ansible_migrate {
 
 mod argocd_migrate {
     include!(radioisotope_source!("/argocd/migrate.rs"));
+    migration_keychain_extra_tests!();
 }
 
 mod doctl_migrate {
@@ -1286,6 +1475,8 @@ mod glab_migrate {
             std::fs::remove_dir_all(temp).unwrap();
         }
     }
+
+    migration_keychain_extra_tests!();
 }
 
 mod jfrog_cli_migrate {
@@ -1294,6 +1485,7 @@ mod jfrog_cli_migrate {
 
 mod maestro_migrate {
     include!(radioisotope_source!("/maestro/migrate.rs"));
+    migration_keychain_extra_tests!();
 }
 
 mod minio_mc_migrate {
@@ -1398,6 +1590,8 @@ mod podman_migrate {
             std::fs::remove_dir_all(temp).unwrap();
         }
     }
+
+    migration_keychain_extra_tests!();
 }
 
 mod qwen_code_migrate {
@@ -1514,6 +1708,7 @@ mod s3cmd_migrate {
 
 mod skopeo_migrate {
     include!(radioisotope_source!("/skopeo/migrate.rs"));
+    migration_keychain_extra_tests!();
 }
 
 mod terraform_migrate {
@@ -1522,6 +1717,7 @@ mod terraform_migrate {
 
 mod transifex_cli_migrate {
     include!(radioisotope_source!("/transifex-cli/migrate.rs"));
+    migration_keychain_extra_tests!();
 }
 
 mod wakatime_cli_migrate {

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -153,6 +153,24 @@ macro_rules! launcher_post_install_extra_tests {
 
                     fs::remove_dir_all(temp).unwrap();
                 }
+
+                #[cfg(unix)]
+                #[test]
+                fn covers_absolute_symlink_original_resolution() {
+                    let temp = temp_dir("absolute-symlink");
+                    fs::create_dir_all(&temp).unwrap();
+                    let target = temp.join("target-launcher");
+                    write_executable(&target, b"#!/bin/sh\nprintf target\n");
+                    let launcher = temp.join("launcher");
+                    std::os::unix::fs::symlink(&target, &launcher).unwrap();
+
+                    assert_eq!(original_launcher_path(&launcher).unwrap(), target);
+
+                    let _ = $wrap(&launcher).unwrap();
+
+                    assert!(launcher_is_wrapped(&launcher).unwrap());
+                    fs::remove_dir_all(temp).unwrap();
+                }
             }
         }
     };
@@ -285,6 +303,24 @@ macro_rules! two_stage_launcher_post_install_extra_tests {
                     );
                     assert!(launcher_is_wrapped(&launcher).unwrap());
 
+                    fs::remove_dir_all(temp).unwrap();
+                }
+
+                #[cfg(unix)]
+                #[test]
+                fn covers_absolute_symlink_original_resolution() {
+                    let temp = temp_dir("absolute-symlink");
+                    fs::create_dir_all(&temp).unwrap();
+                    let target = temp.join("target-launcher");
+                    write_executable(&target, b"#!/bin/sh\nprintf target\n");
+                    let launcher = temp.join("launcher");
+                    std::os::unix::fs::symlink(&target, &launcher).unwrap();
+
+                    assert_eq!(original_launcher_path(&launcher).unwrap(), target);
+
+                    let _ = $wrap(&launcher).unwrap();
+
+                    assert!(launcher_is_wrapped(&launcher).unwrap());
                     fs::remove_dir_all(temp).unwrap();
                 }
             }


### PR DESCRIPTION
## Summary

- add coverage-only radioisotope migration keychain/default-location edge tests
- cover post-install absolute-symlink launcher resolution across wrapper macros
- add dotenv keychain/transfer validation and transfer parser/zeroization edge tests

## Coverage

- baseline: `LH=91103 LF=98338 coverage=92.6427%`
- final: `LH=91787 LF=98656 coverage=93.0374%`

No isotope/radioisotope source repositories or public `/db.json` schema files were modified.

## Verification

- `AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 AUTOMIC_VAULT_REPO_CACHE=data/isotopes AUTOMIC_VAULT_RADIOISOTOPES_REPO=data/radioisotopes/checkout cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1`
- isotope and radioisotope LCOV path greps
- `cargo fmt --check`
- `/usr/bin/python3 scripts/generate-coverage-fixtures.py`
- `git diff --exit-code -- data/combined.json src/lib/rs/fixtures/coverage-combined.json`
- `git diff --check`
