### PR TITLE
Fix in-app secret mutations to use direct authorization

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1031,21 +1031,7 @@ private func performApprovedSecretMutation(
 func performInAppSecretMutation(
     _ mutation: SecretMutation
 ) -> (status: OSStatus?, error: String?) {
-    let callerPath = Bundle.main.executableURL?.path ?? CommandLine.arguments[0]
-    var identity = AVProcessIdentity()
-    let launcher = av_process_identity(getpid(), &identity)
-        ? launcherIdentity(pid: getpid(), identity: identity)
-        : nil
-    return performApprovedSecretMutation(
-        mutation,
-        callerPath: callerPath,
-        pid: getpid(),
-        signing: signingInfo(path: callerPath),
-        launcher: launcher,
-        launcherFallbackPath: callerPath,
-        canRequestHumanApproval: { true },
-        onAccessRequest: { appendAccessRequestRecord($0) }
-    )
+    (mutation.perform(), nil)
 }
 
 private let humanApprovalRequiredEvent = "human-approval-required"


### PR DESCRIPTION
## Summary

- Route in-app secret mutations through the mutation’s direct `perform()` path.
- Avoid incorrectly invoking the approved-secret approval flow for in-app requests.
- Fixes #74

## Testing

- Tested both secret saving flows by human hands.