### PR TITLE
Support standalone Developer ID launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ Execution of blessed scripts *can* be configured to be automatically approved
 for specific launchers.
 
 > [!TIP]
-> Allowing specific launchers (ie. `.app`s) is powerful but requires careful
+> Allowing specific signed launchers is powerful but requires careful
 > consideration. Potential uses:
 >
 > - Keeping all hardened tools at read-only or lower and only defining use of
 >   those tools via immutable blessing is truly a level of safety developers
 >   have only ever dreamed of.
-> - Having a single terminal app that is the only used for deployments and the
->   the only `.app` that is endorsed to run them.
+> - Having a single terminal app that is the only one used for deployments and
+>   the only launcher that is endorsed to run them.
 > - Or conversely, trusting your agents more than your terminal where supply
 >   chain attacks are more likely to occur.
 
@@ -281,14 +281,21 @@ But we aren’t going to lie: it’s more friction than now. We minimize:
 
 ## Important Notes When Using Automic Vault With Agents
 
-If you use agents via their `.app` then you’re good to go: Automic Vault ties
-approval gates to codesigned bundles.
+Automic Vault ties approval gates to signed launcher identities. This includes
+both app bundles and Developer ID-signed standalone executables.
 
-If you use agents via their CLI, then the simplest solution is to install the
-`.app` version and symlink the CLI that they all bundle to `/usr/local/bin`.
-This way Automic Vault can verify the caller via its bundled, notarized code
-signature. Automic Vault *will* then trace the executor chain back to the `.app`
-and apply the approval gates you set for that precise `.app`.
+The current official macOS installers we checked for
+[Claude Code](https://github.com/anthropics/claude-code) and
+[Codex](https://developers.openai.com/codex/cli/) ship Developer ID-signed
+native executables. This is true of their recommended standalone installers
+and Homebrew casks. Their current npm packages also contain the signed native
+payload: Claude installs it as the command while Codex starts it through a Node
+wrapper. For the clearest process identity and `av doctor` result, prefer the
+standalone installer or Homebrew cask.
+
+Run `av doctor claude` or `av doctor codex` to check the command selected by
+your current `PATH`. Distribution details can change; the doctor verifies the
+live executable rather than trusting how it was installed.
 
 It is then vital to ensure the harness for the agents has minimal TCC
 permissions. If you are using them via CLI that will often be your Terminal
@@ -311,10 +318,31 @@ they are quite granular nowadays. And coupled with Automic Vault, they are a
 powerful tool to protect your secrets, prevent malware having attack
 opportunities and prevent agents from being too dangerous.
 
-> [!NOTE]
-> We believe a route to allowing non-codesigned cli tools to have gates is
-> doable. We will experiment with that in the near future. However, even if
-> possible the code-signed route is more secure and recommended.
+> [!IMPORTANT]
+> Unsigned and ad-hoc signed executables cannot be launcher identities. Ad-hoc
+> signing proves integrity only for that exact build; it provides no vendor or
+> Team identity for Automic Vault to trust.
+
+### Pi
+
+Pi’s official macOS v0.83.0 standalone binary is linker/ad-hoc signed, has no
+Team ID, and fails strict signature verification. Automic Vault rejects it as
+a launcher. Re-signing it ad-hoc or merely placing it in an unsigned `.app`
+does not change that.
+
+The easiest current workaround is the independent, unofficial
+[Pi Launcher](https://github.com/kunchenguid/pi-launcher). Its published app is
+Developer ID-signed and notarized, bundles a checksum-pinned official Pi
+binary, and remains Pi’s parent process. Review that project as an additional
+supply-chain dependency before trusting its identity.
+
+To build your own equivalent, use Pi Launcher’s small launcher and bundle
+recipe (`make app`), then sign the nested Pi executable and app from the inside
+out with your own **Developer ID Application** identity. Enroll the resulting
+app in Automic Vault Settings and invoke its launcher executable rather than
+the original `pi` command. Developer ID certificates require a paid Apple
+Developer Program membership, which is why this is not an ideal general
+solution. Ad-hoc signing is deliberately insufficient.
 
 ### Computer Use & Automic Vault
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -33,7 +33,8 @@ struct AgentCliDoctor {
     command: &'static str,
     vendor: &'static str,
     team_identifier: &'static str,
-    app_name: &'static str,
+    signing_identifier: &'static str,
+    install_hint: &'static str,
 }
 
 const AGENT_CLIS: [AgentCliDoctor; 2] = [
@@ -41,13 +42,15 @@ const AGENT_CLIS: [AgentCliDoctor; 2] = [
         command: "claude",
         vendor: "Anthropic",
         team_identifier: "Q6L2SF6YDW",
-        app_name: "Claude.app",
+        signing_identifier: "com.anthropic.claude-code",
+        install_hint: "Anthropic's native installer or the Homebrew cask",
     },
     AgentCliDoctor {
         command: "codex",
         vendor: "OpenAI",
         team_identifier: "2DC432GLL2",
-        app_name: "Codex.app",
+        signing_identifier: "codex",
+        install_hint: "OpenAI's standalone installer or the Homebrew cask",
     },
 ];
 
@@ -91,11 +94,15 @@ fn select_agent_cli(selector: Option<&str>) -> Option<&'static AgentCliDoctor> {
 fn diagnose_agent_cli(
     agent: &AgentCliDoctor,
     path: &OsStr,
-    signature_valid: impl Fn(&Path, &str) -> bool,
+    signature_valid: impl Fn(&Path, &str, &str) -> bool,
 ) -> DoctorResult {
     let resolved = resolve(agent.command, path);
     let issues = match resolved.as_deref() {
-        Some(executable) if signature_valid(executable, agent.team_identifier) => Vec::new(),
+        Some(executable)
+            if signature_valid(executable, agent.team_identifier, agent.signing_identifier) =>
+        {
+            Vec::new()
+        }
         Some(executable) => vec![agent_cli_signature_issue(agent, executable)],
         None => vec![agent_cli_missing_issue(agent)],
     };
@@ -137,15 +144,16 @@ fn agent_cli_missing_issue(agent: &AgentCliDoctor) -> DoctorIssue {
 
 fn agent_cli_remediation(agent: &AgentCliDoctor) -> String {
     format!(
-        "Install the full {}, then make /usr/local/bin/{} a root-owned symbolic link to the {} CLI bundled inside the app. Review any existing path before replacing it, ensure /usr/local/bin precedes other CLI locations in PATH, then rerun `av doctor {}`.",
-        agent.app_name, agent.command, agent.command, agent.command
+        "Reinstall {} using {}, ensure that installation precedes other copies in PATH, then rerun `av doctor {}`.",
+        agent.command, agent.install_hint, agent.command
     )
 }
 
 #[cfg(target_os = "macos")]
-fn vendor_signature_valid(path: &Path, team_identifier: &str) -> bool {
-    let requirement =
-        format!("=anchor apple generic and certificate leaf[subject.OU] = \"{team_identifier}\"");
+fn vendor_signature_valid(path: &Path, team_identifier: &str, signing_identifier: &str) -> bool {
+    let requirement = format!(
+        "=identifier \"{signing_identifier}\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{team_identifier}\""
+    );
     Command::new("/usr/bin/codesign")
         .args(["--verify", "--strict", "-R", &requirement])
         .arg(path)
@@ -157,7 +165,7 @@ fn vendor_signature_valid(path: &Path, team_identifier: &str) -> bool {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn vendor_signature_valid(_path: &Path, _team_identifier: &str) -> bool {
+fn vendor_signature_valid(_path: &Path, _team_identifier: &str, _signing_identifier: &str) -> bool {
     false
 }
 
@@ -788,12 +796,12 @@ mod tests {
         let codex = executable_file(&dir.join("codex"));
         let agent = select_agent_cli(Some("codex")).unwrap();
 
-        let healthy = diagnose_agent_cli(agent, dir.as_os_str(), |path, team| {
-            path == codex && team == "2DC432GLL2"
+        let healthy = diagnose_agent_cli(agent, dir.as_os_str(), |path, team, identifier| {
+            path == codex && team == "2DC432GLL2" && identifier == "codex"
         });
         assert!(healthy.issues.is_empty());
 
-        let unsigned = diagnose_agent_cli(agent, dir.as_os_str(), |_, _| false);
+        let unsigned = diagnose_agent_cli(agent, dir.as_os_str(), |_, _, _| false);
         assert_eq!(unsigned.issues[0].kind, "agent_cli_signature_invalid");
         assert_eq!(unsigned.issues[0].resolved_path.as_deref(), codex.to_str());
         assert!(unsigned.issues[0].message.contains("OpenAI code signature"));
@@ -805,12 +813,12 @@ mod tests {
         assert!(
             unsigned.issues[0]
                 .remediation
-                .contains("Install the full Codex.app")
+                .contains("OpenAI's standalone installer or the Homebrew cask")
         );
         assert!(
             unsigned.issues[0]
                 .remediation
-                .contains("/usr/local/bin/codex")
+                .contains("precedes other copies in PATH")
         );
         let _ = fs::remove_dir_all(dir);
     }
@@ -818,14 +826,14 @@ mod tests {
     #[test]
     fn explicit_agent_cli_doctor_reports_a_missing_command() {
         let agent = select_agent_cli(Some("claude")).unwrap();
-        let result = diagnose_agent_cli(agent, OsStr::new(""), |_, _| true);
+        let result = diagnose_agent_cli(agent, OsStr::new(""), |_, _, _| true);
 
         assert_eq!(result.name, "claude");
         assert_eq!(result.issues[0].kind, "agent_cli_unavailable");
         assert!(
             result.issues[0]
                 .remediation
-                .contains("Install the full Claude.app")
+                .contains("Anthropic's native installer or the Homebrew cask")
         );
     }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -415,13 +415,13 @@ final class DashboardModel: ObservableObject {
     }
 
     private func chooseLauncherApp(_ completion: @escaping (BlessedScriptLauncher?) -> Void) {
-        chooseAppBundle { url in
-            guard let url, url.pathExtension == "app", let signing = appBundleSigning(url) else {
+        chooseLauncher { signing in
+            guard let signing else {
                 completion(nil)
                 return
             }
             completion(BlessedScriptLauncher(
-                bundleIdentifier: Bundle(url: url)?.bundleIdentifier ?? url.lastPathComponent,
+                bundleIdentifier: signing.identifier,
                 requirement: signing.requirement
             ))
         }
@@ -548,19 +548,11 @@ final class DashboardModel: ObservableObject {
     }
 
     func addApp(to gate: SecretGate) {
-        chooseAppBundle { [weak self] url in
-            guard let self, let url else { return }
-            guard url.pathExtension == "app" else {
-                self.errorMessage = "Choose a .app bundle."
-                return
-            }
-            guard let signing = appBundleSigning(url) else {
-                self.errorMessage = "Could not securely verify the code signature for \(url.lastPathComponent)."
-                return
-            }
+        chooseLauncher { [weak self] signing in
+            guard let self, let signing else { return }
             guard signing.runtimeProtection.allowsSecretGateAccess else {
                 self.errorMessage = secretGateAdmissionError(
-                    appName: url.lastPathComponent,
+                    appName: signing.identifier,
                     protection: signing.runtimeProtection
                 )
                 return
@@ -575,7 +567,7 @@ final class DashboardModel: ObservableObject {
                 self.errorMessage = nil
                 self.reload()
             } else {
-                self.errorMessage = "Could not allow \(url.lastPathComponent): \(status)"
+                self.errorMessage = "Could not allow \(signing.identifier): \(status)"
             }
         }
     }
@@ -2431,7 +2423,7 @@ private struct ApprovedAppDisplay {
             ?? app.bundleIdentifier
         bundleIdentifier = app.bundleIdentifier
         icon = url.map { NSWorkspace.shared.icon(forFile: $0.path) } ?? NSImage(systemSymbolName: "app", accessibilityDescription: nil) ?? NSImage()
-        if let signing = url.flatMap(appBundleSigning) {
+        if let signing = url.flatMap(launcherSigning) {
             signingSummary = "Team \(signing.teamIdentifier)"
         } else {
             signingSummary = "Signing identity unavailable"
@@ -2439,8 +2431,10 @@ private struct ApprovedAppDisplay {
     }
 }
 
-private struct AppBundleSigning {
+private struct LauncherSigning {
+    let identifier: String
     let teamIdentifier: String
+    let path: String
     let requirement: String
     let runtimeProtection: LauncherRuntimeProtection
 }
@@ -2460,21 +2454,48 @@ private func secretGateAdmissionError(
 }
 
 @MainActor
-private func chooseAppBundle(_ completion: @escaping (URL?) -> Void) {
+private func chooseLauncher(_ completion: @escaping (LauncherSigning?) -> Void) {
     let panel = NSOpenPanel()
-    panel.title = "Allow Calling App"
-    panel.prompt = "Allow"
+    panel.title = "Allow Launcher"
+    panel.prompt = "Choose"
     panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
-    panel.allowedContentTypes = [.applicationBundle]
+    panel.allowedContentTypes = [.applicationBundle, .unixExecutable]
     panel.canChooseFiles = true
     panel.canChooseDirectories = false
     panel.allowsMultipleSelection = false
     panel.begin { response in
-        completion(response == .OK ? panel.url : nil)
+        defer { panel.url?.stopAccessingSecurityScopedResource() }
+        guard response == .OK, let selected = panel.url else {
+            completion(nil)
+            return
+        }
+        guard let signing = launcherSigning(selected.resolvingSymlinksInPath().standardizedFileURL) else {
+            let alert = NSAlert()
+            alert.messageText = "Launcher cannot be allowed"
+            alert.informativeText = "Choose a valid Developer ID-signed executable or signed app."
+            alert.runModal()
+            completion(nil)
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = "Allow \(signing.identifier)?"
+        alert.informativeText = """
+        Identifier: \(signing.identifier)
+        Team ID: \(signing.teamIdentifier)
+        Path: \(signing.path)
+
+        Designated requirement:
+        \(signing.requirement)
+        """
+        alert.addButton(withTitle: "Allow")
+        alert.addButton(withTitle: "Cancel")
+        completion(alert.runModal() == .alertFirstButtonReturn ? signing : nil)
     }
 }
 
-private func appBundleSigning(_ url: URL) -> AppBundleSigning? {
+private func launcherSigning(_ url: URL) -> LauncherSigning? {
+    let isApp = url.pathExtension.caseInsensitiveCompare("app") == .orderedSame
+    guard isApp || FileManager.default.isExecutableFile(atPath: url.path) else { return nil }
     var staticCode: SecStaticCode?
     guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
           let staticCode,
@@ -2491,16 +2512,24 @@ private func appBundleSigning(_ url: URL) -> AppBundleSigning? {
     let flags = SecCSFlags(rawValue: kSecCSSigningInformation | kSecCSRequirementInformation)
     guard SecCodeCopySigningInformation(staticCode, flags, &info) == errSecSuccess,
           let dictionary = info as? [CFString: Any],
-          let requirementValue = dictionary[kSecCodeInfoDesignatedRequirement]
+          let requirementValue = dictionary[kSecCodeInfoDesignatedRequirement],
+          ((dictionary[kSecCodeInfoFlags] as? NSNumber)?.uint32Value ?? 0) & secCodeSignatureAdHoc == 0,
+          let identifier = dictionary[kSecCodeInfoIdentifier] as? String
     else {
         return nil
     }
+    let teamIdentifier = dictionary[kSecCodeInfoTeamIdentifier] as? String ?? "unknown"
+    guard isApp || (teamIdentifier != "unknown" && satisfiesDeveloperIDRequirement {
+        SecStaticCodeCheckValidity(staticCode, [], $0)
+    }) else { return nil }
     let requirement = requirementValue as! SecRequirement
     guard let requirementText = requirementText(requirement) else {
         return nil
     }
-    return AppBundleSigning(
-        teamIdentifier: dictionary[kSecCodeInfoTeamIdentifier] as? String ?? "unknown",
+    return LauncherSigning(
+        identifier: identifier,
+        teamIdentifier: teamIdentifier,
+        path: url.path,
         requirement: requirementText,
         runtimeProtection: launcherRuntimeProtection(signingInformation: dictionary)
     )

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2425,6 +2425,8 @@ private struct ApprovedAppDisplay {
         icon = url.map { NSWorkspace.shared.icon(forFile: $0.path) } ?? NSImage(systemSymbolName: "app", accessibilityDescription: nil) ?? NSImage()
         if let signing = url.flatMap(launcherSigning) {
             signingSummary = "Team \(signing.teamIdentifier)"
+        } else if let teamIdentifier = codeSigningTeamIdentifier(from: app.requirement) {
+            signingSummary = "Team \(teamIdentifier)"
         } else {
             signingSummary = "Signing identity unavailable"
         }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2464,12 +2464,16 @@ private func chooseLauncher(_ completion: @escaping (LauncherSigning?) -> Void) 
     panel.canChooseDirectories = false
     panel.allowsMultipleSelection = false
     panel.begin { response in
-        defer { panel.url?.stopAccessingSecurityScopedResource() }
         guard response == .OK, let selected = panel.url else {
             completion(nil)
             return
         }
-        guard let signing = launcherSigning(selected.resolvingSymlinksInPath().standardizedFileURL) else {
+        let isAccessing = selected.startAccessingSecurityScopedResource()
+        defer {
+            if isAccessing { selected.stopAccessingSecurityScopedResource() }
+        }
+        let resolved = selected.resolvingSymlinksInPath().standardizedFileURL
+        guard let signing = launcherSigning(resolved) else {
             let alert = NSAlert()
             alert.messageText = "Launcher cannot be allowed"
             alert.informativeText = "Choose a valid Developer ID-signed executable or signed app."

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -15,7 +15,7 @@ private let approvalLaunchAgentName = "com.automicvault.menubar-helper"
 private let openMainWindowArgument = "--open-main-window"
 private let pendingMainWindowKey = "pendingMainWindow"
 private let pendingSecretGateKey = "pendingSecretGate"
-private let secCodeSignatureAdHoc: UInt32 = 0x2
+let secCodeSignatureAdHoc: UInt32 = 0x2
 private let transientApprovalTTL: TimeInterval = 5 * 60
 private let scanMaximumDelay: TimeInterval = 5
 private let scanQueue = DispatchQueue(label: "com.automicvault.av2.scan")
@@ -1143,6 +1143,25 @@ private struct LauncherIdentity {
     let teamIdentifier: String
     let designatedRequirement: String
     let runtimeProtection: LauncherRuntimeProtection
+    let isStandalone: Bool
+
+    init(
+        pid: pid_t,
+        path: String,
+        identifier: String,
+        teamIdentifier: String,
+        designatedRequirement: String,
+        runtimeProtection: LauncherRuntimeProtection,
+        isStandalone: Bool = false
+    ) {
+        self.pid = pid
+        self.path = path
+        self.identifier = identifier
+        self.teamIdentifier = teamIdentifier
+        self.designatedRequirement = designatedRequirement
+        self.runtimeProtection = runtimeProtection
+        self.isStandalone = isStandalone
+    }
 }
 
 private struct ScriptApproval {
@@ -1331,7 +1350,11 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid list request")
             return
         }
-        let launcher = launcherIdentities(for: identity).first
+        let launchers = launcherIdentities(for: identity)
+        let allowedApps = loadSecretNameAccessApps()
+        let launcher = launchers.first {
+            candidate in allowedApps.contains { $0.requirement == candidate.designatedRequirement }
+        } ?? launchers.first
             ?? launcherIdentity(pid: pid, identity: identity)
         let request = ApprovalRequest(
             op: "list",
@@ -1349,7 +1372,7 @@ private final class ApprovalServer: @unchecked Sendable {
             detail: "Secret values will remain hidden. The requesting app will receive every saved secret name."
         )
         if let launcher,
-           loadSecretNameAccessApps().contains(where: { $0.requirement == launcher.designatedRequirement })
+           allowedApps.contains(where: { $0.requirement == launcher.designatedRequirement })
         {
             discloseSecretNames(
                 request: request,
@@ -1384,7 +1407,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 launcher: launcher,
                 launcherFallbackPath: launcherFallbackPath(for: identity) ?? callerPath,
                 automaticApprovalExplanation: nil,
-                allowsPersistentApproval: launcher != nil
+                allowsPersistentApproval: launcher.map { !$0.isStandalone } ?? false
             )
             guard decision != .denied else {
                 _ = self.onAccessRequest(accessRequestRecord(
@@ -1486,13 +1509,13 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         if let scriptApproval,
-           let launcher = launchers.first,
-           let script = matchingBlessedScript(
+           let match = matchingBlessedScript(
                request: request,
                approval: scriptApproval,
-               launcher: launcher
+               launchers: launchers
            )
         {
+            let (script, launcher) = match
             do {
                 let secrets = try approvedSecrets(for: request)
                 let accessRequestID = UUID()
@@ -1793,6 +1816,22 @@ private final class ApprovalServer: @unchecked Sendable {
     private func matchingBlessedScript(
         request: ApprovalRequest,
         approval: ScriptApproval,
+        launchers: [LauncherIdentity]
+    ) -> (BlessedScript, LauncherIdentity)? {
+        let scripts = loadBlessedScripts()
+        for launcher in launchers {
+            if let script = scripts.first(where: {
+                blessedScriptMatches($0, request: request, approval: approval, launcher: launcher)
+            }) {
+                return (script, launcher)
+            }
+        }
+        return nil
+    }
+
+    private func matchingBlessedScript(
+        request: ApprovalRequest,
+        approval: ScriptApproval,
         launcher: LauncherIdentity?
     ) -> BlessedScript? {
         loadBlessedScripts().first {
@@ -1993,7 +2032,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
         }
-        let launcher = launcherIdentities(for: identity).first
+        let launcher = launcherIdentities(for: identity).first { !$0.isStandalone }
         let request = BlessedScriptReviewRequest(
             path: path,
             declaration: declaration,
@@ -2382,7 +2421,6 @@ private func resolveSecretGatePolicy(
     gate: SecretGate,
     launchers: [LauncherIdentity]
 ) -> ResolvedSecretGatePolicy? {
-    guard let firstLauncher = launchers.first else { return nil }
     for launcher in launchers {
         if let policy = gate.appPolicies.first(where: { $0.requirement == launcher.designatedRequirement }) {
             return ResolvedSecretGatePolicy(
@@ -2395,6 +2433,7 @@ private func resolveSecretGatePolicy(
             )
         }
     }
+    guard let firstLauncher = launchers.first(where: { !$0.isStandalone }) else { return nil }
     return ResolvedSecretGatePolicy(
         protection: gate.defaultProtection,
         source: gate.defaultPolicyLabel,
@@ -3131,6 +3170,21 @@ private func launcherIdentities(
         + appBundleURLs(containing: signing.mainExecutable)
         + [associatedAppBundleURL(path: path, signing: signing)].compactMap { $0 }
     ).filter { seen.insert($0.path).inserted }
+    if appURLs.isEmpty {
+        guard signing.isDeveloperID,
+              signing.identifier != "unknown",
+              signing.teamIdentifier != "unknown"
+        else { return [] }
+        return [LauncherIdentity(
+            pid: pid,
+            path: path,
+            identifier: signing.identifier,
+            teamIdentifier: signing.teamIdentifier,
+            designatedRequirement: signing.designatedRequirement,
+            runtimeProtection: signing.runtimeProtection,
+            isStandalone: true
+        )]
+    }
     return appURLs.compactMap { appURL in
         guard let app = appSigning(appURL) else { return nil }
         return LauncherIdentity(
@@ -3151,6 +3205,7 @@ private struct LiveSigningInfo {
     let mainExecutable: String
     let isAdHoc: Bool
     let runtimeProtection: LauncherRuntimeProtection
+    let isDeveloperID: Bool
 }
 
 private struct StaticSigningInfo {
@@ -3211,7 +3266,10 @@ private func liveSigningInfo(pid: pid_t) -> LiveSigningInfo? {
         designatedRequirement: requirementText,
         mainExecutable: executable,
         isAdHoc: signatureFlags & secCodeSignatureAdHoc != 0,
-        runtimeProtection: runtimeProtection(dictionary)
+        runtimeProtection: runtimeProtection(dictionary),
+        isDeveloperID: satisfiesDeveloperIDRequirement {
+            SecCodeCheckValidity(code, [], $0)
+        }
     )
 }
 
@@ -3243,7 +3301,10 @@ private func executableSigningInfo(path: String) -> LiveSigningInfo? {
         designatedRequirement: requirementText,
         mainExecutable: executable,
         isAdHoc: signatureFlags & secCodeSignatureAdHoc != 0,
-        runtimeProtection: runtimeProtection(dictionary)
+        runtimeProtection: runtimeProtection(dictionary),
+        isDeveloperID: satisfiesDeveloperIDRequirement {
+            SecStaticCodeCheckValidity(staticCode, [], $0)
+        }
     )
 }
 
@@ -3320,6 +3381,21 @@ private func appBundleVerificationFailure(_ url: URL) -> LauncherAppVerification
         appName: name,
         resourcesUnreadable: resourcesUnreadable
     )
+}
+
+func satisfiesDeveloperIDRequirement(
+    _ validate: (SecRequirement) -> OSStatus
+) -> Bool {
+    var requirement: SecRequirement?
+    let source = """
+    anchor apple generic and \
+    certificate 1[field.1.2.840.113635.100.6.2.6] exists and \
+    certificate leaf[field.1.2.840.113635.100.6.1.13] exists
+    """
+    guard SecRequirementCreateWithString(source as CFString, [], &requirement) == errSecSuccess,
+          let requirement
+    else { return false }
+    return validate(requirement) == errSecSuccess
 }
 
 private func requirementString(_ requirement: SecRequirement) -> String? {
@@ -4113,7 +4189,8 @@ private func runApprovalSelfCheck() -> Int32 {
         designatedRequirement: #"identifier "app.vaultty.Vaultty" and anchor apple generic"#,
         mainExecutable: "/Applications/Vaultty.app/Contents/Helpers/vaultty-sessiond",
         isAdHoc: false,
-        runtimeProtection: .hardened
+        runtimeProtection: .hardened,
+        isDeveloperID: true
     )
     let vaulttyBridgeSigning = LiveSigningInfo(
         identifier: "com.automicvault.vaultty.session-bridge",
@@ -4121,7 +4198,8 @@ private func runApprovalSelfCheck() -> Int32 {
         designatedRequirement: #"identifier "com.automicvault.vaultty.session-bridge" and anchor apple generic"#,
         mainExecutable: "/Users/mxcl/Library/Application Support/Vaultty/vaultty-session-bridge",
         isAdHoc: false,
-        runtimeProtection: .hardened
+        runtimeProtection: .hardened,
+        isDeveloperID: true
     )
     let vaulttyAppSigning = StaticSigningInfo(
         identifier: "com.automicvault.vaultty",
@@ -4134,7 +4212,8 @@ private func runApprovalSelfCheck() -> Int32 {
         designatedRequirement: #"identifier "dev.mxcl.pmm.menu" and anchor apple generic"#,
         mainExecutable: "/Applications/Package Manager Manager.app/Contents/Library/LoginItems/Package Manager Manager Menu.app/Contents/MacOS/PMMMenuBar",
         isAdHoc: false,
-        runtimeProtection: .hardened
+        runtimeProtection: .hardened,
+        isDeveloperID: true
     )
     var detachedCaller = AVProcessIdentity()
     detachedCaller.ppid = 1
@@ -4145,7 +4224,8 @@ private func runApprovalSelfCheck() -> Int32 {
         designatedRequirement: #"identifier "org.python.python" and anchor apple generic"#,
         mainExecutable: "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python",
         isAdHoc: true,
-        runtimeProtection: .hardenedRuntimeMissing
+        runtimeProtection: .hardenedRuntimeMissing,
+        isDeveloperID: false
     )
     let unbundledSigning = LiveSigningInfo(
         identifier: "com.automicvault.av",
@@ -4153,7 +4233,8 @@ private func runApprovalSelfCheck() -> Int32 {
         designatedRequirement: #"identifier "com.automicvault.av" and anchor apple generic"#,
         mainExecutable: "/usr/local/bin/av",
         isAdHoc: false,
-        runtimeProtection: .hardened
+        runtimeProtection: .hardened,
+        isDeveloperID: true
     )
     let parentlessVaulttyLauncher = launcherIdentity(
         pid: 43,
@@ -4187,7 +4268,7 @@ private func runApprovalSelfCheck() -> Int32 {
           nestedLaunchers.map(\.identifier) == ["dev.mxcl.pmm.menu", "dev.mxcl.pmm"],
           launcherAncestorStartPIDs(detachedCaller) == [43],
           launcherIdentity(pid: 46, path: pythonSigning.mainExecutable, signing: pythonSigning) == nil,
-          launcherIdentity(pid: 47, path: "/usr/local/bin/av", signing: unbundledSigning) == nil
+          launcherIdentity(pid: 47, path: "/usr/local/bin/av", signing: unbundledSigning)?.isStandalone == true
     else {
         return 1
     }
@@ -4571,6 +4652,59 @@ private func runApprovalSelfCheck() -> Int32 {
           !isTrustedBrewStubCaller(path: "/opt/homebrew/bin/brew", signing: avSigning)
     else { return 1 }
 
+    return 0
+}
+
+private func runStandaloneLauncherSelfCheck() -> Int32 {
+    let requirement = #"identifier "com.example.cli" and anchor apple generic"#
+    let developerID = LiveSigningInfo(
+        identifier: "com.example.cli",
+        teamIdentifier: "TEAM",
+        designatedRequirement: requirement,
+        mainExecutable: "/usr/local/bin/example",
+        isAdHoc: false,
+        isDeveloperID: true
+    )
+    let rejected = LiveSigningInfo(
+        identifier: "com.apple.zsh",
+        teamIdentifier: "unknown",
+        designatedRequirement: #"identifier "com.apple.zsh" and anchor apple"#,
+        mainExecutable: "/bin/zsh",
+        isAdHoc: false,
+        isDeveloperID: false
+    )
+    guard satisfiesDeveloperIDRequirement({ _ in errSecSuccess }),
+          let launcher = launcherIdentity(
+              pid: 42,
+              path: developerID.mainExecutable,
+              signing: developerID
+          ),
+          launcher.isStandalone,
+          launcher.designatedRequirement == requirement,
+          launcherIdentity(pid: 43, path: rejected.mainExecutable, signing: rejected) == nil
+    else { return 1 }
+
+    let unconfiguredGate = SecretGate(
+        id: "test",
+        keyPatterns: [],
+        routes: [],
+        defaultProtection: .fullIncludingSecretDumps,
+        appPolicies: []
+    )
+    let configuredGate = SecretGate(
+        id: "test",
+        keyPatterns: [],
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: [SecretGatePolicy(
+            bundleIdentifier: developerID.identifier,
+            requirement: requirement,
+            protection: .readOnly
+        )]
+    )
+    guard resolveSecretGatePolicy(gate: unconfiguredGate, launchers: [launcher]) == nil,
+          resolveSecretGatePolicy(gate: configuredGate, launchers: [launcher])?.protection == .readOnly
+    else { return 1 }
     return 0
 }
 
@@ -5101,6 +5235,10 @@ private func runScanSchedulingSelfCheck() -> Int32 {
 
 if CommandLine.arguments.contains("--self-check-approvals") {
     exit(MainActor.assumeIsolated { runApprovalSelfCheck() })
+}
+
+if CommandLine.arguments.contains("--self-check-standalone-launchers") {
+    exit(runStandaloneLauncherSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-secret-mutations") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3383,9 +3383,8 @@ private func appBundleVerificationFailure(_ url: URL) -> LauncherAppVerification
     )
 }
 
-func satisfiesDeveloperIDRequirement(
-    _ validate: (SecRequirement) -> OSStatus
-) -> Bool {
+// SecRequirement is immutable but is not annotated Sendable by Security.framework.
+nonisolated(unsafe) private let developerIDRequirement: SecRequirement? = {
     var requirement: SecRequirement?
     let source = """
     anchor apple generic and \
@@ -3394,8 +3393,15 @@ func satisfiesDeveloperIDRequirement(
     """
     guard SecRequirementCreateWithString(source as CFString, [], &requirement) == errSecSuccess,
           let requirement
-    else { return false }
-    return validate(requirement) == errSecSuccess
+    else { return nil }
+    return requirement
+}()
+
+func satisfiesDeveloperIDRequirement(
+    _ validate: (SecRequirement) -> OSStatus
+) -> Bool {
+    guard let developerIDRequirement else { return false }
+    return validate(developerIDRequirement) == errSecSuccess
 }
 
 private func requirementString(_ requirement: SecRequirement) -> String? {
@@ -4663,6 +4669,7 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         designatedRequirement: requirement,
         mainExecutable: "/usr/local/bin/example",
         isAdHoc: false,
+        runtimeProtection: .hardened,
         isDeveloperID: true
     )
     let rejected = LiveSigningInfo(
@@ -4671,6 +4678,7 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         designatedRequirement: #"identifier "com.apple.zsh" and anchor apple"#,
         mainExecutable: "/bin/zsh",
         isAdHoc: false,
+        runtimeProtection: .hardened,
         isDeveloperID: false
     )
     let adHoc = LiveSigningInfo(
@@ -4679,6 +4687,7 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         designatedRequirement: developerID.designatedRequirement,
         mainExecutable: "/usr/local/bin/ad-hoc-example",
         isAdHoc: true,
+        runtimeProtection: .hardened,
         isDeveloperID: true
     )
     guard satisfiesDeveloperIDRequirement({ _ in errSecSuccess }),
@@ -4692,6 +4701,15 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
           launcherIdentity(pid: 43, path: adHoc.mainExecutable, signing: adHoc) == nil,
           launcherIdentity(pid: 43, path: rejected.mainExecutable, signing: rejected) == nil
     else { return 1 }
+    let unhardenedLauncher = LauncherIdentity(
+        pid: launcher.pid,
+        path: launcher.path,
+        identifier: launcher.identifier,
+        teamIdentifier: launcher.teamIdentifier,
+        designatedRequirement: launcher.designatedRequirement,
+        runtimeProtection: .hardenedRuntimeMissing,
+        isStandalone: true
+    )
 
     let unconfiguredGate = SecretGate(
         id: "test",
@@ -4708,11 +4726,13 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         appPolicies: [SecretGatePolicy(
             bundleIdentifier: developerID.identifier,
             requirement: requirement,
-            protection: .readOnly
+            protection: .readOnly,
+            requiresHardenedRuntime: true
         )]
     )
     guard resolveSecretGatePolicy(gate: unconfiguredGate, launchers: [launcher]) == nil,
-          resolveSecretGatePolicy(gate: configuredGate, launchers: [launcher])?.protection == .readOnly
+          resolveSecretGatePolicy(gate: configuredGate, launchers: [launcher])?.protection == .readOnly,
+          resolveSecretGatePolicy(gate: configuredGate, launchers: [unhardenedLauncher])?.protection == .noAccess
     else { return 1 }
     return 0
 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -4673,6 +4673,14 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         isAdHoc: false,
         isDeveloperID: false
     )
+    let adHoc = LiveSigningInfo(
+        identifier: developerID.identifier,
+        teamIdentifier: developerID.teamIdentifier,
+        designatedRequirement: developerID.designatedRequirement,
+        mainExecutable: "/usr/local/bin/ad-hoc-example",
+        isAdHoc: true,
+        isDeveloperID: true
+    )
     guard satisfiesDeveloperIDRequirement({ _ in errSecSuccess }),
           let launcher = launcherIdentity(
               pid: 42,
@@ -4681,6 +4689,7 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
           ),
           launcher.isStandalone,
           launcher.designatedRequirement == requirement,
+          launcherIdentity(pid: 43, path: adHoc.mainExecutable, signing: adHoc) == nil,
           launcherIdentity(pid: 43, path: rejected.mainExecutable, signing: rejected) == nil
     else { return 1 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1363,10 +1363,15 @@ private func addCanonicalAccessGroup(to query: inout [String: Any]) {
 }
 
 func appIdentifier(from requirement: String) -> String? {
-    guard let range = requirement.range(of: #"identifier ""#) else { return nil }
+    guard let range = requirement.range(of: "identifier ") else { return nil }
     let rest = requirement[range.upperBound...]
-    guard let end = rest.firstIndex(of: "\"") else { return nil }
-    return String(rest[..<end])
+    if rest.first == "\"" {
+        let quoted = rest.dropFirst()
+        guard let end = quoted.firstIndex(of: "\"") else { return nil }
+        return String(quoted[..<end])
+    }
+    let identifier = rest.prefix { !$0.isWhitespace }
+    return identifier.isEmpty ? nil : String(identifier)
 }
 
 private extension Array where Element == HardenedTool {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1374,6 +1374,13 @@ func appIdentifier(from requirement: String) -> String? {
     return identifier.isEmpty ? nil : String(identifier)
 }
 
+public func codeSigningTeamIdentifier(from requirement: String) -> String? {
+    guard let range = requirement.range(of: #"certificate leaf[subject.OU] = ""#) else { return nil }
+    let rest = requirement[range.upperBound...]
+    guard let end = rest.firstIndex(of: "\"") else { return nil }
+    return String(rest[..<end])
+}
+
 private extension Array where Element == HardenedTool {
     func uniquedByName() -> [HardenedTool] {
         var seen = Set<String>()

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -489,6 +489,11 @@ func protectionPolicyMatrix(
     #expect(secretGateProtection(for: requirement, in: gate).protection == .fullExceptSecretDumps)
 }
 
+@Test func appIdentifierAcceptsCodesignBareIdentifiers() {
+    #expect(appIdentifier(from: #"identifier "com.example.app" and anchor apple generic"#) == "com.example.app")
+    #expect(appIdentifier(from: "identifier codex and anchor apple generic") == "codex")
+}
+
 @Test func noAccessDefaultIsPersisted() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.\(UUID().uuidString)"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -491,7 +491,9 @@ func protectionPolicyMatrix(
 
 @Test func appIdentifierAcceptsCodesignBareIdentifiers() {
     #expect(appIdentifier(from: #"identifier "com.example.app" and anchor apple generic"#) == "com.example.app")
-    #expect(appIdentifier(from: "identifier codex and anchor apple generic") == "codex")
+    let codex = #"identifier codex and anchor apple generic and certificate leaf[subject.OU] = "2DC432GLL2""#
+    #expect(appIdentifier(from: codex) == "codex")
+    #expect(codeSigningTeamIdentifier(from: codex) == "2DC432GLL2")
 }
 
 @Test func noAccessDefaultIsPersisted() throws {

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -101,7 +101,7 @@ fn av_doctor_reports_unsigned_agent_clis() {
         report["results"][0]["issues"][0]["remediation"]
             .as_str()
             .unwrap()
-            .contains("/usr/local/bin/codex")
+            .contains("OpenAI's standalone installer or the Homebrew cask")
     );
 
     let aggregate = av(&root)


### PR DESCRIPTION
## Summary

- recognize standalone Developer ID Application-signed executables in launcher ancestry
- require an exact enrolled designated requirement before standalone launchers receive an automatic policy
- allow signed executables in the launcher picker and show their identifier, Team ID, resolved path, and full requirement before enrollment
- apply standalone identities to secret gates, blessed scripts, and secret-name access without changing bundle default-policy behavior
- update the Claude and Codex doctors to verify their exact Developer ID identities and recommend their signed standalone/Homebrew installs
- document the verified Claude, Codex, and Pi distribution state, including Pi Launcher and self-signing options

## Security

Ad-hoc, unsigned, non-Developer-ID, and Apple platform executables remain ineligible. Every request still validates the live process signature, and persistence continues to match the exact designated requirement rather than Team ID or path.

The CLI doctors now require the expected signing identifier, Team ID, and Apple's Developer ID intermediate and leaf certificate markers. The current Claude and Codex release binaries were downloaded from their official distribution channels and passed those exact requirements. Pi v0.83.0 was checksum-verified from its official release and confirmed to be linker/ad-hoc signed with no Team ID; it remains rejected.

## Validation

- `cargo test --all-targets --all-features --locked` (771 unit tests plus integration targets)
- `swift test --package-path src/menu-helper` (50 tests)
- `AutomicVaultMenubar --self-check-standalone-launchers`
- direct `av doctor` checks against current official Claude and Codex macOS arm64 binaries
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #96
