### PR TITLE
Add local write access for GitHub CLI

### DIFF
--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -21,9 +21,11 @@ Use `av harden gh` to migrate existing `gh` credentials into Automic Vault.
 
 The menu bar app creates a `gh` Secret Gate as soon as the hardened CLI is
 installed. Configure its default and per-app protection levels there. Read Only
-auto-approves known read-only commands and `gh api` GET requests. Full Access
-Except Secret Dumps still prompts for `gh auth token` and `gh auth status
---show-token`.
+auto-approves known read-only commands and `gh api` GET requests. Local Write
+Access additionally approves `repo clone`, `pr checkout`, `gist clone`, and
+download commands, which can change local files but do not mutate GitHub.
+Trusted Access approves remote mutations, but still prompts for `gh auth token`
+and `gh auth status --show-token`.
 
 ## Details
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1355,8 +1355,7 @@ private func classifySecretGateRequest(
 ) -> SecretGateRequestClassification {
     switch gateID {
     case "gh":
-        if ghRequestIsSecretDump(request.args) { return .secretDump }
-        return ghRequestIsReadOnly(request.args) ? .readOnly : .mutating
+        return ghRequestClassification(request.args)
     case "aws":
         return awsRequestIsReadOnly(awsCommandWords(request)) ? .readOnly : .mutating
     case "brew":
@@ -1507,19 +1506,45 @@ private func ghRequestIsReadOnly(_ args: [String]) -> Bool {
     case "pr":
         return ["view", "status", "checks", "diff"].contains(subcommand) || ghSubcommandIsList(subcommand)
     case "run":
-        return ["view", "download"].contains(subcommand) || ghSubcommandIsList(subcommand)
+        return subcommand == "view" || ghSubcommandIsList(subcommand)
     case "workflow":
         return subcommand == "view" || ghSubcommandIsList(subcommand)
     case "release":
-        return ["view", "download"].contains(subcommand) || ghSubcommandIsList(subcommand)
+        return subcommand == "view" || ghSubcommandIsList(subcommand)
     case "gist":
         return subcommand == "view" || ghSubcommandIsList(subcommand)
     case "cache", "secret", "variable", "ruleset", "org", "label", "gpg-key", "ssh-key":
         return ghSubcommandIsList(subcommand) || (command == "ruleset" && subcommand == "view")
     case "attestation":
-        return ["verify", "download", "trusted-root"].contains(subcommand)
+        return ["verify", "trusted-root"].contains(subcommand)
     case "agent-task":
         return ["view", "list"].contains(subcommand)
+    default:
+        return false
+    }
+}
+
+private func ghRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
+    if ghRequestIsSecretDump(args) { return .secretDump }
+    if ghRequestIsReadOnly(args) { return .readOnly }
+    if ghRequestIsLocalWrite(args) { return .localWrite }
+    return .mutating
+}
+
+private func ghRequestIsLocalWrite(_ args: [String]) -> Bool {
+    let words = ghCommandWords(args)
+    guard words.count >= 2 else { return false }
+    let command = ghCanonicalCommand(words[0].lowercased())
+    let subcommand = words[1].lowercased()
+    switch command {
+    case "repo":
+        return subcommand == "clone"
+    case "pr":
+        return subcommand == "checkout"
+    case "gist":
+        return subcommand == "clone"
+    case "run", "release", "attestation":
+        return subcommand == "download"
     default:
         return false
     }
@@ -2987,6 +3012,9 @@ private func runApprovalSelfCheck() -> Int32 {
           !secretGateProtectionAllows(.noAccess, classification: .readOnly),
           secretGateProtectionAllows(.readOnly, classification: .readOnly),
           !secretGateProtectionAllows(.readOnly, classification: .unknown),
+          secretGateProtectionAllows(.readOnlyAndLocalWrites, classification: .readOnly),
+          secretGateProtectionAllows(.readOnlyAndLocalWrites, classification: .localWrite),
+          !secretGateProtectionAllows(.readOnlyAndLocalWrites, classification: .mutating),
           secretGateProtectionAllows(.readOnlyAndUpdates, classification: .readOnly),
           secretGateProtectionAllows(.readOnlyAndUpdates, classification: .update),
           !secretGateProtectionAllows(.readOnlyAndUpdates, classification: .mutating),
@@ -3058,12 +3086,10 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["pr", "diff"],
         ["run", "view"],
         ["run", "list"],
-        ["run", "download"],
         ["workflow", "view"],
         ["workflow", "list"],
         ["release", "view"],
         ["release", "list"],
-        ["release", "download"],
         ["gist", "view"],
         ["gist", "list"],
         ["cache", "list"],
@@ -3075,10 +3101,8 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["rs", "list"],
         ["rs", "ls"],
         ["attestation", "verify"],
-        ["attestation", "download"],
         ["attestation", "trusted-root"],
         ["at", "verify"],
-        ["at", "download"],
         ["at", "trusted-root"],
         ["agent-task", "view"],
         ["agent-task", "list"],
@@ -3098,6 +3122,18 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["api", "--paginate", "repos/owner/repo/actions/runs", "--jq", ".workflow_runs[].id"],
     ]
     guard allowed.allSatisfy(ghRequestIsReadOnly) else { return 1 }
+
+    let localWrites = [
+        ["repo", "clone", "owner/repo"],
+        ["pr", "checkout", "123"],
+        ["gist", "clone", "0123456789abcdef"],
+        ["run", "download", "123456"],
+        ["release", "download", "v1.0.0"],
+        ["attestation", "download", "owner/repo"],
+        ["at", "download", "owner/repo"],
+        ["-R", "owner/repo", "repo", "clone"],
+    ]
+    guard localWrites.allSatisfy({ ghRequestClassification($0) == .localWrite }) else { return 1 }
 
     let denied = [
         ["api"],
@@ -3120,7 +3156,10 @@ private func runGhReadOnlySelfCheck() -> Int32 {
         ["unknown", "view"],
         ["--unknown", "repo", "view"],
     ]
-    guard denied.allSatisfy({ !ghRequestIsReadOnly($0) }) else { return 1 }
+    guard denied.allSatisfy({
+        let classification = ghRequestClassification($0)
+        return classification != .readOnly && classification != .localWrite
+    }) else { return 1 }
     return 0
 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -326,6 +326,7 @@ public struct SecretGateRoute: Codable, Equatable, Sendable {
 public enum SecretGateProtection: String, Codable, CaseIterable, Identifiable, Sendable {
     case noAccess
     case readOnly
+    case readOnlyAndLocalWrites
     case readOnlyAndUpdates
     case fullExceptSecretDumps
     case fullIncludingSecretDumps
@@ -336,6 +337,7 @@ public enum SecretGateProtection: String, Codable, CaseIterable, Identifiable, S
         switch self {
         case .noAccess: "No Access"
         case .readOnly: "Read Only Access"
+        case .readOnlyAndLocalWrites: "Local Write Access"
         case .readOnlyAndUpdates: "Read & Update Access"
         case .fullExceptSecretDumps: "Trusted Access"
         case .fullIncludingSecretDumps: "Full Access"
@@ -346,6 +348,8 @@ public enum SecretGateProtection: String, Codable, CaseIterable, Identifiable, S
         switch self {
         case .noAccess: "All authenticated commands have approval gates"
         case .readOnly: "Commands without side-effects are approved automatically"
+        case .readOnlyAndLocalWrites:
+            "Read-only commands and commands that only change local files are approved automatically"
         case .readOnlyAndUpdates: "Commands without side-effects *and* `brew update` are approved automatically"
         case .fullExceptSecretDumps: "All commands are approved automatically except those that might exfiltrate secrets"
         case .fullIncludingSecretDumps: "All commands are approved automatically"
@@ -358,6 +362,8 @@ public enum SecretGateProtection: String, Codable, CaseIterable, Identifiable, S
             false
         case .readOnly:
             classification == .readOnly
+        case .readOnlyAndLocalWrites:
+            classification == .readOnly || classification == .localWrite
         case .readOnlyAndUpdates:
             classification == .readOnly || classification == .update
         case .fullExceptSecretDumps:
@@ -370,6 +376,7 @@ public enum SecretGateProtection: String, Codable, CaseIterable, Identifiable, S
 
 public enum SecretGateRequestClassification: CaseIterable, Sendable {
     case readOnly
+    case localWrite
     case update
     case mutating
     case secretDump
@@ -414,9 +421,19 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     public var defaultPolicyLabel: String { appPolicies.isEmpty ? "All Apps" : "All Other Apps" }
 
     public var availableProtections: [SecretGateProtection] {
-        keyPatterns.isEmpty
-            ? [.noAccess, .readOnly, .readOnlyAndUpdates, .fullExceptSecretDumps]
-            : [.noAccess, .readOnly, .fullExceptSecretDumps, .fullIncludingSecretDumps]
+        if keyPatterns.isEmpty {
+            return [.noAccess, .readOnly, .readOnlyAndUpdates, .fullExceptSecretDumps]
+        }
+        if id == "gh" {
+            return [
+                .noAccess,
+                .readOnly,
+                .readOnlyAndLocalWrites,
+                .fullExceptSecretDumps,
+                .fullIncludingSecretDumps,
+            ]
+        }
+        return [.noAccess, .readOnly, .fullExceptSecretDumps, .fullIncludingSecretDumps]
     }
 
     public var initialProtection: SecretGateProtection {
@@ -425,6 +442,8 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
 
     public func normalizedProtection(_ protection: SecretGateProtection) -> SecretGateProtection {
         if keyPatterns.isEmpty, protection == .fullIncludingSecretDumps { return .fullExceptSecretDumps }
+        if keyPatterns.isEmpty, protection == .readOnlyAndLocalWrites { return .readOnly }
+        if id != "gh", protection == .readOnlyAndLocalWrites { return .readOnly }
         if !keyPatterns.isEmpty, protection == .readOnlyAndUpdates { return .readOnly }
         return protection
     }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -279,7 +279,14 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(gate.protectionSubtitle(.fullExceptSecretDumps) == "All commands are approved automatically")
 
     let secretGate = try #require(loadSecretGates(hardeners: [testGateMetadata()], service: service).first)
-    #expect(secretGate.availableProtections == [.noAccess, .readOnly, .fullExceptSecretDumps, .fullIncludingSecretDumps])
+    #expect(secretGate.availableProtections == [
+        .noAccess,
+        .readOnly,
+        .readOnlyAndLocalWrites,
+        .fullExceptSecretDumps,
+        .fullIncludingSecretDumps,
+    ])
+    #expect(secretGate.protectionTitle(.readOnlyAndLocalWrites) == "Local Write Access")
     #expect(secretGate.protectionTitle(.fullExceptSecretDumps) == "Trusted Access")
 }
 
@@ -375,6 +382,7 @@ func protectionPolicyMatrix(
     let expected = switch protection {
     case .noAccess: false
     case .readOnly: classification == .readOnly
+    case .readOnlyAndLocalWrites: classification == .readOnly || classification == .localWrite
     case .readOnlyAndUpdates: classification == .readOnly || classification == .update
     case .fullExceptSecretDumps: classification != .secretDump
     case .fullIncludingSecretDumps: true


### PR DESCRIPTION
## Summary

- add a `Local Write Access` protection level for the `gh` Secret Gate
- classify repository, pull request, and gist checkout/clone operations as local writes
- move artifact and attestation downloads from read-only into the local-write tier
- keep remote mutations, unknown commands, and secret dumps outside the new allowlist

## Why

Cloning and downloading can change local files, but they do not carry the same GitHub-side risk as publishing releases, merging pull requests, or deleting repositories. This adds a middle tier between read-only and trusted access without broadening arbitrary API access.

## Validation

- `swift test`
- `swift build`
- `.build/debug/AutomicVaultMenubar --self-check-gh-read-only`
- `git diff --check`
