### PR TITLE
Keep hardened Homebrew compatible with zsh compinit

### DIFF
--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -1,15 +1,17 @@
 use std::ffi::{CStr, CString, OsString};
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V4";
+const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V5";
 const TARGET: &str = "/opt/homebrew/bin/brew";
+const PREFIX: &str = "/opt/homebrew";
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const CASK_USER_UID: &str = "/opt/homebrew/var/automic/cask-user-uid";
+const ZSH_COMPLETIONS: &str = "share/zsh/site-functions";
+const COMPLETION_ACL: &str = "user:automic allow read,write,execute,delete,append,readattr,writeattr,readextattr,writeextattr,readsecurity";
 
 #[derive(Debug, PartialEq, Eq)]
 struct AuthorizationRequest {
@@ -44,18 +46,20 @@ fn main() {
     let (mut command, post_install) =
         approved_command(args, std::env::vars_os(), &cwd, xpc_authorize)
             .unwrap_or_else(|err| fail(err));
-    if let Some(post_install) = post_install {
-        let status = command
-            .status()
-            .unwrap_or_else(|err| fail(format!("failed to run {TARGET}: {err}")));
-        if !status.success() {
-            std::process::exit(status.code().unwrap_or(1));
+    let status = command
+        .status()
+        .unwrap_or_else(|err| fail(format!("failed to run {TARGET}: {err}")));
+    let completion_result = repair_zsh_completion_ownership(Path::new(PREFIX));
+    if !status.success() {
+        if let Err(err) = completion_result {
+            eprintln!("av-brew-stub: {err}");
         }
-        transfer_app_ownership(&post_install).unwrap_or_else(|err| fail(err));
-        return;
+        std::process::exit(status.code().unwrap_or(1));
     }
-    let err = command.exec();
-    fail(format!("failed to exec {TARGET}: {err}"));
+    if let Some(post_install) = post_install {
+        transfer_app_ownership(&post_install).unwrap_or_else(|err| fail(err));
+    }
+    completion_result.unwrap_or_else(|err| fail(err));
 }
 
 fn fail(message: String) -> ! {
@@ -581,6 +585,130 @@ fn ownership_command(post_install: &CaskPostInstall) -> Command {
             &owner,
         ])
         .args(&post_install.apps)
+        .env_clear()
+        .envs(stub_env([]));
+    command
+}
+
+fn repair_zsh_completion_ownership(prefix: &Path) -> Result<(), String> {
+    let automic_uid = unsafe { libc::geteuid() };
+    let configured_uid = configured_cask_uid(Path::new(CASK_USER_UID), automic_uid, unsafe {
+        libc::getegid()
+    })?;
+    let mut repair = Vec::new();
+    for path in zsh_completion_paths(prefix)? {
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|err| format!("failed to inspect {}: {err}", path.display()))?;
+        if metadata.uid() == configured_uid || metadata.uid() == 0 {
+            continue;
+        }
+        if metadata.uid() != automic_uid {
+            return Err(format!(
+                "zsh completion {} has unexpected owner {}",
+                path.display(),
+                metadata.uid()
+            ));
+        }
+        if !metadata.file_type().is_symlink() {
+            let acl = if metadata.file_type().is_dir() {
+                format!("{COMPLETION_ACL},file_inherit,directory_inherit")
+            } else {
+                COMPLETION_ACL.into()
+            };
+            let _ = Command::new("/bin/chmod")
+                .args(["-a", &acl])
+                .arg(&path)
+                .output();
+            let output = Command::new("/bin/chmod")
+                .args(["+a", &acl])
+                .arg(&path)
+                .output()
+                .map_err(|err| format!("failed to grant Homebrew completion access: {err}"))?;
+            if !output.status.success() {
+                return Err(format!(
+                    "failed to grant Homebrew access to {}: {}",
+                    path.display(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
+        }
+        repair.push(path);
+    }
+    if repair.is_empty() {
+        return Ok(());
+    }
+    let caller = caller()?;
+    eprintln!("av-brew-stub: sudo is required to make zsh completions compatible with compinit");
+    let output = completion_ownership_command(&caller, &repair)
+        .output()
+        .map_err(|err| format!("failed to transfer zsh completion ownership: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to transfer zsh completion ownership: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    for path in zsh_completion_paths(prefix)? {
+        let uid = fs::symlink_metadata(&path)
+            .map_err(|err| format!("failed to inspect {}: {err}", path.display()))?
+            .uid();
+        if uid != caller.uid && uid != 0 {
+            return Err(format!(
+                "{} ownership was not transferred to {}",
+                path.display(),
+                caller.uid
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn zsh_completion_paths(prefix: &Path) -> Result<Vec<PathBuf>, String> {
+    let functions = prefix.join(ZSH_COMPLETIONS);
+    if !functions.is_dir() {
+        return Ok(Vec::new());
+    }
+    let canonical_prefix = fs::canonicalize(prefix)
+        .map_err(|err| format!("failed to resolve {}: {err}", prefix.display()))?;
+    let mut paths = std::collections::BTreeSet::from([prefix.join("share/zsh"), functions.clone()]);
+    for entry in fs::read_dir(&functions)
+        .map_err(|err| format!("failed to read {}: {err}", functions.display()))?
+    {
+        let entry =
+            entry.map_err(|err| format!("failed to read {}: {err}", functions.display()))?;
+        if !entry.file_name().as_encoded_bytes().starts_with(b"_") {
+            continue;
+        }
+        let path = entry.path();
+        paths.insert(path.clone());
+        let target = match fs::canonicalize(&path) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == io::ErrorKind::NotFound
+                    && entry.file_type().is_ok_and(|kind| kind.is_symlink()) =>
+            {
+                continue;
+            }
+            Err(err) => return Err(format!("failed to resolve {}: {err}", path.display())),
+        };
+        if !target.starts_with(&canonical_prefix) {
+            return Err(format!(
+                "zsh completion {} resolves outside {}",
+                path.display(),
+                prefix.display()
+            ));
+        }
+        paths.insert(target);
+    }
+    Ok(paths.into_iter().collect())
+}
+
+fn completion_ownership_command(caller: &Caller, paths: &[PathBuf]) -> Command {
+    let owner = format!("{}:{}", caller.uid, caller.gid);
+    let mut command = Command::new("/usr/bin/sudo");
+    command
+        .args(["--", "/usr/sbin/chown", "-P", "-h", "-n", "--", &owner])
+        .args(paths)
         .env_clear()
         .envs(stub_env([]));
     command
@@ -1117,6 +1245,70 @@ mod tests {
                 "--",
                 "501:20",
                 "/Applications/Spotify.app"
+            ]
+        );
+    }
+
+    #[test]
+    fn zsh_completion_paths_include_links_and_in_prefix_targets() {
+        let prefix = temp_path("zsh-completions");
+        let functions = prefix.join(ZSH_COMPLETIONS);
+        let target = prefix.join("Cellar/tool/1/share/zsh/site-functions/_tool");
+        fs::create_dir_all(&functions).unwrap();
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::write(&target, "#compdef tool").unwrap();
+        std::os::unix::fs::symlink(&target, functions.join("_tool")).unwrap();
+        fs::write(functions.join("not-loaded"), "ignored").unwrap();
+
+        let paths = zsh_completion_paths(&prefix).unwrap();
+
+        assert!(paths.contains(&prefix.join("share/zsh")));
+        assert!(paths.contains(&functions));
+        assert!(paths.contains(&prefix.join(ZSH_COMPLETIONS).join("_tool")));
+        assert!(paths.contains(&fs::canonicalize(&target).unwrap()));
+        assert!(!paths.contains(&prefix.join(ZSH_COMPLETIONS).join("not-loaded")));
+        fs::remove_dir_all(prefix).unwrap();
+    }
+
+    #[test]
+    fn zsh_completion_paths_reject_targets_outside_homebrew() {
+        let prefix = temp_path("zsh-completion-escape");
+        let outside = temp_path("zsh-completion-outside");
+        let functions = prefix.join(ZSH_COMPLETIONS);
+        fs::create_dir_all(&functions).unwrap();
+        fs::write(&outside, "unsafe").unwrap();
+        std::os::unix::fs::symlink(&outside, functions.join("_escape")).unwrap();
+
+        assert!(zsh_completion_paths(&prefix).is_err());
+
+        fs::remove_dir_all(prefix).unwrap();
+        fs::remove_file(outside).unwrap();
+    }
+
+    #[test]
+    fn completion_ownership_is_narrow_and_non_recursive() {
+        let paths = vec![
+            PathBuf::from("/opt/homebrew/share/zsh"),
+            PathBuf::from("/opt/homebrew/share/zsh/site-functions/_tool"),
+        ];
+        let command = completion_ownership_command(&Caller { uid: 501, gid: 20 }, &paths);
+
+        assert_eq!(command.get_program(), "/usr/bin/sudo");
+        assert_eq!(
+            command
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            [
+                "--",
+                "/usr/sbin/chown",
+                "-P",
+                "-h",
+                "-n",
+                "--",
+                "501:20",
+                "/opt/homebrew/share/zsh",
+                "/opt/homebrew/share/zsh/site-functions/_tool",
             ]
         );
     }

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -479,7 +479,7 @@ fn caller() -> Result<Caller, String> {
         configured_cask_uid(Path::new(CASK_USER_UID), euid, unsafe { libc::getegid() })?;
     if uid != configured {
         return Err(
-            "casks must be invoked directly by the user configured by `sudo av harden brew`".into(),
+            "ownership transfers must be invoked directly by the user configured by `sudo av harden brew`".into(),
         );
     }
     let entry = unsafe { libc::getpwuid(uid) };
@@ -707,7 +707,7 @@ fn completion_ownership_command(caller: &Caller, paths: &[PathBuf]) -> Command {
     let owner = format!("{}:{}", caller.uid, caller.gid);
     let mut command = Command::new("/usr/bin/sudo");
     command
-        .args(["--", "/usr/sbin/chown", "-P", "-h", "-n", "--", &owner])
+        .args(["--", "/usr/sbin/chown", "-h", "-n", "--", &owner])
         .args(paths)
         .env_clear()
         .envs(stub_env([]));
@@ -1302,7 +1302,6 @@ mod tests {
             [
                 "--",
                 "/usr/sbin/chown",
-                "-P",
                 "-h",
                 "-n",
                 "--",

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -49,7 +49,8 @@ fn main() {
     let status = command
         .status()
         .unwrap_or_else(|err| fail(format!("failed to run {TARGET}: {err}")));
-    let completion_result = repair_zsh_completion_ownership(Path::new(PREFIX));
+    let completion_result =
+        repair_zsh_completion_ownership(Path::new(PREFIX), Path::new(CASK_USER_UID));
     if !status.success() {
         if let Err(err) = completion_result {
             eprintln!("av-brew-stub: {err}");
@@ -590,13 +591,16 @@ fn ownership_command(post_install: &CaskPostInstall) -> Command {
     command
 }
 
-fn repair_zsh_completion_ownership(prefix: &Path) -> Result<(), String> {
+fn repair_zsh_completion_ownership(prefix: &Path, configured_user: &Path) -> Result<(), String> {
+    let paths = zsh_completion_paths(prefix)?;
+    if paths.is_empty() {
+        return Ok(());
+    }
     let automic_uid = unsafe { libc::geteuid() };
-    let configured_uid = configured_cask_uid(Path::new(CASK_USER_UID), automic_uid, unsafe {
-        libc::getegid()
-    })?;
+    let configured_uid =
+        configured_cask_uid(configured_user, automic_uid, unsafe { libc::getegid() })?;
     let mut repair = Vec::new();
-    for path in zsh_completion_paths(prefix)? {
+    for path in paths {
         let metadata = fs::symlink_metadata(&path)
             .map_err(|err| format!("failed to inspect {}: {err}", path.display()))?;
         if metadata.uid() == configured_uid || metadata.uid() == 0 {
@@ -1283,6 +1287,13 @@ mod tests {
 
         fs::remove_dir_all(prefix).unwrap();
         fs::remove_file(outside).unwrap();
+    }
+
+    #[test]
+    fn missing_zsh_completions_need_no_configured_user() {
+        let prefix = temp_path("no-zsh-completions");
+
+        assert!(repair_zsh_completion_ownership(&prefix, Path::new("/missing")).is_ok());
     }
 
     #[test]

--- a/src/isotopes/hardeners/homebrew.md
+++ b/src/isotopes/hardeners/homebrew.md
@@ -6,6 +6,11 @@
 - Approval gates can be configured to stop agents installing things behind your
   back.
 
+The configured desktop account retains ownership of zsh completion files for
+compatibility with zsh's ownership checks. Software running as that account can
+modify code loaded by zsh; the remainder of the Homebrew installation stays
+protected.
+
 ## What it Does
 
 Installs `/usr/local/bin/brew` as a small setuid/setgid Automic Vault launcher
@@ -50,6 +55,10 @@ is that solution.
 - The launcher fails closed when the approval service is unavailable.
 - The stub clears the environment, restores only safe terminal/locale values,
   and executes `/opt/homebrew/bin/brew` directly.
+- Zsh completion directories and the completion files exposed through them are
+  owned by the configured desktop account. The `automic` account receives a
+  narrow ACL so Homebrew can update them, and the launcher transfers newly
+  created completion entries after Homebrew runs.
 
 ## Casks
 

--- a/src/isotopes/hardeners/homebrew.md
+++ b/src/isotopes/hardeners/homebrew.md
@@ -2,7 +2,8 @@
 
 ## Summary
 
-- Only `brew` can alter `/opt/homebrew`
+- Only `brew` can alter `/opt/homebrew`, except for the user-owned zsh
+  completions described below.
 - Approval gates can be configured to stop agents installing things behind your
   back.
 

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -17,10 +17,11 @@ const BREW_TARGET: &str = "/opt/homebrew/bin/brew";
 const BREW_STUB: &str = "/usr/local/bin/brew";
 const APP_BREW_STUB: &str = "/Applications/Automic Vault.app/Contents/MacOS/av-brew-stub";
 const CASK_USER_UID_FILE: &str = "var/automic/cask-user-uid";
+const ZSH_COMPLETIONS: &str = "share/zsh/site-functions";
 const STUB_MARKER_PREFIX: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V";
 #[cfg(test)]
-const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V4";
-const STUB_VERSION: u32 = 4;
+const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V5";
+const STUB_VERSION: u32 = 5;
 const ID_RANGE: std::ops::RangeInclusive<u32> = 550..=599;
 
 unsafe extern "C" {
@@ -31,6 +32,7 @@ unsafe extern "C" {
 struct SourceUser {
     name: String,
     uid: u32,
+    gid: u32,
     home: PathBuf,
 }
 
@@ -105,6 +107,18 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
         source_user.name
     )
     .ok();
+    writeln!(
+        stdout,
+        "├─ keep zsh completions owned by {} for shell compatibility",
+        source_user.name
+    )
+    .ok();
+    writeln!(
+        stdout,
+        "│  warning: software running as {} can modify code loaded by zsh",
+        source_user.name
+    )
+    .ok();
     writeln!(stdout, "├─ install {}", stub.display()).ok();
     writeln!(stdout, "│").ok();
     if !confirm(stdout, yes)? {
@@ -141,6 +155,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     write_cask_user_uid(&prefix.join(CASK_USER_UID_FILE), source_user.uid)?;
     remove_legacy_cask_access(&prefix, &source_user.name)?;
     chown_recursive(&prefix, uid, gid)?;
+    configure_zsh_completion_access(&prefix, &source_user, uid)?;
     migration?;
     install_stub(&source, &stub, uid, gid)?;
     writeln!(
@@ -652,6 +667,89 @@ fn chown_recursive(prefix: &Path, uid: u32, gid: u32) -> Result<(), String> {
     chown_tree(prefix, &skipped, uid, gid)
 }
 
+fn configure_zsh_completion_access(
+    prefix: &Path,
+    source_user: &SourceUser,
+    automic_uid: u32,
+) -> Result<(), String> {
+    let acl = format!(
+        "user:{AUTOMIC_USER} allow read,write,execute,delete,append,readattr,writeattr,readextattr,writeextattr,readsecurity"
+    );
+    let inherited_acl = format!("{acl},file_inherit,directory_inherit");
+    for path in zsh_completion_paths(prefix)? {
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|err| format!("failed to inspect {}: {err}", path.display()))?;
+        if !metadata.file_type().is_symlink() {
+            let entry = if metadata.file_type().is_dir() {
+                &inherited_acl
+            } else {
+                &acl
+            };
+            let _ = Command::new("/bin/chmod")
+                .args(["-a", entry])
+                .arg(&path)
+                .stderr(Stdio::null())
+                .status();
+            let status = Command::new("/bin/chmod")
+                .args(["+a", entry])
+                .arg(&path)
+                .status()
+                .map_err(|err| format!("failed to grant Homebrew zsh completion access: {err}"))?;
+            if !status.success() {
+                return Err(format!(
+                    "failed to grant {AUTOMIC_USER} access to {}",
+                    path.display()
+                ));
+            }
+        }
+        if metadata.uid() == automic_uid || metadata.uid() == 0 {
+            lchown(&path, Some(source_user.uid), Some(source_user.gid))
+                .map_err(|err| format!("failed to chown {}: {err}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn zsh_completion_paths(prefix: &Path) -> Result<Vec<PathBuf>, String> {
+    let functions = prefix.join(ZSH_COMPLETIONS);
+    if !functions.is_dir() {
+        return Ok(Vec::new());
+    }
+    let canonical_prefix = fs::canonicalize(prefix)
+        .map_err(|err| format!("failed to resolve {}: {err}", prefix.display()))?;
+    let mut paths = std::collections::BTreeSet::from([prefix.join("share/zsh"), functions.clone()]);
+    for entry in fs::read_dir(&functions)
+        .map_err(|err| format!("failed to read {}: {err}", functions.display()))?
+    {
+        let entry =
+            entry.map_err(|err| format!("failed to read {}: {err}", functions.display()))?;
+        if !entry.file_name().as_encoded_bytes().starts_with(b"_") {
+            continue;
+        }
+        let path = entry.path();
+        paths.insert(path.clone());
+        let target = match fs::canonicalize(&path) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == io::ErrorKind::NotFound
+                    && entry.file_type().is_ok_and(|kind| kind.is_symlink()) =>
+            {
+                continue;
+            }
+            Err(err) => return Err(format!("failed to resolve {}: {err}", path.display())),
+        };
+        if !target.starts_with(&canonical_prefix) {
+            return Err(format!(
+                "zsh completion {} resolves outside {}",
+                path.display(),
+                prefix.display()
+            ));
+        }
+        paths.insert(target);
+    }
+    Ok(paths.into_iter().collect())
+}
+
 fn chown_tree(path: &Path, skipped: &Path, uid: u32, gid: u32) -> Result<(), String> {
     if path == skipped {
         return Ok(());
@@ -693,6 +791,15 @@ fn source_user() -> Result<SourceUser, String> {
                 .ok()
         })
         .ok_or_else(|| format!("cannot resolve UID for cask user `{user}`"))?;
+    let gid = test_u32("AUTOMIC_VAULT_TEST_BREW_USER_GID")
+        .or_else(|| {
+            dscl_read(&format!("/Users/{user}"), "PrimaryGroupID")
+                .ok()
+                .flatten()?
+                .parse()
+                .ok()
+        })
+        .ok_or_else(|| format!("cannot resolve primary GID for cask user `{user}`"))?;
     let home = crate::test_env_var("AUTOMIC_VAULT_TEST_BREW_USER_HOME")
         .map(PathBuf::from)
         .or_else(|| {
@@ -708,6 +815,7 @@ fn source_user() -> Result<SourceUser, String> {
     Ok(SourceUser {
         name: user,
         uid,
+        gid,
         home,
     })
 }
@@ -1109,7 +1217,7 @@ mod tests {
         assert!(is_managed_stub_file(&path));
         assert!(!stub_is_current(&path));
 
-        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V4 future").unwrap();
+        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V6 future").unwrap();
         assert!(stub_is_current(&path));
 
         for invalid in [
@@ -1265,6 +1373,7 @@ mod tests {
         unsafe {
             std::env::set_var("AUTOMIC_VAULT_TEST_BREW_USER", "alice");
             std::env::set_var("AUTOMIC_VAULT_TEST_BREW_USER_UID", "501");
+            std::env::set_var("AUTOMIC_VAULT_TEST_BREW_USER_GID", "20");
             std::env::set_var("AUTOMIC_VAULT_TEST_BREW_USER_HOME", "/Users/alice");
         }
 
@@ -1273,6 +1382,7 @@ mod tests {
             SourceUser {
                 name: "alice".into(),
                 uid: 501,
+                gid: 20,
                 home: "/Users/alice".into(),
             }
         );
@@ -1294,8 +1404,45 @@ mod tests {
         unsafe {
             std::env::remove_var("AUTOMIC_VAULT_TEST_BREW_USER");
             std::env::remove_var("AUTOMIC_VAULT_TEST_BREW_USER_UID");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_BREW_USER_GID");
             std::env::remove_var("AUTOMIC_VAULT_TEST_BREW_USER_HOME");
         }
+    }
+
+    #[test]
+    fn zsh_completion_paths_include_links_and_in_prefix_targets() {
+        let prefix = temp_path("brew-zsh-completions");
+        let functions = prefix.join(ZSH_COMPLETIONS);
+        let target = prefix.join("Cellar/tool/1/share/zsh/site-functions/_tool");
+        fs::create_dir_all(&functions).unwrap();
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::write(&target, "#compdef tool").unwrap();
+        std::os::unix::fs::symlink(&target, functions.join("_tool")).unwrap();
+        fs::write(functions.join("not-loaded"), "ignored").unwrap();
+
+        let paths = zsh_completion_paths(&prefix).unwrap();
+
+        assert!(paths.contains(&prefix.join("share/zsh")));
+        assert!(paths.contains(&functions));
+        assert!(paths.contains(&prefix.join(ZSH_COMPLETIONS).join("_tool")));
+        assert!(paths.contains(&fs::canonicalize(&target).unwrap()));
+        assert!(!paths.contains(&prefix.join(ZSH_COMPLETIONS).join("not-loaded")));
+        fs::remove_dir_all(prefix).unwrap();
+    }
+
+    #[test]
+    fn zsh_completion_paths_reject_targets_outside_homebrew() {
+        let prefix = temp_path("brew-zsh-completion-escape");
+        let outside = temp_path("brew-zsh-completion-outside");
+        let functions = prefix.join(ZSH_COMPLETIONS);
+        fs::create_dir_all(&functions).unwrap();
+        fs::write(&outside, "unsafe").unwrap();
+        std::os::unix::fs::symlink(&outside, functions.join("_escape")).unwrap();
+
+        assert!(zsh_completion_paths(&prefix).is_err());
+
+        fs::remove_dir_all(prefix).unwrap();
+        fs::remove_file(outside).unwrap();
     }
 
     #[test]

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -155,7 +155,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     write_cask_user_uid(&prefix.join(CASK_USER_UID_FILE), source_user.uid)?;
     remove_legacy_cask_access(&prefix, &source_user.name)?;
     chown_recursive(&prefix, uid, gid)?;
-    configure_zsh_completion_access(&prefix, &source_user, uid)?;
+    configure_zsh_completion_access(&prefix, &source_user)?;
     migration?;
     install_stub(&source, &stub, uid, gid)?;
     writeln!(
@@ -667,11 +667,7 @@ fn chown_recursive(prefix: &Path, uid: u32, gid: u32) -> Result<(), String> {
     chown_tree(prefix, &skipped, uid, gid)
 }
 
-fn configure_zsh_completion_access(
-    prefix: &Path,
-    source_user: &SourceUser,
-    automic_uid: u32,
-) -> Result<(), String> {
+fn configure_zsh_completion_access(prefix: &Path, source_user: &SourceUser) -> Result<(), String> {
     let acl = format!(
         "user:{AUTOMIC_USER} allow read,write,execute,delete,append,readattr,writeattr,readextattr,writeextattr,readsecurity"
     );
@@ -702,7 +698,7 @@ fn configure_zsh_completion_access(
                 ));
             }
         }
-        if metadata.uid() == automic_uid || metadata.uid() == 0 {
+        if metadata.uid() != source_user.uid || metadata.gid() != source_user.gid {
             lchown(&path, Some(source_user.uid), Some(source_user.gid))
                 .map_err(|err| format!("failed to chown {}: {err}", path.display()))?;
         }

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -686,15 +686,16 @@ fn configure_zsh_completion_access(prefix: &Path, source_user: &SourceUser) -> R
                 .arg(&path)
                 .stderr(Stdio::null())
                 .status();
-            let status = Command::new("/bin/chmod")
+            let output = Command::new("/bin/chmod")
                 .args(["+a", entry])
                 .arg(&path)
-                .status()
+                .output()
                 .map_err(|err| format!("failed to grant Homebrew zsh completion access: {err}"))?;
-            if !status.success() {
+            if !output.status.success() {
                 return Err(format!(
-                    "failed to grant {AUTOMIC_USER} access to {}",
-                    path.display()
+                    "failed to grant {AUTOMIC_USER} access to {}: {}",
+                    path.display(),
+                    String::from_utf8_lossy(&output.stderr).trim()
                 ));
             }
         }

--- a/tests/brew_stub_build.rs
+++ b/tests/brew_stub_build.rs
@@ -10,6 +10,6 @@ fn av_brew_stub_binary_is_built() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "AUTOMIC_VAULT_BREW_STUB_V4"
+        "AUTOMIC_VAULT_BREW_STUB_V5"
     );
 }


### PR DESCRIPTION
Fixes #95.

## What changed

- keep zsh completion directories, exposed links, and their in-prefix targets owned by the configured desktop account
- grant the `automic` account narrow inherited ACL access so Homebrew can continue updating completions
- repair newly created completion ownership after Brew exits using the existing explicit `sudo` transfer pattern
- reject completion links that resolve outside the Homebrew prefix
- warn during hardening and document that user-owned completion code is an intentional compatibility exception
- bump the Brew stub compatibility marker to V5 so existing installations receive the migration

## Why

The Homebrew hardener owns `/opt/homebrew` as `automic:vault`, but zsh `compaudit` trusts completion files only when root or the invoking desktop user owns them. That caused every shell startup to warn after hardening.

This keeps Homebrew running as the unprivileged `automic` service account rather than expanding the launcher to setuid-root. The security tradeoff is explicit: software running as the desktop account can modify zsh completion code, while the remainder of Homebrew remains protected.

## Validation

- `cargo test` (all tests pass)
- `cargo fmt --check`
- macOS ACL smoke test using the exact `automic` ACL
- zsh `compaudit` smoke test against a user-owned completion directory carrying that ACL
