### PR TITLE
Support macOS 14 on Apple Silicon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [env]
 RUST_TEST_THREADS = "1"
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-mmacosx-version-min=14.0"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,6 +17,8 @@ CURRENT_VERSION="$(
     package && /^[[:space:]]*version[[:space:]]*=/ { print $2; exit }
   ' "$ROOT/Cargo.toml"
 )"
+MACOSX_DEPLOYMENT_TARGET=14.0
+export MACOSX_DEPLOYMENT_TARGET
 VERSION="$CURRENT_VERSION"
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -436,7 +438,7 @@ xcrun actool "$MENU_HELPER/Resources/AppIcon.icon" \
   --compile "$ICON_BUILD" \
   --platform macosx \
   --target-device mac \
-  --minimum-deployment-target 26.0 \
+  --minimum-deployment-target "$MACOSX_DEPLOYMENT_TARGET" \
   --app-icon AppIcon \
   --include-all-app-icons \
   --enable-on-demand-resources NO \

--- a/src/menu-helper/Package.swift
+++ b/src/menu-helper/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "AutomicVaultMenubar",
-    platforms: [.macOS("26.0")],
+    platforms: [.macOS("14.0")],
     products: [
         .executable(name: "AutomicVaultMenubar", targets: ["MenubarHelper"]),
     ],

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1053,7 +1053,6 @@ struct DashboardRootView: View {
                         }
                     }
                 }
-                .scrollEdgeEffectStyle(.soft, for: .top) // doesn't work :(
         } detail: {
             DashboardDetailView(model: model)
                 .navigationSplitViewColumnWidth(min: 320, ideal: 320)
@@ -2292,7 +2291,9 @@ private struct ProtectionMenu: NSViewRepresentable {
         button.removeAllItems()
         for candidate in gate.availableProtections {
             button.addItem(withTitle: gate.protectionTitle(candidate))
-            button.lastItem?.subtitle = gate.protectionSubtitle(candidate)
+            if #available(macOS 14.4, *) {
+                button.lastItem?.subtitle = gate.protectionSubtitle(candidate)
+            }
             if candidate == .fullExceptSecretDumps || candidate == .fullIncludingSecretDumps {
                 let warning = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "Warning")
                 button.lastItem?.image = candidate == .fullIncludingSecretDumps

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3366,12 +3366,12 @@ private struct ApprovalPromptView: View {
 
             HStack(spacing: 12) {
                 Button("Deny", role: .cancel) { decide(.denied) }
-                    .buttonStyle(.glass)
+                    .buttonStyle(.bordered)
                     .controlSize(.large)
                     .frame(maxWidth: .infinity)
                     .keyboardShortcut(.cancelAction)
                 Button("Approve Once") { decide(.approved) }
-                    .buttonStyle(.glassProminent)
+                    .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                     .tint(.blue)
                     .frame(maxWidth: .infinity)
@@ -3415,7 +3415,6 @@ private struct ApprovalPromptCommandView: View {
                     .fixedSize(horizontal: true, vertical: true)
             }
             .scrollIndicators(.visible)
-            .defaultScrollAnchor(.topLeading, for: .alignment)
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 14) {
                     ApprovalPromptInlineMeta(label: "cwd", value: content.cwd)

--- a/tests/macos_deployment.rs
+++ b/tests/macos_deployment.rs
@@ -1,0 +1,14 @@
+use std::{fs, path::Path};
+
+#[test]
+fn macos_deployment_targets_match() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let read = |path| fs::read_to_string(root.join(path)).unwrap();
+
+    assert!(read(".cargo/config.toml").contains("-mmacosx-version-min=14.0"));
+    let build_script = read("scripts/build.sh");
+    assert!(build_script.contains("MACOSX_DEPLOYMENT_TARGET=14.0"));
+    assert!(build_script.contains("--minimum-deployment-target \"$MACOSX_DEPLOYMENT_TARGET\""));
+    assert!(read("src/menu-helper/Package.swift").contains(".macOS(\"14.0\")"));
+    assert!(read("src/menu-helper/Info.plist").contains("<string>14.0</string>"));
+}


### PR DESCRIPTION
## Summary

- lower the menu helper and asset deployment target from macOS 26 to macOS 14
- replace or guard the five newer AppKit/SwiftUI APIs that prevented Sonoma compilation
- pin the Rust linker minimum for `aarch64-apple-darwin` and keep the release Apple-Silicon-only
- add a regression test that keeps the Cargo, build script, Swift package, and plist deployment declarations aligned

## Root cause

The plist and Homebrew cask advertised macOS 14 support, but the Swift package, asset compiler, and release-built Mach-O binaries inherited macOS 26 deployment requirements. Launch Services therefore rejected the app before launch.

## Impact

The app can be built for macOS 14 on Apple Silicon. This intentionally does **not** add x86_64 or universal binaries: the isotopes do not support Intel yet, so the app must not claim Intel support.

## Validation

- `cargo test --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/build.sh`
- `codesign --verify --deep --strict "target/swift/Automic Vault.app"`
- verified `LC_BUILD_VERSION.minos` is `14.0` for the arm64 menu helper, `av`, and `av-brew-stub`

A Sonoma runtime smoke test remains before marking this ready; no local Sonoma Tart image was available.

Fixes #84
