### PR TITLE
Decouple radioisotope tests from sibling checkouts

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -23,13 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Checkout isotope repositories
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          rm -rf ../av.db/data/isotopes ../av.db/data/radioisotopes
-          scripts/sync-isotope-checkouts.sh
-
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
 
@@ -49,16 +42,9 @@ jobs:
           sudo cp data/combined.json /var/db/automic-vault/db.json
 
       - name: Generate Rust coverage
-        env:
-          AUTOMIC_VAULT_INCLUDE_ISOTOPE_TESTS: "1"
         run: >
-          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov --workspace --no-cfg-coverage --lcov --output-path lcov.info
           -- --test-threads=1
-
-      - name: Verify isotope coverage paths
-        run: |
-          grep -Eq '^SF:.*/data/isotopes/.+\.rs$' lcov.info
-          grep -Eq '^SF:.*/data/radioisotopes/.+\.rs$' lcov.info
 
       - name: Upload Rust coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/build.rs
+++ b/build.rs
@@ -227,11 +227,15 @@ fn generate_isotope_integrations() {
     println!("cargo:rerun-if-env-changed=CARGO_CFG_COVERAGE");
     let default_isotope_root = absolute_path(repo_root.join("../isotopes"));
     let default_radioisotope_root = absolute_path(repo_root.join("../radioisotopes"));
-    let isotope_root =
-        path_env_or_default("AUTOMIC_VAULT_REPO_CACHE", default_isotope_root.clone());
-    let radioisotope_root = path_env_or_default(
+    let isotope_root = path_env_or_fixture(
+        "AUTOMIC_VAULT_REPO_CACHE",
+        default_isotope_root.clone(),
+        repo_root.join("src/lib/rs/fixtures/isotopes"),
+    );
+    let radioisotope_root = path_env_or_fixture(
         "AUTOMIC_VAULT_RADIOISOTOPES_REPO",
         default_radioisotope_root.clone(),
+        repo_root.join("src/lib/rs/fixtures/radioisotopes"),
     );
     let isotope_roots = [isotope_root.clone(), radioisotope_root.clone()];
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
@@ -421,6 +425,21 @@ fn path_env_or_default(key: &str, default: std::path::PathBuf) -> std::path::Pat
         .map(std::path::PathBuf::from)
         .unwrap_or(default);
     absolute_path(path)
+}
+
+fn path_env_or_fixture(
+    key: &str,
+    default: std::path::PathBuf,
+    fixture: std::path::PathBuf,
+) -> std::path::PathBuf {
+    if let Some(path) = std::env::var_os(key).filter(|value| !value.is_empty()) {
+        return absolute_path(std::path::PathBuf::from(path));
+    }
+    let default = absolute_path(default);
+    if default.exists() {
+        return default;
+    }
+    absolute_path(fixture)
 }
 
 fn absolute_path(path: std::path::PathBuf) -> std::path::PathBuf {

--- a/src/lib/rs/fixtures/isotopes/gh/automic-vault.yml
+++ b/src/lib/rs/fixtures/isotopes/gh/automic-vault.yml
@@ -1,0 +1,1 @@
+name: isotope:gh

--- a/src/lib/rs/fixtures/isotopes/gh/detect.rs
+++ b/src/lib/rs/fixtures/isotopes/gh/detect.rs
@@ -1,0 +1,14 @@
+use std::{env, fs, path::PathBuf};
+
+pub fn install_is_insecure() -> Result<bool, String> {
+    Ok(!install_insecurity_reasons()?.is_empty())
+}
+
+pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
+    let path = env::var_os("GH_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env::var_os("HOME").unwrap_or_default()).join(".config/gh"))
+        .join("hosts.yml");
+    let contents = fs::read_to_string(path).unwrap_or_default();
+    Ok(contents.contains("oauth_token").then(|| "GitHub CLI hosts file contains plaintext credentials".to_string()).into_iter().collect())
+}

--- a/src/lib/rs/fixtures/isotopes/gh/detect.rs
+++ b/src/lib/rs/fixtures/isotopes/gh/detect.rs
@@ -6,6 +6,7 @@ pub fn install_is_insecure() -> Result<bool, String> {
 
 pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
     let path = env::var_os("GH_CONFIG_DIR")
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(env::var_os("HOME").unwrap_or_default()).join(".config/gh"))
         .join("hosts.yml");

--- a/src/lib/rs/fixtures/isotopes/gh/migrate.rs
+++ b/src/lib/rs/fixtures/isotopes/gh/migrate.rs
@@ -1,0 +1,3 @@
+pub fn migrate_credentials() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/aws-cli/automic-vault.yml
+++ b/src/lib/rs/fixtures/radioisotopes/aws-cli/automic-vault.yml
@@ -1,0 +1,1 @@
+name: isotope:aws-cli

--- a/src/lib/rs/fixtures/radioisotopes/aws-cli/credential-helper.rs
+++ b/src/lib/rs/fixtures/radioisotopes/aws-cli/credential-helper.rs
@@ -1,0 +1,20 @@
+pub const NAME: &str = "aws";
+
+pub fn credential_helper(invocation: crate::isotope::CredentialHelperInvocation<'_>) -> Result<(), String> {
+    if invocation.args.iter().any(|arg| arg == "--help" || arg == "--version") {
+        return Ok(());
+    }
+    let token = invocation.caller.token.as_deref().ok_or_else(|| "missing approval token".to_string())?;
+    if token.len() < 32 {
+        return Err("invalid approval token".to_string());
+    }
+    let parent = invocation
+        .caller
+        .parent_executable_path
+        .as_deref()
+        .ok_or_else(|| "missing helper parent executable".to_string())?;
+    if !parent.contains("aws") {
+        return Err("credential helper invoked by unexpected launcher".to_string());
+    }
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/aws-cli/detect.rs
+++ b/src/lib/rs/fixtures/radioisotopes/aws-cli/detect.rs
@@ -1,0 +1,14 @@
+use std::{env, fs, path::PathBuf};
+
+pub fn install_is_insecure() -> Result<bool, String> {
+    Ok(!install_insecurity_reasons()?.is_empty())
+}
+
+pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
+    let path = env::var_os("AWS_SHARED_CREDENTIALS_FILE")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env::var_os("HOME").unwrap_or_default()).join(".aws/credentials"));
+    let contents = fs::read_to_string(path).unwrap_or_default();
+    Ok(contents.contains("aws_secret_access_key").then(|| "AWS shared credentials file contains plaintext credentials".to_string()).into_iter().collect())
+}

--- a/src/lib/rs/fixtures/radioisotopes/aws-cli/migrate.rs
+++ b/src/lib/rs/fixtures/radioisotopes/aws-cli/migrate.rs
@@ -1,0 +1,3 @@
+pub fn migrate_credentials() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/aws-cli/post-install.rs
+++ b/src/lib/rs/fixtures/radioisotopes/aws-cli/post-install.rs
@@ -1,0 +1,3 @@
+pub fn post_install() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/git/automic-vault.yml
+++ b/src/lib/rs/fixtures/radioisotopes/git/automic-vault.yml
@@ -1,0 +1,1 @@
+name: isotope:git

--- a/src/lib/rs/fixtures/radioisotopes/git/detect.rs
+++ b/src/lib/rs/fixtures/radioisotopes/git/detect.rs
@@ -1,0 +1,30 @@
+use std::{env, fs, io::Write, process::{Command, Stdio}};
+
+pub fn install_is_insecure() -> Result<bool, String> {
+    Ok(!install_insecurity_reasons()?.is_empty())
+}
+
+pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
+    let mut reasons = Vec::new();
+    let home = env::var_os("HOME").unwrap_or_default();
+    if fs::read_to_string(std::path::PathBuf::from(&home).join(".git-credentials"))
+        .unwrap_or_default()
+        .contains("://")
+    {
+        reasons.push("Git credential store contains plaintext credentials".to_string());
+    }
+    if env::var_os("AUTOMIC_VAULT_TEST_GIT_CREDENTIAL_FILL_DETECTOR").is_some() {
+        let mut child = Command::new("git")
+            .args(["credential", "fill"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(|err| err.to_string())?;
+        child.stdin.as_mut().unwrap().write_all(b"protocol=https\nhost=github.com\n\n").map_err(|err| err.to_string())?;
+        let output = child.wait_with_output().map_err(|err| err.to_string())?;
+        if String::from_utf8_lossy(&output.stdout).contains("password=") {
+            reasons.push("git credential fill returned plaintext credentials. Click Learn More.".to_string());
+        }
+    }
+    Ok(reasons)
+}

--- a/src/lib/rs/fixtures/radioisotopes/huggingface-cli/automic-vault.yml
+++ b/src/lib/rs/fixtures/radioisotopes/huggingface-cli/automic-vault.yml
@@ -1,0 +1,1 @@
+name: isotope:huggingface-cli

--- a/src/lib/rs/fixtures/radioisotopes/huggingface-cli/detect.rs
+++ b/src/lib/rs/fixtures/radioisotopes/huggingface-cli/detect.rs
@@ -1,0 +1,10 @@
+use std::{env, fs, path::PathBuf};
+
+pub fn install_is_insecure() -> Result<bool, String> {
+    Ok(!install_insecurity_reasons()?.is_empty())
+}
+
+pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
+    let path = PathBuf::from(env::var_os("HOME").unwrap_or_default()).join(".cache/huggingface/token");
+    Ok(fs::read_to_string(path).unwrap_or_default().trim().is_empty().then(Vec::new).unwrap_or_else(|| vec!["Hugging Face token file contains plaintext credentials".to_string()]))
+}

--- a/src/lib/rs/fixtures/radioisotopes/huggingface-cli/migrate.rs
+++ b/src/lib/rs/fixtures/radioisotopes/huggingface-cli/migrate.rs
@@ -1,0 +1,3 @@
+pub fn migrate_credentials() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/node@24/automic-vault.yml
+++ b/src/lib/rs/fixtures/radioisotopes/node@24/automic-vault.yml
@@ -1,0 +1,1 @@
+name: isotope:node@24

--- a/src/lib/rs/fixtures/radioisotopes/node@24/detect.rs
+++ b/src/lib/rs/fixtures/radioisotopes/node@24/detect.rs
@@ -1,0 +1,13 @@
+use std::{env, fs, path::PathBuf};
+
+pub fn install_is_insecure() -> Result<bool, String> {
+    Ok(!install_insecurity_reasons()?.is_empty())
+}
+
+pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
+    let path = env::var_os("NPM_CONFIG_USERCONFIG")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env::var_os("HOME").unwrap_or_default()).join(".npmrc"));
+    Ok(fs::read_to_string(path).unwrap_or_default().contains("_authToken").then(|| "npm user config contains plaintext credentials".to_string()).into_iter().collect())
+}

--- a/src/lib/rs/fixtures/radioisotopes/node@24/migrate.rs
+++ b/src/lib/rs/fixtures/radioisotopes/node@24/migrate.rs
@@ -1,0 +1,3 @@
+pub fn migrate_credentials() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/node@24/post-install.rs
+++ b/src/lib/rs/fixtures/radioisotopes/node@24/post-install.rs
@@ -1,0 +1,3 @@
+pub fn post_install() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/terraform/automic-vault.yml
+++ b/src/lib/rs/fixtures/radioisotopes/terraform/automic-vault.yml
@@ -1,0 +1,1 @@
+name: isotope:terraform

--- a/src/lib/rs/fixtures/radioisotopes/terraform/detect.rs
+++ b/src/lib/rs/fixtures/radioisotopes/terraform/detect.rs
@@ -1,0 +1,10 @@
+use std::{env, fs, path::PathBuf};
+
+pub fn install_is_insecure() -> Result<bool, String> {
+    Ok(!install_insecurity_reasons()?.is_empty())
+}
+
+pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
+    let path = PathBuf::from(env::var_os("HOME").unwrap_or_default()).join(".terraform.d/credentials.tfrc.json");
+    Ok(fs::read_to_string(path).unwrap_or_default().contains("token").then(|| "Terraform credentials file contains plaintext credentials".to_string()).into_iter().collect())
+}

--- a/src/lib/rs/fixtures/radioisotopes/terraform/migrate.rs
+++ b/src/lib/rs/fixtures/radioisotopes/terraform/migrate.rs
@@ -1,0 +1,3 @@
+pub fn migrate_credentials() -> Result<(), String> {
+    Ok(())
+}

--- a/src/lib/rs/fixtures/radioisotopes/terraform/post-install.rs
+++ b/src/lib/rs/fixtures/radioisotopes/terraform/post-install.rs
@@ -1,3 +1,3 @@
 pub fn post_install() -> Result<(), String> {
-    Err("terraform fixture post-install failed".to_string())
+    Ok(())
 }

--- a/src/lib/rs/fixtures/radioisotopes/terraform/post-install.rs
+++ b/src/lib/rs/fixtures/radioisotopes/terraform/post-install.rs
@@ -1,0 +1,3 @@
+pub fn post_install() -> Result<(), String> {
+    Err("terraform fixture post-install failed".to_string())
+}

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -4540,18 +4540,22 @@ managed_secrets = ["dep:managed-secrets"]"#,
                 RequestedPackage::Isotope("terraform".to_string()),
             ] {
                 seed_terraform_install();
-                let err = run_i_package(
+                let result = run_i_package(
                     &config,
                     requested,
                     InstallOptions {
                         intent: InstallIntent::Install,
                     },
-                )
-                .unwrap_err();
-                assert!(
-                    err.contains("terraform"),
-                    "expected terraform install error, got: {err}"
                 );
+                if using_radioisotope_fixture_integrations() {
+                    result.unwrap();
+                } else {
+                    let err = result.unwrap_err();
+                    assert!(
+                        err.contains("terraform"),
+                        "expected terraform install error, got: {err}"
+                    );
+                }
             }
         }
 
@@ -5384,7 +5388,15 @@ managed_secrets = ["dep:managed-secrets"]"#,
         let _lock = test_env_lock().lock().unwrap();
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
+        let cwd = temp.path().join("cwd");
         fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+        fs::write(
+            cwd.join("hosts.yml"),
+            "github.com:\n  oauth_token: cwd-token\n",
+        )
+        .unwrap();
+        let _cwd = CurrentDirGuard::set(&cwd);
         let missing_path = temp.path().join("missing");
         let missing = missing_path.to_str().unwrap();
         let _env = TestEnvGuard::set(&[
@@ -5401,7 +5413,7 @@ managed_secrets = ["dep:managed-secrets"]"#,
             ("DCOS_DIR", missing),
             ("DIGITALOCEAN_CONFIG", missing),
             ("DOCKER_CONFIG", missing),
-            ("GH_CONFIG_DIR", missing),
+            ("GH_CONFIG_DIR", ""),
             ("GLAB_CONFIG_DIR", missing),
             ("HCLOUD_CONFIG", missing),
             ("HELM_CONFIG_HOME", missing),
@@ -13840,6 +13852,22 @@ EOF
                     },
                 }
             }
+        }
+    }
+
+    struct CurrentDirGuard(PathBuf);
+
+    impl CurrentDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = env::current_dir().unwrap();
+            env::set_current_dir(path).unwrap();
+            Self(previous)
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            env::set_current_dir(&self.0).unwrap();
         }
     }
 

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -5374,6 +5374,10 @@ managed_secrets = ["dep:managed-secrets"]"#,
         );
     }
 
+    fn using_radioisotope_fixture_integrations() -> bool {
+        env!("AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO").contains("/fixtures/radioisotopes")
+    }
+
     #[test]
     fn generated_isotope_integrations_tolerate_empty_home() {
         let _lock = test_env_lock().lock().unwrap();
@@ -5763,42 +5767,53 @@ machine example.com login user password netrc-token
             }
         }
 
-        for expected in [
-            "acli",
-            "akamai",
-            "algolia",
-            "argocd",
-            "atuin",
-            "bash",
-            "bitwarden-cli",
-            "certbot",
-            "cloudflare-wrangler",
-            "cloudflared",
-            "docker",
-            "docker-machine",
-            "fastlane",
-            "gh",
-            "kubernetes-cli",
-            "openvpn",
-            "supabase",
-            "terraform",
-            "vercel-cli",
-            "zsh",
-        ] {
+        let expected: &[&str] = if using_radioisotope_fixture_integrations() {
+            &["gh", "huggingface-cli", "node@24", "terraform"]
+        } else {
+            &[
+                "acli",
+                "akamai",
+                "algolia",
+                "argocd",
+                "atuin",
+                "bash",
+                "bitwarden-cli",
+                "certbot",
+                "cloudflare-wrangler",
+                "cloudflared",
+                "docker",
+                "docker-machine",
+                "fastlane",
+                "gh",
+                "kubernetes-cli",
+                "openvpn",
+                "supabase",
+                "terraform",
+                "vercel-cli",
+                "zsh",
+            ]
+        };
+
+        for expected in expected {
             assert!(
-                triggered.contains(&expected),
+                triggered.contains(expected),
                 "expected {expected} to report seeded secrets, got {triggered:?}"
             );
         }
-        assert!(
-            triggered.len() >= 30,
-            "expected broad generated detector coverage, got {triggered:?}"
-        );
+        if !using_radioisotope_fixture_integrations() {
+            assert!(
+                triggered.len() >= 30,
+                "expected broad generated detector coverage, got {triggered:?}"
+            );
+        }
     }
 
     #[test]
     fn generated_isotope_migrations_scrub_seeded_secret_files() {
         let _lock = test_env_lock().lock().unwrap();
+        if using_radioisotope_fixture_integrations() {
+            return;
+        }
         if isotope_integrations::INTEGRATIONS
             .iter()
             .all(|integration| integration.migrate.is_none())
@@ -6179,6 +6194,9 @@ machine example.com login user password netrc-token
     #[test]
     fn generated_radioisotope_migrations_cover_additional_default_paths() {
         let _lock = test_env_lock().lock().unwrap();
+        if using_radioisotope_fixture_integrations() {
+            return;
+        }
         if isotope_integrations::INTEGRATIONS
             .iter()
             .all(|integration| integration.migrate.is_none())
@@ -6546,7 +6564,14 @@ machine example.com login user password netrc-token
                 "expected wrong parent error for {name}, got {wrong_parent}"
             );
         }
-        assert_eq!(helpers.len(), 9);
+        assert_eq!(
+            helpers.len(),
+            if using_radioisotope_fixture_integrations() {
+                1
+            } else {
+                9
+            }
+        );
     }
 
     #[test]

--- a/src/lib/rs/lib.rs
+++ b/src/lib/rs/lib.rs
@@ -5375,7 +5375,8 @@ managed_secrets = ["dep:managed-secrets"]"#,
     }
 
     fn using_radioisotope_fixture_integrations() -> bool {
-        env!("AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO").contains("/fixtures/radioisotopes")
+        Path::new(env!("AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO"))
+            == Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib/rs/fixtures/radioisotopes")
     }
 
     #[test]

--- a/tests/radioisotope_detect_edges.rs
+++ b/tests/radioisotope_detect_edges.rs
@@ -456,9 +456,11 @@ mod aws_cli_detect {
 
             let previous_home = std::env::var_os("HOME");
             let previous_credentials = std::env::var_os("AWS_SHARED_CREDENTIALS_FILE");
+            let previous_config = std::env::var_os("AWS_CONFIG_FILE");
             unsafe {
                 std::env::remove_var("HOME");
                 std::env::remove_var("AWS_SHARED_CREDENTIALS_FILE");
+                std::env::remove_var("AWS_CONFIG_FILE");
             }
             assert!(install_insecurity_reasons().unwrap_err().contains("HOME"));
             unsafe {
@@ -476,6 +478,10 @@ mod aws_cli_detect {
                 match previous_credentials {
                     Some(value) => std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", value),
                     None => std::env::remove_var("AWS_SHARED_CREDENTIALS_FILE"),
+                }
+                match previous_config {
+                    Some(value) => std::env::set_var("AWS_CONFIG_FILE", value),
+                    None => std::env::remove_var("AWS_CONFIG_FILE"),
                 }
             }
             fs::remove_dir_all(root).unwrap();

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -373,10 +373,9 @@ mod aws_cli_post_install {
         }
 
         #[test]
-        fn covers_post_install_and_patch_error_edges() {
+        fn covers_post_install_error_edges() {
             let root = temp_path("post-install-errors");
             let launcher = root.join("aws");
-            let lib = root.join("lib");
             assert!(
                 prefix_aws_launcher(&launcher, ENTRYPOINT_PREFIX)
                     .unwrap_err()
@@ -388,30 +387,6 @@ mod aws_cli_post_install {
             assert_eq!(
                 std::fs::read_to_string(&launcher).unwrap(),
                 format!("{ENTRYPOINT_PREFIX}print('aws')\n")
-            );
-
-            assert!(
-                patch_aws_plugin_loaders(&lib)
-                    .unwrap_err()
-                    .contains("failed to read")
-            );
-            std::fs::create_dir_all(&lib).unwrap();
-            assert!(
-                patch_aws_plugin_loaders(&lib)
-                    .unwrap_err()
-                    .contains("failed to find")
-            );
-            assert!(
-                patch_aws_plugin_loader(&launcher)
-                    .unwrap_err()
-                    .contains("failed to patch")
-            );
-            assert!(
-                patch_aws_plugin_loader_contents(
-                    "def load_plugins():\n    _load_plugins(BUILTIN_PLUGINS, event_hooks)\n"
-                )
-                .unwrap_err()
-                .contains("legacy external plugin")
             );
 
             std::fs::remove_dir_all(root).unwrap();

--- a/tests/radioisotope_wrappers.rs
+++ b/tests/radioisotope_wrappers.rs
@@ -22,7 +22,7 @@ fn radioisotope_av_inject_shell_wrappers_run_with_missing_optional_credentials()
     }
 
     let root = radioisotope_root();
-    if root.to_string_lossy().contains("/fixtures/radioisotopes") {
+    if root == radioisotope_fixture_root() {
         return;
     }
     let templates = collect_av_inject_shell_wrappers(&root);
@@ -100,6 +100,10 @@ fn radioisotope_root() -> PathBuf {
         .map(PathBuf::from)
         .map(absolute_radioisotope_path)
         .unwrap_or_else(|| PathBuf::from(env!("AUTOMIC_VAULT_GENERATED_RADIOISOTOPES_REPO")))
+}
+
+fn radioisotope_fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib/rs/fixtures/radioisotopes")
 }
 
 fn absolute_radioisotope_path(path: PathBuf) -> PathBuf {

--- a/tests/radioisotope_wrappers.rs
+++ b/tests/radioisotope_wrappers.rs
@@ -22,6 +22,9 @@ fn radioisotope_av_inject_shell_wrappers_run_with_missing_optional_credentials()
     }
 
     let root = radioisotope_root();
+    if root.to_string_lossy().contains("/fixtures/radioisotopes") {
+        return;
+    }
     let templates = collect_av_inject_shell_wrappers(&root);
     assert!(
         templates.len() >= MIN_AV_INJECT_SHELL_WRAPPER_COUNT,


### PR DESCRIPTION
## Summary
- fall back to checked-in isotope/radioisotope fixtures when sibling repos are absent
- keep AV generated integration tests exercising representative fixtures by default
- remove live isotope checkout and cfg(coverage) isotope assertions from AV coverage CI
- keep compatibility fixes for the current aws-cli radioisotope test surface

## Verification
- `cargo fmt --check`
- `AV_DOTENV_KEYCHAIN_ACCESS_GROUP=TESTTEAM.com.automicvault.dotenv AUTOMIC_VAULT_REPO_CACHE=src/lib/rs/fixtures/isotopes AUTOMIC_VAULT_RADIOISOTOPES_REPO=src/lib/rs/fixtures/radioisotopes cargo test -- --test-threads=1`
- `AV_DOTENV_KEYCHAIN_ACCESS_GROUP=TESTTEAM.com.automicvault.dotenv cargo test -- --test-threads=1`
- `AV_DOTENV_KEYCHAIN_ACCESS_GROUP=TESTTEAM.com.automicvault.dotenv cargo llvm-cov --workspace --no-cfg-coverage --lcov --output-path lcov.info -- --test-threads=1`
- GitHub Rust Coverage check passed on this PR
- paired radioisotopes workflow dispatch passed against this branch: https://github.com/automic-vault/radioisotopes/actions/runs/28037970764

## Coverage
- AV default coverage after moving live radioisotope coverage out: 33 files, 41,609/45,061 lines, 92.34%
- live current-radioisotope coverage was verified through the radioisotopes-owned harness: 348 files, 38,164/46,544 lines, 82.00%

Paired radioisotopes PR: https://github.com/automic-vault/radioisotopes/pull/10
