### PR TITLE
Add blessed script management to the CLI and menubar helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ you approved. If we cannot verify that identity, automatic approval fails closed
 Code signing proves identity and integrity—not good intentions. You still choose
 which apps to trust.
 
+### Blessed scripts
+
+A script can declare the tool access it needs next to its `av inject` shebang:
+
+```sh
+#!/usr/local/bin/av inject +TOKEN /bin/sh
+# --- automic-vault
+# capabilities:
+#   gh: read-only
+#   aws: trusted
+# ---
+```
+
+Run `av bless PATH` to review it in the Automic Vault app. Approval is bound to
+that canonical path, exact file contents, injection declaration, and the selected
+signed launcher apps. While that exact script runs, declared tool requests are
+approved up to their listed level; undeclared or broader requests are denied.
+Editing the script requires an explicit re-bless.
+
 &nbsp;
 
 

--- a/src/cli/bless.rs
+++ b/src/cli/bless.rs
@@ -1,0 +1,41 @@
+use std::ffi::OsString;
+use std::io::Write;
+
+pub(crate) fn run(args: Vec<OsString>, stderr: &mut dyn Write) -> i32 {
+    match run_inner(args) {
+        Ok(()) => 0,
+        Err(err) => {
+            let _ = writeln!(stderr, "av bless: {err}");
+            1
+        }
+    }
+}
+
+fn run_inner(args: Vec<OsString>) -> Result<(), String> {
+    let [path] = args.as_slice() else {
+        return Err("usage: av bless PATH".into());
+    };
+    let path = std::fs::canonicalize(path)
+        .map_err(|err| format!("failed to resolve {}: {err}", path.to_string_lossy()))?;
+    if !path.is_file() {
+        return Err(format!("not a regular file: {}", path.display()));
+    }
+    let path = path
+        .to_str()
+        .ok_or_else(|| "script path must be valid UTF-8".to_string())?;
+    crate::secrets::bless_script(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bless_requires_exactly_one_path() {
+        assert_eq!(run_inner(vec![]).unwrap_err(), "usage: av bless PATH");
+        assert_eq!(
+            run_inner(vec!["a".into(), "b".into()]).unwrap_err(),
+            "usage: av bless PATH"
+        );
+    }
+}

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{CString, OsString};
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -33,6 +36,7 @@ struct ApprovalRequest {
     allow_missing_keys: bool,
     env_conflicts: Vec<String>,
     shebang_script: Option<String>,
+    script_data: Option<Vec<u8>>,
 }
 
 unsafe extern "C" {
@@ -165,13 +169,38 @@ fn parse(args: Vec<OsString>) -> Result<Options, String> {
     }
 }
 
-fn exec(options: Options, stderr: &mut dyn Write) -> i32 {
+fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
     if unsafe { geteuid() } == 0 {
         let _ = writeln!(stderr, "av inject: must not be run as root");
         return 1;
     }
 
-    let (target, env) = match prepare_injection(&options, stderr, approve_injection, build_env) {
+    let verified_script = match options
+        .shebang_script
+        .as_ref()
+        .map(VerifiedScript::open)
+        .transpose()
+    {
+        Ok(script) => script,
+        Err(err) => {
+            let _ = writeln!(stderr, "av inject: {err}");
+            return 1;
+        }
+    };
+    let original_script = options.shebang_script.clone();
+    if let Some(script) = &verified_script {
+        options.shebang_script = Some(script.path.clone().into_os_string());
+    }
+
+    let (target, mut env) = match prepare_injection(
+        &options,
+        stderr,
+        verified_script
+            .as_ref()
+            .map(|script| script.data.as_slice()),
+        approve_injection,
+        build_env,
+    ) {
         Ok(prepared) => prepared,
         Err(err) => {
             let _ = writeln!(stderr, "av inject: {err}");
@@ -179,8 +208,21 @@ fn exec(options: Options, stderr: &mut dyn Write) -> i32 {
         }
     };
 
+    let mut args = options.args.clone();
+    if let (Some(script), Some(original)) = (&verified_script, original_script) {
+        if let Some(index) = args.iter().position(|arg| {
+            arg == &original || std::fs::canonicalize(arg).is_ok_and(|path| path == script.path)
+        }) {
+            args[index] = OsString::from(format!("/dev/fd/{}", script.file.as_raw_fd()));
+        }
+        env.insert(
+            OsString::from("AV_SCRIPT_PATH"),
+            script.path.clone().into_os_string(),
+        );
+    }
+
     let err = Command::new(&target)
-        .args(&options.args)
+        .args(args)
         .env_clear()
         .envs(env)
         .exec();
@@ -195,6 +237,7 @@ fn exec(options: Options, stderr: &mut dyn Write) -> i32 {
 fn prepare_injection<A, B>(
     options: &Options,
     stderr: &mut dyn Write,
+    script_data: Option<&[u8]>,
     approve: A,
     build: B,
 ) -> Result<(PathBuf, BTreeMap<OsString, OsString>), String>
@@ -207,13 +250,17 @@ where
     ) -> Result<BTreeMap<OsString, OsString>, String>,
 {
     let target = resolve_target(&options.target)?;
-    let request = approval_request(options, &target)?;
+    let request = approval_request(options, &target, script_data)?;
     let secrets = approve(&request)?;
     let env = build(options, stderr, secrets)?;
     Ok((target, env))
 }
 
-fn approval_request(options: &Options, target: &Path) -> Result<ApprovalRequest, String> {
+fn approval_request(
+    options: &Options,
+    target: &Path,
+    script_data: Option<&[u8]>,
+) -> Result<ApprovalRequest, String> {
     let current_env = std::env::vars_os().collect::<BTreeMap<_, _>>();
     let env_conflicts = options
         .keys
@@ -233,7 +280,50 @@ fn approval_request(options: &Options, target: &Path) -> Result<ApprovalRequest,
         allow_missing_keys: options.allow_missing_keys,
         env_conflicts,
         shebang_script: options.shebang_script.as_ref().map(os_display),
+        script_data: script_data.map(<[u8]>::to_vec),
     })
+}
+
+struct VerifiedScript {
+    file: File,
+    path: PathBuf,
+    data: Vec<u8>,
+}
+
+impl VerifiedScript {
+    fn open(path: &OsString) -> Result<Self, String> {
+        let path = std::fs::canonicalize(path)
+            .map_err(|err| format!("failed to resolve script {}: {err}", path.to_string_lossy()))?;
+        let mut file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&path)
+            .map_err(|err| format!("failed to open script {}: {err}", path.display()))?;
+        if !file
+            .metadata()
+            .map_err(|err| format!("failed to inspect script {}: {err}", path.display()))?
+            .is_file()
+        {
+            return Err(format!("script is not a regular file: {}", path.display()));
+        }
+        let mut data = Vec::new();
+        Read::by_ref(&mut file)
+            .take(1024 * 1024 + 1)
+            .read_to_end(&mut data)
+            .map_err(|err| format!("failed to read script {}: {err}", path.display()))?;
+        if data.len() > 1024 * 1024 {
+            return Err("script exceeds the 1 MiB blessing limit".into());
+        }
+        file.rewind()
+            .map_err(|err| format!("failed to rewind script {}: {err}", path.display()))?;
+        if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, 0) } == -1 {
+            return Err(format!(
+                "failed to preserve verified script descriptor: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(Self { file, path, data })
+    }
 }
 
 fn os_display(value: &OsString) -> String {
@@ -366,6 +456,12 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
         fn xpc_dictionary_set_bool(xdict: XpcObject, key: *const c_char, value: bool);
         fn xpc_dictionary_get_bool(xdict: XpcObject, key: *const c_char) -> bool;
         fn xpc_dictionary_set_string(xdict: XpcObject, key: *const c_char, value: *const c_char);
+        fn xpc_dictionary_set_data(
+            xdict: XpcObject,
+            key: *const c_char,
+            bytes: *const c_void,
+            length: usize,
+        );
         fn xpc_dictionary_get_string(xdict: XpcObject, key: *const c_char) -> *const c_char;
         fn xpc_dictionary_get_dictionary(xdict: XpcObject, key: *const c_char) -> XpcObject;
         fn xpc_dictionary_set_value(xdict: XpcObject, key: *const c_char, value: XpcObject);
@@ -436,6 +532,14 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
         set_string(message, b"cwd\0", &request.cwd)?;
         if let Some(script) = &request.shebang_script {
             set_string(message, b"shebang_script\0", script)?;
+        }
+        if let Some(data) = &request.script_data {
+            xpc_dictionary_set_data(
+                message,
+                b"script_data\0".as_ptr().cast(),
+                data.as_ptr().cast(),
+                data.len(),
+            );
         }
         xpc_dictionary_set_bool(
             message,
@@ -576,6 +680,7 @@ mod tests {
         let err = prepare_injection(
             &options,
             &mut stderr,
+            None,
             |_| Err("user denied injection".into()),
             |_, _, _| panic!("approval denial must happen before loading secrets"),
         )
@@ -594,7 +699,7 @@ mod tests {
             args: os(&["hi"]),
             shebang_script: Some("/tmp/tool".into()),
         };
-        let request = approval_request(&options, Path::new("/bin/echo")).unwrap();
+        let request = approval_request(&options, Path::new("/bin/echo"), Some(b"script")).unwrap();
 
         assert_eq!(request.keys, ["A", "B"]);
         assert_eq!(request.target, "/bin/echo");
@@ -602,6 +707,7 @@ mod tests {
         assert!(request.replace_existing_env);
         assert!(request.allow_missing_keys);
         assert_eq!(request.shebang_script.as_deref(), Some("/tmp/tool"));
+        assert_eq!(request.script_data.as_deref(), Some(b"script".as_slice()));
     }
 
     #[test]

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{CString, OsString};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, Write};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -314,8 +314,26 @@ impl VerifiedScript {
         if data.len() > 1024 * 1024 {
             return Err("script exceeds the 1 MiB blessing limit".into());
         }
-        file.rewind()
-            .map_err(|err| format!("failed to rewind script {}: {err}", path.display()))?;
+        let mut template = CString::new("/tmp/automic-vault-script.XXXXXX")
+            .unwrap()
+            .into_bytes_with_nul();
+        let descriptor = unsafe { libc::mkstemp(template.as_mut_ptr().cast()) };
+        if descriptor == -1 {
+            return Err(format!(
+                "failed to snapshot verified script: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let mut file = unsafe { File::from_raw_fd(descriptor) };
+        if unsafe { libc::unlink(template.as_ptr().cast()) } == -1 {
+            return Err(format!(
+                "failed to unlink verified script snapshot: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        file.write_all(&data)
+            .and_then(|()| file.rewind())
+            .map_err(|err| format!("failed to snapshot verified script: {err}"))?;
         if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, 0) } == -1 {
             return Err(format!(
                 "failed to preserve verified script descriptor: {}",
@@ -708,6 +726,20 @@ mod tests {
         assert!(request.allow_missing_keys);
         assert_eq!(request.shebang_script.as_deref(), Some("/tmp/tool"));
         assert_eq!(request.script_data.as_deref(), Some(b"script".as_slice()));
+    }
+
+    #[test]
+    fn verified_script_executes_the_approved_snapshot() {
+        let path = temp_script("approved");
+        let mut script = VerifiedScript::open(&path.clone().into_os_string()).unwrap();
+        std::fs::write(&path, "changed").unwrap();
+        let mut executed = String::new();
+
+        script.file.read_to_string(&mut executed).unwrap();
+
+        assert_eq!(script.data, b"approved");
+        assert_eq!(executed, "approved");
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 
+mod bless;
 mod doctor;
 mod inject;
 mod open;
@@ -16,6 +17,7 @@ Usage:
   av doctor [COMMAND] [--json]
   av detectors --json
   av hardeners --json
+  av bless PATH
   av inject +KEY [--] COMMAND
   av save KEY
   av harden
@@ -167,6 +169,7 @@ where
             2
         }
         Some("inject") => inject::run(rest, stdout, stderr, shebang_script),
+        Some("bless") => bless::run(rest, stderr),
         Some("open") => {
             let Some(secret_gate) = parse_open_args(&rest) else {
                 let _ = writeln!(stderr, "{USAGE}");

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -5,6 +5,12 @@ import Security
 import SwiftUI
 import UniformTypeIdentifiers
 
+struct BlessedScriptReviewRequest: Sendable {
+    let path: String
+    let declaration: BlessedScriptDeclaration
+    let launcher: BlessedScriptLauncher
+}
+
 @MainActor
 final class AutomicVaultMainWindowController: NSHostingController<DashboardRootView> {
     private let model = DashboardModel()
@@ -36,6 +42,18 @@ final class AutomicVaultMainWindowController: NSHostingController<DashboardRootV
 
     func showSecretGate(id: String) {
         model.showSecretGate(id: id)
+    }
+
+    func reviewBlessing(
+        _ request: BlessedScriptReviewRequest,
+        completion: @escaping (String?) -> Void
+    ) {
+        model.reviewBlessing(request, completion: completion)
+    }
+
+    override func viewDidDisappear() {
+        super.viewDidDisappear()
+        model.cancelPendingBlessing()
     }
 }
 
@@ -82,9 +100,12 @@ final class DashboardModel: ObservableObject {
     @Published var selectedItemID: String?
     @Published var searchText = ""
     @Published private(set) var cliInstallState: CLIInstallState?
+    @Published private(set) var pendingBlessing: BlessedScriptReviewRequest?
+    @Published private(set) var pendingBlessingLaunchers: [BlessedScriptLauncher] = []
 
     private var reloadTask: Task<Void, Never>?
     private var detectorFindingsGeneration = 0
+    private var blessingCompletion: ((String?) -> Void)?
 
     init(snapshot: DashboardSnapshot = .empty, cliInstallState: CLIInstallState? = nil) {
         self.snapshot = snapshot
@@ -148,6 +169,8 @@ final class DashboardModel: ObservableObject {
                     ].joined(separator: "\n")
                 )
             }
+        case .blessedScripts:
+            blessedScriptItems(snapshot.blessedScripts, pending: pendingBlessing)
         case .allSecrets:
             snapshot.secrets.map {
                 DashboardItem(id: $0.account, title: $0.account, subtitle: $0.subtitle, detail: "Secret value is hidden.\n\($0.subtitle)")
@@ -187,6 +210,19 @@ final class DashboardModel: ObservableObject {
         return snapshot.secretGates.first
     }
 
+    var selectedBlessedScript: BlessedScript? {
+        if let selectedItemID,
+           let script = snapshot.blessedScripts.first(where: { $0.path == selectedItemID }) {
+            return script
+        }
+        return snapshot.blessedScripts.first
+    }
+
+    var selectedPendingBlessing: BlessedScriptReviewRequest? {
+        guard pendingBlessing?.path == selectedItem?.id else { return nil }
+        return pendingBlessing
+    }
+
     var selectedStoredSecret: StoredSecret? {
         if let selectedItemID,
            let secret = snapshot.secrets.first(where: { $0.account == selectedItemID }) {
@@ -210,6 +246,7 @@ final class DashboardModel: ObservableObject {
         case .doctor: snapshot.doctorIssues.count
         case .hardenedTools: snapshot.hardenedTools.count
         case .secretGates: snapshot.secretGates.count
+        case .blessedScripts: snapshot.blessedScripts.count + (pendingBlessing == nil ? 0 : 1)
         case .allSecrets: snapshot.secrets.count
         case .secretUsage: snapshot.accessRequests.count
         }
@@ -234,6 +271,136 @@ final class DashboardModel: ObservableObject {
     func showSecretGate(id: String) {
         selectedSection = .secretGates
         selectedItemID = id
+    }
+
+    func reviewBlessing(
+        _ request: BlessedScriptReviewRequest,
+        completion: @escaping (String?) -> Void
+    ) {
+        guard pendingBlessing == nil else {
+            completion("another script blessing is already awaiting review")
+            return
+        }
+        pendingBlessing = request
+        pendingBlessingLaunchers = [request.launcher]
+        blessingCompletion = completion
+        selectedSection = .blessedScripts
+        selectedItemID = request.path
+    }
+
+    func approvePendingBlessing() {
+        guard let request = pendingBlessing, !pendingBlessingLaunchers.isEmpty else { return }
+        let declaration = request.declaration
+        let script = BlessedScript(
+            path: request.path,
+            checksum: declaration.checksum,
+            keys: declaration.keys,
+            target: declaration.target,
+            replaceExistingEnv: declaration.replaceExistingEnv,
+            allowMissingKeys: declaration.allowMissingKeys,
+            capabilities: declaration.manifest.capabilities,
+            launchers: pendingBlessingLaunchers
+        )
+        let status = saveBlessedScript(script)
+        guard status == errSecSuccess else {
+            errorMessage = "Could not bless script: \(status)"
+            return
+        }
+        finishPendingBlessing(nil)
+        selectedItemID = script.path
+        reload()
+    }
+
+    func cancelPendingBlessing() {
+        guard pendingBlessing != nil else { return }
+        finishPendingBlessing("script blessing was cancelled")
+    }
+
+    func addAppToPendingBlessing() {
+        guard let launcher = chooseLauncherApp(),
+              !pendingBlessingLaunchers.contains(where: { $0.requirement == launcher.requirement })
+        else { return }
+        pendingBlessingLaunchers.append(launcher)
+    }
+
+    func removePendingBlessingLauncher(_ launcher: BlessedScriptLauncher) {
+        pendingBlessingLaunchers.removeAll { $0.requirement == launcher.requirement }
+    }
+
+    func addApp(to script: BlessedScript) {
+        guard let launcher = chooseLauncherApp(),
+              !script.launchers.contains(where: { $0.requirement == launcher.requirement })
+        else { return }
+        let updated = BlessedScript(
+            path: script.path,
+            checksum: script.checksum,
+            keys: script.keys,
+            target: script.target,
+            replaceExistingEnv: script.replaceExistingEnv,
+            allowMissingKeys: script.allowMissingKeys,
+            capabilities: script.capabilities,
+            launchers: script.launchers + [launcher],
+            blessedAt: script.blessedAt
+        )
+        finishPolicyUpdate(saveBlessedScript(updated), error: "Could not add calling app")
+    }
+
+    func removeLauncher(_ launcher: BlessedScriptLauncher, from script: BlessedScript) {
+        let launchers = script.launchers.filter { $0.requirement != launcher.requirement }
+        guard !launchers.isEmpty else {
+            errorMessage = "A blessed script must allow at least one calling app."
+            return
+        }
+        let updated = BlessedScript(
+            path: script.path,
+            checksum: script.checksum,
+            keys: script.keys,
+            target: script.target,
+            replaceExistingEnv: script.replaceExistingEnv,
+            allowMissingKeys: script.allowMissingKeys,
+            capabilities: script.capabilities,
+            launchers: launchers,
+            blessedAt: script.blessedAt
+        )
+        finishPolicyUpdate(saveBlessedScript(updated), error: "Could not remove calling app")
+    }
+
+    func revoke(_ script: BlessedScript) {
+        let status = removeBlessedScript(path: script.path)
+        if status == errSecSuccess {
+            selectedItemID = nil
+            reload()
+        } else {
+            errorMessage = "Could not revoke blessing: \(status)"
+        }
+    }
+
+    private func finishPendingBlessing(_ error: String?) {
+        let completion = blessingCompletion
+        blessingCompletion = nil
+        pendingBlessing = nil
+        pendingBlessingLaunchers = []
+        completion?(error)
+    }
+
+    private func chooseLauncherApp() -> BlessedScriptLauncher? {
+        let panel = NSOpenPanel()
+        panel.title = "Allow Calling App"
+        panel.prompt = "Allow"
+        panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url, url.pathExtension == "app",
+              let signing = appBundleSigning(url)
+        else {
+            return nil
+        }
+        return BlessedScriptLauncher(
+            bundleIdentifier: Bundle(url: url)?.bundleIdentifier ?? url.lastPathComponent,
+            requirement: signing.requirement
+        )
     }
 
     func accessRequests(for item: DashboardItem) -> [AccessRequestRecord] {
@@ -476,6 +643,35 @@ private func detectorItemPrecedes(_ lhs: DashboardItem, _ rhs: DashboardItem) ->
         return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
     }
     return (lhs.kind ?? "").localizedStandardCompare(rhs.kind ?? "") == .orderedAscending
+}
+
+private func blessedScriptItem(_ script: BlessedScript) -> DashboardItem {
+    let currentChecksum = try? blessedScriptDeclaration(
+        data: Data(contentsOf: URL(fileURLWithPath: script.path))
+    ).checksum
+    let status = currentChecksum == script.checksum ? "Blessed" : "Changed"
+    return DashboardItem(
+        id: script.path,
+        title: URL(fileURLWithPath: script.path).lastPathComponent,
+        subtitle: status,
+        detail: script.path
+    )
+}
+
+private func blessedScriptItems(
+    _ blessed: [BlessedScript],
+    pending: BlessedScriptReviewRequest?
+) -> [DashboardItem] {
+    let scripts = blessed.map(blessedScriptItem)
+    guard let pending, !scripts.contains(where: { $0.id == pending.path }) else { return scripts }
+    return [
+        DashboardItem(
+            id: pending.path,
+            title: URL(fileURLWithPath: pending.path).lastPathComponent,
+            subtitle: "Pending review",
+            detail: pending.path
+        )
+    ] + scripts
 }
 
 private func detectorSeveritySortPriority(_ severity: String?) -> Int {
@@ -778,6 +974,7 @@ enum DashboardSection: String, CaseIterable, Identifiable {
     case detectors
     case hardenedTools
     case secretGates
+    case blessedScripts
     case allSecrets
     case secretUsage
     case doctor
@@ -790,6 +987,7 @@ enum DashboardSection: String, CaseIterable, Identifiable {
         case .doctor: "Doctor"
         case .hardenedTools: "Hardened Tools"
         case .secretGates: "Secret Gates"
+        case .blessedScripts: "Blessed Scripts"
         case .allSecrets: "Secrets"
         case .secretUsage: "Secret Usage"
         }
@@ -801,6 +999,7 @@ enum DashboardSection: String, CaseIterable, Identifiable {
         case .doctor: "stethoscope"
         case .hardenedTools: "hammer"
         case .secretGates: "lock.shield"
+        case .blessedScripts: "checkmark.seal"
         case .allSecrets: "key"
         case .secretUsage: "clock.arrow.circlepath"
         }
@@ -875,6 +1074,18 @@ struct DashboardRootView: View {
                     if model.selectedSection == .secretGates, let gate = model.selectedSecretGate {
                         Button {
                             model.addApp(to: gate)
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                        .help("Add Calling App")
+                    }
+                    if model.selectedSection == .blessedScripts {
+                        Button {
+                            if model.selectedPendingBlessing != nil {
+                                model.addAppToPendingBlessing()
+                            } else if let script = model.selectedBlessedScript {
+                                model.addApp(to: script)
+                            }
                         } label: {
                             Image(systemName: "plus")
                         }
@@ -1006,6 +1217,20 @@ private struct DashboardDetailView: View {
         ScrollView {
             if model.selectedSection == .secretGates, let gate = model.selectedSecretGate {
                 SecretGateDetailView(model: model, gate: gate)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 32)
+                    .padding(.bottom, 28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if model.selectedSection == .blessedScripts,
+                      let pending = model.selectedPendingBlessing {
+                BlessedScriptReviewView(model: model, request: pending)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 32)
+                    .padding(.bottom, 28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if model.selectedSection == .blessedScripts,
+                      let script = model.selectedBlessedScript {
+                BlessedScriptDetailView(model: model, script: script)
                     .padding(.horizontal, 22)
                     .padding(.top, 32)
                     .padding(.bottom, 28)
@@ -1153,6 +1378,7 @@ private struct EmptyListView: View {
         case .doctor: "No doctor issues"
         case .hardenedTools: "No hardened tools"
         case .secretGates: "No configured gates"
+        case .blessedScripts: "No blessed scripts"
         case .allSecrets: "No stored secrets"
         case .secretUsage: "No secret usage logged"
         }
@@ -1453,7 +1679,7 @@ private struct InfoBlock: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title.uppercased())
-                .font(.system(size: 11, weight: .bold))
+                .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .tracking(0.7)
             Text(text)
@@ -1740,6 +1966,138 @@ private struct AccessMetaLine: View {
             .font(.system(size: 11))
             .foregroundStyle(.secondary)
             .textSelection(.enabled)
+    }
+}
+
+private struct BlessedScriptReviewView: View {
+    @ObservedObject var model: DashboardModel
+    let request: BlessedScriptReviewRequest
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(URL(fileURLWithPath: request.path).lastPathComponent)
+                    .font(.system(size: 24, weight: .semibold))
+                Text("Review before granting durable script authority.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            BlessedScriptFields(
+                path: request.path,
+                checksum: request.declaration.checksum,
+                keys: request.declaration.keys,
+                capabilities: request.declaration.manifest.capabilities
+            )
+            launcherList(model.pendingBlessingLaunchers) {
+                model.removePendingBlessingLauncher($0)
+            }
+            if request.declaration.manifest.capabilities.values.contains(.fullIncludingSecretDumps) {
+                InfoBlock(
+                    title: "Full Access",
+                    text: "This script requests access to operations that may reveal protected secret values."
+                )
+            }
+            HStack {
+                Button("Cancel", role: .cancel) { model.cancelPendingBlessing() }
+                Spacer()
+                Button("Bless Script") { model.approvePendingBlessing() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model.pendingBlessingLaunchers.isEmpty)
+            }
+            if let error = model.errorMessage {
+                InfoBlock(title: "Error", text: error)
+            }
+        }
+    }
+}
+
+private struct BlessedScriptDetailView: View {
+    @ObservedObject var model: DashboardModel
+    let script: BlessedScript
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(URL(fileURLWithPath: script.path).lastPathComponent)
+                    .font(.system(size: 24, weight: .semibold))
+                Text(status)
+                    .font(.system(size: 13))
+                    .foregroundStyle(status == "Blessed" ? .green : .orange)
+            }
+            BlessedScriptFields(
+                path: script.path,
+                checksum: script.checksum,
+                keys: script.keys,
+                capabilities: script.capabilities
+            )
+            launcherList(script.launchers) {
+                model.removeLauncher($0, from: script)
+            }
+            HStack {
+                Spacer()
+                Button("Revoke Blessing", role: .destructive) { model.revoke(script) }
+            }
+            if let error = model.errorMessage {
+                InfoBlock(title: "Error", text: error)
+            }
+        }
+    }
+
+    private var status: String {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: script.path)),
+              let checksum = try? blessedScriptDeclaration(data: data).checksum
+        else {
+            return "Changed"
+        }
+        return checksum == script.checksum ? "Blessed" : "Changed"
+    }
+}
+
+private struct BlessedScriptFields: View {
+    let path: String
+    let checksum: String
+    let keys: [String]
+    let capabilities: [String: SecretGateProtection]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            SecretGateField("Path", path)
+            SecretGateField("SHA-256", checksum, monospaced: true)
+            SecretGateField("Secrets", keys.joined(separator: ", "))
+            SecretGateField(
+                "Capabilities",
+                capabilities.sorted(by: { $0.key < $1.key })
+                    .map { "\($0.key): \($0.value.title)" }
+                    .joined(separator: ", ")
+            )
+        }
+    }
+}
+
+@MainActor
+private func launcherList(
+    _ launchers: [BlessedScriptLauncher],
+    remove: @escaping (BlessedScriptLauncher) -> Void
+) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+        Text("Calling Apps")
+            .font(.system(size: 13, weight: .semibold))
+        ForEach(launchers, id: \.requirement) { launcher in
+            HStack {
+                Text(launcher.bundleIdentifier)
+                    .textSelection(.enabled)
+                Spacer()
+                Button {
+                    remove(launcher)
+                } label: {
+                    Image(systemName: "minus.circle")
+                }
+                .buttonStyle(.plain)
+                .help("Remove Calling App")
+            }
+            .padding(10)
+            .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 8))
+        }
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -246,7 +246,11 @@ final class DashboardModel: ObservableObject {
         case .doctor: snapshot.doctorIssues.count
         case .hardenedTools: snapshot.hardenedTools.count
         case .secretGates: snapshot.secretGates.count
-        case .blessedScripts: snapshot.blessedScripts.count + (pendingBlessing == nil ? 0 : 1)
+        case .blessedScripts:
+            snapshot.blessedScripts.count
+                + (pendingBlessing.map { pending in
+                    snapshot.blessedScripts.contains { $0.path == pending.path } ? 0 : 1
+                } ?? 0)
         case .allSecrets: snapshot.secrets.count
         case .secretUsage: snapshot.accessRequests.count
         }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -646,9 +646,7 @@ private func detectorItemPrecedes(_ lhs: DashboardItem, _ rhs: DashboardItem) ->
 }
 
 private func blessedScriptItem(_ script: BlessedScript) -> DashboardItem {
-    let currentChecksum = try? blessedScriptDeclaration(
-        data: Data(contentsOf: URL(fileURLWithPath: script.path))
-    ).checksum
+    let currentChecksum = try? blessedScriptDeclaration(data: readBlessedScript(path: script.path)).checksum
     let status = currentChecksum == script.checksum ? "Blessed" : "Changed"
     return DashboardItem(
         id: script.path,
@@ -2044,7 +2042,7 @@ private struct BlessedScriptDetailView: View {
     }
 
     private var status: String {
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: script.path)),
+        guard let data = try? readBlessedScript(path: script.path),
               let checksum = try? blessedScriptDeclaration(data: data).checksum
         else {
             return "Changed"

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1750,11 +1750,7 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "script path must be canonical")
             return
         }
-        var info = stat()
-        guard path.withCString({ lstat($0, &info) }) == 0,
-              info.st_mode & S_IFMT == S_IFREG,
-              info.st_size <= 1024 * 1024,
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+        guard let data = try? readBlessedScript(path: path),
               let declaration = try? blessedScriptDeclaration(data: data)
         else {
             reply(peer, to: message, ok: false, error: "script is not a valid blessable file")
@@ -3026,7 +3022,7 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
         ? URL(fileURLWithPath: script)
         : URL(fileURLWithPath: request.cwd).appendingPathComponent(script)
     let path = url.standardizedFileURL.resolvingSymlinksInPath().path
-    guard let data = request.scriptData ?? (try? Data(contentsOf: URL(fileURLWithPath: path))) else {
+    guard let data = request.scriptData ?? (try? readBlessedScript(path: path)) else {
         return nil
     }
     let checksum = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -211,6 +211,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Task { @MainActor in self?.didRecordAccessRequest(record) }
                 }
                 return recorded
+            } onBlessRequest: { [weak self] request, completion in
+                guard let self else {
+                    completion("Automic Vault is unavailable")
+                    return
+                }
+                self.showMainWindow(secretGateID: nil)
+                guard let controller = self.mainWindow?.contentViewController
+                    as? AutomicVaultMainWindowController
+                else {
+                    completion("Automic Vault could not open the blessing review")
+                    return
+                }
+                controller.reviewBlessing(request, completion: completion)
             } canRequestHumanApproval: { [weak self] in
                 self?.isUserSessionActive == true && self?.areScreensAwake == true
             }
@@ -1111,6 +1124,10 @@ private final class ApprovalServer: @unchecked Sendable {
     private let hardeners: [HardenerMetadata]?
     private let onAutoApproval: @MainActor (AutoApprovalRecord) -> Void
     private let onAccessRequest: @Sendable (AccessRequestRecord) -> Bool
+    private let onBlessRequest: @MainActor (
+        BlessedScriptReviewRequest,
+        @escaping (String?) -> Void
+    ) -> Void
     private let canRequestHumanApproval: @MainActor () -> Bool
     private var listener: xpc_connection_t?
     // ponytail: in-memory per-process cache; use persistent approvals for cross-process trust.
@@ -1121,6 +1138,10 @@ private final class ApprovalServer: @unchecked Sendable {
         hardeners: [HardenerMetadata]? = nil,
         onAutoApproval: @escaping @MainActor (AutoApprovalRecord) -> Void = { _ in },
         onAccessRequest: @escaping @Sendable (AccessRequestRecord) -> Bool = { appendAccessRequestRecord($0) },
+        onBlessRequest: @escaping @MainActor (
+            BlessedScriptReviewRequest,
+            @escaping (String?) -> Void
+        ) -> Void = { _, completion in completion("script blessing is unavailable") },
         canRequestHumanApproval: @escaping @MainActor () -> Bool = { true }
     ) throws {
         guard let teamIdentifier = selfTeamIdentifier() else {
@@ -1131,6 +1152,7 @@ private final class ApprovalServer: @unchecked Sendable {
         self.hardeners = hardeners
         self.onAutoApproval = onAutoApproval
         self.onAccessRequest = onAccessRequest
+        self.onBlessRequest = onBlessRequest
         self.canRequestHumanApproval = canRequestHumanApproval
     }
 
@@ -1216,6 +1238,8 @@ private final class ApprovalServer: @unchecked Sendable {
             handleSave(message, on: peer, caller: mutationCaller)
         case "load" where isTrustedAvCaller(path: callerPath, signing: signing):
             handleLoad(message, on: peer)
+        case "bless" where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleBless(message, on: peer, identity: identity)
         case "delete" where isTrustedAvCaller(path: callerPath, signing: signing):
             handleDelete(message, on: peer, caller: mutationCaller)
         case "save" where isTrustedGhCaller(path: callerPath, signing: signing):
@@ -1500,6 +1524,74 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         reply(peer, to: message, ok: true, error: nil, value: value)
+    }
+
+    private func handleBless(
+        _ message: xpc_object_t,
+        on peer: xpc_connection_t,
+        identity: AVProcessIdentity
+    ) {
+        guard let pathPointer = xpc_dictionary_get_string(message, "path") else {
+            reply(peer, to: message, ok: false, error: "invalid bless request")
+            return
+        }
+        let path = String(cString: pathPointer)
+        guard path.hasPrefix("/"),
+              URL(fileURLWithPath: path).standardizedFileURL.path == path,
+              URL(fileURLWithPath: path).resolvingSymlinksInPath().path == path
+        else {
+            reply(peer, to: message, ok: false, error: "script path must be canonical")
+            return
+        }
+        var info = stat()
+        guard path.withCString({ lstat($0, &info) }) == 0,
+              info.st_mode & S_IFMT == S_IFREG,
+              info.st_size <= 1024 * 1024,
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let declaration = try? blessedScriptDeclaration(data: data)
+        else {
+            reply(peer, to: message, ok: false, error: "script is not a valid blessable file")
+            return
+        }
+        let metadata = hardeners ?? loadHardenerMetadata(avExecutableURL: avExecutableURL())
+        for (id, protection) in declaration.manifest.capabilities {
+            guard let descriptor = metadata.lazy.compactMap(\.secretGate).first(where: { $0.id == id }) else {
+                reply(peer, to: message, ok: false, error: "unknown script capability: \(id)")
+                return
+            }
+            let gate = SecretGate(
+                id: descriptor.id,
+                keyPatterns: descriptor.keyPatterns,
+                routes: descriptor.routes,
+                defaultProtection: .noAccess,
+                appPolicies: []
+            )
+            guard gate.availableProtections.contains(protection) else {
+                reply(peer, to: message, ok: false, error: "unsupported access level for \(id)")
+                return
+            }
+        }
+        guard let launcher = launcherIdentities(for: identity).first else {
+            reply(peer, to: message, ok: false, error: "calling app identity is unavailable")
+            return
+        }
+        let request = BlessedScriptReviewRequest(
+            path: path,
+            declaration: declaration,
+            launcher: BlessedScriptLauncher(
+                bundleIdentifier: launcher.identifier,
+                requirement: launcher.designatedRequirement
+            )
+        )
+        DispatchQueue.main.async {
+            guard self.canRequestHumanApproval() else {
+                self.reply(peer, to: message, ok: false, error: "user approval is unavailable")
+                return
+            }
+            self.onBlessRequest(request) { error in
+                self.reply(peer, to: message, ok: error == nil, error: error)
+            }
+        }
     }
 
     private func handleGhSave(

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1952,6 +1952,13 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         let op = String(cString: opPointer)
         guard op == "inject" || op == "keys" || op == "authorize" else { return nil }
+        let scriptData: Data?
+        if xpc_dictionary_get_value(message, "script_data") != nil {
+            guard let data = xpcData(message, key: "script_data") else { return nil }
+            scriptData = data
+        } else {
+            scriptData = nil
+        }
 
         return ApprovalRequest(
             op: op,
@@ -1963,7 +1970,7 @@ private final class ApprovalServer: @unchecked Sendable {
             allowMissingKeys: xpc_dictionary_get_bool(message, "allow_missing_keys"),
             envConflicts: envConflicts,
             shebangScript: xpc_dictionary_get_string(message, "shebang_script").map(String.init(cString:)),
-            scriptData: xpcData(message, key: "script_data"),
+            scriptData: scriptData,
             tool: xpc_dictionary_get_string(message, "tool").map(String.init(cString:)),
             title: xpc_dictionary_get_string(message, "title").map(String.init(cString:)),
             detail: xpc_dictionary_get_string(message, "detail").map(String.init(cString:))
@@ -1986,7 +1993,9 @@ private final class ApprovalServer: @unchecked Sendable {
 
     private func xpcData(_ message: xpc_object_t, key: String) -> Data? {
         var length = 0
-        guard let bytes = xpc_dictionary_get_data(message, key, &length) else { return nil }
+        guard let bytes = xpc_dictionary_get_data(message, key, &length),
+              length <= blessedScriptMaximumBytes
+        else { return nil }
         return Data(bytes: bytes, count: length)
     }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -873,6 +873,7 @@ private struct ApprovalRequest {
     let allowMissingKeys: Bool
     let envConflicts: [String]
     let shebangScript: String?
+    let scriptData: Data?
     let tool: String?
     let title: String?
     let detail: String?
@@ -1118,6 +1119,28 @@ private struct ScriptApproval {
     let checksum: String
 }
 
+private func blessedScriptMatches(
+    _ script: BlessedScript,
+    request: ApprovalRequest,
+    approval: ScriptApproval,
+    launcher: LauncherIdentity
+) -> Bool {
+    request.op == "inject"
+        && request.scriptData != nil
+        && script.path == approval.path
+        && script.checksum == approval.checksum
+        && script.keys == request.keys.sorted()
+        && script.target == request.target
+        && script.replaceExistingEnv == request.replaceExistingEnv
+        && script.allowMissingKeys == request.allowMissingKeys
+        && script.launchers.contains { $0.requirement == launcher.designatedRequirement }
+}
+
+private struct BlessedExecutionKey: Hashable {
+    let pid: Int32
+    let startUsec: UInt64
+}
+
 private final class ApprovalServer: @unchecked Sendable {
     private let serviceName: String
     private let teamIdentifier: String
@@ -1132,6 +1155,8 @@ private final class ApprovalServer: @unchecked Sendable {
     private var listener: xpc_connection_t?
     // ponytail: in-memory per-process cache; use persistent approvals for cross-process trust.
     private var transientApprovals = TransientApprovalCache()
+    private let blessedExecutionsLock = NSLock()
+    private var blessedExecutions: [BlessedExecutionKey: BlessedScript] = [:]
 
     init(
         serviceName: String,
@@ -1271,20 +1296,81 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
         }
-        if let key = missingRequiredSecret(for: request) {
-            reply(peer, to: message, ok: false, error: "failed to load isotope key \(key): \(errSecItemNotFound)")
-            return
-        }
         let scriptApproval = scriptApproval(for: request)
         var launchers = launcherIdentities(for: identity)
         let launcherFallbackPath = launcherFallbackPath(for: identity) ?? callerPath
         if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {
             launchers.append(launcher)
         }
+        let metadata = hardeners ?? loadHardenerMetadata(avExecutableURL: avExecutableURL())
+        if let script = activeBlessedScript(pid: pid, identity: identity) {
+            handleBlessedCapability(
+                script,
+                request: request,
+                signing: signing,
+                metadata: metadata,
+                launcher: launchers.first,
+                callerPath: callerPath,
+                peer: peer,
+                message: message
+            )
+            return
+        }
+        if let scriptApproval,
+           let launcher = launchers.first,
+           let script = matchingBlessedScript(
+               request: request,
+               approval: scriptApproval,
+               launcher: launcher
+           )
+        {
+            do {
+                let secrets = try approvedSecrets(for: request)
+                let accessRequestID = UUID()
+                let record = accessRequestRecord(
+                    id: accessRequestID,
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Approved",
+                    approvalSource: "Auto",
+                    reason: "Blessed script \(script.path)",
+                    launcher: launcher
+                )
+                guard onAccessRequest(record) else {
+                    reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                    return
+                }
+                registerBlessedExecution(script, pid: pid, identity: identity)
+                Task { @MainActor in
+                    self.onAutoApproval(autoApprovalRecord(
+                        accessRequestID: accessRequestID,
+                        request: request,
+                        script: scriptApproval,
+                        launcher: launcher
+                    ))
+                }
+                reply(peer, to: message, ok: true, error: nil, secrets: secrets)
+            } catch {
+                _ = onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Failed",
+                    approvalSource: "Auto",
+                    reason: error.localizedDescription,
+                    launcher: launcher
+                ))
+                reply(peer, to: message, ok: false, error: error.localizedDescription)
+            }
+            return
+        }
+        if let key = missingRequiredSecret(for: request) {
+            reply(peer, to: message, ok: false, error: "failed to load isotope key \(key): \(errSecItemNotFound)")
+            return
+        }
         let configuredGate = matchingSecretGate(
             request: request,
             signing: signing,
-            hardeners: hardeners ?? loadHardenerMetadata(avExecutableURL: avExecutableURL())
+            hardeners: metadata
         )
         let resolvedPolicy = configuredGate.flatMap { resolveSecretGatePolicy(gate: $0, launchers: launchers) }
         let classification = configuredGate.map {
@@ -1481,6 +1567,126 @@ private final class ApprovalServer: @unchecked Sendable {
                 ))
                 self.reply(peer, to: message, ok: false, error: error.localizedDescription)
             }
+        }
+    }
+
+    private func matchingBlessedScript(
+        request: ApprovalRequest,
+        approval: ScriptApproval,
+        launcher: LauncherIdentity
+    ) -> BlessedScript? {
+        loadBlessedScripts().first {
+            blessedScriptMatches($0, request: request, approval: approval, launcher: launcher)
+        }
+    }
+
+    private func registerBlessedExecution(
+        _ script: BlessedScript,
+        pid: pid_t,
+        identity: AVProcessIdentity
+    ) {
+        blessedExecutionsLock.lock()
+        blessedExecutions[BlessedExecutionKey(pid: pid, startUsec: identity.start_usec)] = script
+        blessedExecutionsLock.unlock()
+    }
+
+    private func activeBlessedScript(pid: pid_t, identity: AVProcessIdentity) -> BlessedScript? {
+        let currentBlessings = loadBlessedScripts()
+        blessedExecutionsLock.lock()
+        blessedExecutions = blessedExecutions.filter { key, script in
+            var current = AVProcessIdentity()
+            return currentBlessings.contains(script)
+                && av_process_identity(key.pid, &current)
+                && current.start_usec == key.startUsec
+        }
+        let executions = blessedExecutions
+        blessedExecutionsLock.unlock()
+
+        var currentPID = pid
+        var currentIdentity = identity
+        for _ in 0..<64 {
+            if let script = executions[BlessedExecutionKey(
+                pid: currentPID,
+                startUsec: currentIdentity.start_usec
+            )] {
+                return script
+            }
+            guard currentIdentity.ppid > 1 else { return nil }
+            currentPID = currentIdentity.ppid
+            guard av_process_identity(currentPID, &currentIdentity) else { return nil }
+        }
+        return nil
+    }
+
+    private func handleBlessedCapability(
+        _ script: BlessedScript,
+        request: ApprovalRequest,
+        signing: SigningInfo,
+        metadata: [HardenerMetadata],
+        launcher: LauncherIdentity?,
+        callerPath: String,
+        peer: xpc_connection_t,
+        message: xpc_object_t
+    ) {
+        guard let gate = matchingSecretGateDefinition(
+            request: request,
+            signing: signing,
+            hardeners: metadata
+        ),
+        let protection = script.capabilities[gate.id],
+        secretGateProtectionAllows(
+            protection,
+            classification: classifySecretGateRequest(gateID: gate.id, request: request)
+        )
+        else {
+            _ = onAccessRequest(accessRequestRecord(
+                request: request,
+                callerPath: callerPath,
+                decision: "Denied",
+                approvalSource: "Auto",
+                reason: "Denied by blessed script capability ceiling",
+                launcher: launcher
+            ))
+            reply(peer, to: message, ok: false, error: "\(request.op) denied")
+            return
+        }
+
+        do {
+            let secrets = try approvedSecrets(for: request)
+            let accessRequestID = UUID()
+            guard onAccessRequest(accessRequestRecord(
+                id: accessRequestID,
+                request: request,
+                callerPath: callerPath,
+                decision: "Approved",
+                approvalSource: "Auto",
+                reason: "Blessed script \(script.path)",
+                launcher: launcher
+            )) else {
+                reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                return
+            }
+            if let launcher {
+                Task { @MainActor in
+                    self.onAutoApproval(autoApprovalRecord(
+                        accessRequestID: accessRequestID,
+                        request: request,
+                        script: ScriptApproval(path: script.path, checksum: script.checksum),
+                        launcher: launcher
+                    ))
+                }
+            }
+            reply(peer, to: message, ok: true, error: nil, secrets: secrets)
+        } catch {
+            _ = onAccessRequest(accessRequestRecord(
+                request: request,
+                callerPath: callerPath,
+                decision: "Failed",
+                approvalSource: "Auto",
+                reason: error.localizedDescription,
+                launcher: launcher
+            ))
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
         }
     }
 
@@ -1760,6 +1966,7 @@ private final class ApprovalServer: @unchecked Sendable {
             allowMissingKeys: xpc_dictionary_get_bool(message, "allow_missing_keys"),
             envConflicts: envConflicts,
             shebangScript: xpc_dictionary_get_string(message, "shebang_script").map(String.init(cString:)),
+            scriptData: xpcData(message, key: "script_data"),
             tool: xpc_dictionary_get_string(message, "tool").map(String.init(cString:)),
             title: xpc_dictionary_get_string(message, "title").map(String.init(cString:)),
             detail: xpc_dictionary_get_string(message, "detail").map(String.init(cString:))
@@ -1778,6 +1985,12 @@ private final class ApprovalServer: @unchecked Sendable {
             strings.append(String(cString: pointer))
         }
         return strings
+    }
+
+    private func xpcData(_ message: xpc_object_t, key: String) -> Data? {
+        var length = 0
+        guard let bytes = xpc_dictionary_get_data(message, key, &length) else { return nil }
+        return Data(bytes: bytes, count: length)
     }
 
     private func reply(
@@ -1872,17 +2085,43 @@ private func matchingSecretGate(
     hardeners: [HardenerMetadata],
     service: String = secretGatePoliciesKeychainService
 ) -> SecretGate? {
-    loadSecretGates(hardeners: hardeners, service: service).first { gate in
-        gate.routes.contains { route in
-            route.operation == request.op
-                && route.callerIdentifiers.contains(signing.identifier)
-                && normalizedExecutablePath(route.targetPath) == normalizedExecutablePath(request.target)
-                && route.scriptPath.map { standardizedPath($0, cwd: request.cwd) }
-                    == resolvedShebangScriptPath(request)
-                && routeKeysMatch(route.keyPatterns, request.keys)
-                && route.replaceExistingEnv == request.replaceExistingEnv
-                && route.allowMissingKeys == request.allowMissingKeys
-        }
+    loadSecretGates(hardeners: hardeners, service: service).first {
+        secretGateMatches($0, request: request, signing: signing)
+    }
+}
+
+private func matchingSecretGateDefinition(
+    request: ApprovalRequest,
+    signing: SigningInfo,
+    hardeners: [HardenerMetadata]
+) -> SecretGate? {
+    hardeners.lazy.compactMap(\.secretGate).map {
+        SecretGate(
+            id: $0.id,
+            keyPatterns: $0.keyPatterns,
+            routes: $0.routes,
+            defaultProtection: .noAccess,
+            appPolicies: []
+        )
+    }.first {
+        secretGateMatches($0, request: request, signing: signing)
+    }
+}
+
+private func secretGateMatches(
+    _ gate: SecretGate,
+    request: ApprovalRequest,
+    signing: SigningInfo
+) -> Bool {
+    gate.routes.contains { route in
+        route.operation == request.op
+            && route.callerIdentifiers.contains(signing.identifier)
+            && normalizedExecutablePath(route.targetPath) == normalizedExecutablePath(request.target)
+            && route.scriptPath.map { standardizedPath($0, cwd: request.cwd) }
+                == resolvedShebangScriptPath(request)
+            && routeKeysMatch(route.keyPatterns, request.keys)
+            && route.replaceExistingEnv == request.replaceExistingEnv
+            && route.allowMissingKeys == request.allowMissingKeys
     }
 }
 
@@ -2785,8 +3024,10 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
     let url = script.hasPrefix("/")
         ? URL(fileURLWithPath: script)
         : URL(fileURLWithPath: request.cwd).appendingPathComponent(script)
-    let path = url.standardizedFileURL.path
-    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+    let path = url.standardizedFileURL.resolvingSymlinksInPath().path
+    guard let data = request.scriptData ?? (try? Data(contentsOf: URL(fileURLWithPath: path))) else {
+        return nil
+    }
     let checksum = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     return ScriptApproval(path: path, checksum: checksum)
 }
@@ -3606,6 +3847,7 @@ private func runApprovalSelfCheck() -> Int32 {
             allowMissingKeys: false,
             envConflicts: [],
             shebangScript: nil,
+            scriptData: nil,
             tool: "gh",
             title: nil,
             detail: nil
@@ -3722,6 +3964,7 @@ private func runApprovalSelfCheck() -> Int32 {
         keys: [String] = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         args: [String] = ["-f", "/usr/local/bin/aws", "s3", "ls"],
         shebangScript: String? = "/usr/local/bin/aws",
+        scriptData: Data? = nil,
         replaceExistingEnv: Bool = false,
         allowMissingKeys: Bool = false,
         envConflicts: [String] = []
@@ -3736,6 +3979,7 @@ private func runApprovalSelfCheck() -> Int32 {
             allowMissingKeys: allowMissingKeys,
             envConflicts: envConflicts,
             shebangScript: shebangScript,
+            scriptData: scriptData,
             tool: nil,
             title: nil,
             detail: nil
@@ -3759,6 +4003,43 @@ private func runApprovalSelfCheck() -> Int32 {
             )]
         )
     )
+    let blessedRequest = awsRequest(shebangScript: "/tmp/script", scriptData: Data("script".utf8))
+    let blessedScript = BlessedScript(
+        path: "/tmp/script",
+        checksum: "checksum",
+        keys: blessedRequest.keys,
+        target: blessedRequest.target,
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        capabilities: ["aws": .readOnly],
+        launchers: [BlessedScriptLauncher(
+            bundleIdentifier: blockedLauncher.identifier,
+            requirement: blockedLauncher.designatedRequirement
+        )]
+    )
+    guard matchingSecretGateDefinition(
+        request: readOnlyAws,
+        signing: avSigning,
+        hardeners: [HardenerMetadata(
+            name: awsMetadata.name,
+            hardened: false,
+            secretGate: awsMetadata.secretGate
+        )]
+    )?.id == "aws",
+        blessedScriptMatches(
+            blessedScript,
+            request: blessedRequest,
+            approval: ScriptApproval(path: "/tmp/script", checksum: "checksum"),
+            launcher: blockedLauncher
+        ),
+        !blessedScriptMatches(
+            blessedScript,
+            request: awsRequest(shebangScript: "/tmp/script"),
+            approval: ScriptApproval(path: "/tmp/script", checksum: "checksum"),
+            launcher: blockedLauncher
+        )
+    else { return 1 }
+
     guard matchingSecretGate(request: readOnlyAws, signing: avSigning, hardeners: [awsMetadata])?.id == "aws",
           missingRequiredSecret(for: readOnlyAws, exists: { $0 == "AWS_SECRET_ACCESS_KEY" }) == "AWS_ACCESS_KEY_ID",
           missingRequiredSecret(for: readOnlyAws, exists: { _ in true }) == nil,
@@ -3814,6 +4095,7 @@ private func runApprovalSelfCheck() -> Int32 {
         allowMissingKeys: false,
         envConflicts: [],
         shebangScript: nil,
+        scriptData: nil,
         tool: "brew",
         title: nil,
         detail: nil
@@ -4183,6 +4465,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
         allowMissingKeys: false,
         envConflicts: [],
         shebangScript: "/usr/local/bin/aws",
+        scriptData: nil,
         tool: nil,
         title: nil,
         detail: nil
@@ -4197,6 +4480,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
         allowMissingKeys: true,
         envConflicts: [],
         shebangScript: "/usr/local/bin/pulumi",
+        scriptData: nil,
         tool: nil,
         title: nil,
         detail: nil

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3898,6 +3898,7 @@ private func runApprovalSelfCheck() -> Int32 {
         allowMissingKeys: false,
         envConflicts: [],
         shebangScript: nil,
+        scriptData: nil,
         tool: "stripe",
         title: "Stripe credential requested",
         detail: nil

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -923,6 +923,7 @@ enum SecretMutation {
             allowMissingKeys: false,
             envConflicts: [],
             shebangScript: nil,
+            scriptData: nil,
             tool: URL(fileURLWithPath: callerPath).lastPathComponent,
             title: properties.title,
             detail: properties.detail

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -162,8 +162,13 @@ private func parseInjectShebang(
     _ line: String
 ) throws -> (keys: [String], target: String, replaceExistingEnv: Bool, allowMissingKeys: Bool) {
     var words = line.dropFirst(2).split(whereSeparator: \.isWhitespace).map(String.init)
-    guard !words.isEmpty else { throw BlessedScriptManifestError.invalidShebang }
-    _ = words.removeFirst()
+    guard let interpreter = words.first,
+          interpreter.hasPrefix("/"),
+          URL(fileURLWithPath: interpreter).lastPathComponent == "av"
+    else {
+        throw BlessedScriptManifestError.invalidShebang
+    }
+    words.removeFirst()
     guard words.first == "inject" else { throw BlessedScriptManifestError.invalidShebang }
     words.removeFirst()
 

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -5,7 +5,7 @@ import Security
 
 public let blessedScriptsKeychainService = "com.automicvault.blessed-scripts"
 public let blessedScriptsKeychainAccount = "BlessedScriptsV1"
-private let blessedScriptMaximumBytes = 1024 * 1024
+public let blessedScriptMaximumBytes = 1024 * 1024
 
 private enum BlessedScriptFileError: Error {
     case invalid

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -1,0 +1,253 @@
+import CryptoKit
+import Foundation
+import Security
+
+public let blessedScriptsKeychainService = "com.automicvault.blessed-scripts"
+public let blessedScriptsKeychainAccount = "BlessedScriptsV1"
+
+public struct BlessedScriptManifest: Equatable, Sendable {
+    public let capabilities: [String: SecretGateProtection]
+
+    public init(capabilities: [String: SecretGateProtection]) {
+        self.capabilities = capabilities
+    }
+}
+
+public struct BlessedScriptLauncher: Codable, Equatable, Sendable {
+    public let bundleIdentifier: String
+    public let requirement: String
+
+    public init(bundleIdentifier: String, requirement: String) {
+        self.bundleIdentifier = bundleIdentifier
+        self.requirement = requirement
+    }
+}
+
+public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
+    public let path: String
+    public let checksum: String
+    public let keys: [String]
+    public let target: String
+    public let replaceExistingEnv: Bool
+    public let allowMissingKeys: Bool
+    public let capabilities: [String: SecretGateProtection]
+    public let launchers: [BlessedScriptLauncher]
+    public let blessedAt: Date
+
+    public var id: String { path }
+
+    public init(
+        path: String,
+        checksum: String,
+        keys: [String],
+        target: String,
+        replaceExistingEnv: Bool,
+        allowMissingKeys: Bool,
+        capabilities: [String: SecretGateProtection],
+        launchers: [BlessedScriptLauncher],
+        blessedAt: Date = Date()
+    ) {
+        self.path = path
+        self.checksum = checksum
+        self.keys = keys.sorted()
+        self.target = target
+        self.replaceExistingEnv = replaceExistingEnv
+        self.allowMissingKeys = allowMissingKeys
+        self.capabilities = capabilities
+        self.launchers = launchers
+        self.blessedAt = blessedAt
+    }
+}
+
+public enum BlessedScriptManifestError: Error, Equatable, LocalizedError {
+    case invalidUTF8
+    case missingShebang
+    case invalidShebang
+    case missingManifest
+    case malformedManifest(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidUTF8: "script must be valid UTF-8"
+        case .missingShebang: "script must start with an av inject shebang"
+        case .invalidShebang: "invalid av inject shebang"
+        case .missingManifest: "script has no Automic Vault manifest"
+        case .malformedManifest(let reason): "invalid Automic Vault manifest: \(reason)"
+        }
+    }
+}
+
+public struct BlessedScriptDeclaration: Equatable, Sendable {
+    public let checksum: String
+    public let keys: [String]
+    public let target: String
+    public let replaceExistingEnv: Bool
+    public let allowMissingKeys: Bool
+    public let manifest: BlessedScriptManifest
+}
+
+public func blessedScriptDeclaration(data: Data) throws -> BlessedScriptDeclaration {
+    guard let source = String(data: data, encoding: .utf8) else {
+        throw BlessedScriptManifestError.invalidUTF8
+    }
+    let lines = source.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    guard let shebang = lines.first, shebang.hasPrefix("#!") else {
+        throw BlessedScriptManifestError.missingShebang
+    }
+    let injection = try parseInjectShebang(shebang)
+    let manifest = try parseBlessedScriptManifest(lines: lines)
+    return BlessedScriptDeclaration(
+        checksum: SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined(),
+        keys: injection.keys,
+        target: injection.target,
+        replaceExistingEnv: injection.replaceExistingEnv,
+        allowMissingKeys: injection.allowMissingKeys,
+        manifest: manifest
+    )
+}
+
+private func parseInjectShebang(
+    _ line: String
+) throws -> (keys: [String], target: String, replaceExistingEnv: Bool, allowMissingKeys: Bool) {
+    var words = line.dropFirst(2).split(whereSeparator: \.isWhitespace).map(String.init)
+    guard !words.isEmpty else { throw BlessedScriptManifestError.invalidShebang }
+    _ = words.removeFirst()
+    guard words.first == "inject" else { throw BlessedScriptManifestError.invalidShebang }
+    words.removeFirst()
+
+    var keys = Set<String>()
+    var replaceExistingEnv = false
+    var allowMissingKeys = false
+    while let word = words.first {
+        words.removeFirst()
+        switch word {
+        case "--replace-existing-env":
+            replaceExistingEnv = true
+        case "--allow-missing-keys":
+            allowMissingKeys = true
+        case "--":
+            guard let target = words.first, !keys.isEmpty else {
+                throw BlessedScriptManifestError.invalidShebang
+            }
+            return (keys.sorted(), target, replaceExistingEnv, allowMissingKeys)
+        default:
+            if word.hasPrefix("+") {
+                let key = String(word.dropFirst())
+                guard validBlessedSecretKey(key), keys.insert(key).inserted else {
+                    throw BlessedScriptManifestError.invalidShebang
+                }
+            } else {
+                guard !keys.isEmpty else { throw BlessedScriptManifestError.invalidShebang }
+                return (keys.sorted(), word, replaceExistingEnv, allowMissingKeys)
+            }
+        }
+    }
+    throw BlessedScriptManifestError.invalidShebang
+}
+
+private func validBlessedSecretKey(_ key: String) -> Bool {
+    guard let first = key.first, first == "_" || first.isASCII && first.isLetter else { return false }
+    return key.dropFirst().allSatisfy { $0 == "_" || $0.isASCII && ($0.isLetter || $0.isNumber) }
+}
+
+private func parseBlessedScriptManifest(lines: [String]) throws -> BlessedScriptManifest {
+    guard lines.count > 1, lines[1] == "# --- automic-vault" else {
+        throw BlessedScriptManifestError.missingManifest
+    }
+    var capabilities: [String: SecretGateProtection] = [:]
+    var index = 2
+    guard index < lines.count, lines[index] == "# capabilities:" else {
+        throw BlessedScriptManifestError.malformedManifest("expected `capabilities:`")
+    }
+    index += 1
+    while index < lines.count, lines[index] != "# ---" {
+        let line = lines[index]
+        guard line.hasPrefix("#   "),
+              let separator = line.firstIndex(of: ":")
+        else {
+            throw BlessedScriptManifestError.malformedManifest("line \(index + 1)")
+        }
+        let gate = line[line.index(line.startIndex, offsetBy: 4)..<separator]
+        let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+        guard validGateID(String(gate)),
+              let protection = manifestProtection(value),
+              capabilities.updateValue(protection, forKey: String(gate)) == nil
+        else {
+            throw BlessedScriptManifestError.malformedManifest("line \(index + 1)")
+        }
+        index += 1
+    }
+    guard index < lines.count, lines[index] == "# ---", !capabilities.isEmpty else {
+        throw BlessedScriptManifestError.malformedManifest("missing closing marker or capabilities")
+    }
+    return BlessedScriptManifest(capabilities: capabilities)
+}
+
+private func validGateID(_ value: String) -> Bool {
+    !value.isEmpty && value.count <= 64 && value.allSatisfy {
+        $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-" || $0 == "_")
+    }
+}
+
+private func manifestProtection(_ value: String) -> SecretGateProtection? {
+    switch value {
+    case "read-only": .readOnly
+    case "local-write": .readOnlyAndLocalWrites
+    case "read-and-updates": .readOnlyAndUpdates
+    case "trusted": .fullExceptSecretDumps
+    case "full": .fullIncludingSecretDumps
+    default: nil
+    }
+}
+
+public func loadBlessedScripts(
+    service: String = blessedScriptsKeychainService,
+    account: String = blessedScriptsKeychainAccount
+) -> [BlessedScript] {
+    guard case .success(let data) = loadKeychainDataResult(service: service, account: account),
+          let scripts = try? JSONDecoder().decode([BlessedScript].self, from: data)
+    else {
+        return []
+    }
+    return scripts.sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+}
+
+@discardableResult
+public func saveBlessedScript(
+    _ script: BlessedScript,
+    service: String = blessedScriptsKeychainService,
+    account: String = blessedScriptsKeychainAccount
+) -> OSStatus {
+    var scripts = loadBlessedScripts(service: service, account: account)
+    scripts.removeAll { $0.path == script.path }
+    scripts.append(script)
+    return saveBlessedScripts(scripts, service: service, account: account)
+}
+
+@discardableResult
+public func removeBlessedScript(
+    path: String,
+    service: String = blessedScriptsKeychainService,
+    account: String = blessedScriptsKeychainAccount
+) -> OSStatus {
+    let scripts = loadBlessedScripts(service: service, account: account).filter { $0.path != path }
+    if scripts.isEmpty {
+        let status = deleteStoredSecret(account: account, service: service)
+        return status == errSecItemNotFound ? errSecSuccess : status
+    }
+    return saveBlessedScripts(scripts, service: service, account: account)
+}
+
+private func saveBlessedScripts(_ scripts: [BlessedScript], service: String, account: String) -> OSStatus {
+    guard let data = try? JSONEncoder().encode(scripts.sorted {
+        $0.path.localizedStandardCompare($1.path) == .orderedAscending
+    }) else {
+        return errSecParam
+    }
+    return saveKeychainData(
+        data,
+        service: service,
+        account: account,
+        accessibility: .afterFirstUnlock
+    )
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -126,7 +126,7 @@ private func parseInjectShebang(
         case "--allow-missing-keys":
             allowMissingKeys = true
         case "--":
-            guard let target = words.first, !keys.isEmpty else {
+            guard let target = words.first, target.hasPrefix("/"), !keys.isEmpty else {
                 throw BlessedScriptManifestError.invalidShebang
             }
             return (keys.sorted(), target, replaceExistingEnv, allowMissingKeys)
@@ -137,7 +137,9 @@ private func parseInjectShebang(
                     throw BlessedScriptManifestError.invalidShebang
                 }
             } else {
-                guard !keys.isEmpty else { throw BlessedScriptManifestError.invalidShebang }
+                guard !keys.isEmpty, word.hasPrefix("/") else {
+                    throw BlessedScriptManifestError.invalidShebang
+                }
                 return (keys.sorted(), word, replaceExistingEnv, allowMissingKeys)
             }
         }

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -1,9 +1,61 @@
 import CryptoKit
+import Darwin
 import Foundation
 import Security
 
 public let blessedScriptsKeychainService = "com.automicvault.blessed-scripts"
 public let blessedScriptsKeychainAccount = "BlessedScriptsV1"
+private let blessedScriptMaximumBytes = 1024 * 1024
+
+private enum BlessedScriptFileError: Error {
+    case invalid
+}
+
+public func readBlessedScript(path: String) throws -> Data {
+    let descriptor = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+    guard descriptor >= 0 else { throw BlessedScriptFileError.invalid }
+    defer { close(descriptor) }
+
+    var info = stat()
+    var resolvedPath = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+    var canonicalPath = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+    guard fcntl(descriptor, F_GETPATH, &resolvedPath) == 0,
+          path.withCString({ realpath($0, &canonicalPath) }) != nil
+    else {
+        throw BlessedScriptFileError.invalid
+    }
+    let openedPath = String(
+        decoding: resolvedPath.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
+        as: UTF8.self
+    )
+    let canonicalPathString = String(
+        decoding: canonicalPath.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
+        as: UTF8.self
+    )
+    guard fstat(descriptor, &info) == 0,
+          info.st_mode & S_IFMT == S_IFREG,
+          info.st_size <= blessedScriptMaximumBytes,
+          openedPath == canonicalPathString
+    else {
+        throw BlessedScriptFileError.invalid
+    }
+
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+    while data.count <= blessedScriptMaximumBytes {
+        let limit = min(buffer.count, blessedScriptMaximumBytes + 1 - data.count)
+        let count = buffer.withUnsafeMutableBytes {
+            Darwin.read(descriptor, $0.baseAddress, limit)
+        }
+        if count == 0 { return data }
+        if count < 0 {
+            if errno == EINTR { continue }
+            throw BlessedScriptFileError.invalid
+        }
+        data.append(contentsOf: buffer.prefix(count))
+    }
+    throw BlessedScriptFileError.invalid
+}
 
 public struct BlessedScriptManifest: Equatable, Sendable {
     public let capabilities: [String: SecretGateProtection]

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1106,13 +1106,13 @@ private func loadKeychainData(service: String, account: String) -> Data? {
     return data
 }
 
-private enum KeychainDataLoad {
+enum KeychainDataLoad {
     case success(Data)
     case notFound
     case failure(OSStatus)
 }
 
-private func loadKeychainDataResult(service: String, account: String) -> KeychainDataLoad {
+func loadKeychainDataResult(service: String, account: String) -> KeychainDataLoad {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: service,
@@ -1165,7 +1165,7 @@ private func setKeychainAccessibility(
     )
 }
 
-private func saveKeychainData(
+func saveKeychainData(
     _ data: Data,
     service: String,
     account: String,

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -17,6 +17,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
     public var hardenedTools: [HardenedTool]
     public var hardeners: [HardenerMetadata]
     public var secretGates: [SecretGate]
+    public var blessedScripts: [BlessedScript]
     public var secrets: [StoredSecret]
     public var accessRequests: [AccessRequestRecord]
     public var doctorIssues: [DoctorIssue]
@@ -27,6 +28,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         hardenedTools: [HardenedTool],
         hardeners: [HardenerMetadata] = [],
         secretGates: [SecretGate],
+        blessedScripts: [BlessedScript] = [],
         secrets: [StoredSecret],
         accessRequests: [AccessRequestRecord] = [],
         doctorIssues: [DoctorIssue] = []
@@ -36,6 +38,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         self.hardenedTools = hardenedTools
         self.hardeners = hardeners
         self.secretGates = secretGates
+        self.blessedScripts = blessedScripts
         self.secrets = secrets
         self.accessRequests = accessRequests
         self.doctorIssues = doctorIssues
@@ -47,6 +50,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         hardenedTools: [],
         hardeners: [],
         secretGates: [],
+        blessedScripts: [],
         secrets: [],
         accessRequests: [],
         doctorIssues: []
@@ -80,6 +84,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             hardenedTools: hardenedTools,
             hardeners: hardenerMetadata,
             secretGates: loadSecretGates(hardeners: hardenerMetadata, service: policyService),
+            blessedScripts: loadBlessedScripts(),
             secrets: secrets,
             accessRequests: loadAccessRequestRecords(),
             doctorIssues: loadDoctorIssues(avExecutableURL: avExecutableURL)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+@Test func blessedScriptManifestParsesStrictCommentYAML() throws {
+    let data = Data("""
+    #!/usr/local/bin/av inject --replace-existing-env +B +A /bin/sh
+    # --- automic-vault
+    # capabilities:
+    #   gh: read-only
+    #   aws: trusted
+    # ---
+    echo ok
+    """.utf8)
+
+    let declaration = try blessedScriptDeclaration(data: data)
+
+    #expect(declaration.keys == ["A", "B"])
+    #expect(declaration.target == "/bin/sh")
+    #expect(declaration.replaceExistingEnv)
+    #expect(!declaration.allowMissingKeys)
+    #expect(declaration.manifest.capabilities == [
+        "gh": .readOnly,
+        "aws": .fullExceptSecretDumps,
+    ])
+    #expect(declaration.checksum.count == 64)
+}
+
+@Test(arguments: [
+    """
+    #!/bin/sh
+    # --- automic-vault
+    # capabilities:
+    #   gh: read-only
+    # ---
+    """,
+    """
+    #!/usr/local/bin/av inject +A /bin/sh
+    # capabilities:
+    #   gh: read-only
+    # ---
+    """,
+    """
+    #!/usr/local/bin/av inject +A /bin/sh
+    # --- automic-vault
+    # capabilities:
+    #   gh: read-only
+    #   gh: trusted
+    # ---
+    """,
+    """
+    #!/usr/local/bin/av inject +A /bin/sh
+    # --- automic-vault
+    # capabilities:
+    #   gh: anything
+    # ---
+    """,
+])
+func malformedBlessedScriptManifestsFailClosed(_ source: String) {
+    #expect(throws: (any Error).self) {
+        try blessedScriptDeclaration(data: Data(source.utf8))
+    }
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -35,6 +35,13 @@ import Testing
     # ---
     """,
     """
+    #!/bin/sh inject +A /bin/sh
+    # --- automic-vault
+    # capabilities:
+    #   gh: read-only
+    # ---
+    """,
+    """
     #!/usr/local/bin/av inject +A /bin/sh
     # capabilities:
     #   gh: read-only

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -68,3 +68,21 @@ func malformedBlessedScriptManifestsFailClosed(_ source: String) {
         try blessedScriptDeclaration(data: Data(source.utf8))
     }
 }
+
+@Test func blessedScriptReadsAreBoundedAndRejectSymlinks() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("av-blessed-script-\(UUID().uuidString)", isDirectory: true)
+    let script = directory.appendingPathComponent("script")
+    let link = directory.appendingPathComponent("link")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let canonicalPath = script.resolvingSymlinksInPath().path
+
+    try Data(repeating: 0, count: 1024 * 1024 + 1).write(to: script)
+    #expect(throws: (any Error).self) { try readBlessedScript(path: canonicalPath) }
+
+    try Data("ok".utf8).write(to: script)
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: script)
+    #expect(throws: (any Error).self) { try readBlessedScript(path: link.path) }
+    #expect(try readBlessedScript(path: canonicalPath) == Data("ok".utf8))
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -55,6 +55,13 @@ import Testing
     #   gh: anything
     # ---
     """,
+    """
+    #!/usr/local/bin/av inject +A sh
+    # --- automic-vault
+    # capabilities:
+    #   gh: read-only
+    # ---
+    """,
 ])
 func malformedBlessedScriptManifestsFailClosed(_ source: String) {
     #expect(throws: (any Error).self) {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -10,7 +10,7 @@ pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
         return std::fs::write(&path, value)
             .map_err(|err| format!("failed to write {}: {err}", path.display()));
     }
-    xpc_secret_request("save", account, Some(value)).map(|_| ())
+    xpc_request("save", b"key\0", account, Some((b"value\0", value))).map(|_| ())
 }
 
 pub(crate) fn load_secret(account: &str) -> Result<String, String> {
@@ -19,15 +19,20 @@ pub(crate) fn load_secret(account: &str) -> Result<String, String> {
         return std::fs::read_to_string(&path)
             .map_err(|err| format!("failed to read {}: {err}", path.display()));
     }
-    xpc_secret_request("load", account, None)?
+    xpc_request("load", b"key\0", account, None)?
         .ok_or_else(|| format!("failed to load isotope key {account}"))
 }
 
+pub(crate) fn bless_script(path: &str) -> Result<(), String> {
+    xpc_request("bless", b"path\0", path, None).map(|_| ())
+}
+
 #[cfg(target_os = "macos")]
-fn xpc_secret_request(
+fn xpc_request(
     operation: &str,
-    account: &str,
-    value: Option<&str>,
+    field: &'static [u8],
+    field_value: &str,
+    extra: Option<(&'static [u8], &str)>,
 ) -> Result<Option<String>, String> {
     use std::ffi::CString;
     use std::os::raw::{c_char, c_int, c_void};
@@ -100,9 +105,9 @@ fn xpc_secret_request(
 
     unsafe {
         set_string(message, b"op\0", operation)?;
-        set_string(message, b"key\0", account)?;
-        if let Some(value) = value {
-            set_string(message, b"value\0", value)?;
+        set_string(message, field, field_value)?;
+        if let Some((field, value)) = extra {
+            set_string(message, field, value)?;
         }
         xpc_dictionary_set_bool(message, b"interactive\0".as_ptr().cast(), true);
     }
@@ -155,10 +160,11 @@ fn xpc_secret_request(
 }
 
 #[cfg(not(target_os = "macos"))]
-fn xpc_secret_request(
+fn xpc_request(
     _operation: &str,
-    _account: &str,
-    _value: Option<&str>,
+    _field: &'static [u8],
+    _field_value: &str,
+    _extra: Option<(&'static [u8], &str)>,
 ) -> Result<Option<String>, String> {
     Err("menu bar secret storage is only available on macOS".to_string())
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -166,5 +166,5 @@ fn xpc_request(
     _field_value: &str,
     _extra: Option<(&'static [u8], &str)>,
 ) -> Result<Option<String>, String> {
-    Err("menu bar secret storage is only available on macOS".to_string())
+    Err("the Automic Vault menu bar approval service is only available on macOS".to_string())
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -106,8 +106,8 @@ fn xpc_request(
     unsafe {
         set_string(message, b"op\0", operation)?;
         set_string(message, field, field_value)?;
-        if let Some((field, value)) = extra {
-            set_string(message, field, value)?;
+        if let Some((extra_field, value)) = extra {
+            set_string(message, extra_field, value)?;
         }
         xpc_dictionary_set_bool(message, b"interactive\0".as_ptr().cast(), true);
     }

--- a/tests/inject_cli.rs
+++ b/tests/inject_cli.rs
@@ -58,7 +58,7 @@ fn av_inject_accepts_shebang_dispatch() {
     }
 
     assert!(output.status.success(), "{}", stderr(&output));
-    assert!(stdout(&output).contains(&script.to_string_lossy().into_owned()));
+    assert!(stdout(&output).contains("/dev/fd/"));
     let _ = fs::remove_dir_all(home);
 }
 


### PR DESCRIPTION
## Summary

- Add blessed script handling across the CLI, secrets flow, and menubar helper
- Expose blessed scripts in the dashboard and main window
- Document the feature and add coverage for script behavior and injection

## Testing

- Added `BlessedScripts` unit tests
- Added CLI injection tests
- Not run (not requested)