### PR TITLE
[codex] Ignore local coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /cache
 /data/db.json
 /data/combined.json
+/data/isotopes
 /data/isotopes.json*
 /data/isotopes/
 /data/pkg-cross-ecosystem.json
@@ -17,6 +18,7 @@
 /data/pkg-page-enrichment.json
 /data/pkg-version-freshness.json
 /data/radioisotopes/
+/lcov.info
 /target
 /src/target
 /dist/


### PR DESCRIPTION
## Summary
- Confirmed Rust coverage is already above the automation target: 87,772 / 94,623 lines = 92.7597%.
- Ignored local CI-style coverage artifacts (`lcov.info` and the symlink form of `data/isotopes`) so coverage runs do not leave worktree noise.

## Validation
- `/usr/bin/python3 scripts/generate-coverage-fixtures.py`
- `git diff --exit-code -- data/combined.json src/lib/rs/fixtures/coverage-combined.json`
- `scripts/sync-isotope-checkouts.sh`
- `AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1`
- Verified isotope coverage paths are present in `lcov.info`.

## Notes
- No coverage-increasing test change was needed because the measured total already exceeds 92%.
- `codex-automation` label was not available in this repository.