### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run tests
+        run: cargo test --all-targets --all-features --locked
+
+  swift:
+    name: Swift
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        run: swift test --package-path src/menu-helper --disable-automatic-resolution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 

--- a/src/isotopes/detectors/sip/mod.rs
+++ b/src/isotopes/detectors/sip/mod.rs
@@ -11,6 +11,10 @@ pub(crate) fn findings(_home: &Path) -> Vec<Finding> {
         return Vec::new();
     }
 
+    if let Some(status) = crate::test_env_string("AUTOMIC_VAULT_TEST_SIP_STATUS") {
+        return finding_for_status(&status).into_iter().collect();
+    }
+
     let Ok(output) = Command::new("/usr/bin/csrutil").arg("status").output() else {
         return Vec::new();
     };

--- a/tests/scan_cli.rs
+++ b/tests/scan_cli.rs
@@ -86,6 +86,10 @@ fn av_scan(home: &std::path::Path) -> Output {
             "AUTOMIC_VAULT_TEST_BREW_TARGET",
             home.join("missing-opt-homebrew/bin/brew"),
         )
+        .env(
+            "AUTOMIC_VAULT_TEST_SIP_STATUS",
+            "System Integrity Protection status: enabled.",
+        )
         .env("AUTOMIC_VAULT_DISABLE_GIT_CREDENTIAL_FILL_DETECTOR", "1")
         .env("AUTOMIC_VAULT_DISABLE_SUDO_DETECTOR", "1")
         .output()
@@ -99,6 +103,10 @@ fn av_scan_json(home: &std::path::Path) -> Output {
         .env(
             "AUTOMIC_VAULT_TEST_BREW_TARGET",
             home.join("missing-opt-homebrew/bin/brew"),
+        )
+        .env(
+            "AUTOMIC_VAULT_TEST_SIP_STATUS",
+            "System Integrity Protection status: enabled.",
         )
         .env("AUTOMIC_VAULT_DISABLE_GIT_CREDENTIAL_FILL_DETECTOR", "1")
         .env("AUTOMIC_VAULT_DISABLE_SUDO_DETECTOR", "1")


### PR DESCRIPTION
## Summary

- add GitHub Actions CI for pull requests and pushes to `main`
- enforce Rust formatting and run the complete locked Rust test suite
- run Swift package tests without automatic dependency resolution
- use macOS 26 runners for the product's supported platform
- make the scan integration test independent of the runner's SIP configuration

## Security

- grant the workflow only read access to repository contents
- pin `actions/checkout` to an immutable commit
- prevent checkout from persisting GitHub credentials
- cancel superseded runs and cap each job at 20 minutes
- keep the SIP status override behind the existing debug-only, Cargo-build test boundary; release binaries continue to query `/usr/bin/csrutil`

## Validation

- `actionlint .github/workflows/ci.yml`
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked` (754 tests)
- `swift test --package-path src/menu-helper --disable-automatic-resolution` (31 tests)
