### PR TITLE
Handle AWS operations that require long-lived credentials

### DIFF
--- a/src/isotopes/hardeners/aws
+++ b/src/isotopes/hardeners/aws
@@ -33,10 +33,11 @@ trap cleanup EXIT INT TERM
 mkdir -p "$tmp/home"
 : > "$tmp/credentials"
 
-# aws-vault checks for stored credentials by profile name before invoking pass.
-source_profile_for() {
+# Read one setting without allowing the user's AWS config to enter the
+# credential-bearing AWS CLI process.
+profile_value_for() {
   [[ -r $aws_config ]] || return 0
-  awk -v wanted="$1" '
+  awk -v wanted="$1" -v key="$2" '
     /^\[[^]]+\]$/ {
       section = $0
       sub(/^\[/, "", section)
@@ -45,7 +46,7 @@ source_profile_for() {
       in_section = section == wanted
       next
     }
-    in_section && /^[[:space:]]*source_profile[[:space:]]*=/ {
+    in_section && $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
       sub(/^[^=]*=/, "")
       gsub(/^[[:space:]]+|[[:space:]]+$/, "")
       print
@@ -54,10 +55,68 @@ source_profile_for() {
   ' "$aws_config"
 }
 
+# aws-vault checks for stored credentials by profile name before invoking pass.
 master_profile=$profile
-while source_profile=$(source_profile_for "$master_profile"); [[ -n $source_profile && $source_profile != "$master_profile" ]]; do
+while source_profile=$(profile_value_for "$master_profile" source_profile); [[ -n $source_profile && $source_profile != "$master_profile" ]]; do
   master_profile=$source_profile
 done
+
+needs_long_lived_credentials() {
+  local index=1 service operation arg
+  while (( index <= ${#aws_args} )); do
+    arg=${aws_args[index]}
+    case "$arg" in
+      --ca-bundle|--cli-binary-format|--cli-input-json|--cli-input-yaml|--color|--endpoint-url|--max-items|--output|--page-size|--query|--region|--starting-token)
+        (( index += 2 ))
+        ;;
+      --ca-bundle=*|--cli-binary-format=*|--cli-input-json=*|--cli-input-yaml=*|--color=*|--endpoint-url=*|--max-items=*|--output=*|--page-size=*|--query=*|--region=*|--starting-token=*|--debug|--no-cli-auto-prompt|--no-cli-pager|--no-paginate|--no-sign-request|--no-verify-ssl|--only-show-errors|--version)
+        (( index += 1 ))
+        ;;
+      --*|-*)
+        return 1
+        ;;
+      *)
+        service=${arg:l}
+        operation=${aws_args[index + 1]:-}
+        operation=${operation:l}
+        [[ $operation != help ]] || return 1
+        [[ $service == iam ]] && return 0
+        [[ $service == sts && $operation != assume-role && $operation != get-caller-identity ]] && return 0
+        return 1
+        ;;
+    esac
+  done
+  return 1
+}
+
+# GetSessionToken credentials cannot call IAM or most STS operations without
+# MFA. Role and MFA-backed profiles retain the safer short-lived path.
+if needs_long_lived_credentials \
+  && [[ -z $(profile_value_for "$profile" role_arn) ]] \
+  && [[ -z $(profile_value_for "$profile" mfa_serial) ]]; then
+  /usr/bin/env \
+    -u AWS_PROFILE \
+    -u AWS_DEFAULT_PROFILE \
+    -u AWS_SESSION_TOKEN \
+    -u AWS_SECURITY_TOKEN \
+    -u AWS_CREDENTIAL_EXPIRATION \
+    -u AWS_WEB_IDENTITY_TOKEN_FILE \
+    -u AWS_ROLE_ARN \
+    -u AWS_ROLE_SESSION_NAME \
+    -u AWS_CONTAINER_CREDENTIALS_FULL_URI \
+    -u AWS_CONTAINER_CREDENTIALS_RELATIVE_URI \
+    -u AWS_CONTAINER_AUTHORIZATION_TOKEN \
+    -u AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE \
+    HOME="$tmp/home" \
+    AWS_CONFIG_FILE=/dev/null \
+    AWS_SHARED_CREDENTIALS_FILE="$tmp/credentials" \
+    AWS_EC2_METADATA_DISABLED=true \
+    AWS_PAGER= \
+    PAGER=cat \
+    AWS_CLI_AUTO_PROMPT=off \
+    /opt/homebrew/bin/aws --no-cli-pager "${aws_args[@]}"
+  exit
+fi
 
 # This marker satisfies pass backend discovery; it contains no credentials.
 marker=$store/$prefix/$master_profile.gpg

--- a/src/isotopes/hardeners/aws_cli.md
+++ b/src/isotopes/hardeners/aws_cli.md
@@ -35,6 +35,13 @@ The real AWS CLI receives an empty home and credential/config files plus
 processes, plugins, cached login credentials, and output pagers from running
 inside the credential-bearing process.
 
+AWS does not permit non-MFA `GetSessionToken` credentials to call IAM or most
+STS operations. For those operations on a base profile without MFA, the wrapper
+marks the credential request as high sensitivity and explains why it must inject
+the original long-lived keys directly into the isolated AWS CLI. Only a Secret
+Gate set to Full Access can approve that request automatically. MFA and role
+profiles keep using short-lived credentials.
+
 ## Caveats
 
 - The import phase only migrates the `default` profile from the shared

--- a/src/isotopes/hardeners/aws_cli.rs
+++ b/src/isotopes/hardeners/aws_cli.rs
@@ -364,6 +364,7 @@ mod tests {
         assert!(AWS_STUB.contains("--profile=*)"));
         assert!(AWS_STUB.contains("AWS_CONFIG_FILE=/dev/null"));
         assert!(AWS_STUB.contains("/opt/homebrew/bin/aws --no-cli-pager"));
+        assert!(AWS_STUB.contains("needs_long_lived_credentials"));
         assert!(AWS_STUB.contains("mktemp -d"));
         assert!(!AWS_STUB.contains("aws-vault-pass.$$"));
         assert!(AWS_STUB.contains("#!/bin/sh\nset -eu"));
@@ -478,6 +479,54 @@ mod tests {
         assert!(isolated_credentials.starts_with(&temp.display().to_string()));
         assert_eq!(fs::read_dir(&temp).unwrap().count(), 0);
         assert!(!capture.join("zshenv-secret").exists());
+
+        let status = Command::new(&wrapper)
+            .args(["iam", "get-role", "--role-name", "example"])
+            .env("AWS_ACCESS_KEY_ID", "long-term-key")
+            .env("AWS_SECRET_ACCESS_KEY", "long-term-secret")
+            .env("TMPDIR", &temp)
+            .status()
+            .unwrap();
+
+        assert!(status.success());
+        assert_eq!(
+            fs::read_to_string(capture.join("access-key")).unwrap(),
+            "long-term-key\n"
+        );
+        assert_eq!(fs::read_dir(&temp).unwrap().count(), 0);
+
+        let config = dir.join("config");
+        fs::write(
+            &config,
+            "[profile dev]\nrole_arn = arn:aws:iam::123456789012:role/dev\nsource_profile = default\n",
+        )
+        .unwrap();
+        let status = Command::new(&wrapper)
+            .args([
+                "--profile",
+                "dev",
+                "iam",
+                "get-role",
+                "--role-name",
+                "example",
+            ])
+            .env("AWS_ACCESS_KEY_ID", "long-term-key")
+            .env("AWS_SECRET_ACCESS_KEY", "long-term-secret")
+            .env("AWS_CONFIG_FILE", &config)
+            .env("TMPDIR", &temp)
+            .status()
+            .unwrap();
+
+        assert!(status.success());
+        assert!(
+            fs::read_to_string(capture.join("vault-args"))
+                .unwrap()
+                .starts_with("exec dev --server -- ")
+        );
+        assert_eq!(
+            fs::read_to_string(capture.join("access-key")).unwrap(),
+            "unset\n"
+        );
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2216,7 +2216,7 @@ private func classifySecretGateRequest(
 }
 
 private func awsRequestMayUseLongLivedCredentials(_ request: ApprovalRequest) -> Bool {
-    let words = awsCommandWords(request).map { $0.lowercased() }
+    let words = awsCommandWords(awsCommandWords(request)).map { $0.lowercased() }
     guard words.count >= 2, words[1] != "help" else { return false }
     if words[0] == "iam" { return true }
     return words[0] == "sts"
@@ -4170,6 +4170,10 @@ private func runApprovalSelfCheck() -> Int32 {
           ) == nil,
           classifySecretGateRequest(gateID: "aws", request: readOnlyAws) == .readOnly,
           classifySecretGateRequest(gateID: "aws", request: longLivedAws) == .secretDump,
+          classifySecretGateRequest(
+              gateID: "aws",
+              request: awsRequest(args: ["-f", "/usr/local/bin/aws", "--profile", "dev", "iam", "get-role"])
+          ) == .secretDump,
           contextualLongLivedAws.title == "Use long-lived AWS credentials?",
           contextualLongLivedAws.detail?.contains("retain every IAM permission") == true,
           classifySecretGateRequest(

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1279,10 +1279,11 @@ private final class ApprovalServer: @unchecked Sendable {
         callerPath: String,
         signing: SigningInfo
     ) {
-        guard let request = approvalRequest(from: message) else {
+        guard let parsedRequest = approvalRequest(from: message) else {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
         }
+        let request = approvalRequestWithCredentialContext(parsedRequest)
         let scriptApproval = scriptApproval(for: request)
         var launchers = launcherIdentities(for: identity)
         let launcherFallbackPath = launcherFallbackPath(for: identity) ?? callerPath
@@ -1440,7 +1441,10 @@ private final class ApprovalServer: @unchecked Sendable {
             tool: request.tool
         )
         DispatchQueue.main.async {
-            let cachedDecision = self.transientApprovals.decision(for: transientApproval)
+            let requiresFreshApproval = awsRequestMayUseLongLivedCredentials(request)
+            let cachedDecision = requiresFreshApproval
+                ? nil
+                : self.transientApprovals.decision(for: transientApproval)
             if let decision = cachedDecision {
                 if decision == .denied {
                     _ = self.onAccessRequest(accessRequestRecord(
@@ -1515,7 +1519,9 @@ private final class ApprovalServer: @unchecked Sendable {
                 automaticApprovalExplanation: automaticApprovalExplanation
             )
             guard decision != .denied else {
-                self.transientApprovals.remember(.denied, for: transientApproval)
+                if !requiresFreshApproval {
+                    self.transientApprovals.remember(.denied, for: transientApproval)
+                }
                 _ = self.onAccessRequest(accessRequestRecord(
                     request: request,
                     callerPath: callerPath,
@@ -1553,7 +1559,9 @@ private final class ApprovalServer: @unchecked Sendable {
                     )
                     return
                 }
-                self.transientApprovals.remember(.approved, for: transientApproval)
+                if !requiresFreshApproval {
+                    self.transientApprovals.remember(.approved, for: transientApproval)
+                }
                 self.reply(
                     peer,
                     to: message,
@@ -2198,12 +2206,41 @@ private func classifySecretGateRequest(
     case "gh":
         return ghRequestClassification(request.args)
     case "aws":
+        if awsRequestMayUseLongLivedCredentials(request) { return .secretDump }
         return awsRequestIsReadOnly(awsCommandWords(request)) ? .readOnly : .mutating
     case "brew":
         return brewRequestClassification(request.args)
     default:
         return .unknown
     }
+}
+
+private func awsRequestMayUseLongLivedCredentials(_ request: ApprovalRequest) -> Bool {
+    let words = awsCommandWords(request).map { $0.lowercased() }
+    guard words.count >= 2, words[1] != "help" else { return false }
+    if words[0] == "iam" { return true }
+    return words[0] == "sts"
+        && words[1] != "assume-role"
+        && words[1] != "get-caller-identity"
+}
+
+private func approvalRequestWithCredentialContext(_ request: ApprovalRequest) -> ApprovalRequest {
+    guard awsRequestMayUseLongLivedCredentials(request) else { return request }
+    return ApprovalRequest(
+        op: request.op,
+        keys: request.keys,
+        target: request.target,
+        args: request.args,
+        cwd: request.cwd,
+        replaceExistingEnv: request.replaceExistingEnv,
+        allowMissingKeys: request.allowMissingKeys,
+        envConflicts: request.envConflicts,
+        shebangScript: request.shebangScript,
+        scriptData: request.scriptData,
+        tool: request.tool,
+        title: "Use long-lived AWS credentials?",
+        detail: "AWS does not allow non-MFA GetSessionToken credentials to call this operation. Unless the selected profile uses MFA or assumes a role, Automic Vault will inject your original AWS access keys directly into AWS CLI; they retain every IAM permission assigned to those keys."
+    )
 }
 
 private func brewRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
@@ -4033,6 +4070,10 @@ private func runApprovalSelfCheck() -> Int32 {
         )
     }
     let readOnlyAws = awsRequest()
+    let longLivedAws = awsRequest(
+        args: ["-f", "/usr/local/bin/aws", "iam", "get-role", "--role-name", "example"]
+    )
+    let contextualLongLivedAws = approvalRequestWithCredentialContext(longLivedAws)
     let awsMetadata = HardenerMetadata(
         name: "aws",
         hardened: true,
@@ -4104,6 +4145,7 @@ private func runApprovalSelfCheck() -> Int32 {
     else { return 1 }
 
     guard matchingSecretGate(request: readOnlyAws, signing: avSigning, hardeners: [awsMetadata])?.id == "aws",
+          matchingSecretGate(request: longLivedAws, signing: avSigning, hardeners: [awsMetadata])?.id == "aws",
           missingRequiredSecret(for: readOnlyAws, exists: { $0 == "AWS_SECRET_ACCESS_KEY" }) == "AWS_ACCESS_KEY_ID",
           missingRequiredSecret(for: readOnlyAws, exists: { _ in true }) == nil,
           missingRequiredSecret(for: awsRequest(allowMissingKeys: true), exists: { _ in false }) == nil,
@@ -4127,6 +4169,9 @@ private func runApprovalSelfCheck() -> Int32 {
               hardeners: [awsMetadata]
           ) == nil,
           classifySecretGateRequest(gateID: "aws", request: readOnlyAws) == .readOnly,
+          classifySecretGateRequest(gateID: "aws", request: longLivedAws) == .secretDump,
+          contextualLongLivedAws.title == "Use long-lived AWS credentials?",
+          contextualLongLivedAws.detail?.contains("retain every IAM permission") == true,
           classifySecretGateRequest(
               gateID: "aws",
               request: awsRequest(args: ["-f", "/usr/local/bin/aws", "s3", "rm", "s3://bucket/key"])


### PR DESCRIPTION
## Summary

- Detect AWS IAM and most STS operations that cannot use non-MFA session credentials.
- Require fresh Secret Gate approval before injecting original long-lived AWS keys.
- Preserve short-lived credential handling for MFA-backed and role profiles.
- Add wrapper and approval self-check coverage plus documentation.

## Testing

- Added Rust integration coverage for direct and role-based AWS IAM requests.
- Extended approval self-checks for credential classification and context.