### PR TITLE
Fix approval prompt window focus behavior

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2011,6 +2011,20 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
     return ScriptApproval(path: path, checksum: checksum)
 }
 
+private final class ApprovalPanel: NSPanel {
+    private var allowsKey = false
+
+    override var canBecomeKey: Bool { allowsKey }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown, !isKeyWindow {
+            allowsKey = true
+            makeKey()
+        }
+        super.sendEvent(event)
+    }
+}
+
 @MainActor
 private func fitApprovalPanel(_ panel: NSPanel, maximumHeight: CGFloat, animate: Bool) {
     guard let contentView = panel.contentView else { return }
@@ -2061,7 +2075,7 @@ private func showApprovalAlert(
     )
     var decision = ApprovalDecision.denied
     let maximumHeight = NSScreen.main?.visibleFrame.height ?? 660
-    let panel = NSPanel(
+    let panel = ApprovalPanel(
         contentRect: NSRect(x: 0, y: 0, width: 560, height: 660),
         styleMask: [.borderless, .nonactivatingPanel],
         backing: .buffered,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2011,10 +2011,6 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
     return ScriptApproval(path: path, checksum: checksum)
 }
 
-private final class ApprovalPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
-}
-
 @MainActor
 private func fitApprovalPanel(_ panel: NSPanel, maximumHeight: CGFloat, animate: Bool) {
     guard let contentView = panel.contentView else { return }
@@ -2065,7 +2061,7 @@ private func showApprovalAlert(
     )
     var decision = ApprovalDecision.denied
     let maximumHeight = NSScreen.main?.visibleFrame.height ?? 660
-    let panel = ApprovalPanel(
+    let panel = NSPanel(
         contentRect: NSRect(x: 0, y: 0, width: 560, height: 660),
         styleMask: [.borderless, .nonactivatingPanel],
         backing: .buffered,
@@ -2099,7 +2095,7 @@ private func showApprovalAlert(
     )
     fitApprovalPanel(panel, maximumHeight: maximumHeight, animate: false)
     panel.center()
-    panel.makeKeyAndOrderFront(nil)
+    panel.orderFrontRegardless()
     NSApp.runModal(for: panel)
     panel.orderOut(nil)
     return decision

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2041,7 +2041,6 @@ private func showApprovalAlert(
     launcher: LauncherIdentity?,
     launcherFallbackPath: String
 ) -> ApprovalDecision {
-    NSApp.activate(ignoringOtherApps: true)
     let requester = approvalPromptRequester(launcher: launcher, fallback: launcherFallbackPath)
     let content = ApprovalPromptContent(
         requesterName: requester.name,
@@ -2068,7 +2067,7 @@ private func showApprovalAlert(
     let maximumHeight = NSScreen.main?.visibleFrame.height ?? 660
     let panel = ApprovalPanel(
         contentRect: NSRect(x: 0, y: 0, width: 560, height: 660),
-        styleMask: [.borderless],
+        styleMask: [.borderless, .nonactivatingPanel],
         backing: .buffered,
         defer: false
     )


### PR DESCRIPTION
## Summary
- Prevent the approval prompt from forcibly activating the app.
- Configure the approval panel as non-activating to preserve the current app focus.

## Testing
- Not run (not requested)