### PR TITLE
Classify read-only GitHub GraphQL requests safely

### DIFF
--- a/src/menu-helper/Package.resolved
+++ b/src/menu-helper/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9d1857e23e0c2e7e0078be292b28a43488fa2ccfbe7f08d5bf9b10f92622394b",
+  "originHash" : "ede9a93651619bce39b9270df330f1f9a27d39a0bd130a594bac382d7e7a0e6c",
   "pins" : [
     {
       "identity" : "appupdater",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "2e9a9bccebdb381e2738119a20f3eee85ab60280",
         "version" : "3.0.6"
+      }
+    },
+    {
+      "identity" : "graphql",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GraphQLSwift/GraphQL.git",
+      "state" : {
+        "revision" : "2d27d8f477c1112b668dff24493a2d5e0b6c5b00",
+        "version" : "4.2.0"
       }
     },
     {
@@ -26,6 +35,15 @@
       "state" : {
         "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
         "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {

--- a/src/menu-helper/Package.swift
+++ b/src/menu-helper/Package.swift
@@ -10,10 +10,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/mxcl/AppUpdater.git", from: "3.0.6"),
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "4.2.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.1"),
     ],
     targets: [
-        .target(name: "MenubarHelperCore"),
+        .target(
+            name: "MenubarHelperCore",
+            dependencies: [
+                .product(name: "GraphQL", package: "GraphQL"),
+            ]
+        ),
         .target(name: "CProcessInfo", publicHeadersPath: "include"),
         .executableTarget(
             name: "MenubarHelper",

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1613,7 +1613,7 @@ private func ghApiRequestIsReadOnly(_ args: [String]) -> Bool {
 private struct GhGraphQLArguments {
     private var queries: [String] = []
     private var operationNames: [String] = []
-    private var hasIndirectOperationInput = false
+    private var hasIndirectFieldInput = false
 
     mutating func add(field: String, readsFile: Bool) {
         let parts = field.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
@@ -1621,11 +1621,11 @@ private struct GhGraphQLArguments {
 
         let name = String(parts[0])
         let value = String(parts[1])
-        guard name == "query" || name == "operationName" else { return }
         if readsFile, value.hasPrefix("@") {
-            hasIndirectOperationInput = true
+            hasIndirectFieldInput = true
             return
         }
+        guard name == "query" || name == "operationName" else { return }
         if name == "query" {
             queries.append(value)
         } else {
@@ -1634,7 +1634,7 @@ private struct GhGraphQLArguments {
     }
 
     var isReadOnly: Bool {
-        guard !hasIndirectOperationInput,
+        guard !hasIndirectFieldInput,
               queries.count == 1,
               operationNames.count <= 1,
               let query = queries.first
@@ -3173,6 +3173,7 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["api", "graphql", "-f", "query=query Read { viewer { login } } mutation Write { addStar(input: {}) { clientMutationId } }"],
         ["api", "graphql", "-f", "query=query Read { viewer { login } } mutation Write { addStar(input: {}) { clientMutationId } }", "-f", "operationName=Write"],
         ["api", "graphql", "-F", "query=@query.graphql"],
+        ["api", "graphql", "-f", "query={ viewer { login } }", "-F", "secret=@/etc/passwd"],
         ["api", "graphql", "-f", "query={ viewer { login } }", "-f", "query={ viewer { name } }"],
         ["api", "graphql", "--input", "body.json"],
         ["auth", "token"],

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1488,15 +1488,15 @@ private func standardizedPath(_ path: String, cwd: String) -> String {
 }
 
 private func ghRequestIsReadOnly(_ args: [String]) -> Bool {
-    let words = ghCommandWords(args).map { $0.lowercased() }
+    let words = ghCommandWords(args)
     guard let firstWord = words.first else { return false }
-    let command = ghCanonicalCommand(firstWord)
+    let command = ghCanonicalCommand(firstWord.lowercased())
     if words.contains("--show-token") { return false }
     if command == "api" { return ghApiRequestIsReadOnly(Array(words.dropFirst())) }
     if ["alias", "extension", "config", "skill"].contains(command) { return false }
     if ["status", "browse", "search"].contains(command) { return true }
     guard words.count >= 2 else { return false }
-    let subcommand = words[1]
+    let subcommand = words[1].lowercased()
     switch command {
     case "auth":
         return subcommand == "status"
@@ -1544,25 +1544,27 @@ private func ghSubcommandIsList(_ subcommand: String) -> Bool {
 
 private func ghApiRequestIsReadOnly(_ args: [String]) -> Bool {
     var index = 0
-    var endpointSeen = false
+    var endpoints: [String] = []
     var method: String?
     var hasFields = false
+    var graphQLArguments = GhGraphQLArguments()
     while index < args.count {
         let arg = args[index]
         switch arg {
         case "--":
             return false
-        case "-x", "--method":
+        case "-X", "--method":
             guard index + 1 < args.count else { return false }
             method = args[index + 1].uppercased()
             index += 2
-        case "-f", "--field", "--raw-field":
+        case "-f", "--raw-field", "-F", "--field":
             guard index + 1 < args.count else { return false }
             hasFields = true
+            graphQLArguments.add(field: args[index + 1], readsFile: arg == "-F" || arg == "--field")
             index += 2
         case "--input":
             return false
-        case "-h", "--header", "--preview", "--cache", "-q", "--jq", "-t", "--template", "--hostname":
+        case "-H", "--header", "-p", "--preview", "--cache", "-q", "--jq", "-t", "--template", "--hostname":
             guard index + 1 < args.count else { return false }
             index += 2
         case "-i", "--include", "--paginate", "--slurp", "--silent", "--verbose":
@@ -1570,8 +1572,12 @@ private func ghApiRequestIsReadOnly(_ args: [String]) -> Bool {
         default:
             if let value = arg.value(afterOption: "--method=") {
                 method = value.uppercased()
-            } else if arg.hasPrefix("--field=") || arg.hasPrefix("--raw-field=") {
+            } else if let field = arg.value(afterOption: "--field=") {
                 hasFields = true
+                graphQLArguments.add(field: field, readsFile: true)
+            } else if let field = arg.value(afterOption: "--raw-field=") {
+                hasFields = true
+                graphQLArguments.add(field: field, readsFile: false)
             } else if arg.hasPrefix("--input=") {
                 return false
             } else if arg.hasPrefix("--header=")
@@ -1581,19 +1587,62 @@ private func ghApiRequestIsReadOnly(_ args: [String]) -> Bool {
                 || arg.hasPrefix("--template=")
                 || arg.hasPrefix("--hostname=") {
                 // read-only option with inline value
-            } else if arg.hasPrefix("-x"), arg.count > 2 {
+            } else if arg.hasPrefix("-X"), arg.count > 2 {
                 method = String(arg.dropFirst(2)).uppercased()
-            } else if arg.hasPrefix("-f") {
+            } else if arg.hasPrefix("-f"), arg.count > 2 {
                 hasFields = true
+                graphQLArguments.add(field: String(arg.dropFirst(2)), readsFile: false)
+            } else if arg.hasPrefix("-F"), arg.count > 2 {
+                hasFields = true
+                graphQLArguments.add(field: String(arg.dropFirst(2)), readsFile: true)
             } else if arg.hasPrefix("-") {
                 return false
             } else {
-                endpointSeen = true
+                endpoints.append(arg)
             }
             index += 1
         }
     }
-    return endpointSeen && (method ?? (hasFields ? "POST" : "GET")) == "GET"
+    guard endpoints.count == 1 else { return false }
+    if endpoints[0] == "graphql" {
+        return graphQLArguments.isReadOnly
+    }
+    return (method ?? (hasFields ? "POST" : "GET")) == "GET"
+}
+
+private struct GhGraphQLArguments {
+    private var queries: [String] = []
+    private var operationNames: [String] = []
+    private var hasIndirectOperationInput = false
+
+    mutating func add(field: String, readsFile: Bool) {
+        let parts = field.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return }
+
+        let name = String(parts[0])
+        let value = String(parts[1])
+        guard name == "query" || name == "operationName" else { return }
+        if readsFile, value.hasPrefix("@") {
+            hasIndirectOperationInput = true
+            return
+        }
+        if name == "query" {
+            queries.append(value)
+        } else {
+            operationNames.append(value)
+        }
+    }
+
+    var isReadOnly: Bool {
+        guard !hasIndirectOperationInput,
+              queries.count == 1,
+              operationNames.count <= 1,
+              let query = queries.first
+        else {
+            return false
+        }
+        return graphQLRequestIsReadOnly(query: query, operationName: operationNames.first)
+    }
 }
 
 private func ghCommandWords(_ args: [String]) -> [String] {
@@ -2927,7 +2976,9 @@ private func runApprovalSelfCheck() -> Int32 {
           isGhTokenKey("GH_TOKEN_GITHUB_COM_MXCL"),
           !isGhTokenKey("GITHUB_TOKEN"),
           !isGhTokenKey("GH_TOKEN_bad-key")
-    else { return 1 }
+    else {
+        return 1
+    }
 
     let avSigning = SigningInfo(identifier: "com.automicvault.av", teamIdentifier: "TEAM")
     func awsRequest(
@@ -3096,6 +3147,17 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["api", "-XGET", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/releases/latest"],
         ["api", "--method=GET", "-f", "per_page=1", "search/issues"],
         ["api", "--paginate", "repos/owner/repo/actions/runs", "--jq", ".workflow_runs[].id"],
+        ["api", "graphql", "-f", "query=query { viewer { login } }"],
+        ["api", "graphql", "-fquery={ viewer { login } }"],
+        [
+            "api", "graphql",
+            "-f", "query=query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { body bodyHTML } } }",
+            "-f", "owner=automic-vault",
+            "-f", "repo=automic-vault",
+            "-F", "number=49",
+            "--hostname", "github.com",
+        ],
+        ["api", "graphql", "-f", "query=query Read { viewer { login } } mutation Write { addStar(input: {}) { clientMutationId } }", "-f", "operationName=Read"],
     ]
     guard allowed.allSatisfy(ghRequestIsReadOnly) else { return 1 }
 
@@ -3105,6 +3167,14 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["api", "-X", "DELETE", "repos/owner/repo"],
         ["api", "-f", "name=value", "repos/owner/repo"],
         ["api", "--input", "body.json", "repos/owner/repo"],
+        ["api", "graphql"],
+        ["api", "graphql", "-f", "query=mutation { addStar(input: {}) { clientMutationId } }"],
+        ["api", "graphql", "-f", "query=subscription { viewer { login } }"],
+        ["api", "graphql", "-f", "query=query Read { viewer { login } } mutation Write { addStar(input: {}) { clientMutationId } }"],
+        ["api", "graphql", "-f", "query=query Read { viewer { login } } mutation Write { addStar(input: {}) { clientMutationId } }", "-f", "operationName=Write"],
+        ["api", "graphql", "-F", "query=@query.graphql"],
+        ["api", "graphql", "-f", "query={ viewer { login } }", "-f", "query={ viewer { name } }"],
+        ["api", "graphql", "--input", "body.json"],
         ["auth", "token"],
         ["auth", "status", "--show-token"],
         ["alias", "set", "x", "repo view"],

--- a/src/menu-helper/Sources/MenubarHelperCore/GraphQLRequest.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GraphQLRequest.swift
@@ -1,0 +1,24 @@
+import GraphQL
+
+public func graphQLRequestIsReadOnly(
+    query: String,
+    operationName: String? = nil
+) -> Bool {
+    guard let document = try? parse(source: query) else { return false }
+
+    let operations = document.definitions.compactMap { definition in
+        definition as? OperationDefinition
+    }
+
+    let operation: OperationDefinition
+    if let operationName {
+        let matches = operations.filter { $0.name?.value == operationName }
+        guard matches.count == 1, let match = matches.first else { return false }
+        operation = match
+    } else {
+        guard operations.count == 1, let onlyOperation = operations.first else { return false }
+        operation = onlyOperation
+    }
+
+    return operation.operation == .query
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/GraphQLRequestTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/GraphQLRequestTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import MenubarHelperCore
+
+@Test func graphQLQueriesAreReadOnly() {
+    #expect(graphQLRequestIsReadOnly(query: "query { viewer { login } }"))
+    #expect(graphQLRequestIsReadOnly(query: "{ viewer { login } }"))
+    #expect(graphQLRequestIsReadOnly(query: """
+    query PullRequest($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) { body bodyHTML }
+      }
+    }
+    """))
+}
+
+@Test func graphQLMutationsAndSubscriptionsAreNotReadOnly() {
+    #expect(!graphQLRequestIsReadOnly(query: "mutation { addStar(input: {}) { clientMutationId } }"))
+    #expect(!graphQLRequestIsReadOnly(query: "subscription { viewer { login } }"))
+}
+
+@Test func graphQLSelectedOperationDeterminesClassification() {
+    let document = """
+    query Read { viewer { login } }
+    mutation Write { addStar(input: {}) { clientMutationId } }
+    """
+
+    #expect(graphQLRequestIsReadOnly(query: document, operationName: "Read"))
+    #expect(!graphQLRequestIsReadOnly(query: document, operationName: "Write"))
+    #expect(!graphQLRequestIsReadOnly(query: document, operationName: "Missing"))
+    #expect(!graphQLRequestIsReadOnly(query: document))
+}
+
+@Test func graphQLClassificationFailsClosed() {
+    #expect(!graphQLRequestIsReadOnly(query: ""))
+    #expect(!graphQLRequestIsReadOnly(query: "not graphql"))
+    #expect(!graphQLRequestIsReadOnly(query: "fragment Login on User { login }"))
+}


### PR DESCRIPTION
## Summary
- Add GraphQL parsing to distinguish query operations from mutations and subscriptions
- Handle GitHub CLI GraphQL arguments, operation names, and indirect file inputs
- Expand self-checks and unit tests for read-only classification
- Add GraphQL and Swift Collections package dependencies

## Testing
- Added MenubarHelperCore tests covering queries, mutations, subscriptions, named operations, and invalid input
- Expanded GitHub read-only approval self-check cases