### PR TITLE
Check keys before approval

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -708,6 +708,17 @@ private func approvalEvent(for cachedDecision: ApprovalDecision?) -> String? {
     cachedDecision == nil ? humanApprovalRequiredEvent : nil
 }
 
+private func missingRequiredSecret(
+    for request: ApprovalRequest,
+    exists: (String) -> Bool = { storedSecretExists(account: $0) }
+) -> String? {
+    guard !request.allowMissingKeys else { return nil }
+    let conflicts = Set(request.envConflicts)
+    return request.keys.first {
+        (request.replaceExistingEnv || !conflicts.contains($0)) && !exists($0)
+    }
+}
+
 private struct TransientApprovalCache {
     private enum Key: Hashable {
         case approval(TransientApprovalKey)
@@ -883,6 +894,10 @@ private final class ApprovalServer: @unchecked Sendable {
     ) {
         guard let request = approvalRequest(from: message) else {
             reply(peer, to: message, ok: false, error: "invalid approval request")
+            return
+        }
+        if let key = missingRequiredSecret(for: request) {
+            reply(peer, to: message, ok: false, error: "failed to load isotope key \(key): \(errSecItemNotFound)")
             return
         }
         let scriptApproval = scriptApproval(for: request)
@@ -2933,7 +2948,10 @@ private func runApprovalSelfCheck() -> Int32 {
     func awsRequest(
         keys: [String] = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         args: [String] = ["-f", "/usr/local/bin/aws", "s3", "ls"],
-        shebangScript: String? = "/usr/local/bin/aws"
+        shebangScript: String? = "/usr/local/bin/aws",
+        replaceExistingEnv: Bool = false,
+        allowMissingKeys: Bool = false,
+        envConflicts: [String] = []
     ) -> ApprovalRequest {
         ApprovalRequest(
             op: "inject",
@@ -2941,9 +2959,9 @@ private func runApprovalSelfCheck() -> Int32 {
             target: "/bin/zsh",
             args: args,
             cwd: "/tmp",
-            replaceExistingEnv: false,
-            allowMissingKeys: false,
-            envConflicts: [],
+            replaceExistingEnv: replaceExistingEnv,
+            allowMissingKeys: allowMissingKeys,
+            envConflicts: envConflicts,
             shebangScript: shebangScript,
             tool: nil,
             title: nil,
@@ -2969,6 +2987,21 @@ private func runApprovalSelfCheck() -> Int32 {
         )
     )
     guard matchingSecretGate(request: readOnlyAws, signing: avSigning, hardeners: [awsMetadata])?.id == "aws",
+          missingRequiredSecret(for: readOnlyAws, exists: { $0 == "AWS_SECRET_ACCESS_KEY" }) == "AWS_ACCESS_KEY_ID",
+          missingRequiredSecret(for: readOnlyAws, exists: { _ in true }) == nil,
+          missingRequiredSecret(for: awsRequest(allowMissingKeys: true), exists: { _ in false }) == nil,
+          missingRequiredSecret(
+              for: awsRequest(keys: ["AWS_ACCESS_KEY_ID"], envConflicts: ["AWS_ACCESS_KEY_ID"]),
+              exists: { _ in false }
+          ) == nil,
+          missingRequiredSecret(
+              for: awsRequest(
+                  keys: ["AWS_ACCESS_KEY_ID"],
+                  replaceExistingEnv: true,
+                  envConflicts: ["AWS_ACCESS_KEY_ID"]
+              ),
+              exists: { _ in false }
+          ) == "AWS_ACCESS_KEY_ID",
           matchingSecretGate(request: awsRequest(keys: ["AWS_ACCESS_KEY_ID"]), signing: avSigning, hardeners: [awsMetadata]) == nil,
           matchingSecretGate(request: awsRequest(shebangScript: nil), signing: avSigning, hardeners: [awsMetadata]) == nil,
           matchingSecretGate(

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -923,6 +923,18 @@ public func loadStoredSecrets(service: String = automicVaultKeychainService) -> 
     .sorted { $0.account.localizedStandardCompare($1.account) == .orderedAscending }
 }
 
+public func storedSecretExists(account: String, service: String = automicVaultKeychainService) -> Bool {
+    var query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+        kSecUseDataProtectionKeychain as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    addCanonicalAccessGroup(to: &query)
+    return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+}
+
 private func keychainProperties(for item: [String: Any], dataProtection: Bool) -> [String] {
     [
         dataProtection ? "Data Protection Enabled" : nil,

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -445,6 +445,16 @@ func protectionPolicyMatrix(
     #expect(loadStoredSecrets(service: service).isEmpty)
 }
 
+@Test func storedSecretExistenceDoesNotRequireLoadingItsValue() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.\(UUID().uuidString)"
+    #expect(!storedSecretExists(account: "API_TOKEN", service: service))
+    #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: service) == errSecSuccess)
+    defer { _ = deleteStoredSecret(account: "API_TOKEN", service: service) }
+
+    #expect(storedSecretExists(account: "API_TOKEN", service: service))
+}
+
 @Test func storedSecretsUseDataProtectionKeychain() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.\(UUID().uuidString)"


### PR DESCRIPTION
## What changed

- Check that every required isotope key exists before entering the approval flow.
- Preserve `--allow-missing-keys`, existing-environment, and replacement semantics.
- Query Keychain metadata only, without loading secret values before approval.

## Why

The approval service previously announced and displayed a human approval prompt before loading requested Keychain entries. A missing key therefore caused a pointless prompt followed by `errSecItemNotFound` (`-25300`).

Missing required keys now fail immediately with the existing error, before any approval event or prompt.

## Validation

- `swift test --package-path src/menu-helper` (32 tests)
- `cargo test` (all unit and integration targets)
- `git diff --check`
