### PR TITLE
Detect unsafe PATH precedence in shells and macOS GUI environments

### DIFF
--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -28,14 +28,17 @@ impl Style {
 
 pub(crate) fn run<W: Write>(stdout: &mut W, style: Style, show_all: bool) -> i32 {
     let findings = scan_home(home());
-    print(stdout, &findings, style, show_all);
+    let gui_path = isotopes::macos_gui_path();
+    print_report(stdout, &findings, gui_path.as_deref(), style, show_all);
     0
 }
 
 pub(crate) fn run_json<W: Write>(stdout: &mut W) -> i32 {
     let findings = scan_home(home());
+    let gui_path = isotopes::macos_gui_path();
     let report = serde_json::json!({
         "findings": findings.iter().map(json_finding).collect::<Vec<_>>(),
+        "gui_path": gui_path.as_deref().map(|path| path.to_string_lossy()),
     });
     let _ = writeln!(stdout, "{report}");
     0
@@ -102,7 +105,18 @@ fn scan_home(home: impl AsRef<Path>) -> Vec<Finding> {
     isotopes::findings(home.as_ref())
 }
 
+#[cfg(test)]
 fn print<W: Write>(stdout: &mut W, findings: &[Finding], style: Style, show_all: bool) {
+    print_report(stdout, findings, None, style, show_all);
+}
+
+fn print_report<W: Write>(
+    stdout: &mut W,
+    findings: &[Finding],
+    gui_path: Option<&std::ffi::OsStr>,
+    style: Style,
+    show_all: bool,
+) {
     let visible = findings
         .iter()
         .filter(|finding| show_all || !is_hidden(finding))
@@ -114,6 +128,16 @@ fn print<W: Write>(stdout: &mut W, findings: &[Finding], style: Style, show_all:
 
     let _ = writeln!(stdout, "╭─ {}", style.paint("36", "system exposure audit"));
     let _ = writeln!(stdout, "│");
+    if let Some(gui_path) = gui_path {
+        let gui_path = if gui_path.is_empty() {
+            "<unset>".into()
+        } else {
+            gui_path.to_string_lossy()
+        };
+        let _ = writeln!(stdout, "◇ {}", style.paint("2", "GUI PATH (before shells)"));
+        write_wrapped(stdout, "│  ", &gui_path, style, Some("36"));
+        let _ = writeln!(stdout, "│");
+    }
     if findings.is_empty() {
         let _ = writeln!(stdout, "◇ {}", style.paint("32", "No problems found"));
         let _ = writeln!(stdout, "│");
@@ -377,6 +401,23 @@ mod tests {
             String::from_utf8(stdout).unwrap(),
             "╭─ system exposure audit\n│\n◆ 1 finding requires attention\n│\n└─ 1. example\n│  severity HIGH\n│\n│  problem\n│  Example detector found a risky setting.\n│\n│  solution\n│  Run `examplectl fix` or edit the affected file.\n│\n│  full details & caveats\n│  https://example.test/docs/example.md\n│\n│  affected files\n│  • /tmp/example.conf:7\n│\n╰─ scan complete\n"
         );
+    }
+
+    #[test]
+    fn print_displays_the_gui_path_as_information() {
+        let mut stdout = Vec::new();
+
+        print_report(
+            &mut stdout,
+            &[],
+            Some(std::ffi::OsStr::new("/usr/bin:/bin")),
+            Style::plain(),
+            false,
+        );
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(output.contains("◇ GUI PATH (before shells)\n│  /usr/bin:/bin\n"));
+        assert!(output.contains("◇ No problems found\n"));
     }
 
     #[test]

--- a/src/cli/shell_secrets.rs
+++ b/src/cli/shell_secrets.rs
@@ -11,10 +11,12 @@ pub(crate) fn bash_reasons() -> Result<Vec<String>, String> {
     if let Some(path) = std::env::var_os("BASH_ENV").filter(|value| !value.is_empty()) {
         paths.push(PathBuf::from(path));
     }
-    reasons(
+    let mut reasons = reasons(
         paths,
         "Bash startup file contains plaintext-looking credential assignment",
-    )
+    )?;
+    reasons.extend(path_reasons("Bash"));
+    Ok(reasons)
 }
 
 pub(crate) fn zsh_reasons() -> Result<Vec<String>, String> {
@@ -23,12 +25,27 @@ pub(crate) fn zsh_reasons() -> Result<Vec<String>, String> {
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or(home);
-    reasons(
+    let mut reasons = reasons(
         [".zshenv", ".zprofile", ".zshrc", ".zlogin", ".zlogout"]
             .into_iter()
             .map(|file| root.join(file)),
         "Zsh startup file contains plaintext-looking credential assignment",
-    )
+    )?;
+    reasons.extend(path_reasons("Zsh"));
+    Ok(reasons)
+}
+
+fn path_reasons(shell: &str) -> Vec<String> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    crate::path_security::user_writable_entries_before_system_paths(&path)
+        .into_iter()
+        .map(|entry| {
+            format!(
+                "{shell} PATH has a user-writable directory before protected system directories: {}",
+                entry.display()
+            )
+        })
+        .collect()
 }
 
 fn reasons(paths: impl IntoIterator<Item = PathBuf>, message: &str) -> Result<Vec<String>, String> {

--- a/src/isotopes/detectors/bash/detector.md
+++ b/src/isotopes/detectors/bash/detector.md
@@ -3,6 +3,8 @@
 ## Trigger Conditions
 
 - Bash startup file contains plaintext-looking credential assignment.
+- Bash `PATH` places a user-writable directory before protected system
+  directories.
 
 ## Sensitive Files
 
@@ -11,12 +13,21 @@
 - `~/.bash_login`
 - `~/.profile`
 - `$BASH_ENV`
+- Directories listed in `$PATH`
 
-## Why This is not Yet Hardened
+## Mitigation
 
 Bash startup files contain arbitrary user programs and shared environment
 configuration. Automic Vault cannot rewrite them without changing shell
 behavior or guessing which commands need each secret. Move the reported value
-with `av save KEY`, then inject it only into the command that needs it.
+with `av save KEY`, then inject it only into the command that needs it. For an
+unsafe `PATH`, move every protected system directory before the reported
+user-writable directories and remove empty or relative entries.
+
+## Why This is not Yet Hardened
+
+Automic Vault does not rewrite shell startup programs because doing so could
+change command resolution, alter shell behavior, or execute attacker-controlled
+configuration.
 
 [Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).

--- a/src/isotopes/detectors/macos/detector.md
+++ b/src/isotopes/detectors/macos/detector.md
@@ -1,0 +1,27 @@
+# macOS Detector
+
+## Trigger Conditions
+
+- The launchd `PATH` inherited by GUI applications places a user-writable
+  directory before protected system directories.
+
+The scan report also prints the GUI `PATH` as informational context, including
+when its ordering is safe. An unset launchd `PATH` is printed as `<unset>` and
+is not reported as insecure because system command lookup then uses the
+platform default rather than an empty path entry.
+
+## Sensitive Files
+
+- Directories listed in the launchd `PATH`
+
+## Mitigation
+
+Move protected system directories before user-writable directories in the
+launchd `PATH`, remove empty and relative entries, then log out and back in.
+Review LaunchAgents and other software that modifies the launchd environment
+before changing it; an unexpected entry may indicate persistence.
+
+Automic Vault does not modify the GUI environment automatically. Its source can
+be a LaunchAgent, a system policy, or software with different lifecycle and
+ownership requirements, so a blind rewrite could conceal persistence or break
+applications.

--- a/src/isotopes/detectors/macos/mod.rs
+++ b/src/isotopes/detectors/macos/mod.rs
@@ -1,0 +1,99 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::{AffectedFile, Finding};
+
+const DOCS_URL: &str = "https://github.com/automic-vault/automic-vault/blob/main/src/isotopes/detectors/macos/detector.md";
+
+pub(crate) fn findings(_home: &Path) -> Vec<Finding> {
+    let Some(path) = gui_path() else {
+        return Vec::new();
+    };
+    findings_for_gui_path(&path)
+}
+
+fn findings_for_gui_path(path: &std::ffi::OsStr) -> Vec<Finding> {
+    if path.is_empty() {
+        return Vec::new();
+    }
+
+    crate::path_security::user_writable_entries_before_system_paths(path)
+        .into_iter()
+        .map(|entry| Finding {
+            source: "macOS",
+            homepage: DOCS_URL,
+            severity: "high",
+            explanation: format!(
+                "macOS GUI PATH has a user-writable directory before protected system directories: {}",
+                entry.display()
+            ),
+            solution: "Move protected system directories before user-writable directories in the launchd PATH, then log out and back in.".to_string(),
+            affected: vec![AffectedFile {
+                path: entry.display().to_string(),
+                line: None,
+            }],
+            docs_url: DOCS_URL,
+        })
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn gui_path() -> Option<OsString> {
+    use std::os::unix::ffi::OsStringExt;
+    use std::process::{Command, Stdio};
+
+    let mut output = Command::new("/bin/launchctl")
+        .args(["getenv", "PATH"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    while output
+        .stdout
+        .last()
+        .is_some_and(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        output.stdout.pop();
+    }
+    Some(OsString::from_vec(output.stdout))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn gui_path() -> Option<OsString> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn reports_each_writable_gui_entry_before_a_system_path() {
+        let root = std::env::temp_dir().join(format!("av-macos-path-{}", std::process::id()));
+        let writable = root.join("writable");
+        let protected = root.join("protected");
+        std::fs::create_dir_all(&writable).unwrap();
+        std::fs::create_dir_all(&protected).unwrap();
+        std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let path = std::env::join_paths([&writable, &protected]).unwrap();
+
+        let findings = findings_for_gui_path(&path);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].source, "macOS");
+        assert_eq!(findings[0].severity, "high");
+        assert_eq!(findings[0].affected[0].path, writable.display().to_string());
+        std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn does_not_treat_an_unset_launchd_path_as_an_empty_entry() {
+        assert!(findings_for_gui_path(std::ffi::OsStr::new("")).is_empty());
+    }
+}

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -65,6 +65,7 @@ mod js_release_age;
 mod k6;
 mod kubernetes_cli;
 mod luarocks;
+mod macos;
 mod maestro;
 mod mariadb;
 mod maven;
@@ -275,6 +276,7 @@ const DETECTORS: &[Detector] = &[
     detector!(kubernetes_cli),
     detector!(luarocks),
     detector!(maestro),
+    detector!(macos),
     detector!(mariadb),
     detector!(maven),
     detector!(mcp_remote),
@@ -378,6 +380,10 @@ pub(crate) fn findings(home: &Path) -> Vec<Finding> {
     findings
 }
 
+pub(crate) fn macos_gui_path() -> Option<std::ffi::OsString> {
+    macos::gui_path()
+}
+
 pub(crate) fn documented_solution(documentation: &str) -> Option<String> {
     if let Some(mitigation) = documentation
         .split_once("## Mitigation")
@@ -429,6 +435,7 @@ fn detector_name(module: &str) -> String {
     match module {
         "mysql_8_0" => "mysql@8.0".to_string(),
         "mysql_8_4" => "mysql@8.4".to_string(),
+        "macos" => "macOS".to_string(),
         "node_18" => "node@18".to_string(),
         "openssl_3" => "openssl@3".to_string(),
         _ => module.replace('_', "-"),
@@ -441,7 +448,7 @@ mod tests {
 
     #[test]
     fn scan_runs_every_registered_isotope() {
-        assert_eq!(DETECTORS.len(), 156);
+        assert_eq!(DETECTORS.len(), 157);
     }
 
     #[test]
@@ -462,6 +469,7 @@ mod tests {
         assert!(names.contains(&"git-credential-oauth".to_string()));
         assert!(names.contains(&"git-credentials-file".to_string()));
         assert!(names.contains(&"homebrew".to_string()));
+        assert!(names.contains(&"macOS".to_string()));
         assert!(names.contains(&"sip".to_string()));
         assert!(names.contains(&"mysql@8.0".to_string()));
         assert!(names.contains(&"sudo".to_string()));

--- a/src/isotopes/detectors/zsh/detector.md
+++ b/src/isotopes/detectors/zsh/detector.md
@@ -3,6 +3,8 @@
 ## Trigger Conditions
 
 - Zsh startup file contains plaintext-looking credential assignment.
+- Zsh `PATH` places a user-writable directory before protected system
+  directories.
 
 ## Sensitive Files
 
@@ -16,12 +18,21 @@
 - `~/.zshrc`
 - `~/.zlogin`
 - `~/.zlogout`
+- Directories listed in `$PATH`
 
-## Why This is not Yet Hardened
+## Mitigation
 
 Zsh startup files contain arbitrary user programs and shared environment
 configuration. Automic Vault cannot rewrite them without changing shell
 behavior or guessing which commands need each secret. Move the reported value
-with `av save KEY`, then inject it only into the command that needs it.
+with `av save KEY`, then inject it only into the command that needs it. For an
+unsafe `PATH`, move every protected system directory before the reported
+user-writable directories and remove empty or relative entries.
+
+## Why This is not Yet Hardened
+
+Automic Vault does not rewrite shell startup programs because doing so could
+change command resolution, alter shell behavior, or execute attacker-controlled
+configuration.
 
 [Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).

--- a/src/isotopes/mod.rs
+++ b/src/isotopes/mod.rs
@@ -13,6 +13,10 @@ pub(crate) fn detector_metadata() -> Vec<detectors::DetectorMetadata> {
     detectors::metadata()
 }
 
+pub(crate) fn macos_gui_path() -> Option<std::ffi::OsString> {
+    detectors::macos_gui_path()
+}
+
 pub(crate) fn hardener_metadata() -> Vec<hardeners::HardenerMetadata> {
     hardeners::metadata()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod isotopes;
+mod path_security;
 mod secrets;
 
 pub use cli::{run, run_terminal};

--- a/src/path_security.rs
+++ b/src/path_security.rs
@@ -6,13 +6,12 @@ use std::path::{Path, PathBuf};
 pub(crate) fn user_writable_entries_before_system_paths(path: &OsStr) -> Vec<PathBuf> {
     let entries = std::env::split_paths(path)
         .map(|entry| {
+            let writable = !entry.is_absolute() || is_user_writable_or_creatable(&entry);
             let displayed = if entry.as_os_str().is_empty() {
                 PathBuf::from(".")
             } else {
                 entry
             };
-            let checked = absolute_path(&displayed);
-            let writable = is_user_writable_or_creatable(&checked);
             (displayed, writable)
         })
         .collect::<Vec<_>>();
@@ -30,16 +29,6 @@ pub(crate) fn user_writable_entries_before_system_paths(path: &OsStr) -> Vec<Pat
         })
         .filter_map(|(_, (entry, _))| seen.insert(entry.as_os_str().to_owned()).then_some(entry))
         .collect()
-}
-
-fn absolute_path(path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("/"))
-            .join(path)
-    }
 }
 
 fn is_user_writable_or_creatable(path: &Path) -> bool {
@@ -114,17 +103,21 @@ mod tests {
     }
 
     #[test]
-    fn treats_creatable_and_empty_entries_as_user_writable() {
+    fn treats_creatable_relative_and_empty_entries_as_user_writable() {
         let root = temp_dir("creatable");
         let missing = root.join("missing");
         let protected = root.join("protected");
         std::fs::create_dir_all(&protected).unwrap();
         std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o555)).unwrap();
-        let path = OsString::from(format!(":{}:{}", missing.display(), protected.display()));
+        let path = OsString::from(format!(
+            ":relative:{}:{}",
+            missing.display(),
+            protected.display()
+        ));
 
         assert_eq!(
             user_writable_entries_before_system_paths(&path),
-            vec![PathBuf::from("."), missing]
+            vec![PathBuf::from("."), PathBuf::from("relative"), missing]
         );
         std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o755)).unwrap();
         std::fs::remove_dir_all(root).unwrap();

--- a/src/path_security.rs
+++ b/src/path_security.rs
@@ -1,0 +1,132 @@
+use std::collections::HashSet;
+use std::ffi::{CString, OsStr, OsString};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn user_writable_entries_before_system_paths(path: &OsStr) -> Vec<PathBuf> {
+    let entries = std::env::split_paths(path)
+        .map(|entry| {
+            let displayed = if entry.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                entry
+            };
+            let checked = absolute_path(&displayed);
+            let writable = is_user_writable_or_creatable(&checked);
+            (displayed, writable)
+        })
+        .collect::<Vec<_>>();
+
+    let last_system_path = entries.iter().rposition(|(_, writable)| !writable);
+    let all_entries_are_writable = last_system_path.is_none();
+    let mut seen = HashSet::<OsString>::new();
+
+    entries
+        .into_iter()
+        .enumerate()
+        .filter(|(index, (_, writable))| {
+            *writable
+                && (all_entries_are_writable || last_system_path.is_some_and(|last| *index < last))
+        })
+        .filter_map(|(_, (entry, _))| seen.insert(entry.as_os_str().to_owned()).then_some(entry))
+        .collect()
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("/"))
+            .join(path)
+    }
+}
+
+fn is_user_writable_or_creatable(path: &Path) -> bool {
+    let mut candidate = path;
+    loop {
+        if candidate.exists() {
+            if !candidate.is_dir() {
+                return candidate.parent().is_some_and(is_user_writable);
+            }
+            return is_user_writable(candidate);
+        }
+        let Some(parent) = candidate.parent() else {
+            return false;
+        };
+        candidate = parent;
+    }
+}
+
+fn is_user_writable(path: &Path) -> bool {
+    let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+    // SAFETY: `path` is a live, NUL-terminated C string and access does not retain it.
+    unsafe { libc::access(path.as_ptr(), libc::W_OK) == 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("av-path-security-{label}-{}", std::process::id()));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn reports_writable_entries_that_precede_protected_entries() {
+        let root = temp_dir("order");
+        let writable = root.join("writable");
+        let protected = root.join("protected");
+        let trailing = root.join("trailing");
+        std::fs::create_dir_all(&writable).unwrap();
+        std::fs::create_dir_all(&protected).unwrap();
+        std::fs::create_dir_all(&trailing).unwrap();
+        std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let path = std::env::join_paths([&writable, &protected, &trailing]).unwrap();
+        let insecure = user_writable_entries_before_system_paths(&path);
+
+        assert_eq!(insecure, vec![writable]);
+        std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reports_an_entirely_user_writable_path() {
+        let root = temp_dir("all-writable");
+        let one = root.join("one");
+        let two = root.join("two");
+        std::fs::create_dir_all(&one).unwrap();
+        std::fs::create_dir_all(&two).unwrap();
+        let path = std::env::join_paths([&one, &two]).unwrap();
+
+        assert_eq!(
+            user_writable_entries_before_system_paths(&path),
+            vec![one, two]
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn treats_creatable_and_empty_entries_as_user_writable() {
+        let root = temp_dir("creatable");
+        let missing = root.join("missing");
+        let protected = root.join("protected");
+        std::fs::create_dir_all(&protected).unwrap();
+        std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let path = OsString::from(format!(":{}:{}", missing.display(), protected.display()));
+
+        assert_eq!(
+            user_writable_entries_before_system_paths(&path),
+            vec![PathBuf::from("."), missing]
+        );
+        std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/tests/scan_cli.rs
+++ b/tests/scan_cli.rs
@@ -9,7 +9,11 @@ fn av_scan_reports_clean_home() {
 
     assert!(output.status.success());
     let stdout = stdout(&output);
-    assert!(stdout.starts_with("╭─ system exposure audit\n│\n◇ GUI PATH (before shells)\n"));
+    assert!(stdout.starts_with("╭─ system exposure audit\n│\n"));
+    #[cfg(target_os = "macos")]
+    assert!(stdout.contains("◇ GUI PATH (before shells)\n"));
+    #[cfg(not(target_os = "macos"))]
+    assert!(!stdout.contains("GUI PATH"));
     assert!(stdout.contains("◇ No problems found\n"));
     assert!(stdout.ends_with("╰─ vault sealed\n"));
     assert_eq!(stderr(&output), "");

--- a/tests/scan_cli.rs
+++ b/tests/scan_cli.rs
@@ -8,10 +8,10 @@ fn av_scan_reports_clean_home() {
     let output = av_scan(&home);
 
     assert!(output.status.success());
-    assert_eq!(
-        stdout(&output),
-        "╭─ system exposure audit\n│\n◇ No problems found\n│\n╰─ vault sealed\n"
-    );
+    let stdout = stdout(&output);
+    assert!(stdout.starts_with("╭─ system exposure audit\n│\n◇ GUI PATH (before shells)\n"));
+    assert!(stdout.contains("◇ No problems found\n"));
+    assert!(stdout.ends_with("╰─ vault sealed\n"));
     assert_eq!(stderr(&output), "");
 
     let _ = fs::remove_dir_all(home);
@@ -42,6 +42,7 @@ fn av_scan_reports_findings() {
         assert!(
             line.starts_with('╭')
                 || line.starts_with('◆')
+                || line.starts_with('◇')
                 || line.starts_with('└')
                 || line.starts_with('├')
                 || line.starts_with('╰')
@@ -88,6 +89,7 @@ fn av_scan(home: &std::path::Path) -> Output {
         )
         .env("AUTOMIC_VAULT_DISABLE_GIT_CREDENTIAL_FILL_DETECTOR", "1")
         .env("AUTOMIC_VAULT_DISABLE_SUDO_DETECTOR", "1")
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
         .output()
         .unwrap()
 }
@@ -102,6 +104,7 @@ fn av_scan_json(home: &std::path::Path) -> Output {
         )
         .env("AUTOMIC_VAULT_DISABLE_GIT_CREDENTIAL_FILL_DETECTOR", "1")
         .env("AUTOMIC_VAULT_DISABLE_SUDO_DETECTOR", "1")
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
         .output()
         .unwrap()
 }


### PR DESCRIPTION
## Summary

- Add shared detection for user-writable PATH entries ahead of protected system directories.
- Report unsafe PATH ordering in Bash, Zsh, and macOS launchd environments.
- Display the macOS GUI PATH in scan output and JSON reports.
- Document mitigation guidance and add detector, CLI, and path-security tests.

## Testing

- Added unit tests for PATH precedence, creatable and empty entries, macOS detection, and report output.
- Updated scan integration coverage for GUI PATH output and clean environments.
- Not run (not requested)