### PR TITLE
Report human approval decisions

### DIFF
--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -593,16 +593,6 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
         return Err("Automic Vault approval did not reply".into());
     }
 
-    let human_approval_decision =
-        unsafe { xpc_dictionary_get_string(reply, b"human_approval_decision\0".as_ptr().cast()) };
-    if !human_approval_decision.is_null() {
-        if let Some(decision) = human_approval_message(unsafe {
-            std::ffi::CStr::from_ptr(human_approval_decision).to_bytes()
-        }) {
-            eprintln!("automic vault: {decision}");
-        }
-    }
-
     let result = unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
             let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
@@ -618,34 +608,45 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
             } else {
                 Err(error)
             }
-        } else if xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {
-            let mut secrets = SecretValues::new();
-            let values = xpc_dictionary_get_dictionary(reply, b"secrets\0".as_ptr().cast());
-            if !values.is_null() {
-                for key in &request.keys {
-                    let key_cstr = CString::new(key.as_str())
-                        .map_err(|_| format!("invalid key returned by approval: {key:?}"))?;
-                    let value = xpc_dictionary_get_string(values, key_cstr.as_ptr());
-                    if !value.is_null() {
-                        secrets.insert(
-                            key.clone(),
-                            std::ffi::CStr::from_ptr(value)
-                                .to_string_lossy()
-                                .into_owned(),
-                        );
-                    }
+        } else {
+            let decision =
+                xpc_dictionary_get_string(reply, b"human_approval_decision\0".as_ptr().cast());
+            if !decision.is_null() {
+                if let Some(decision) =
+                    human_approval_message(std::ffi::CStr::from_ptr(decision).to_bytes())
+                {
+                    eprintln!("automic vault: {decision}");
                 }
             }
-            Ok(secrets)
-        } else {
-            let error = xpc_dictionary_get_string(reply, b"error\0".as_ptr().cast());
-            Err(if error.is_null() {
-                "injection denied".into()
+            if xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {
+                let mut secrets = SecretValues::new();
+                let values = xpc_dictionary_get_dictionary(reply, b"secrets\0".as_ptr().cast());
+                if !values.is_null() {
+                    for key in &request.keys {
+                        let key_cstr = CString::new(key.as_str())
+                            .map_err(|_| format!("invalid key returned by approval: {key:?}"))?;
+                        let value = xpc_dictionary_get_string(values, key_cstr.as_ptr());
+                        if !value.is_null() {
+                            secrets.insert(
+                                key.clone(),
+                                std::ffi::CStr::from_ptr(value)
+                                    .to_string_lossy()
+                                    .into_owned(),
+                            );
+                        }
+                    }
+                }
+                Ok(secrets)
             } else {
-                std::ffi::CStr::from_ptr(error)
-                    .to_string_lossy()
-                    .into_owned()
-            })
+                let error = xpc_dictionary_get_string(reply, b"error\0".as_ptr().cast());
+                Err(if error.is_null() {
+                    "injection denied".into()
+                } else {
+                    std::ffi::CStr::from_ptr(error)
+                        .to_string_lossy()
+                        .into_owned()
+                })
+            }
         }
     };
     unsafe { xpc_release(reply) };

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -593,6 +593,16 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
         return Err("Automic Vault approval did not reply".into());
     }
 
+    let human_approval_decision =
+        unsafe { xpc_dictionary_get_string(reply, b"human_approval_decision\0".as_ptr().cast()) };
+    if !human_approval_decision.is_null() {
+        if let Some(decision) = human_approval_message(unsafe {
+            std::ffi::CStr::from_ptr(human_approval_decision).to_bytes()
+        }) {
+            eprintln!("automic vault: {decision}");
+        }
+    }
+
     let result = unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
             let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
@@ -642,9 +652,24 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
     result
 }
 
+fn human_approval_message(decision: &[u8]) -> Option<&'static str> {
+    match decision {
+        b"approved" => Some("approved"),
+        b"denied" => Some("denied"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reports_only_known_human_approval_decisions() {
+        assert_eq!(human_approval_message(b"approved"), Some("approved"));
+        assert_eq!(human_approval_message(b"denied"), Some("denied"));
+        assert_eq!(human_approval_message(b"unexpected"), None);
+    }
 
     fn os(values: &[&str]) -> Vec<OsString> {
         values.iter().map(OsString::from).collect()

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1524,7 +1524,13 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: "Denied in prompt",
                     launcher: launcher
                 ))
-                self.reply(peer, to: message, ok: false, error: "\(request.op) denied")
+                self.reply(
+                    peer,
+                    to: message,
+                    ok: false,
+                    error: "\(request.op) denied",
+                    humanApprovalDecision: "denied"
+                )
                 return
             }
             do {
@@ -1538,11 +1544,24 @@ private final class ApprovalServer: @unchecked Sendable {
                     launcher: launcher
                 )
                 guard self.onAccessRequest(record) else {
-                    self.reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                    self.reply(
+                        peer,
+                        to: message,
+                        ok: false,
+                        error: "approval audit log is unavailable",
+                        humanApprovalDecision: "approved"
+                    )
                     return
                 }
                 self.transientApprovals.remember(.approved, for: transientApproval)
-                self.reply(peer, to: message, ok: true, error: nil, secrets: secrets)
+                self.reply(
+                    peer,
+                    to: message,
+                    ok: true,
+                    error: nil,
+                    secrets: secrets,
+                    humanApprovalDecision: "approved"
+                )
             } catch {
                 _ = self.onAccessRequest(accessRequestRecord(
                     request: request,
@@ -1552,7 +1571,13 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: error.localizedDescription,
                     launcher: launcher
                 ))
-                self.reply(peer, to: message, ok: false, error: error.localizedDescription)
+                self.reply(
+                    peer,
+                    to: message,
+                    ok: false,
+                    error: error.localizedDescription,
+                    humanApprovalDecision: "approved"
+                )
             }
         }
     }
@@ -1990,7 +2015,8 @@ private final class ApprovalServer: @unchecked Sendable {
         ok: Bool,
         error: String?,
         secrets: [String: String]? = nil,
-        value: String? = nil
+        value: String? = nil,
+        humanApprovalDecision: String? = nil
     ) {
         let response = xpc_dictionary_create_reply(message) ?? xpc_dictionary_create_empty()
         xpc_dictionary_set_bool(response, "ok", ok)
@@ -2012,6 +2038,11 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         if let value {
             value.withCString { xpc_dictionary_set_string(response, "value", $0) }
+        }
+        if let humanApprovalDecision {
+            humanApprovalDecision.withCString {
+                xpc_dictionary_set_string(response, "human_approval_decision", $0)
+            }
         }
         xpc_connection_send_message(peer, response)
     }


### PR DESCRIPTION
## What changed

- Return the human's approval decision in the authenticated XPC reply.
- Print `automic vault: approved` or `automic vault: denied` after the prompt is resolved.
- Ignore unknown decision values and cover the mapping with a unit test.

## Why

`automic vault: human approval required` only indicates that the CLI is waiting. Without a final status, a later tool failure can be mistaken for an approval failure.

## Validation

- `cargo fmt --check`
- `cargo test --locked` (763 tests)
- `swift test --package-path src/menu-helper` (44 tests)
