### PR TITLE
[codex] Increase radioisotope post-install coverage

### DIFF
--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -72,6 +72,7 @@ macro_rules! launcher_post_install_extra_tests {
                 #[test]
                 fn covers_top_level_post_install_missing_launcher_error_or_noop() {
                     if let Err(error) = post_install() {
+                        assert!(
                             error.contains("failed to read")
                                 || error.contains("failed to stat")
                                 || error.contains("failed to write"),
@@ -234,6 +235,7 @@ macro_rules! two_stage_launcher_post_install_extra_tests {
                 #[test]
                 fn covers_top_level_post_install_missing_launcher_error_or_noop() {
                     if let Err(error) = post_install() {
+                        assert!(
                             error.contains("failed to read")
                                 || error.contains("failed to stat")
                                 || error.contains("failed to write"),

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -233,9 +233,8 @@ macro_rules! two_stage_launcher_post_install_extra_tests {
                 }
 
                 #[test]
-                fn covers_top_level_post_install_missing_launcher_error() {
+                fn covers_top_level_post_install_missing_launcher_error_or_noop() {
                     if let Err(error) = post_install() {
-                        assert!(
                             error.contains("failed to read")
                                 || error.contains("failed to stat")
                                 || error.contains("failed to write"),

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -70,6 +70,18 @@ macro_rules! launcher_post_install_extra_tests {
                 }
 
                 #[test]
+                fn covers_top_level_post_install_missing_launcher_error() {
+                    if let Err(error) = post_install() {
+                        assert!(
+                            error.contains("failed to read")
+                                || error.contains("failed to stat")
+                                || error.contains("failed to write"),
+                            "unexpected post_install error: {error}"
+                        );
+                    }
+                }
+
+                #[test]
                 fn covers_existing_original_invalid_data_and_quoting_edges() {
                     let temp = temp_dir("existing-original");
                     fs::create_dir_all(&temp).unwrap();
@@ -218,6 +230,18 @@ macro_rules! two_stage_launcher_post_install_extra_tests {
                     let mut permissions = fs::metadata(path).unwrap().permissions();
                     permissions.set_mode(0o755);
                     fs::set_permissions(path, permissions).unwrap();
+                }
+
+                #[test]
+                fn covers_top_level_post_install_missing_launcher_error() {
+                    if let Err(error) = post_install() {
+                        assert!(
+                            error.contains("failed to read")
+                                || error.contains("failed to stat")
+                                || error.contains("failed to write"),
+                            "unexpected post_install error: {error}"
+                        );
+                    }
                 }
 
                 #[test]

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -70,9 +70,8 @@ macro_rules! launcher_post_install_extra_tests {
                 }
 
                 #[test]
-                fn covers_top_level_post_install_missing_launcher_error() {
+                fn covers_top_level_post_install_missing_launcher_error_or_noop() {
                     if let Err(error) = post_install() {
-                        assert!(
                             error.contains("failed to read")
                                 || error.contains("failed to stat")
                                 || error.contains("failed to write"),


### PR DESCRIPTION
## Summary
- add shared coverage tests for radioisotope post-install entrypoints
- execute each generated wrapper entrypoint and accept its existing missing-launcher/no-op behavior
- keep isotope and radioisotope source repositories unchanged

## Validation
- `cargo fmt --check`
- `TEAM_IDENTIFIER=AB12A12ABC AV_DOTENV_KEYCHAIN_ACCESS_GROUP=TESTTEAM.com.automicvault.dotenv AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --test radioisotope_post_install_edges --no-report -- --test-threads=1`
- `TEAM_IDENTIFIER=AB12A12ABC AV_DOTENV_KEYCHAIN_ACCESS_GROUP=TESTTEAM.com.automicvault.dotenv AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS=1 cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1`
- `cargo llvm-cov report --summary-only` -> total regions 90.24%, total lines 93.18%
- isotope LCOV path checks for `data/isotopes` and `data/radioisotopes`

## Notes
- Local sudo could not refresh `/var/db/automic-vault/db.json`; an existing root-owned debug database from 2026-06-20 was present and used for the run.
