### PR TITLE
[codex] Add isotope parser edge coverage

### DIFF
--- a/src/lib/rs/isotope.rs
+++ b/src/lib/rs/isotope.rs
@@ -2725,6 +2725,52 @@ mod tests {
     }
 
     #[test]
+    fn isotopes_interpreter_helpers_cover_more_parser_edges() {
+        let args = vec![OsString::from("-S")];
+        assert_eq!(interpreter_script_operand(&args), None);
+
+        let args = vec![OsString::from("--"), OsString::from("script.sh")];
+        assert_eq!(
+            interpreter_script_operand(&args),
+            Some(Path::new("script.sh"))
+        );
+
+        let args = vec![OsString::from("-"), OsString::from("stdin-script")];
+        assert_eq!(interpreter_script_operand(&args), Some(Path::new("-")));
+
+        let args = vec![OsString::from_vec(b"bad-\xff".to_vec())];
+        assert_eq!(interpreter_script_operand(&args), None);
+
+        assert_eq!(
+            interpreter_script_for_always_allow(Path::new("/usr/local/bin/not-a-script"), &[])
+                .unwrap(),
+            None
+        );
+
+        let empty =
+            interpreter_script_for_always_allow(Path::new("/usr/local/bin/uv"), &[]).unwrap();
+        assert_eq!(empty, None);
+
+        let unknown_global = interpreter_script_for_always_allow(
+            Path::new("/usr/local/bin/uv"),
+            &[OsString::from("--unknown"), OsString::from("run")],
+        )
+        .unwrap();
+        assert_eq!(unknown_global, None);
+
+        let unknown_run = interpreter_script_for_always_allow(
+            Path::new("/usr/local/bin/uv"),
+            &[
+                OsString::from("run"),
+                OsString::from("--unknown"),
+                OsString::from("tool.py"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(unknown_run, None);
+    }
+
+    #[test]
     fn isotopes_always_allow_scope_and_path_helpers_cover_expected_paths() {
         let executable = Path::new("/bin/sh");
         let file = File::open(executable).unwrap();


### PR DESCRIPTION
## Summary
- add isotope parser edge coverage for interpreter script operands and uv run handling
- keep the coverage environment aligned with CI, including synced isotope/radioisotope checkouts

## Validation
- `/usr/bin/python3 scripts/generate-coverage-fixtures.py`
- `scripts/sync-isotope-checkouts.sh`
- `cargo test --workspace isotopes_interpreter_helpers_cover_more_parser_edges -- --test-threads=1`
- `AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1`
- `cargo llvm-cov report --summary-only` => line coverage `92.83%`
- `grep -Eq '^SF:.*/data/isotopes/.+\.rs$' lcov.info`
- `grep -Eq '^SF:.*/data/radioisotopes/.+\.rs$' lcov.info`
