### PR TITLE
Accept OSC-prefixed login-shell PATH output

### DIFF
--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1322,7 +1322,15 @@ func loginShellPATH() -> String? {
 func loginShellPATH(from data: Data) -> String? {
     String(data: data, encoding: .utf8)?
         .split(whereSeparator: \.isNewline)
-        .last(where: { $0.hasPrefix("/") })
+        .compactMap { line -> Substring? in
+            var line = line
+            while line.hasPrefix("\u{1B}]") {
+                guard let terminator = line.firstIndex(of: "\u{07}") else { return nil }
+                line = line[line.index(after: terminator)...]
+            }
+            return line.hasPrefix("/") ? line : nil
+        }
+        .last
         .map(String.init)
 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1315,14 +1315,15 @@ func loginShellPATH() -> String? {
     }
     let data = output.fileHandleForReading.readDataToEndOfFile()
     process.waitUntilExit()
-    guard process.terminationStatus == 0,
-          let path = String(data: data, encoding: .utf8)?
-            .split(whereSeparator: \.isNewline)
-            .last(where: { $0.hasPrefix("/") })
-            .map(String.init),
-          !path.isEmpty
-    else { return nil }
-    return path
+    guard process.terminationStatus == 0 else { return nil }
+    return loginShellPATH(from: data)
+}
+
+func loginShellPATH(from data: Data) -> String? {
+    String(data: data, encoding: .utf8)?
+        .split(whereSeparator: \.isNewline)
+        .last(where: { $0.hasPrefix("/") })
+        .map(String.init)
 }
 
 public func defaultAVExecutableURL() -> URL {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1320,18 +1320,19 @@ func loginShellPATH() -> String? {
 }
 
 func loginShellPATH(from data: Data) -> String? {
-    String(data: data, encoding: .utf8)?
-        .split(whereSeparator: \.isNewline)
-        .compactMap { line -> Substring? in
-            var line = line
-            while line.hasPrefix("\u{1B}]") {
-                guard let terminator = line.firstIndex(of: "\u{07}") else { return nil }
-                line = line[line.index(after: terminator)...]
-            }
-            return line.hasPrefix("/") ? line : nil
+    guard let output = String(data: data, encoding: .utf8) else { return nil }
+    var path: Substring?
+    for outputLine in output.split(whereSeparator: \.isNewline) {
+        var line = outputLine
+        while line.hasPrefix("\u{1B}]") {
+            guard let terminator = line.firstIndex(of: "\u{07}") else { return nil }
+            line = line[line.index(after: terminator)...]
         }
-        .last
-        .map(String.init)
+        if line.hasPrefix("/") {
+            path = line
+        }
+    }
+    return path.map(String.init)
 }
 
 public func defaultAVExecutableURL() -> URL {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -167,6 +167,10 @@ import Testing
     #expect(issues.map(\.kind) == ["hardening_not_applied", "login_shell_path_unavailable"])
 }
 
+@Test func loginShellPATHUsesLastAbsoluteLine() {
+    #expect(loginShellPATH(from: Data("startup noise\n/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
+}
+
 @Test func JSONLoaderCanAcceptDoctorIssueExitStatus() throws {
     let data = try #require(loadJSON(
         avExecutableURL: URL(fileURLWithPath: "/bin/sh"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -169,6 +169,8 @@ import Testing
 
 @Test func loginShellPATHUsesLastAbsoluteLine() {
     #expect(loginShellPATH(from: Data("startup noise\n/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
+    #expect(loginShellPATH(from: Data("\u{1B}]0;zsh\u{07}/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
+    #expect(loginShellPATH(from: Data("\u{1B}]0;zsh/usr/bin:/bin\n".utf8)) == nil)
 }
 
 @Test func JSONLoaderCanAcceptDoctorIssueExitStatus() throws {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -171,6 +171,7 @@ import Testing
     #expect(loginShellPATH(from: Data("startup noise\n/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
     #expect(loginShellPATH(from: Data("\u{1B}]0;zsh\u{07}/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
     #expect(loginShellPATH(from: Data("\u{1B}]0;zsh/usr/bin:/bin\n".utf8)) == nil)
+    #expect(loginShellPATH(from: Data("\u{1B}]0;zsh\n/usr/bin:/bin\n".utf8)) == nil)
 }
 
 @Test func JSONLoaderCanAcceptDoctorIssueExitStatus() throws {


### PR DESCRIPTION
Closes #61.

## What changed

- extract login-shell PATH parsing into a focused, testable function
- strip only leading OSC sequences terminated by BEL before applying the existing absolute-path check
- retain fail-closed behavior for unterminated OSC sequences and unrelated startup output

## Root cause

`loginShellPATH()` required the selected output line to start with `/`. A shell startup hook that emitted an OSC terminal-title sequence without a newline placed control bytes before an otherwise valid PATH, so Doctor treated the PATH as unavailable.

## Validation

```sh
swift test --package-path src/menu-helper --disable-automatic-resolution
```

40 tests passed.