### PR TITLE
Expand transfer coverage tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -470,8 +470,16 @@ fn coverage_path_alias(
 }
 
 fn ensure_coverage_include_alias(source_root: &std::path::Path, include_root: &std::path::Path) {
-    if std::fs::symlink_metadata(include_root).is_ok() {
-        return;
+    match std::fs::symlink_metadata(include_root) {
+        Ok(metadata) => {
+            validate_coverage_include_alias(source_root, include_root, &metadata);
+            return;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => panic!(
+            "failed to inspect coverage include path {}: {err}",
+            include_root.display()
+        ),
     }
     let Some(parent) = include_root.parent() else {
         return;
@@ -492,6 +500,40 @@ fn ensure_coverage_include_alias(source_root: &std::path::Path, include_root: &s
         include_root.display(),
         source_root.display()
     );
+}
+
+fn validate_coverage_include_alias(
+    source_root: &std::path::Path,
+    include_root: &std::path::Path,
+    metadata: &std::fs::Metadata,
+) {
+    if !metadata.file_type().is_symlink() {
+        panic!(
+            "coverage include path {} already exists but is not a symlink to {}",
+            include_root.display(),
+            source_root.display()
+        );
+    }
+
+    let expected = canonical_coverage_alias_path(source_root, "coverage source root");
+    let actual = canonical_coverage_alias_path(include_root, "coverage include path");
+    if actual != expected {
+        let target = std::fs::read_link(include_root)
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|err| format!("<unreadable: {err}>"));
+        panic!(
+            "coverage include path {} points to {} (resolved to {}) but expected {}",
+            include_root.display(),
+            target,
+            actual.display(),
+            expected.display()
+        );
+    }
+}
+
+fn canonical_coverage_alias_path(path: &std::path::Path, description: &str) -> std::path::PathBuf {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|err| panic!("failed to resolve {description} {}: {err}", path.display()))
 }
 
 fn coverage_include_path(

--- a/build.rs
+++ b/build.rs
@@ -203,21 +203,36 @@ fn generate_isotope_integrations() {
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_RADIOISOTOPES_REPO");
     println!("cargo:rerun-if-env-changed=AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_COVERAGE");
+    let default_isotope_root = absolute_path(av_db_root.join("../isotopes"));
+    let default_radioisotope_root = absolute_path(av_db_root.join("../radioisotopes"));
     let isotope_root =
-        path_env_or_default("AUTOMIC_VAULT_REPO_CACHE", av_db_root.join("../isotopes"));
+        path_env_or_default("AUTOMIC_VAULT_REPO_CACHE", default_isotope_root.clone());
     let radioisotope_root = path_env_or_default(
         "AUTOMIC_VAULT_RADIOISOTOPES_REPO",
-        av_db_root.join("../radioisotopes"),
+        default_radioisotope_root.clone(),
     );
-    println!(
-        "cargo:rustc-env=AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO={}",
-        radioisotope_root.display()
-    );
-    let isotope_roots = [isotope_root, radioisotope_root];
+    let isotope_roots = [isotope_root.clone(), radioisotope_root.clone()];
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let generated_sources_dir = std::path::Path::new(&out_dir).join("isotope-generated");
     let output_path = std::path::Path::new(&out_dir).join("isotope_integrations.rs");
     let include_isotope_tests = include_isotope_tests_for_coverage();
+    let coverage_path_aliases = if include_isotope_tests {
+        coverage_path_aliases(
+            repo_root,
+            &isotope_root,
+            &default_isotope_root,
+            &radioisotope_root,
+            &default_radioisotope_root,
+        )
+    } else {
+        Vec::new()
+    };
+    let generated_radioisotope_root =
+        coverage_include_root(&radioisotope_root, &coverage_path_aliases);
+    println!(
+        "cargo:rustc-env=AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO={}",
+        generated_radioisotope_root.display()
+    );
 
     let mut entries = Vec::new();
     for root in isotope_roots {
@@ -254,6 +269,7 @@ fn generate_isotope_integrations() {
                 &entry.module_name,
                 "detect",
                 path,
+                &coverage_path_aliases,
             );
             output.push_str(&format!(
                 "  #[allow(clippy::all, dead_code, unused_parens, unused_variables)] pub(crate) mod detect {{ include!(r#\"{}\"#); }}\n",
@@ -267,6 +283,7 @@ fn generate_isotope_integrations() {
                 &entry.module_name,
                 "migrate",
                 path,
+                &coverage_path_aliases,
             );
             output.push_str(&format!(
                 "  #[allow(clippy::all, dead_code, unused_parens, unused_variables)] pub(crate) mod migrate {{ include!(r#\"{}\"#); }}\n",
@@ -280,6 +297,7 @@ fn generate_isotope_integrations() {
                 &entry.module_name,
                 "post_install",
                 path,
+                &coverage_path_aliases,
             );
             output.push_str(&format!(
                 "  #[allow(clippy::all, dead_code, unused_parens, unused_variables)] pub(crate) mod post_install {{ include!(r#\"{}\"#); }}\n",
@@ -293,6 +311,7 @@ fn generate_isotope_integrations() {
                 &entry.module_name,
                 "credential_helper",
                 path,
+                &coverage_path_aliases,
             );
             output.push_str(&format!(
                 "  #[allow(clippy::all, dead_code, unused_parens, unused_variables)] pub(crate) mod credential_helper {{ include!(r#\"{}\"#); }}\n",
@@ -406,15 +425,109 @@ fn env_flag(key: &str) -> bool {
     })
 }
 
+struct CoveragePathAlias {
+    source_root: std::path::PathBuf,
+    include_root: std::path::PathBuf,
+}
+
+fn coverage_path_aliases(
+    repo_root: &std::path::Path,
+    isotope_root: &std::path::Path,
+    default_isotope_root: &std::path::Path,
+    radioisotope_root: &std::path::Path,
+    default_radioisotope_root: &std::path::Path,
+) -> Vec<CoveragePathAlias> {
+    [
+        coverage_path_alias(
+            isotope_root,
+            default_isotope_root,
+            repo_root.join("data/isotopes"),
+        ),
+        coverage_path_alias(
+            radioisotope_root,
+            default_radioisotope_root,
+            repo_root.join("data/radioisotopes/checkout"),
+        ),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+fn coverage_path_alias(
+    source_root: &std::path::Path,
+    default_root: &std::path::Path,
+    include_root: std::path::PathBuf,
+) -> Option<CoveragePathAlias> {
+    if source_root != default_root {
+        return None;
+    }
+    ensure_coverage_include_alias(source_root, &include_root);
+    Some(CoveragePathAlias {
+        source_root: source_root.to_path_buf(),
+        include_root,
+    })
+}
+
+fn ensure_coverage_include_alias(source_root: &std::path::Path, include_root: &std::path::Path) {
+    if std::fs::symlink_metadata(include_root).is_ok() {
+        return;
+    }
+    let Some(parent) = include_root.parent() else {
+        return;
+    };
+    std::fs::create_dir_all(parent)
+        .unwrap_or_else(|err| panic!("failed to create {}: {err}", parent.display()));
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source_root, include_root).unwrap_or_else(|err| {
+        panic!(
+            "failed to link coverage include path {} to {}: {err}",
+            include_root.display(),
+            source_root.display()
+        )
+    });
+    #[cfg(not(unix))]
+    panic!(
+        "coverage include path aliasing requires Unix symlinks: {} -> {}",
+        include_root.display(),
+        source_root.display()
+    );
+}
+
+fn coverage_include_path(
+    source_path: &std::path::Path,
+    aliases: &[CoveragePathAlias],
+) -> Option<std::path::PathBuf> {
+    aliases.iter().find_map(|alias| {
+        source_path
+            .strip_prefix(&alias.source_root)
+            .ok()
+            .map(|relative| alias.include_root.join(relative))
+    })
+}
+
+fn coverage_include_root<'a>(
+    source_root: &'a std::path::Path,
+    aliases: &'a [CoveragePathAlias],
+) -> &'a std::path::Path {
+    aliases
+        .iter()
+        .find(|alias| alias.source_root == source_root)
+        .map(|alias| alias.include_root.as_path())
+        .unwrap_or(source_root)
+}
+
 fn isotope_include_path(
     include_isotope_tests: bool,
     generated_sources_dir: &std::path::Path,
     module_name: &str,
     suffix: &str,
     source_path: &std::path::Path,
+    coverage_path_aliases: &[CoveragePathAlias],
 ) -> std::path::PathBuf {
     if include_isotope_tests {
-        return source_path.to_path_buf();
+        return coverage_include_path(source_path, coverage_path_aliases)
+            .unwrap_or_else(|| source_path.to_path_buf());
     }
 
     sanitized_isotope_source(generated_sources_dir, module_name, suffix, source_path)

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -13144,11 +13144,7 @@ managed_secrets = ["dep:managed-secrets"]"#,
         fs::write(root.join(".next/.env"), "TOKEN=secret_secret\n").unwrap();
         fs::write(root.join("cache/.env"), "TOKEN=secret_secret\n").unwrap();
         fs::write(root.join("Vendor/.env"), "TOKEN=secret_secret\n").unwrap();
-        fs::write(
-            root.join("isotopes/example/.env"),
-            "TOKEN=secret_secret\n",
-        )
-        .unwrap();
+        fs::write(root.join("isotopes/example/.env"), "TOKEN=secret_secret\n").unwrap();
         fs::write(
             root.join("radioisotopes/example/.env"),
             "TOKEN=secret_secret\n",

--- a/src/lib/rs/transfer.rs
+++ b/src/lib/rs/transfer.rs
@@ -800,6 +800,8 @@ fn print_transfer_receive_usage(program_name: &str) {
 mod tests {
     use super::*;
     use std::cell::RefCell;
+    use std::os::unix::ffi::OsStringExt;
+    use std::os::unix::fs::PermissionsExt;
 
     #[derive(Default)]
     struct StubTransferStore {
@@ -859,6 +861,41 @@ mod tests {
                 .insert(key.to_string(), value.to_string());
             Ok(())
         }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = env::var_os(key);
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe {
+                    env::set_var(self.key, value);
+                },
+                None => unsafe {
+                    env::remove_var(self.key);
+                },
+            }
+        }
+    }
+
+    fn write_executable_script(path: &Path, body: &str) {
+        fs::write(path, body).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
     }
 
     fn transfer_keypair() -> (String, String) {
@@ -950,6 +987,37 @@ mod tests {
             parse_transfer_command("av transfer", [OsString::from("--version")].into_iter())
                 .unwrap()
                 .is_none()
+        );
+        assert!(
+            parse_transfer_command(
+                "av transfer",
+                [OsString::from("host"), OsString::from("--help")].into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            parse_transfer_command(
+                "av transfer",
+                [OsString::from("host"), OsString::from("--version")].into_iter()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert_eq!(
+            parse_transfer_command("av transfer", [OsString::from("--file")].into_iter())
+                .unwrap_err(),
+            "missing value for --file"
+        );
+        assert_eq!(
+            parse_transfer_command("av transfer", [OsString::from("--no-dotenv")].into_iter())
+                .unwrap_err(),
+            "missing ssh target"
+        );
+        assert_eq!(
+            parse_transfer_command("av transfer", [OsString::from_vec(vec![0xff])].into_iter())
+                .unwrap_err(),
+            "ssh target must be valid UTF-8"
         );
         assert!(
             parse_transfer_command(
@@ -1226,6 +1294,64 @@ mod tests {
     }
 
     #[test]
+    fn transfer_send_checks_remote_and_streams_bundle_to_ssh() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        let payload_path = temp.path().join("payload.json");
+        let log_path = temp.path().join("ssh.log");
+        write_executable_script(
+            &bin.join("ssh"),
+            &format!(
+                "\
+#!/bin/sh
+printf '%s\\n' \"$*\" >> '{}'
+case \"$*\" in
+  *--check*) exit 0 ;;
+esac
+/bin/cat > '{}'
+",
+                log_path.display(),
+                payload_path.display()
+            ),
+        );
+        let prior_path = env::var_os("PATH").unwrap_or_default();
+        let test_path = format!("{}:{}", bin.display(), prior_path.to_string_lossy());
+        let _path = EnvVarGuard::set("PATH", OsStr::new(&test_path));
+        let store = StubTransferStore::default();
+        store
+            .isotope_exports
+            .borrow_mut()
+            .insert("TOKEN".to_string(), "secret".to_string());
+        let options = TransferSendOptions {
+            ssh_target: "me@mac".to_string(),
+            file: PathBuf::from(".env"),
+            include_dotenv: false,
+            keys: vec!["TOKEN".to_string()],
+            replace: true,
+            ssh_options: vec!["-p 2222".to_string()],
+            remote_av: DEFAULT_REMOTE_AV.to_string(),
+            remote_av_explicit: false,
+        };
+
+        run_transfer_send(&options, &store).unwrap();
+
+        let ssh_log = fs::read_to_string(log_path).unwrap();
+        assert!(ssh_log.contains("--check"));
+        assert!(ssh_log.contains("--stdin"));
+        assert!(ssh_log.contains("--replace"));
+        let payload = fs::read_to_string(payload_path).unwrap();
+        let bundle: TransferBundle = serde_json::from_str(&payload).unwrap();
+        assert_eq!(bundle.items.len(), 1);
+        assert!(matches!(
+            &bundle.items[0],
+            TransferBundleItem::IsotopeSecret { key, value }
+                if key == "TOKEN" && value == "secret"
+        ));
+    }
+
+    #[test]
     fn transfer_ssh_command_shell_quotes_remote_command() {
         let options = TransferSendOptions {
             ssh_target: "me@mac".to_string(),
@@ -1341,8 +1467,24 @@ mod tests {
         );
 
         assert_eq!(
+            transfer_check_failure_result(
+                "me@mac",
+                "exit status: 1",
+                "av transfer: vaultd unavailable\n",
+            )
+            .unwrap_err(),
+            "receiving Automic Vault.app is unavailable on me@mac; open Automic Vault.app there and try again (vaultd unavailable)"
+        );
+
+        assert_eq!(
             transfer_check_failure_result("me@mac", "exit status: 255", "").unwrap_err(),
             "transfer check failed on me@mac: ssh exited with exit status: 255"
+        );
+
+        assert_eq!(
+            transfer_check_failure_result("me@mac", "exit status: 1", "remote exploded\n")
+                .unwrap_err(),
+            "transfer check failed on me@mac: remote exploded"
         );
     }
 


### PR DESCRIPTION
## Summary
- Added transfer parser edge coverage for send help/version, missing values, missing targets, and non-UTF-8 SSH targets.
- Added a fake-ssh send-path test that covers remote receiver checking, bundle streaming, and replace propagation without touching real SSH.
- Added coverage-build path aliasing so default sibling isotope checkouts are included through data/isotopes and data/radioisotopes/checkout, matching CI LCOV path verification.
- No data repo source changes or public db schema changes.

## Coverage
- Baseline: 87100/93713 lines, 92.9433%.
- Final: 87243/93817 lines, 92.9927%.

## Verification
- cargo fmt --check
- git diff --check
- /usr/bin/python3 scripts/generate-coverage-fixtures.py
- git diff --exit-code -- data/combined.json src/lib/rs/fixtures/coverage-combined.json
- AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1
- LCOV path checks for data/isotopes and data/radioisotopes coverage sources
- Coveralls workflow passed on commit 2af51cb.