### PR TITLE
Handle keychain access across sleep and locked sessions

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1166,6 +1166,9 @@ private struct StoredSecretDetailView: View {
                 InfoBlock(title: "Error", text: error)
             }
         }
+        .onChange(of: secret.accessibility) { _, accessibility in
+            isAvailableWhileLocked = accessibility.isAvailableWhileLocked
+        }
     }
 
     private var availabilityBinding: Binding<Bool> {

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -626,7 +626,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
           model.count(for: .secretUsage) == 1,
           model.selectedStoredSecret?.accessibility == .afterFirstUnlock,
           gateHeight > 0,
-          secretDetailHeight.map { $0 > 0 } == true,
+          secretDetailHeight.map({ $0 > 0 }) == true,
           appRowHeight < 140
     else { return 1 }
     guard model.items.first(where: { $0.id == "aws" })?.isHardened == true,

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -178,6 +178,14 @@ final class DashboardModel: ObservableObject {
         return snapshot.secretGates.first
     }
 
+    var selectedStoredSecret: StoredSecret? {
+        if let selectedItemID,
+           let secret = snapshot.secrets.first(where: { $0.account == selectedItemID }) {
+            return secret
+        }
+        return snapshot.secrets.first
+    }
+
     var selectedAccessRequest: AccessRequestRecord? {
         if let selectedItemID,
            let record = snapshot.accessRequests.first(where: { $0.id.uuidString == selectedItemID }) {
@@ -235,17 +243,40 @@ final class DashboardModel: ObservableObject {
         }
     }
 
-    func addSecret(account: String, value: String) {
+    func addSecret(
+        account: String,
+        value: String,
+        accessibility: StoredSecretAccessibility = .whenUnlocked
+    ) {
         let account = account.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !account.isEmpty, !value.isEmpty else { return }
-        let status = saveStoredSecret(account: account, value: value)
+        let status = saveStoredSecret(
+            account: account,
+            value: value,
+            accessibility: accessibility
+        )
         if status == errSecSuccess {
+            errorMessage = nil
             selectedSection = .allSecrets
             selectedItemID = account
             reload()
         } else {
             errorMessage = "Could not save \(account): \(status)"
         }
+    }
+
+    func setAccessibility(_ accessibility: StoredSecretAccessibility, for secret: StoredSecret) -> Bool {
+        let status = setStoredSecretAccessibility(
+            account: secret.account,
+            accessibility: accessibility
+        )
+        if status == errSecSuccess {
+            errorMessage = nil
+            reload()
+            return true
+        }
+        errorMessage = "Could not update \(secret.account): \(status)"
+        return false
     }
 
     func deleteSelectedSecret() {
@@ -551,7 +582,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
         ],
         secretGates: [],
         secrets: [
-            StoredSecret(account: "AWS_TOKEN"),
+            StoredSecret(account: "AWS_TOKEN", accessibility: .afterFirstUnlock),
             StoredSecret(account: "GITHUB_TOKEN"),
         ],
         accessRequests: [accessRequest],
@@ -584,13 +615,18 @@ func runDashboardSearchSelfCheck() -> Int32 {
         gate: gate,
         setProtection: { _ in }
     ).frame(width: 500)).fittingSize.height
+    let secretDetailHeight = model.selectedStoredSecret.map {
+        NSHostingView(rootView: StoredSecretDetailView(model: model, secret: $0)).fittingSize.height
+    }
     guard DashboardSection.allCases.last == .doctor,
           model.count(for: .detectors) == 3,
           model.count(for: .doctor) == 1,
           model.count(for: .hardenedTools) == 2,
           model.count(for: .allSecrets) == 2,
           model.count(for: .secretUsage) == 1,
+          model.selectedStoredSecret?.accessibility == .afterFirstUnlock,
           gateHeight > 0,
+          secretDetailHeight.map { $0 > 0 } == true,
           appRowHeight < 140
     else { return 1 }
     guard model.items.first(where: { $0.id == "aws" })?.isHardened == true,
@@ -907,6 +943,13 @@ private struct DashboardDetailView: View {
                     .padding(.top, 32)
                     .padding(.bottom, 28)
                     .frame(maxWidth: .infinity, alignment: .leading)
+            } else if model.selectedSection == .allSecrets, let secret = model.selectedStoredSecret {
+                StoredSecretDetailView(model: model, secret: secret)
+                    .id(secret.account)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 32)
+                    .padding(.bottom, 28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             } else if let item = model.selectedItem {
                 VStack(alignment: .leading, spacing: 18) {
                     Text(item.title)
@@ -917,23 +960,6 @@ private struct DashboardDetailView: View {
                         .font(.system(size: 14))
                         .foregroundStyle(.secondary)
                     InfoBlock(title: model.selectedSection.title, text: item.detail)
-                    if model.selectedSection == .allSecrets {
-                        HStack {
-                            Button { model.isRenamingSecret = true } label: {
-                                Label("Rename Secret", systemImage: "pencil")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.large)
-                            Button { model.deleteSelectedSecret() } label: {
-                                Label("Delete Secret", systemImage: "trash")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.large)
-                            .tint(.red)
-                        }
-                    }
                     if let error = model.errorMessage {
                         InfoBlock(title: "Error", text: error)
                     }
@@ -1041,6 +1067,7 @@ private struct AddSecretView: View {
     @ObservedObject var model: DashboardModel
     @State private var account = ""
     @State private var value = ""
+    @State private var isAvailableWhileLocked = false
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -1052,11 +1079,21 @@ private struct AddSecretView: View {
                 .textFieldStyle(.roundedBorder)
             SecureField("Value", text: $value)
                 .textFieldStyle(.roundedBorder)
+            Toggle("Available While Locked", isOn: $isAvailableWhileLocked)
+                .toggleStyle(.switch)
+            Text("Allows already-approved apps to use this secret while your Mac is locked, after the first unlock following a restart.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
                 Button("Save") {
-                    model.addSecret(account: account, value: value)
+                    model.addSecret(
+                        account: account,
+                        value: value,
+                        accessibility: isAvailableWhileLocked ? .afterFirstUnlock : .whenUnlocked
+                    )
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
@@ -1066,6 +1103,84 @@ private struct AddSecretView: View {
         .padding(22)
         .frame(width: 360)
         .background(.ultraThinMaterial)
+    }
+}
+
+private struct StoredSecretDetailView: View {
+    @ObservedObject var model: DashboardModel
+    let secret: StoredSecret
+    @State private var isAvailableWhileLocked: Bool
+
+    init(model: DashboardModel, secret: StoredSecret) {
+        self.model = model
+        self.secret = secret
+        _isAvailableWhileLocked = State(initialValue: secret.accessibility.isAvailableWhileLocked)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(secret.account)
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(3)
+            Text(secret.subtitle)
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+            InfoBlock(
+                title: "All Secrets",
+                text: "Secret value is hidden.\n\(secret.subtitle)"
+            )
+
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle("Available While Locked", isOn: availabilityBinding)
+                    .toggleStyle(.switch)
+                Text("Allows already-approved apps to use this secret while your Mac is locked, after the first unlock following a restart.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            }
+
+            HStack {
+                Button { model.isRenamingSecret = true } label: {
+                    Label("Rename Secret", systemImage: "pencil")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                Button { model.deleteSelectedSecret() } label: {
+                    Label("Delete Secret", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .tint(.red)
+            }
+
+            if let error = model.errorMessage {
+                InfoBlock(title: "Error", text: error)
+            }
+        }
+    }
+
+    private var availabilityBinding: Binding<Bool> {
+        Binding {
+            isAvailableWhileLocked
+        } set: { isAvailable in
+            let previous = isAvailableWhileLocked
+            isAvailableWhileLocked = isAvailable
+            let accessibility: StoredSecretAccessibility = isAvailable
+                ? .afterFirstUnlock
+                : .whenUnlocked
+            if !model.setAccessibility(accessibility, for: secret) {
+                isAvailableWhileLocked = previous
+            }
+        }
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -42,6 +42,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var scanWorkItem: DispatchWorkItem?
     private var eventStream: FSEventStreamRef?
     private var mainWindow: NSWindow?
+    private var isUserSessionActive = true
+    private var areScreensAwake = true
     private let updater = AppUpdater(owner: "automic-vault", repo: "automic-vault")
     private var isCheckingForUpdates = false
     #if !DEBUG
@@ -61,6 +63,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         startServicesAndOpenMainWindowIfRequested()
+    }
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        let center = NSWorkspace.shared.notificationCenter
+        center.addObserver(
+            self,
+            selector: #selector(userSessionDidResignActive(_:)),
+            name: NSWorkspace.sessionDidResignActiveNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(userSessionDidBecomeActive(_:)),
+            name: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(screensDidSleep(_:)),
+            name: NSWorkspace.screensDidSleepNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(screensDidWake(_:)),
+            name: NSWorkspace.screensDidWakeNotification,
+            object: nil
+        )
+    }
+
+    @objc private func userSessionDidResignActive(_ notification: Notification) {
+        isUserSessionActive = false
+        if NSApp.modalWindow is ApprovalPanel {
+            NSApp.abortModal()
+        }
+    }
+
+    @objc private func userSessionDidBecomeActive(_ notification: Notification) {
+        isUserSessionActive = true
+    }
+
+    @objc private func screensDidSleep(_ notification: Notification) {
+        areScreensAwake = false
+        if NSApp.modalWindow is ApprovalPanel {
+            NSApp.abortModal()
+        }
+    }
+
+    @objc private func screensDidWake(_ notification: Notification) {
+        areScreensAwake = true
     }
 
     private func installStatusMenu() {
@@ -129,6 +181,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Task { @MainActor in self?.didRecordAccessRequest(record) }
                 }
                 return recorded
+            } canRequestHumanApproval: { [weak self] in
+                self?.isUserSessionActive == true && self?.areScreensAwake == true
             }
             try approval.start()
             self.approval = approval
@@ -141,6 +195,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
         stopServices()
     }
 
@@ -762,6 +817,7 @@ private final class ApprovalServer: @unchecked Sendable {
     private let hardeners: [HardenerMetadata]?
     private let onAutoApproval: @MainActor (AutoApprovalRecord) -> Void
     private let onAccessRequest: @Sendable (AccessRequestRecord) -> Bool
+    private let canRequestHumanApproval: @MainActor () -> Bool
     private var listener: xpc_connection_t?
     // ponytail: in-memory per-process cache; use persistent approvals for cross-process trust.
     private var transientApprovals = TransientApprovalCache()
@@ -770,7 +826,8 @@ private final class ApprovalServer: @unchecked Sendable {
         serviceName: String,
         hardeners: [HardenerMetadata]? = nil,
         onAutoApproval: @escaping @MainActor (AutoApprovalRecord) -> Void = { _ in },
-        onAccessRequest: @escaping @Sendable (AccessRequestRecord) -> Bool = { appendAccessRequestRecord($0) }
+        onAccessRequest: @escaping @Sendable (AccessRequestRecord) -> Bool = { appendAccessRequestRecord($0) },
+        canRequestHumanApproval: @escaping @MainActor () -> Bool = { true }
     ) throws {
         guard let teamIdentifier = selfTeamIdentifier() else {
             throw AppError("missing menu bar signing team identifier")
@@ -780,6 +837,7 @@ private final class ApprovalServer: @unchecked Sendable {
         self.hardeners = hardeners
         self.onAutoApproval = onAutoApproval
         self.onAccessRequest = onAccessRequest
+        self.canRequestHumanApproval = canRequestHumanApproval
     }
 
     func start() throws {
@@ -1017,6 +1075,24 @@ private final class ApprovalServer: @unchecked Sendable {
                     ))
                     self.reply(peer, to: message, ok: false, error: error.localizedDescription)
                 }
+                return
+            }
+
+            guard self.canRequestHumanApproval() else {
+                _ = self.onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Denied",
+                    approvalSource: "Auto",
+                    reason: "User session is inactive",
+                    launcher: launcher
+                ))
+                self.reply(
+                    peer,
+                    to: message,
+                    ok: false,
+                    error: "\(request.op) denied while user session is inactive"
+                )
                 return
             }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -102,6 +102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func userSessionDidBecomeActive(_ notification: Notification) {
         isUserSessionActive = true
+        _ = migrateBackgroundKeychainItems()
     }
 
     @objc private func screensDidSleep(_ notification: Notification) {
@@ -170,6 +171,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func startServices() {
         statusItem.button?.image = brandImage()
         statusItem.button?.alphaValue = 1
+        _ = migrateBackgroundKeychainItems()
         autoApprovals = loadAccessRequestRecords().compactMap(autoApprovalRecord)
         refreshAutoApprovalMenuItems()
         do {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -440,12 +440,40 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     }
 }
 
+public enum StoredSecretAccessibility: Equatable, Sendable {
+    case whenUnlocked
+    case afterFirstUnlock
+
+    public var isAvailableWhileLocked: Bool {
+        self == .afterFirstUnlock
+    }
+
+    fileprivate var keychainValue: CFString {
+        switch self {
+        case .whenUnlocked: kSecAttrAccessibleWhenUnlocked
+        case .afterFirstUnlock: kSecAttrAccessibleAfterFirstUnlock
+        }
+    }
+
+    fileprivate init(keychainValue: Any?) {
+        self = keychainValue as? String == kSecAttrAccessibleAfterFirstUnlock as String
+            ? .afterFirstUnlock
+            : .whenUnlocked
+    }
+}
+
 public struct StoredSecret: Equatable, Sendable {
     public let account: String
+    public let accessibility: StoredSecretAccessibility
     public let keychainProperties: [String]
 
-    public init(account: String, keychainProperties: [String] = []) {
+    public init(
+        account: String,
+        accessibility: StoredSecretAccessibility = .whenUnlocked,
+        keychainProperties: [String] = []
+    ) {
         self.account = account
+        self.accessibility = accessibility
         self.keychainProperties = keychainProperties
     }
 
@@ -826,7 +854,12 @@ private func saveSecretGatePolicyRecords(
             [$0.gateID, $0.requirement ?? ""].joined(separator: "\u{1f}")
                 .localizedStandardCompare([$1.gateID, $1.requirement ?? ""].joined(separator: "\u{1f}")) == .orderedAscending
         }
-        return saveKeychainData(try JSONEncoder().encode(sorted), service: service, account: account)
+        return saveKeychainData(
+            try JSONEncoder().encode(sorted),
+            service: service,
+            account: account,
+            accessibility: .afterFirstUnlock
+        )
     } catch {
         return errSecParam
     }
@@ -849,12 +882,13 @@ private func setSecretGatePolicyRecord(
 
 public func loadAccessRequestRecords(
     defaults: UserDefaults? = nil,
-    key: String = accessRequestLogDefaultsKey
+    key: String = accessRequestLogDefaultsKey,
+    service: String = accessRequestLogKeychainService
 ) -> [AccessRequestRecord] {
     if let defaults {
         return decodeAccessRequestRecords(defaults.data(forKey: key))
     }
-    switch loadKeychainDataResult(service: accessRequestLogKeychainService, account: key) {
+    switch loadKeychainDataResult(service: service, account: key) {
     case .success(let data):
         return decodeAccessRequestRecords(data)
     case .failure:
@@ -863,7 +897,12 @@ public func loadAccessRequestRecords(
         let legacy = decodeAccessRequestRecords(UserDefaults.standard.data(forKey: key))
         guard !legacy.isEmpty,
               let data = try? JSONEncoder().encode(legacy),
-              saveKeychainData(data, service: accessRequestLogKeychainService, account: key) == errSecSuccess
+              saveKeychainData(
+                  data,
+                  service: service,
+                  account: key,
+                  accessibility: .afterFirstUnlock
+              ) == errSecSuccess
         else { return legacy }
         UserDefaults.standard.removeObject(forKey: key)
         _ = UserDefaults.standard.synchronize()
@@ -884,21 +923,29 @@ private func decodeAccessRequestRecords(_ data: Data?) -> [AccessRequestRecord] 
 public func appendAccessRequestRecord(
     _ record: AccessRequestRecord,
     defaults: UserDefaults? = nil,
-    key: String = accessRequestLogDefaultsKey
+    key: String = accessRequestLogDefaultsKey,
+    service: String = accessRequestLogKeychainService
 ) -> Bool {
     accessRequestLogLock.lock()
     defer { accessRequestLogLock.unlock() }
-    let records = Array(([record] + loadAccessRequestRecords(defaults: defaults, key: key)).prefix(50))
+    let records = Array(
+        ([record] + loadAccessRequestRecords(defaults: defaults, key: key, service: service)).prefix(50)
+    )
     guard let data = try? JSONEncoder().encode(records) else { return false }
     if let defaults {
         defaults.set(data, forKey: key)
         guard defaults.synchronize() else { return false }
     } else {
-        guard saveKeychainData(data, service: accessRequestLogKeychainService, account: key) == errSecSuccess else {
+        guard saveKeychainData(
+            data,
+            service: service,
+            account: key,
+            accessibility: .afterFirstUnlock
+        ) == errSecSuccess else {
             return false
         }
     }
-    return loadAccessRequestRecords(defaults: defaults, key: key).first?.id == record.id
+    return loadAccessRequestRecords(defaults: defaults, key: key, service: service).first?.id == record.id
 }
 
 public func loadStoredSecrets(service: String = automicVaultKeychainService) -> [StoredSecret] {
@@ -918,7 +965,13 @@ public func loadStoredSecrets(service: String = automicVaultKeychainService) -> 
     }
     return items.compactMap { item in
         guard let account = item[kSecAttrAccount as String] as? String else { return nil }
-        return StoredSecret(account: account, keychainProperties: keychainProperties(for: item, dataProtection: true))
+        return StoredSecret(
+            account: account,
+            accessibility: StoredSecretAccessibility(
+                keychainValue: item[kSecAttrAccessible as String]
+            ),
+            keychainProperties: keychainProperties(for: item, dataProtection: true)
+        )
     }
     .sorted { $0.account.localizedStandardCompare($1.account) == .orderedAscending }
 }
@@ -964,8 +1017,26 @@ private func accessibleLabel(_ value: Any?) -> String? {
     }
 }
 
-public func saveStoredSecret(account: String, value: String, service: String = automicVaultKeychainService) -> OSStatus {
-    saveKeychainData(Data(value.utf8), service: service, account: account)
+public func saveStoredSecret(
+    account: String,
+    value: String,
+    accessibility: StoredSecretAccessibility = .whenUnlocked,
+    service: String = automicVaultKeychainService
+) -> OSStatus {
+    saveKeychainData(
+        Data(value.utf8),
+        service: service,
+        account: account,
+        accessibility: accessibility
+    )
+}
+
+public func setStoredSecretAccessibility(
+    account: String,
+    accessibility: StoredSecretAccessibility,
+    service: String = automicVaultKeychainService
+) -> OSStatus {
+    setKeychainAccessibility(accessibility, service: service, account: account)
 }
 
 public func renameStoredSecret(account: String, to newAccount: String, service: String = automicVaultKeychainService) -> OSStatus {
@@ -1024,7 +1095,49 @@ private func loadKeychainDataResult(service: String, account: String) -> Keychai
     return .success(data)
 }
 
-private func saveKeychainData(_ data: Data, service: String, account: String) -> OSStatus {
+@discardableResult
+public func migrateBackgroundKeychainItems(
+    policyService: String = secretGatePoliciesKeychainService,
+    policyAccount: String = secretGatePoliciesKeychainAccount,
+    accessLogService: String = accessRequestLogKeychainService,
+    accessLogAccount: String = accessRequestLogDefaultsKey
+) -> OSStatus {
+    for (service, account) in [
+        (policyService, policyAccount),
+        (accessLogService, accessLogAccount),
+    ] {
+        let status = setKeychainAccessibility(.afterFirstUnlock, service: service, account: account)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            return status
+        }
+    }
+    return errSecSuccess
+}
+
+private func setKeychainAccessibility(
+    _ accessibility: StoredSecretAccessibility,
+    service: String,
+    account: String
+) -> OSStatus {
+    var query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+        kSecUseDataProtectionKeychain as String: true,
+    ]
+    addCanonicalAccessGroup(to: &query)
+    return SecItemUpdate(
+        query as CFDictionary,
+        [kSecAttrAccessible as String: accessibility.keychainValue] as CFDictionary
+    )
+}
+
+private func saveKeychainData(
+    _ data: Data,
+    service: String,
+    account: String,
+    accessibility: StoredSecretAccessibility = .whenUnlocked
+) -> OSStatus {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: service,
@@ -1034,7 +1147,7 @@ private func saveKeychainData(_ data: Data, service: String, account: String) ->
     addCanonicalAccessGroup(to: &query)
     let attributes: [String: Any] = [
         kSecValueData as String: data,
-        kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+        kSecAttrAccessible as String: accessibility.keychainValue,
     ]
     let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     if status != errSecItemNotFound {
@@ -1042,7 +1155,7 @@ private func saveKeychainData(_ data: Data, service: String, account: String) ->
     }
     var addQuery = query
     addQuery[kSecValueData as String] = data
-    addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+    addQuery[kSecAttrAccessible as String] = accessibility.keychainValue
     return SecItemAdd(addQuery as CFDictionary, nil)
 }
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -292,6 +292,7 @@ private func secretlessGateMetadata() -> HardenerMetadata {
 
     #expect(initializeSecretGatePolicies(hardeners: [metadata], service: service, account: account) == errSecSuccess)
     #expect(loadSecretGates(hardeners: [metadata], service: service, account: account).first?.defaultProtection == .fullExceptSecretDumps)
+    #expect(keychainAccessibility(account: account, service: service) == kSecAttrAccessibleAfterFirstUnlock as String)
 }
 
 @Test func malformedPoliciesFailClosedAndAreNotReplaced() throws {
@@ -439,6 +440,8 @@ func protectionPolicyMatrix(
 
     let secrets = loadStoredSecrets(service: service)
     #expect(secrets.map(\.account) == ["API_TOKEN"])
+    #expect(secrets.first?.accessibility == .whenUnlocked)
+    #expect(secrets.first?.accessibility.isAvailableWhileLocked == false)
     #expect(secrets.first?.keychainProperties.contains("Data Protection Enabled") == true)
     #expect(secrets.first?.keychainProperties.contains("iCloud Off") == true)
     #expect(deleteStoredSecret(account: "API_TOKEN", service: service) == errSecSuccess)
@@ -451,29 +454,74 @@ func protectionPolicyMatrix(
     #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: service) == errSecSuccess)
     defer { _ = deleteStoredSecret(account: "API_TOKEN", service: service) }
 
-    let query: [String: Any] = [
-        kSecClass as String: kSecClassGenericPassword,
-        kSecAttrService as String: service,
-        kSecAttrAccount as String: "API_TOKEN",
-        kSecUseDataProtectionKeychain as String: true,
-        kSecReturnAttributes as String: true,
-        kSecMatchLimit as String: kSecMatchLimitOne,
-    ]
-    var result: CFTypeRef?
-    #expect(SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess)
-    let attributes = try #require(result as? [String: Any])
-    #expect(attributes[kSecAttrAccessible as String] as? String == kSecAttrAccessibleWhenUnlocked as String)
+    #expect(keychainAccessibility(account: "API_TOKEN", service: service) == kSecAttrAccessibleWhenUnlocked as String)
+}
+
+@Test func storedSecretAccessibilityCanChangeWithoutChangingValue() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.\(UUID().uuidString)"
+    defer { _ = deleteStoredSecret(account: "API_TOKEN", service: service) }
+
+    #expect(saveStoredSecret(
+        account: "API_TOKEN",
+        value: "secret",
+        accessibility: .afterFirstUnlock,
+        service: service
+    ) == errSecSuccess)
+    #expect(loadStoredSecrets(service: service).first?.accessibility == .afterFirstUnlock)
+    #expect(keychainAccessibility(account: "API_TOKEN", service: service) == kSecAttrAccessibleAfterFirstUnlock as String)
+
+    #expect(setStoredSecretAccessibility(
+        account: "API_TOKEN",
+        accessibility: .whenUnlocked,
+        service: service
+    ) == errSecSuccess)
+    #expect(loadStoredSecret(account: "API_TOKEN", service: service) == "secret")
+    #expect(loadStoredSecrets(service: service).first?.accessibility == .whenUnlocked)
+    #expect(keychainAccessibility(account: "API_TOKEN", service: service) == kSecAttrAccessibleWhenUnlocked as String)
 }
 
 @Test func storedSecretsCanBeRenamed() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.\(UUID().uuidString)"
-    #expect(saveStoredSecret(account: "OLD_TOKEN", value: "secret", service: service) == errSecSuccess)
+    #expect(saveStoredSecret(
+        account: "OLD_TOKEN",
+        value: "secret",
+        accessibility: .afterFirstUnlock,
+        service: service
+    ) == errSecSuccess)
     defer { _ = deleteStoredSecret(account: "OLD_TOKEN", service: service) }
     defer { _ = deleteStoredSecret(account: "NEW_TOKEN", service: service) }
 
     #expect(renameStoredSecret(account: "OLD_TOKEN", to: "NEW_TOKEN", service: service) == errSecSuccess)
     #expect(loadStoredSecrets(service: service).map(\.account) == ["NEW_TOKEN"])
+    #expect(loadStoredSecrets(service: service).first?.accessibility == .afterFirstUnlock)
+}
+
+@Test func backgroundMetadataMigratesWithoutChangingSecretAccessibility() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let policyService = "com.automicvault.tests.policy.\(UUID().uuidString)"
+    let accessLogService = "com.automicvault.tests.log.\(UUID().uuidString)"
+    let secretService = "com.automicvault.tests.secret.\(UUID().uuidString)"
+    let policyAccount = "policies"
+    let accessLogAccount = "access-log"
+    defer { _ = deleteStoredSecret(account: policyAccount, service: policyService) }
+    defer { _ = deleteStoredSecret(account: accessLogAccount, service: accessLogService) }
+    defer { _ = deleteStoredSecret(account: "API_TOKEN", service: secretService) }
+
+    #expect(saveStoredSecret(account: policyAccount, value: "[]", service: policyService) == errSecSuccess)
+    #expect(saveStoredSecret(account: accessLogAccount, value: "[]", service: accessLogService) == errSecSuccess)
+    #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: secretService) == errSecSuccess)
+
+    #expect(migrateBackgroundKeychainItems(
+        policyService: policyService,
+        policyAccount: policyAccount,
+        accessLogService: accessLogService,
+        accessLogAccount: accessLogAccount
+    ) == errSecSuccess)
+    #expect(keychainAccessibility(account: policyAccount, service: policyService) == kSecAttrAccessibleAfterFirstUnlock as String)
+    #expect(keychainAccessibility(account: accessLogAccount, service: accessLogService) == kSecAttrAccessibleAfterFirstUnlock as String)
+    #expect(keychainAccessibility(account: "API_TOKEN", service: secretService) == kSecAttrAccessibleWhenUnlocked as String)
 }
 
 @Test func accessRequestLogKeepsNewestFifty() throws {
@@ -526,6 +574,10 @@ func protectionPolicyMatrix(
     )
 
     #expect(appendAccessRequestRecord(record, key: key))
+    #expect(keychainAccessibility(
+        account: key,
+        service: accessRequestLogKeychainService
+    ) == kSecAttrAccessibleAfterFirstUnlock as String)
     UserDefaults.standard.set(Data("[]".utf8), forKey: key)
     _ = UserDefaults.standard.synchronize()
 
@@ -567,4 +619,20 @@ private func dataProtectionKeychainAvailable() -> Bool {
     let status = saveStoredSecret(account: "PROBE", value: "secret", service: service)
     defer { _ = deleteStoredSecret(account: "PROBE", service: service) }
     return status != errSecMissingEntitlement
+}
+
+private func keychainAccessibility(account: String, service: String) -> String? {
+    let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+        kSecUseDataProtectionKeychain as String: true,
+        kSecReturnAttributes as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    var result: CFTypeRef?
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+          let attributes = result as? [String: Any]
+    else { return nil }
+    return attributes[kSecAttrAccessible as String] as? String
 }


### PR DESCRIPTION
## Summary
- Add configurable keychain accessibility for stored secrets.
- Support changing secret availability from the dashboard.
- Prevent human approval prompts while the user session is inactive or screens are asleep.
- Migrate background policy and access-log items to remain available after first unlock.

## Testing
- Added coverage for keychain accessibility defaults, updates, and background-item migration.
- Extended dashboard self-checks for stored-secret detail rendering.