### PR TITLE
Enable radioisotope coverage suites

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -42,6 +42,8 @@ jobs:
           sudo cp data/combined.json /var/db/automic-vault/db.json
 
       - name: Sync isotope checkouts
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: scripts/sync-isotope-checkouts.sh
 
       - name: Generate Rust coverage

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -41,6 +41,9 @@ jobs:
           sudo mkdir -p /var/db/automic-vault
           sudo cp data/combined.json /var/db/automic-vault/db.json
 
+      - name: Sync isotope checkouts
+        run: scripts/sync-isotope-checkouts.sh
+
       - name: Generate Rust coverage
         run: >
           cargo llvm-cov --workspace --no-cfg-coverage --lcov --output-path lcov.info

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -51,6 +51,9 @@ jobs:
           cargo llvm-cov --workspace --no-cfg-coverage --lcov --output-path lcov.info
           -- --test-threads=1
 
+      - name: Trust Coveralls Homebrew tap
+        run: brew trust coverallsapp/coveralls
+
       - name: Upload Rust coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/tests/radioisotope_credential_helpers.rs
+++ b/tests/radioisotope_credential_helpers.rs
@@ -1,4 +1,3 @@
-#![cfg(coverage)]
 #![allow(dead_code)]
 
 use std::cell::RefCell;

--- a/tests/radioisotope_detect_edges.rs
+++ b/tests/radioisotope_detect_edges.rs
@@ -1,4 +1,3 @@
-#![cfg(coverage)]
 #![allow(dead_code)]
 
 use std::ffi::{OsStr, OsString};

--- a/tests/radioisotope_post_install_edges.rs
+++ b/tests/radioisotope_post_install_edges.rs
@@ -1,4 +1,3 @@
-#![cfg(coverage)]
 #![allow(dead_code)]
 
 macro_rules! radioisotope_source {


### PR DESCRIPTION
## Summary
- sync isotope/radioisotope checkouts in the Rust coverage workflow before generating coverage
- enable the existing radioisotope credential helper, detector, and post-install edge suites under the CI coverage flags
- leave the migration edge suite gated because the standalone target needs additional keychain FFI linkage

## Validation
- `AV_DOTENV_KEYCHAIN_ACCESS_GROUP=TESTTEAM.com.automicvault.dotenv cargo llvm-cov --workspace --no-cfg-coverage --lcov --output-path lcov.info -- --test-threads=1`
- line coverage: `62260/67483 = 92.26%`
