### PR TITLE
Add approved secret name listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ secrets only when your gate policy allows it or you approve.
 $ av save TOKEN_NAME
 # Confirmation window appears
 
+$ av list
+# Approval window appears unless the calling app is allowed in Settings
+
 $ av inject +TOKEN_NAME -- /bin/bash
 # Approval window appears
 ```

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -7,7 +7,8 @@ pub(super) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn 
         return 2;
     }
     match crate::secrets::list_secret_names() {
-        Ok(names) => {
+        Ok(mut names) => {
+            names.sort();
             for name in names {
                 let _ = writeln!(stdout, "{name}");
             }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,0 +1,47 @@
+use std::ffi::OsString;
+use std::io::Write;
+
+pub(super) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    if !args.is_empty() {
+        let _ = writeln!(stderr, "usage: av list");
+        return 2;
+    }
+    match crate::secrets::list_secret_names() {
+        Ok(names) => {
+            for name in names {
+                let _ = writeln!(stdout, "{name}");
+            }
+            0
+        }
+        Err(err) => {
+            let _ = writeln!(stderr, "av list: {err}");
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lists_only_test_keychain_files_in_name_order() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("av-list-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("ignored-directory")).unwrap();
+        std::fs::write(dir.join("Z_SECRET"), "z").unwrap();
+        std::fs::write(dir.join("A_SECRET"), "a").unwrap();
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &dir) };
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let code = run(Vec::new(), &mut stdout, &mut stderr);
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR") };
+        assert_eq!(code, 0);
+        assert_eq!(String::from_utf8(stdout).unwrap(), "A_SECRET\nZ_SECRET\n");
+        assert!(stderr.is_empty());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ use std::io::{IsTerminal, Write};
 mod bless;
 mod doctor;
 mod inject;
+mod list;
 mod open;
 mod save;
 mod scan;
@@ -23,6 +24,7 @@ commands:
   $ av bless <path>                       # approve a script for secret access
   $ av inject +KEY... [--] <command>      # inject secrets into a command
   $ av inject -- <command>                # run an approved script
+  $ av list                               # list saved secret names
   $ av save <key>                         # store a secret
   $ av harden <tool> [-y|--yes]           # harden a tool; migrate credentials
   $ av open [--secret-gate <id>]          # open the Automic Vault app
@@ -228,6 +230,7 @@ where
             2
         }
         Some("inject") => inject::run(rest, stdout, stderr, shebang_script),
+        Some("list") => list::run(rest, stdout, stderr),
         Some("bless") => bless::run(rest, stderr),
         Some("open") => {
             let Some(secret_gate) = parse_open_args(&rest) else {
@@ -584,6 +587,7 @@ mod tests {
             assert_eq!(stderr, "");
             assert!(stdout.contains("\ncommands:\n"));
             assert!(stdout.contains("$ av harden <tool> [-y|--yes]"));
+            assert!(stdout.contains("$ av list"));
             assert!(stdout.contains("$ av open [--secret-gate <id>]"));
             assert!(stdout.contains("\nmodes:\n"));
             assert!(stdout.contains("$ av help"));

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -187,6 +187,13 @@ final class DashboardModel: ObservableObject {
                     date: $0.date
                 )
             }
+        case .settings:
+            [DashboardItem(
+                id: "secret-name-access",
+                title: "Secret Name Access",
+                subtitle: "Apps allowed to run av list",
+                detail: "Manage verified apps that may list saved secret names without prompting."
+            )]
         }
         let query = searchQuery
         guard !query.isEmpty else { return base }
@@ -255,6 +262,7 @@ final class DashboardModel: ObservableObject {
                 } ?? 0)
         case .allSecrets: snapshot.secrets.count
         case .secretUsage: snapshot.accessRequests.count
+        case .settings: 0
         }
     }
 
@@ -353,6 +361,23 @@ final class DashboardModel: ObservableObject {
             )
             self.finishPolicyUpdate(saveBlessedScript(updated), error: "Could not add calling app")
         }
+    }
+
+    func addSecretNameAccessApp() {
+        chooseLauncherApp { [weak self] launcher in
+            guard let self, let launcher else { return }
+            self.finishPolicyUpdate(
+                allowSecretNameAccess(launcher),
+                error: "Could not allow \(launcher.bundleIdentifier)"
+            )
+        }
+    }
+
+    func removeSecretNameAccessApp(_ app: BlessedScriptLauncher) {
+        finishPolicyUpdate(
+            removeSecretNameAccess(app),
+            error: "Could not remove \(app.bundleIdentifier)"
+        )
     }
 
     func removeLauncher(_ launcher: BlessedScriptLauncher, from script: BlessedScript) {
@@ -968,6 +993,7 @@ enum DashboardSection: String, CaseIterable, Identifiable {
     case allSecrets
     case secretUsage
     case doctor
+    case settings
 
     var id: String { rawValue }
 
@@ -980,6 +1006,7 @@ enum DashboardSection: String, CaseIterable, Identifiable {
         case .blessedScripts: "Blessed Scripts"
         case .allSecrets: "Secrets"
         case .secretUsage: "Secret Usage"
+        case .settings: "Settings"
         }
     }
 
@@ -992,6 +1019,7 @@ enum DashboardSection: String, CaseIterable, Identifiable {
         case .blessedScripts: "checkmark.seal"
         case .allSecrets: "key"
         case .secretUsage: "clock.arrow.circlepath"
+        case .settings: "gearshape"
         }
     }
 }
@@ -1079,6 +1107,14 @@ struct DashboardRootView: View {
                             Image(systemName: "plus")
                         }
                         .help("Add Calling App")
+                    }
+                    if model.selectedSection == .settings {
+                        Button {
+                            model.addSecretNameAccessApp()
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                        .help("Allow App to List Secret Names")
                     }
                     Button {
                         model.reload()
@@ -1230,6 +1266,12 @@ private struct DashboardDetailView: View {
                     .padding(.top, 32)
                     .padding(.bottom, 28)
                     .frame(maxWidth: .infinity, alignment: .leading)
+            } else if model.selectedSection == .settings {
+                SecretNameAccessSettingsView(model: model)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 32)
+                    .padding(.bottom, 28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             } else if model.selectedSection == .detectors, let item = model.selectedItem {
                 ReferenceDetailView(
                     item: item,
@@ -1370,6 +1412,7 @@ private struct EmptyListView: View {
         case .blessedScripts: "No blessed scripts"
         case .allSecrets: "No stored secrets"
         case .secretUsage: "No secret usage logged"
+        case .settings: "No settings"
         }
     }
 }
@@ -2074,13 +2117,15 @@ private struct BlessedScriptFields: View {
 @MainActor
 private func launcherList(
     _ launchers: [BlessedScriptLauncher],
+    title: String = "Calling Apps",
+    empty: String = "No calling apps endorsed.",
     remove: @escaping (BlessedScriptLauncher) -> Void
 ) -> some View {
     VStack(alignment: .leading, spacing: 10) {
-        Text("Calling Apps")
+        Text(title)
             .font(.system(size: 13, weight: .semibold))
         if launchers.isEmpty {
-            Text("No calling apps endorsed.")
+            Text(empty)
                 .foregroundStyle(.secondary)
         }
         ForEach(launchers, id: \.requirement) { launcher in
@@ -2098,6 +2143,32 @@ private func launcherList(
             }
             .padding(10)
             .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}
+
+private struct SecretNameAccessSettingsView: View {
+    @ObservedObject var model: DashboardModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Secret Name Access")
+                    .font(.system(size: 24, weight: .semibold))
+                Text("These verified apps may run av list without an approval window.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            launcherList(
+                model.snapshot.secretNameAccessApps,
+                title: "Always Allowed Apps",
+                empty: "No apps are always allowed. Other apps must request approval."
+            ) {
+                model.removeSecretNameAccessApp($0)
+            }
+            if let error = model.errorMessage {
+                InfoBlock(title: "Error", text: error)
+            }
         }
     }
 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3624,7 +3624,7 @@ private struct ApprovalPromptView: View {
 
             Text(allowsPersistentApproval
                 ? "Always Allow trusts this verified app until removed in Settings"
-                : "“Always Approve” for apps available in the Automic Vault app")
+                : "Always Allow is available for verified apps in the Automic Vault app.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -965,6 +965,7 @@ private struct TransientApprovalKey: Hashable {
 private enum ApprovalDecision: Equatable {
     case denied
     case approved
+    case alwaysApproved
 }
 
 @MainActor
@@ -1071,7 +1072,7 @@ private struct TransientApprovalCache {
         prune(now: now)
         let key = switch decision {
         case .denied: Key.denial(pid: key.pid, startUsec: key.startUsec)
-        case .approved: Key.approval(key)
+        case .approved, .alwaysApproved: Key.approval(key)
         }
         expirations[key] = now.addingTimeInterval(transientApprovalTTL)
     }
@@ -1248,6 +1249,8 @@ private final class ApprovalServer: @unchecked Sendable {
         switch op {
         case "inject", "keys", "authorize":
             handleInject(message, on: peer, pid: pid, identity: identity, callerPath: callerPath, signing: signing)
+        case "list" where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleList(message, on: peer, pid: pid, identity: identity, callerPath: callerPath, signing: signing)
         case "save" where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(message, on: peer, caller: mutationCaller)
         case "load" where isTrustedAvCaller(path: callerPath, signing: signing):
@@ -1271,6 +1274,131 @@ private final class ApprovalServer: @unchecked Sendable {
         default:
             reply(peer, to: message, ok: false, error: "invalid XPC operation")
         }
+    }
+
+    private func handleList(
+        _ message: xpc_object_t,
+        on peer: xpc_connection_t,
+        pid: pid_t,
+        identity: AVProcessIdentity,
+        callerPath: String,
+        signing: SigningInfo
+    ) {
+        guard let cwdPointer = xpc_dictionary_get_string(message, "cwd") else {
+            reply(peer, to: message, ok: false, error: "invalid list request")
+            return
+        }
+        let launcher = launcherIdentities(for: identity).first
+            ?? launcherIdentity(pid: pid, identity: identity)
+        let request = ApprovalRequest(
+            op: "list",
+            keys: [],
+            target: callerPath,
+            args: ["list"],
+            cwd: String(cString: cwdPointer),
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "av",
+            title: "List saved secret names?",
+            detail: "Secret values will remain hidden. The requesting app will receive every saved secret name."
+        )
+        if let launcher,
+           loadSecretNameAccessApps().contains(where: { $0.requirement == launcher.designatedRequirement })
+        {
+            discloseSecretNames(
+                request: request,
+                callerPath: callerPath,
+                launcher: launcher,
+                approvalSource: "Auto",
+                reason: "Always allowed in Settings",
+                peer: peer,
+                message: message
+            )
+            return
+        }
+        DispatchQueue.main.async {
+            guard self.canRequestHumanApproval() else {
+                _ = self.onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Denied",
+                    approvalSource: "Auto",
+                    reason: "User session is inactive",
+                    launcher: launcher
+                ))
+                self.reply(peer, to: message, ok: false, error: "list denied while user session is inactive")
+                return
+            }
+            let decision = showApprovalAlert(
+                request: request,
+                callerPath: callerPath,
+                pid: pid,
+                signing: signing,
+                scriptApproval: nil,
+                launcher: launcher,
+                launcherFallbackPath: launcherFallbackPath(for: identity) ?? callerPath,
+                automaticApprovalExplanation: nil,
+                allowsPersistentApproval: launcher != nil
+            )
+            guard decision != .denied else {
+                _ = self.onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Denied",
+                    approvalSource: "Manual",
+                    reason: "Denied in prompt",
+                    launcher: launcher
+                ))
+                self.reply(peer, to: message, ok: false, error: "list denied")
+                return
+            }
+            if decision == .alwaysApproved, let launcher {
+                let status = allowSecretNameAccess(BlessedScriptLauncher(
+                    bundleIdentifier: launcher.identifier,
+                    requirement: launcher.designatedRequirement
+                ))
+                guard status == errSecSuccess else {
+                    self.reply(peer, to: message, ok: false, error: "failed to save list access: \(status)")
+                    return
+                }
+            }
+            self.discloseSecretNames(
+                request: request,
+                callerPath: callerPath,
+                launcher: launcher,
+                approvalSource: "Manual",
+                reason: decision == .alwaysApproved ? "Always allowed in prompt" : "Allowed once in prompt",
+                peer: peer,
+                message: message
+            )
+        }
+    }
+
+    private func discloseSecretNames(
+        request: ApprovalRequest,
+        callerPath: String,
+        launcher: LauncherIdentity?,
+        approvalSource: String,
+        reason: String,
+        peer: xpc_connection_t,
+        message: xpc_object_t
+    ) {
+        let names = loadStoredSecrets().map(\.account)
+        guard onAccessRequest(accessRequestRecord(
+            request: request,
+            callerPath: callerPath,
+            decision: "Approved",
+            approvalSource: approvalSource,
+            reason: reason,
+            launcher: launcher
+        )) else {
+            reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+            return
+        }
+        reply(peer, to: message, ok: true, error: nil, names: names)
     }
 
     private func handleInject(
@@ -2035,6 +2163,7 @@ private final class ApprovalServer: @unchecked Sendable {
         error: String?,
         secrets: [String: String]? = nil,
         value: String? = nil,
+        names: [String]? = nil,
         humanApprovalDecision: String? = nil
     ) {
         let response = xpc_dictionary_create_reply(message) ?? xpc_dictionary_create_empty()
@@ -2057,6 +2186,13 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         if let value {
             value.withCString { xpc_dictionary_set_string(response, "value", $0) }
+        }
+        if let names {
+            let array = xpc_array_create_empty()
+            for name in names {
+                name.withCString { xpc_array_set_string(array, XPC_ARRAY_APPEND, $0) }
+            }
+            xpc_dictionary_set_value(response, "names", array)
         }
         if let humanApprovalDecision {
             humanApprovalDecision.withCString {
@@ -3177,7 +3313,8 @@ private func showApprovalAlert(
     scriptApproval: ScriptApproval?,
     launcher: LauncherIdentity?,
     launcherFallbackPath: String,
-    automaticApprovalExplanation: String?
+    automaticApprovalExplanation: String?,
+    allowsPersistentApproval: Bool = false
 ) -> ApprovalDecision {
     let receivedAt = Date()
     let requester = approvalPromptRequester(launcher: launcher, fallback: launcherFallbackPath)
@@ -3221,6 +3358,7 @@ private func showApprovalAlert(
         rootView: ApprovalPromptView(
             content: content,
             maximumHeight: maximumHeight,
+            allowsPersistentApproval: allowsPersistentApproval,
             decide: {
                 decision = $0
                 NSApp.stopModal()
@@ -3377,6 +3515,7 @@ private struct ApprovalPromptContent {
 private struct ApprovalPromptView: View {
     let content: ApprovalPromptContent
     var maximumHeight: CGFloat? = nil
+    var allowsPersistentApproval = false
     let decide: (ApprovalDecision) -> Void
     let contentSizeDidChange: () -> Void
     @State private var showsDetails = false
@@ -3466,9 +3605,18 @@ private struct ApprovalPromptView: View {
                     .tint(.blue)
                     .frame(maxWidth: .infinity)
                     .keyboardShortcut(.defaultAction)
+                if allowsPersistentApproval {
+                    Button("Always Allow") { decide(.alwaysApproved) }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                        .tint(.blue)
+                        .frame(maxWidth: .infinity)
+                }
             }
 
-            Text("“Always Approve” for apps available in the Automic Vault app")
+            Text(allowsPersistentApproval
+                ? "Always Allow trusts this verified app until removed in Settings"
+                : "“Always Approve” for apps available in the Automic Vault app")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2201,6 +2201,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 name.withCString { xpc_array_set_string(array, XPC_ARRAY_APPEND, $0) }
             }
             xpc_dictionary_set_value(response, "names", array)
+            xpc_release(array)
         }
         if let humanApprovalDecision {
             humanApprovalDecision.withCString {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1361,6 +1361,14 @@ private final class ApprovalServer: @unchecked Sendable {
                     requirement: launcher.designatedRequirement
                 ))
                 guard status == errSecSuccess else {
+                    _ = self.onAccessRequest(accessRequestRecord(
+                        request: request,
+                        callerPath: callerPath,
+                        decision: "Failed",
+                        approvalSource: "Manual",
+                        reason: "Could not save persistent access: \(status)",
+                        launcher: launcher
+                    ))
                     self.reply(peer, to: message, ok: false, error: "failed to save list access: \(status)")
                     return
                 }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -6,6 +6,8 @@ import Security
 public let automicVaultKeychainService = "com.automicvault.isotope"
 public let secretGatePoliciesKeychainService = "com.automicvault.gate-policies"
 public let secretGatePoliciesKeychainAccount = "SecretGatePoliciesV2"
+public let secretNameAccessKeychainService = "com.automicvault.secret-name-access"
+public let secretNameAccessKeychainAccount = "SecretNameAccessV1"
 public let accessRequestLogDefaultsKey = "AccessRequestLog"
 public let accessRequestLogKeychainService = "com.automicvault.access-log"
 private let accessRequestLogLock = NSLock()
@@ -18,6 +20,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
     public var hardeners: [HardenerMetadata]
     public var secretGates: [SecretGate]
     public var blessedScripts: [BlessedScript]
+    public var secretNameAccessApps: [BlessedScriptLauncher]
     public var secrets: [StoredSecret]
     public var accessRequests: [AccessRequestRecord]
     public var doctorIssues: [DoctorIssue]
@@ -29,6 +32,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         hardeners: [HardenerMetadata] = [],
         secretGates: [SecretGate],
         blessedScripts: [BlessedScript] = [],
+        secretNameAccessApps: [BlessedScriptLauncher] = [],
         secrets: [StoredSecret],
         accessRequests: [AccessRequestRecord] = [],
         doctorIssues: [DoctorIssue] = []
@@ -39,6 +43,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         self.hardeners = hardeners
         self.secretGates = secretGates
         self.blessedScripts = blessedScripts
+        self.secretNameAccessApps = secretNameAccessApps
         self.secrets = secrets
         self.accessRequests = accessRequests
         self.doctorIssues = doctorIssues
@@ -51,6 +56,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         hardeners: [],
         secretGates: [],
         blessedScripts: [],
+        secretNameAccessApps: [],
         secrets: [],
         accessRequests: [],
         doctorIssues: []
@@ -85,6 +91,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             hardeners: hardenerMetadata,
             secretGates: loadSecretGates(hardeners: hardenerMetadata, service: policyService),
             blessedScripts: loadBlessedScripts(),
+            secretNameAccessApps: loadSecretNameAccessApps(),
             secrets: secrets,
             accessRequests: loadAccessRequestRecords(),
             doctorIssues: loadDoctorIssues(avExecutableURL: avExecutableURL)
@@ -906,6 +913,88 @@ private func setSecretGatePolicyRecord(
     return saveSecretGatePolicyRecords(records, service: service, account: account)
 }
 
+public func loadSecretNameAccessApps(
+    service: String = secretNameAccessKeychainService,
+    account: String = secretNameAccessKeychainAccount
+) -> [BlessedScriptLauncher] {
+    guard case .success(let apps) = loadSecretNameAccessAppsResult(service: service, account: account)
+    else { return [] }
+    return apps.sorted { $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending }
+}
+
+public func allowSecretNameAccess(
+    _ app: BlessedScriptLauncher,
+    service: String = secretNameAccessKeychainService,
+    account: String = secretNameAccessKeychainAccount
+) -> OSStatus {
+    var apps: [BlessedScriptLauncher]
+    switch loadSecretNameAccessAppsResult(service: service, account: account) {
+    case .success(let loaded): apps = loaded
+    case .failure(let status): return status
+    }
+    apps.removeAll { $0.requirement == app.requirement }
+    apps.append(app)
+    return saveSecretNameAccessApps(apps, service: service, account: account)
+}
+
+public func removeSecretNameAccess(
+    _ app: BlessedScriptLauncher,
+    service: String = secretNameAccessKeychainService,
+    account: String = secretNameAccessKeychainAccount
+) -> OSStatus {
+    let apps: [BlessedScriptLauncher]
+    switch loadSecretNameAccessAppsResult(service: service, account: account) {
+    case .success(let loaded): apps = loaded
+    case .failure(let status): return status
+    }
+    return saveSecretNameAccessApps(
+        apps.filter { $0.requirement != app.requirement },
+        service: service,
+        account: account
+    )
+}
+
+private enum SecretNameAccessAppsLoad {
+    case success([BlessedScriptLauncher])
+    case failure(OSStatus)
+}
+
+private func loadSecretNameAccessAppsResult(
+    service: String,
+    account: String
+) -> SecretNameAccessAppsLoad {
+    switch loadKeychainDataResult(service: service, account: account) {
+    case .notFound:
+        return .success([])
+    case .failure(let status):
+        return .failure(status)
+    case .success(let data):
+        guard let apps = try? JSONDecoder().decode([BlessedScriptLauncher].self, from: data)
+        else { return .failure(errSecDecode) }
+        return .success(apps)
+    }
+}
+
+private func saveSecretNameAccessApps(
+    _ apps: [BlessedScriptLauncher],
+    service: String,
+    account: String
+) -> OSStatus {
+    if apps.isEmpty {
+        let status = deleteStoredSecret(account: account, service: service)
+        return status == errSecItemNotFound ? errSecSuccess : status
+    }
+    guard let data = try? JSONEncoder().encode(apps.sorted {
+        $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending
+    }) else { return errSecParam }
+    return saveKeychainData(
+        data,
+        service: service,
+        account: account,
+        accessibility: .afterFirstUnlock
+    )
+}
+
 public func loadAccessRequestRecords(
     defaults: UserDefaults? = nil,
     key: String = accessRequestLogDefaultsKey,
@@ -1138,11 +1227,14 @@ public func migrateBackgroundKeychainItems(
     policyService: String = secretGatePoliciesKeychainService,
     policyAccount: String = secretGatePoliciesKeychainAccount,
     accessLogService: String = accessRequestLogKeychainService,
-    accessLogAccount: String = accessRequestLogDefaultsKey
+    accessLogAccount: String = accessRequestLogDefaultsKey,
+    secretNameAccessService: String = secretNameAccessKeychainService,
+    secretNameAccessAccount: String = secretNameAccessKeychainAccount
 ) -> OSStatus {
     for (service, account) in [
         (policyService, policyAccount),
         (accessLogService, accessLogAccount),
+        (secretNameAccessService, secretNameAccessAccount),
     ] {
         let status = setKeychainAccessibility(.afterFirstUnlock, service: service, account: account)
         if status != errSecSuccess && status != errSecItemNotFound {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -334,6 +334,35 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(loadStoredSecret(account: account, service: service) == "not json")
 }
 
+@Test func secretNameAccessAppsArePersistedSortedAndRevocable() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.\(UUID().uuidString)"
+    let account = "name-access.\(UUID().uuidString)"
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+    let zeta = BlessedScriptLauncher(bundleIdentifier: "com.example.zeta", requirement: "zeta")
+    let alpha = BlessedScriptLauncher(bundleIdentifier: "com.example.alpha", requirement: "alpha")
+
+    #expect(allowSecretNameAccess(zeta, service: service, account: account) == errSecSuccess)
+    #expect(allowSecretNameAccess(alpha, service: service, account: account) == errSecSuccess)
+    #expect(loadSecretNameAccessApps(service: service, account: account) == [alpha, zeta])
+    #expect(keychainAccessibility(account: account, service: service) == kSecAttrAccessibleAfterFirstUnlock as String)
+    #expect(removeSecretNameAccess(alpha, service: service, account: account) == errSecSuccess)
+    #expect(loadSecretNameAccessApps(service: service, account: account) == [zeta])
+}
+
+@Test func malformedSecretNameAccessPolicyFailsClosedAndIsNotReplaced() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.\(UUID().uuidString)"
+    let account = "name-access.\(UUID().uuidString)"
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+    #expect(saveStoredSecret(account: account, value: "not json", service: service) == errSecSuccess)
+
+    let app = BlessedScriptLauncher(bundleIdentifier: "com.example.app", requirement: "requirement")
+    #expect(loadSecretNameAccessApps(service: service, account: account).isEmpty)
+    #expect(allowSecretNameAccess(app, service: service, account: account) == errSecDecode)
+    #expect(loadStoredSecret(account: account, service: service) == "not json")
+}
+
 @Test func secretlessGateNormalizesLegacyFullPolicy() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.\(UUID().uuidString)"

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -2,6 +2,11 @@ use std::path::PathBuf;
 
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 
+struct XpcReply {
+    value: Option<String>,
+    names: Vec<String>,
+}
+
 pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
     if let Some(dir) = crate::test_keychain_dir() {
         std::fs::create_dir_all(&dir)
@@ -10,7 +15,7 @@ pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
         return std::fs::write(&path, value)
             .map_err(|err| format!("failed to write {}: {err}", path.display()));
     }
-    xpc_request("save", b"key\0", account, Some((b"value\0", value))).map(|_| ())
+    xpc_request("save", Some((b"key\0", account)), Some((b"value\0", value))).map(|_| ())
 }
 
 pub(crate) fn load_secret(account: &str) -> Result<String, String> {
@@ -19,21 +24,39 @@ pub(crate) fn load_secret(account: &str) -> Result<String, String> {
         return std::fs::read_to_string(&path)
             .map_err(|err| format!("failed to read {}: {err}", path.display()));
     }
-    xpc_request("load", b"key\0", account, None)?
+    xpc_request("load", Some((b"key\0", account)), None)?
+        .value
         .ok_or_else(|| format!("failed to load isotope key {account}"))
 }
 
 pub(crate) fn bless_script(path: &str) -> Result<(), String> {
-    xpc_request("bless", b"path\0", path, None).map(|_| ())
+    xpc_request("bless", Some((b"path\0", path)), None).map(|_| ())
+}
+
+pub(crate) fn list_secret_names() -> Result<Vec<String>, String> {
+    if let Some(dir) = crate::test_keychain_dir() {
+        let mut names = std::fs::read_dir(dir)
+            .map_err(|err| format!("failed to list test keychain: {err}"))?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_type().ok()?.is_file().then(|| entry.file_name()))
+            .filter_map(|name| name.into_string().ok())
+            .collect::<Vec<_>>();
+        names.sort();
+        return Ok(names);
+    }
+    let cwd = std::env::current_dir()
+        .map_err(|err| format!("failed to read current directory: {err}"))?
+        .to_string_lossy()
+        .into_owned();
+    Ok(xpc_request("list", Some((b"cwd\0", &cwd)), None)?.names)
 }
 
 #[cfg(target_os = "macos")]
 fn xpc_request(
     operation: &str,
-    field: &'static [u8],
-    field_value: &str,
+    field: Option<(&'static [u8], &str)>,
     extra: Option<(&'static [u8], &str)>,
-) -> Result<Option<String>, String> {
+) -> Result<XpcReply, String> {
     use std::ffi::CString;
     use std::os::raw::{c_char, c_int, c_void};
 
@@ -41,6 +64,7 @@ fn xpc_request(
 
     unsafe extern "C" {
         static _xpc_type_error: u8;
+        static _xpc_type_array: u8;
         static _xpc_error_key_description: *const c_char;
 
         fn xpc_connection_create_mach_service(
@@ -59,6 +83,9 @@ fn xpc_request(
         fn xpc_dictionary_get_bool(xdict: XpcObject, key: *const c_char) -> bool;
         fn xpc_dictionary_set_string(xdict: XpcObject, key: *const c_char, value: *const c_char);
         fn xpc_dictionary_get_string(xdict: XpcObject, key: *const c_char) -> *const c_char;
+        fn xpc_dictionary_get_value(xdict: XpcObject, key: *const c_char) -> XpcObject;
+        fn xpc_array_get_count(array: XpcObject) -> usize;
+        fn xpc_array_get_string(array: XpcObject, index: usize) -> *const c_char;
         fn xpc_get_type(object: XpcObject) -> *const c_void;
         fn xpc_release(object: XpcObject);
         fn xpc_connection_set_peer_code_signing_requirement(
@@ -105,7 +132,9 @@ fn xpc_request(
 
     unsafe {
         set_string(message, b"op\0", operation)?;
-        set_string(message, field, field_value)?;
+        if let Some((field, value)) = field {
+            set_string(message, field, value)?;
+        }
         if let Some((extra_field, value)) = extra {
             set_string(message, extra_field, value)?;
         }
@@ -139,11 +168,29 @@ fn xpc_request(
             }
         } else if xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {
             let value = xpc_dictionary_get_string(reply, b"value\0".as_ptr().cast());
-            Ok((!value.is_null()).then(|| {
+            let value = (!value.is_null()).then(|| {
                 std::ffi::CStr::from_ptr(value)
                     .to_string_lossy()
                     .into_owned()
-            }))
+            });
+            let names = xpc_dictionary_get_value(reply, b"names\0".as_ptr().cast());
+            let names = if names.is_null()
+                || xpc_get_type(names) != std::ptr::addr_of!(_xpc_type_array).cast()
+            {
+                Vec::new()
+            } else {
+                (0..xpc_array_get_count(names))
+                    .filter_map(|index| {
+                        let name = xpc_array_get_string(names, index);
+                        (!name.is_null()).then(|| {
+                            std::ffi::CStr::from_ptr(name)
+                                .to_string_lossy()
+                                .into_owned()
+                        })
+                    })
+                    .collect()
+            };
+            Ok(XpcReply { value, names })
         } else {
             let error = xpc_dictionary_get_string(reply, b"error\0".as_ptr().cast());
             Err(if error.is_null() {
@@ -162,9 +209,8 @@ fn xpc_request(
 #[cfg(not(target_os = "macos"))]
 fn xpc_request(
     _operation: &str,
-    _field: &'static [u8],
-    _field_value: &str,
+    _field: Option<(&'static [u8], &str)>,
     _extra: Option<(&'static [u8], &str)>,
-) -> Result<Option<String>, String> {
+) -> Result<XpcReply, String> {
     Err("the Automic Vault menu bar approval service is only available on macOS".to_string())
 }

--- a/tests/list_cli.rs
+++ b/tests/list_cli.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn av_list_prints_names_without_values() {
+    let keychain = std::env::temp_dir().join(format!("av-list-cli-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&keychain);
+    fs::create_dir_all(&keychain).unwrap();
+    fs::write(keychain.join("Z_SECRET"), "must-not-leak").unwrap();
+    fs::write(keychain.join("A_SECRET"), "also-secret").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_av"))
+        .arg("list")
+        .env("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "A_SECRET\nZ_SECRET\n"
+    );
+    assert!(output.stderr.is_empty());
+    let _ = fs::remove_dir_all(keychain);
+}


### PR DESCRIPTION
Closes #99

## Summary
- add `av list`, returning sorted secret names one per line and never values
- require a verified launcher allowlist grant or an interactive approval before disclosing the inventory
- add Settings management for always-allowed apps and audit requests in Secret Usage without recording names

## Security
- only the signed `av` client may invoke the list operation
- secret names are loaded only after authorization
- persistent grants bind to the launcher designated requirement; unverified launchers can only receive one-time approval
- malformed policy data fails closed, and audit records never contain the returned names

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `./scripts/build.sh`
- all bundled executable self-checks