### PR TITLE
Allow blessings without detected launchers

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -8,7 +8,7 @@ import UniformTypeIdentifiers
 struct BlessedScriptReviewRequest: Sendable {
     let path: String
     let declaration: BlessedScriptDeclaration
-    let launcher: BlessedScriptLauncher
+    let launcher: BlessedScriptLauncher?
 }
 
 @MainActor
@@ -286,14 +286,14 @@ final class DashboardModel: ObservableObject {
             return
         }
         pendingBlessing = request
-        pendingBlessingLaunchers = [request.launcher]
+        pendingBlessingLaunchers = request.launcher.map { [$0] } ?? []
         blessingCompletion = completion
         selectedSection = .blessedScripts
         selectedItemID = request.path
     }
 
     func approvePendingBlessing() {
-        guard let request = pendingBlessing, !pendingBlessingLaunchers.isEmpty else { return }
+        guard let request = pendingBlessing else { return }
         let declaration = request.declaration
         let script = BlessedScript(
             path: request.path,
@@ -351,10 +351,6 @@ final class DashboardModel: ObservableObject {
 
     func removeLauncher(_ launcher: BlessedScriptLauncher, from script: BlessedScript) {
         let launchers = script.launchers.filter { $0.requirement != launcher.requirement }
-        guard !launchers.isEmpty else {
-            errorMessage = "A blessed script must allow at least one calling app."
-            return
-        }
         let updated = BlessedScript(
             path: script.path,
             checksum: script.checksum,
@@ -2013,7 +2009,6 @@ private struct BlessedScriptReviewView: View {
                 Spacer()
                 Button("Bless Script") { model.approvePendingBlessing() }
                     .buttonStyle(.borderedProminent)
-                    .disabled(model.pendingBlessingLaunchers.isEmpty)
             }
             if let error = model.errorMessage {
                 InfoBlock(title: "Error", text: error)
@@ -2093,6 +2088,10 @@ private func launcherList(
     VStack(alignment: .leading, spacing: 10) {
         Text("Calling Apps")
             .font(.system(size: 13, weight: .semibold))
+        if launchers.isEmpty {
+            Text("No calling apps endorsed.")
+                .foregroundStyle(.secondary)
+        }
         ForEach(launchers, id: \.requirement) { launcher in
             HStack {
                 Text(launcher.bundleIdentifier)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1760,17 +1760,16 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
         }
-        guard let launcher = launcherIdentities(for: identity).first else {
-            reply(peer, to: message, ok: false, error: "calling app identity is unavailable")
-            return
-        }
+        let launcher = launcherIdentities(for: identity).first
         let request = BlessedScriptReviewRequest(
             path: path,
             declaration: declaration,
-            launcher: BlessedScriptLauncher(
-                bundleIdentifier: launcher.identifier,
-                requirement: launcher.designatedRequirement
-            )
+            launcher: launcher.map {
+                BlessedScriptLauncher(
+                    bundleIdentifier: $0.identifier,
+                    requirement: $0.designatedRequirement
+                )
+            }
         )
         DispatchQueue.main.async {
             guard self.canRequestHumanApproval() else {
@@ -4035,6 +4034,16 @@ private func runApprovalSelfCheck() -> Int32 {
             requirement: blockedLauncher.designatedRequirement
         )]
     )
+    let unendorsedBlessedScript = BlessedScript(
+        path: blessedScript.path,
+        checksum: blessedScript.checksum,
+        keys: blessedScript.keys,
+        target: blessedScript.target,
+        replaceExistingEnv: blessedScript.replaceExistingEnv,
+        allowMissingKeys: blessedScript.allowMissingKeys,
+        capabilities: blessedScript.capabilities,
+        launchers: []
+    )
     guard matchingSecretGateDefinition(
         request: readOnlyAws,
         signing: avSigning,
@@ -4053,6 +4062,12 @@ private func runApprovalSelfCheck() -> Int32 {
         !blessedScriptMatches(
             blessedScript,
             request: awsRequest(shebangScript: "/tmp/script"),
+            approval: ScriptApproval(path: "/tmp/script", checksum: "checksum"),
+            launcher: blockedLauncher
+        ),
+        !blessedScriptMatches(
+            unendorsedBlessedScript,
+            request: blessedRequest,
             approval: ScriptApproval(path: "/tmp/script", checksum: "checksum"),
             launcher: blockedLauncher
         )


### PR DESCRIPTION
## Summary

- allow bless review when the calling app identity cannot be determined
- permit saving a blessing with no endorsed calling apps and adding them later
- allow removing the final endorsed app and show the empty state explicitly

## Security

An empty launcher list remains fail-closed: blessed-script matching still requires an exact designated-requirement match, so the blessing grants no automatic authority until an app is endorsed.

## Root cause

Bless creation and management treated launcher detection as mandatory even though launcher endorsement is an independently editable policy.

## Validation

- `swift test --package-path src/menu-helper --disable-automatic-resolution` (43 tests)
- `src/menu-helper/.build/debug/AutomicVaultMenubar --self-check-approvals`