### PR TITLE
Allow blessing secret-only scripts

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -483,8 +483,7 @@ final class DashboardModel: ObservableObject {
         return false
     }
 
-    func deleteSelectedSecret() {
-        guard selectedSection == .allSecrets, let account = selectedItem?.id else { return }
+    func deleteSecret(account: String) {
         let result = performInAppSecretMutation(.delete(account: account))
         guard let status = result.status else {
             errorMessage = result.error
@@ -1498,7 +1497,7 @@ private struct StoredSecretDetailView: View {
         .alert("Delete \(secret.account)?", isPresented: $isConfirmingDelete) {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
-                model.deleteSelectedSecret()
+                model.deleteSecret(account: secret.account)
             }
         } message: {
             Text("This secret will be permanently deleted.")

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1435,6 +1435,7 @@ private struct StoredSecretDetailView: View {
     @ObservedObject var model: DashboardModel
     let secret: StoredSecret
     @State private var isAvailableWhileLocked: Bool
+    @State private var isConfirmingDelete = false
 
     init(model: DashboardModel, secret: StoredSecret) {
         self.model = model
@@ -1478,7 +1479,7 @@ private struct StoredSecretDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
-                Button { model.deleteSelectedSecret() } label: {
+                Button { isConfirmingDelete = true } label: {
                     Label("Delete Secret", systemImage: "trash")
                         .frame(maxWidth: .infinity)
                 }
@@ -1493,6 +1494,14 @@ private struct StoredSecretDetailView: View {
         }
         .onChange(of: secret.accessibility) { _, accessibility in
             isAvailableWhileLocked = accessibility.isAvailableWhileLocked
+        }
+        .alert("Delete \(secret.account)?", isPresented: $isConfirmingDelete) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                model.deleteSelectedSecret()
+            }
+        } message: {
+            Text("This secret will be permanently deleted.")
         }
     }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2567,7 +2567,6 @@ private func handOffToLaunchAgentIfNeeded() throws -> Bool {
         try? Data(contentsOf: installed),
         configured
     )
-    try configured.write(to: installed, options: .atomic)
 
     let domain = "gui/\(getuid())"
     let service = "\(domain)/\(approvalLaunchAgentName)"
@@ -2579,6 +2578,7 @@ private func handOffToLaunchAgentIfNeeded() throws -> Bool {
             // The matching plist may exist while its job is not loaded.
         }
     }
+    try configured.write(to: installed, options: .atomic)
     try? runLaunchctl(["bootout", service])
     do {
         try runLaunchctl(["bootstrap", domain, installed.path])

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2562,20 +2562,45 @@ private func handOffToLaunchAgentIfNeeded() throws -> Bool {
         withIntermediateDirectories: true
     )
     let template = try Data(contentsOf: launchAgent)
-    try configuredLaunchAgent(template: template, executableURL: executableURL)
-        .write(to: installed, options: .atomic)
+    let configured = try configuredLaunchAgent(template: template, executableURL: executableURL)
+    let configurationChanged = !launchAgentConfigurationsMatch(
+        try? Data(contentsOf: installed),
+        configured
+    )
+    try configured.write(to: installed, options: .atomic)
 
     let domain = "gui/\(getuid())"
-    try? runLaunchctl(["bootout", "\(domain)/\(approvalLaunchAgentName)"])
+    let service = "\(domain)/\(approvalLaunchAgentName)"
+    if !configurationChanged {
+        do {
+            try runLaunchctl(["kickstart", "-k", service])
+            return true
+        } catch {
+            // The matching plist may exist while its job is not loaded.
+        }
+    }
+    try? runLaunchctl(["bootout", service])
     do {
         try runLaunchctl(["bootstrap", domain, installed.path])
     } catch {
         usleep(200_000)
         try runLaunchctl(["bootstrap", domain, installed.path])
     }
-    try runLaunchctl(["enable", "\(domain)/\(approvalLaunchAgentName)"])
-    try runLaunchctl(["kickstart", "-k", "\(domain)/\(approvalLaunchAgentName)"])
+    try runLaunchctl(["enable", service])
+    try runLaunchctl(["kickstart", "-k", service])
     return true
+}
+
+private func launchAgentConfigurationsMatch(_ lhsData: Data?, _ rhsData: Data) -> Bool {
+    guard let lhsData,
+          let lhs = try? PropertyListSerialization.propertyList(from: lhsData, format: nil)
+            as? NSDictionary,
+          let rhs = try? PropertyListSerialization.propertyList(from: rhsData, format: nil)
+            as? NSDictionary
+    else {
+        return false
+    }
+    return lhs == rhs
 }
 
 private func configuredLaunchAgent(template: Data, executableURL: URL) throws -> Data {
@@ -4423,6 +4448,11 @@ private func runLaunchAgentHandoffSelfCheck() -> Int32 {
     let executableURL = URL(fileURLWithPath: "/Users/example/My Apps/Automic Vault.app/Contents/MacOS/AutomicVaultMenubar")
     let configured = try! configuredLaunchAgent(template: template, executableURL: executableURL)
     let plist = try! PropertyListSerialization.propertyList(from: configured, format: nil) as! [String: Any]
+    let binaryConfigured = try! PropertyListSerialization.data(
+        fromPropertyList: plist,
+        format: .binary,
+        options: 0
+    )
     guard !isLaunchAgentInstance(environment: [:]),
           isLaunchAgentInstance(environment: ["XPC_SERVICE_NAME": approvalLaunchAgentName]),
           shouldHandOffToLaunchAgent(environment: [:], launchAgentURL: URL(fileURLWithPath: "/tmp/agent.plist")),
@@ -4435,6 +4465,8 @@ private func runLaunchAgentHandoffSelfCheck() -> Int32 {
           requestedSecretGateID(arguments: ["AutomicVaultMenubar", "--secret-gate", "../aws"]) == nil,
           secretGateID(from: URL(string: "automic-vault://secret-gate/aws")!) == "aws",
           secretGateID(from: URL(string: "automic-vault://secret-gate/aws/extra")!) == nil,
+          launchAgentConfigurationsMatch(configured, binaryConfigured),
+          !launchAgentConfigurationsMatch(nil, configured),
           plist["ProgramArguments"] as? [String] == [executableURL.path],
           String(decoding: configured, as: UTF8.self).contains("/Applications/") == false
     else {

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -211,7 +211,7 @@ private func validBlessedSecretKey(_ key: String) -> Bool {
 
 private func parseBlessedScriptManifest(lines: [String]) throws -> BlessedScriptManifest {
     guard lines.count > 1, lines[1] == "# --- automic-vault" else {
-        throw BlessedScriptManifestError.missingManifest
+        return BlessedScriptManifest(capabilities: [:])
     }
     var capabilities: [String: SecretGateProtection] = [:]
     var index = 2

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -26,6 +26,18 @@ import Testing
     #expect(declaration.checksum.count == 64)
 }
 
+@Test func blessedScriptManifestIsOptional() throws {
+    let data = Data("""
+    #!/usr/local/bin/av inject +TOKEN /bin/sh
+    echo ok
+    """.utf8)
+
+    let declaration = try blessedScriptDeclaration(data: data)
+
+    #expect(declaration.keys == ["TOKEN"])
+    #expect(declaration.manifest.capabilities.isEmpty)
+}
+
 @Test(arguments: [
     """
     #!/bin/sh
@@ -37,12 +49,6 @@ import Testing
     """
     #!/bin/sh inject +A /bin/sh
     # --- automic-vault
-    # capabilities:
-    #   gh: read-only
-    # ---
-    """,
-    """
-    #!/usr/local/bin/av inject +A /bin/sh
     # capabilities:
     #   gh: read-only
     # ---


### PR DESCRIPTION
## Summary

- allow scripts using `av inject` to be blessed without Automic Vault front matter
- treat an absent manifest as an empty capability set
- keep marked manifests strictly validated

The injected secret declaration, exact script checksum and path, target, flags, and signed launcher checks remain unchanged. Empty capabilities continue to deny subsequent tool capability requests.

## Validation

- `swift test` in `src/menu-helper` (44 tests passed)

Closes #77
