### PR TITLE
Detect stale Stripe CLI Keychain credentials and bound scan delays

### DIFF
--- a/src/isotopes/detectors/gh_cli/mod.rs
+++ b/src/isotopes/detectors/gh_cli/mod.rs
@@ -20,7 +20,7 @@ pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
             ));
         }
     }
-    if keychain_allows_security_tool(&hosts_paths)? {
+    if keychain_services_allow_security_tool(&gh_keychain_services(&hosts_paths))? {
         reasons.push(
             "GitHub CLI keychain item allows non-interactive extraction by the security tool"
                 .to_string(),
@@ -106,12 +106,12 @@ fn gh_keychain_services(hosts_paths: &[PathBuf]) -> Vec<String> {
 }
 
 #[cfg(target_os = "macos")]
-fn keychain_allows_security_tool(hosts_paths: &[PathBuf]) -> Result<bool, String> {
-    macos_keychain::keychain_allows_security_tool(&gh_keychain_services(hosts_paths))
+pub(crate) fn keychain_services_allow_security_tool(services: &[String]) -> Result<bool, String> {
+    macos_keychain::keychain_allows_security_tool(services)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn keychain_allows_security_tool(_hosts_paths: &[PathBuf]) -> Result<bool, String> {
+pub(crate) fn keychain_services_allow_security_tool(_services: &[String]) -> Result<bool, String> {
     Ok(false)
 }
 

--- a/src/isotopes/detectors/stripe_cli/detector.md
+++ b/src/isotopes/detectors/stripe_cli/detector.md
@@ -3,6 +3,8 @@
 ## Trigger Conditions
 
 - Stripe CLI config contains plaintext API keys.
+- Stripe CLI Keychain credentials can be extracted non-interactively through
+  `/usr/bin/security`.
 
 ## Sensitive Files
 

--- a/src/isotopes/detectors/stripe_cli/mod.rs
+++ b/src/isotopes/detectors/stripe_cli/mod.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+const KEYCHAIN_SERVICES: &[&str] = &["StripeCLI"];
+
 pub fn install_is_insecure() -> Result<bool, String> {
     install_insecurity_reasons().map(|reasons| !reasons.is_empty())
 }
@@ -19,6 +21,17 @@ pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
                 path.display()
             ));
         }
+    }
+    if super::gh_cli::keychain_services_allow_security_tool(
+        &KEYCHAIN_SERVICES
+            .iter()
+            .map(|service| (*service).to_string())
+            .collect::<Vec<_>>(),
+    )? {
+        reasons.push(
+            "Stripe CLI keychain item allows non-interactive extraction by the security tool"
+                .to_string(),
+        );
     }
     Ok(reasons)
 }
@@ -86,6 +99,11 @@ mod tests {
         assert!(!stripe_config_contains_plaintext_key(
             "[default]\nlive_mode_api_key = \"sk_live_*********0000\"\n"
         ));
+    }
+
+    #[test]
+    fn checks_the_upstream_stripe_cli_keychain_service() {
+        assert_eq!(KEYCHAIN_SERVICES, ["StripeCLI"]);
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -17,6 +17,7 @@ private let pendingMainWindowKey = "pendingMainWindow"
 private let pendingSecretGateKey = "pendingSecretGate"
 private let secCodeSignatureAdHoc: UInt32 = 0x2
 private let transientApprovalTTL: TimeInterval = 5 * 60
+private let scanMaximumDelay: TimeInterval = 5
 private let scanQueue = DispatchQueue(label: "com.automicvault.av2.scan")
 private var toastWindows: [NSWindow] = []
 
@@ -46,6 +47,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }()
     private var approval: ApprovalServer?
     private var scanWorkItem: DispatchWorkItem?
+    private var scanBurstStartedAt: TimeInterval?
     private var eventStream: FSEventStreamRef?
     private var mainWindow: NSWindow?
     private var isUserSessionActive = true
@@ -224,6 +226,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func stopServices() {
         scanWorkItem?.cancel()
         scanWorkItem = nil
+        scanBurstStartedAt = nil
         if let eventStream {
             FSEventStreamStop(eventStream)
             FSEventStreamInvalidate(eventStream)
@@ -410,8 +413,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func scheduleScan(after delay: TimeInterval) {
+        let delay = boundedScanDelay(
+            now: ProcessInfo.processInfo.systemUptime,
+            burstStartedAt: &scanBurstStartedAt,
+            debounceDelay: delay,
+            maximumDelay: scanMaximumDelay
+        )
         scanWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
+            self?.scanWorkItem = nil
+            self?.scanBurstStartedAt = nil
             self?.runScan()
         }
         scanWorkItem = workItem
@@ -716,6 +727,17 @@ private enum ScanResult {
     case clean(Int)
     case findings([DetectorFinding], Int, ScanAlertLevel)
     case failed
+}
+
+private func boundedScanDelay(
+    now: TimeInterval,
+    burstStartedAt: inout TimeInterval?,
+    debounceDelay: TimeInterval,
+    maximumDelay: TimeInterval
+) -> TimeInterval {
+    let startedAt = burstStartedAt ?? now
+    burstStartedAt = startedAt
+    return min(debounceDelay, max(0, startedAt + maximumDelay - now))
 }
 
 private enum ScanAlertLevel {
@@ -4078,6 +4100,32 @@ private func runMenuStatusSelfCheck() -> Int32 {
     return 0
 }
 
+private func runScanSchedulingSelfCheck() -> Int32 {
+    var burstStartedAt: TimeInterval?
+    guard boundedScanDelay(
+        now: 10,
+        burstStartedAt: &burstStartedAt,
+        debounceDelay: 1,
+        maximumDelay: 5
+    ) == 1,
+    boundedScanDelay(
+        now: 14.5,
+        burstStartedAt: &burstStartedAt,
+        debounceDelay: 1,
+        maximumDelay: 5
+    ) == 0.5,
+    boundedScanDelay(
+        now: 15,
+        burstStartedAt: &burstStartedAt,
+        debounceDelay: 1,
+        maximumDelay: 5
+    ) == 0
+    else {
+        return 1
+    }
+    return 0
+}
+
 if CommandLine.arguments.contains("--self-check-approvals") {
     exit(MainActor.assumeIsolated { runApprovalSelfCheck() })
 }
@@ -4112,6 +4160,10 @@ if CommandLine.arguments.contains("--self-check-launch-agent-handoff") {
 
 if CommandLine.arguments.contains("--self-check-menu-status") {
     exit(runMenuStatusSelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-scan-scheduling") {
+    exit(runScanSchedulingSelfCheck())
 }
 
 let app = NSApplication.shared

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -413,7 +413,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func scheduleScan(after delay: TimeInterval) {
-        let delay = boundedScanDelay(
+        let scheduledDelay = boundedScanDelay(
             now: ProcessInfo.processInfo.systemUptime,
             burstStartedAt: &scanBurstStartedAt,
             debounceDelay: delay,
@@ -426,7 +426,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.runScan()
         }
         scanWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + scheduledDelay, execute: workItem)
     }
 
     private func runScan() {


### PR DESCRIPTION
## Summary

- Detect Stripe CLI credentials exposed through `/usr/bin/security`.
- Reuse shared macOS Keychain security-tool detection.
- Bound filesystem-triggered scan debounce delays to five seconds.
- Add focused self-checks for the Stripe service name and scan scheduling.

## Testing

- Added Rust unit coverage for the upstream Stripe CLI Keychain service.
- Added a Swift scan-scheduling self-check covering debounce and maximum-delay behavior.
- Not run (not requested).