### PR TITLE
fix(poetry detector): detect real-world pypi-token auth.toml format

### DIFF
--- a/src/isotopes/detectors/poetry/mod.rs
+++ b/src/isotopes/detectors/poetry/mod.rs
@@ -52,19 +52,29 @@ fn read_to_string(path: &Path) -> Result<String, String> {
 
 fn poetry_auth_contains_secret(contents: &str) -> bool {
     let mut in_secret_table = false;
+    let mut in_pypi_token_table = false;
     for line in contents.lines() {
         let line = line.split('#').next().unwrap_or("").trim();
         if line.is_empty() {
             continue;
         }
         if line.starts_with('[') && line.ends_with(']') {
-            in_secret_table = line.contains("pypi-token") || line.contains("http-basic");
+            let header = &line[1..line.len() - 1];
+            in_secret_table = header.contains("pypi-token") || header.contains("http-basic");
+            // `poetry config pypi-token.<repo> <token>` writes a flat
+            // `[pypi-token]` table keyed by repository name, e.g.
+            // `[pypi-token]\npypi = "..."`, unlike `[http-basic.<repo>]`
+            // which nests `password`/`token` keys per repo.
+            in_pypi_token_table = header == "pypi-token";
             continue;
         }
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
         let key = key.trim().trim_matches('"').trim_matches('\'');
+        if in_pypi_token_table && secret_value(trim_quotes(value.trim())) {
+            return true;
+        }
         if in_secret_table
             && matches!(key, "password" | "token")
             && secret_value(trim_quotes(value.trim()))
@@ -101,6 +111,17 @@ mod tests {
         ));
         assert!(!poetry_auth_contains_secret(
             "[http-basic.private]\nusername = \"u\"\n"
+        ));
+    }
+
+    #[test]
+    fn detects_pypi_token_in_the_flat_table_shape_poetry_actually_writes() {
+        // `poetry config pypi-token.pypi <token>` writes auth.toml via
+        // Config.auth_config_source.add_property("pypi-token.pypi", token),
+        // which serializes as a flat table keyed by repository name, not a
+        // dotted subtable with a `token =` key.
+        assert!(poetry_auth_contains_secret(
+            "[pypi-token]\npypi = \"pypi-AgEIcHlwaS5vcmc\"\n"
         ));
     }
 }


### PR DESCRIPTION
## Summary

`av scan`'s Poetry detector (`poetry_auth_contains_secret`) misses the most common real-world shape of `auth.toml` written by `poetry config pypi-token.<repo> <token>`.

Poetry's `password_manager.py` writes token credentials via `auth_config_source.add_property(f"pypi-token.{repo_name}", token)`, which serializes as a **flat table keyed by the repository name**:

```toml
[pypi-token]
pypi = "pypi-AgEIcHlwaS5vcmc..."
```

The detector only flagged an entry when the TOML key was literally `password` or `token`, or when a key contained the substring `pypi-token`. Since the key here is the repo name (e.g. `pypi`), neither branch fires, and `av scan` silently reports no findings even though a plaintext PyPI token is sitting on disk. This is the documented, recommended way to configure PyPI credentials in Poetry today, so it's a false negative in the most common case, not an edge case.

The pre-existing test (`detects_poetry_auth_toml_secrets`) gave false confidence: it encoded a table shape (`[pypi-token.pypi]` with a nested `token =` key) that Poetry does not actually produce.

## Fix

Track whether the current TOML table header is exactly `pypi-token` (the flat form Poetry writes), and when so, treat any key's non-empty, non-placeholder value as a secret - since the key there is a repository name, not a fixed field name. This is distinct from `[http-basic.<repo>]` tables, where `password`/`token` remain the literal keys.

## Test plan

- [x] Added `detects_pypi_token_in_the_flat_table_shape_poetry_actually_writes`, reproducing the real auth.toml shape; confirmed it fails against the prior implementation
- [x] Full test suite (768 tests) passes with no regressions
- [x] `cargo fmt --check` is clean