### PR TITLE
Require hardened launchers for new secret gate access

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -555,7 +555,7 @@ final class DashboardModel: ObservableObject {
                 return
             }
             guard let signing = appBundleSigning(url) else {
-                self.errorMessage = "Could not read code signing identity for \(url.lastPathComponent)."
+                self.errorMessage = "Could not securely verify the code signature for \(url.lastPathComponent)."
                 return
             }
             guard signing.runtimeProtection.allowsSecretGateAccess else {
@@ -2492,18 +2492,10 @@ private func appBundleSigning(_ url: URL) -> AppBundleSigning? {
     guard let requirementText = requirementText(requirement) else {
         return nil
     }
-    let signatureFlags = (dictionary[kSecCodeInfoFlags] as? NSNumber)?.uint32Value ?? 0
-    let entitlements = dictionary[kSecCodeInfoEntitlementsDict] as? [String: Any] ?? [:]
-    let enabledEntitlements = Set(entitlements.compactMap { key, value in
-        (value as? NSNumber)?.boolValue == true ? key : nil
-    })
     return AppBundleSigning(
         teamIdentifier: dictionary[kSecCodeInfoTeamIdentifier] as? String ?? "unknown",
         requirement: requirementText,
-        runtimeProtection: launcherRuntimeProtection(
-            signatureFlags: signatureFlags,
-            enabledEntitlements: enabledEntitlements
-        )
+        runtimeProtection: launcherRuntimeProtection(signingInformation: dictionary)
     )
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -554,11 +554,23 @@ final class DashboardModel: ObservableObject {
                 self.errorMessage = "Choose a .app bundle."
                 return
             }
-            guard let requirement = appBundleSigning(url)?.requirement else {
+            guard let signing = appBundleSigning(url) else {
                 self.errorMessage = "Could not read code signing identity for \(url.lastPathComponent)."
                 return
             }
-            let status = setSecretGateAppProtection(requirement: requirement, protection: .readOnly, for: gate)
+            guard signing.runtimeProtection.allowsSecretGateAccess else {
+                self.errorMessage = secretGateAdmissionError(
+                    appName: url.lastPathComponent,
+                    protection: signing.runtimeProtection
+                )
+                return
+            }
+            let status = setSecretGateAppProtection(
+                requirement: signing.requirement,
+                protection: .readOnly,
+                for: gate,
+                requiresHardenedRuntime: true
+            )
             if status == errSecSuccess {
                 self.errorMessage = nil
                 self.reload()
@@ -577,7 +589,12 @@ final class DashboardModel: ObservableObject {
 
     func setProtection(_ protection: SecretGateProtection, for app: SecretGatePolicy, in gate: SecretGate) {
         finishPolicyUpdate(
-            setSecretGateAppProtection(requirement: app.requirement, protection: protection, for: gate),
+            setSecretGateAppProtection(
+                requirement: app.requirement,
+                protection: protection,
+                for: gate,
+                requiresHardenedRuntime: app.requiresHardenedRuntime
+            ),
             error: "Could not update \(app.bundleIdentifier)"
         )
     }
@@ -2418,6 +2435,21 @@ private struct ApprovedAppDisplay {
 private struct AppBundleSigning {
     let teamIdentifier: String
     let requirement: String
+    let runtimeProtection: LauncherRuntimeProtection
+}
+
+private func secretGateAdmissionError(
+    appName: String,
+    protection: LauncherRuntimeProtection
+) -> String {
+    switch protection {
+    case .hardened:
+        return ""
+    case .hardenedRuntimeMissing:
+        return "\(appName) does not enable Hardened Runtime and cannot receive secret-gate access."
+    case .unsafeEntitlements(let entitlements):
+        return "\(appName) weakens Hardened Runtime with \(entitlements.joined(separator: ", ")) and cannot receive secret-gate access."
+    }
 }
 
 @MainActor
@@ -2438,7 +2470,12 @@ private func chooseAppBundle(_ completion: @escaping (URL?) -> Void) {
 private func appBundleSigning(_ url: URL) -> AppBundleSigning? {
     var staticCode: SecStaticCode?
     guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
-          let staticCode
+          let staticCode,
+          SecStaticCodeCheckValidity(
+              staticCode,
+              SecCSFlags(rawValue: kSecCSStrictValidate | kSecCSCheckNestedCode),
+              nil
+          ) == errSecSuccess
     else {
         return nil
     }
@@ -2455,9 +2492,18 @@ private func appBundleSigning(_ url: URL) -> AppBundleSigning? {
     guard let requirementText = requirementText(requirement) else {
         return nil
     }
+    let signatureFlags = (dictionary[kSecCodeInfoFlags] as? NSNumber)?.uint32Value ?? 0
+    let entitlements = dictionary[kSecCodeInfoEntitlementsDict] as? [String: Any] ?? [:]
+    let enabledEntitlements = Set(entitlements.compactMap { key, value in
+        (value as? NSNumber)?.boolValue == true ? key : nil
+    })
     return AppBundleSigning(
         teamIdentifier: dictionary[kSecCodeInfoTeamIdentifier] as? String ?? "unknown",
-        requirement: requirementText
+        requirement: requirementText,
+        runtimeProtection: launcherRuntimeProtection(
+            signatureFlags: signatureFlags,
+            enabledEntitlements: enabledEntitlements
+        )
     )
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1100,6 +1100,7 @@ private struct LauncherIdentity {
     let identifier: String
     let teamIdentifier: String
     let designatedRequirement: String
+    let runtimeProtection: LauncherRuntimeProtection
 }
 
 private struct ScriptApproval {
@@ -2334,7 +2335,10 @@ private func resolveSecretGatePolicy(
     for launcher in launchers {
         if let policy = gate.appPolicies.first(where: { $0.requirement == launcher.designatedRequirement }) {
             return ResolvedSecretGatePolicy(
-                protection: policy.protection,
+                protection: policy.requiresHardenedRuntime
+                    && !launcher.runtimeProtection.allowsSecretGateAccess
+                    ? .noAccess
+                    : policy.protection,
                 source: shortAppName(launcher.identifier),
                 launcher: launcher
             )
@@ -3054,7 +3058,8 @@ private func launcherIdentities(
             path: path,
             identifier: app.identifier,
             teamIdentifier: app.teamIdentifier,
-            designatedRequirement: app.designatedRequirement
+            designatedRequirement: app.designatedRequirement,
+            runtimeProtection: signing.runtimeProtection
         )
     }
 }
@@ -3065,12 +3070,25 @@ private struct LiveSigningInfo {
     let designatedRequirement: String
     let mainExecutable: String
     let isAdHoc: Bool
+    let runtimeProtection: LauncherRuntimeProtection
 }
 
 private struct StaticSigningInfo {
     let identifier: String
     let teamIdentifier: String
     let designatedRequirement: String
+}
+
+private func runtimeProtection(_ dictionary: [CFString: Any]) -> LauncherRuntimeProtection {
+    let signatureFlags = (dictionary[kSecCodeInfoFlags] as? NSNumber)?.uint32Value ?? 0
+    let entitlements = dictionary[kSecCodeInfoEntitlementsDict] as? [String: Any] ?? [:]
+    let enabledEntitlements = Set(entitlements.compactMap { key, value in
+        (value as? NSNumber)?.boolValue == true ? key : nil
+    })
+    return launcherRuntimeProtection(
+        signatureFlags: signatureFlags,
+        enabledEntitlements: enabledEntitlements
+    )
 }
 
 private struct LauncherAppVerificationFailure {
@@ -3120,7 +3138,8 @@ private func liveSigningInfo(pid: pid_t) -> LiveSigningInfo? {
         teamIdentifier: dictionary[kSecCodeInfoTeamIdentifier] as? String ?? "unknown",
         designatedRequirement: requirementText,
         mainExecutable: executable,
-        isAdHoc: signatureFlags & secCodeSignatureAdHoc != 0
+        isAdHoc: signatureFlags & secCodeSignatureAdHoc != 0,
+        runtimeProtection: runtimeProtection(dictionary)
     )
 }
 
@@ -3151,7 +3170,8 @@ private func executableSigningInfo(path: String) -> LiveSigningInfo? {
         teamIdentifier: dictionary[kSecCodeInfoTeamIdentifier] as? String ?? "unknown",
         designatedRequirement: requirementText,
         mainExecutable: executable,
-        isAdHoc: signatureFlags & secCodeSignatureAdHoc != 0
+        isAdHoc: signatureFlags & secCodeSignatureAdHoc != 0,
+        runtimeProtection: runtimeProtection(dictionary)
     )
 }
 
@@ -3933,7 +3953,8 @@ private func runApprovalSelfCheck() -> Int32 {
             path: "/Applications/Vaultty.app/Contents/Helpers/vaultty-sessiond",
             identifier: "com.automicvault.vaultty",
             teamIdentifier: "TEAM",
-            designatedRequirement: #"identifier "com.automicvault.vaultty" and anchor apple generic"#
+            designatedRequirement: #"identifier "com.automicvault.vaultty" and anchor apple generic"#,
+            runtimeProtection: .hardened
         ),
         fallback: "/opt/homebrew/bin/gh"
     )
@@ -4019,14 +4040,16 @@ private func runApprovalSelfCheck() -> Int32 {
         teamIdentifier: "TEAM",
         designatedRequirement: #"identifier "app.vaultty.Vaultty" and anchor apple generic"#,
         mainExecutable: "/Applications/Vaultty.app/Contents/Helpers/vaultty-sessiond",
-        isAdHoc: false
+        isAdHoc: false,
+        runtimeProtection: .hardened
     )
     let vaulttyBridgeSigning = LiveSigningInfo(
         identifier: "com.automicvault.vaultty.session-bridge",
         teamIdentifier: "TEAM",
         designatedRequirement: #"identifier "com.automicvault.vaultty.session-bridge" and anchor apple generic"#,
         mainExecutable: "/Users/mxcl/Library/Application Support/Vaultty/vaultty-session-bridge",
-        isAdHoc: false
+        isAdHoc: false,
+        runtimeProtection: .hardened
     )
     let vaulttyAppSigning = StaticSigningInfo(
         identifier: "com.automicvault.vaultty",
@@ -4038,7 +4061,8 @@ private func runApprovalSelfCheck() -> Int32 {
         teamIdentifier: "TEAM",
         designatedRequirement: #"identifier "dev.mxcl.pmm.menu" and anchor apple generic"#,
         mainExecutable: "/Applications/Package Manager Manager.app/Contents/Library/LoginItems/Package Manager Manager Menu.app/Contents/MacOS/PMMMenuBar",
-        isAdHoc: false
+        isAdHoc: false,
+        runtimeProtection: .hardened
     )
     var detachedCaller = AVProcessIdentity()
     detachedCaller.ppid = 1
@@ -4048,14 +4072,16 @@ private func runApprovalSelfCheck() -> Int32 {
         teamIdentifier: "unknown",
         designatedRequirement: #"identifier "org.python.python" and anchor apple generic"#,
         mainExecutable: "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python",
-        isAdHoc: true
+        isAdHoc: true,
+        runtimeProtection: .hardenedRuntimeMissing
     )
     let unbundledSigning = LiveSigningInfo(
         identifier: "com.automicvault.av",
         teamIdentifier: "TEAM",
         designatedRequirement: #"identifier "com.automicvault.av" and anchor apple generic"#,
         mainExecutable: "/usr/local/bin/av",
-        isAdHoc: false
+        isAdHoc: false,
+        runtimeProtection: .hardened
     )
     let parentlessVaulttyLauncher = launcherIdentity(
         pid: 43,
@@ -4133,7 +4159,39 @@ private func runApprovalSelfCheck() -> Int32 {
         path: "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT",
         identifier: "com.openai.codex",
         teamIdentifier: "TEAM",
-        designatedRequirement: blockedRequirement
+        designatedRequirement: blockedRequirement,
+        runtimeProtection: .hardened
+    )
+    let unhardenedLauncher = LauncherIdentity(
+        pid: blockedLauncher.pid,
+        path: blockedLauncher.path,
+        identifier: blockedLauncher.identifier,
+        teamIdentifier: blockedLauncher.teamIdentifier,
+        designatedRequirement: blockedLauncher.designatedRequirement,
+        runtimeProtection: .hardenedRuntimeMissing
+    )
+    let runtimeProtectedGate = SecretGate(
+        id: "gh",
+        keyPatterns: ["GH_TOKEN_*"],
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: [SecretGatePolicy(
+            bundleIdentifier: blockedLauncher.identifier,
+            requirement: blockedRequirement,
+            protection: .readOnly,
+            requiresHardenedRuntime: true
+        )]
+    )
+    let grandfatheredGate = SecretGate(
+        id: "gh",
+        keyPatterns: ["GH_TOKEN_*"],
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: [SecretGatePolicy(
+            bundleIdentifier: blockedLauncher.identifier,
+            requirement: blockedRequirement,
+            protection: .readOnly
+        )]
     )
     let ghMetadata = HardenerMetadata(
         name: "gh",
@@ -4204,6 +4262,9 @@ private func runApprovalSelfCheck() -> Int32 {
     }
     guard resolveSecretGatePolicy(gate: policyGate, launchers: []) == nil,
           resolveSecretGatePolicy(gate: policyGate, launchers: [blockedLauncher])?.protection == .noAccess,
+          resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [blockedLauncher])?.protection == .readOnly,
+          resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [unhardenedLauncher])?.protection == .noAccess,
+          resolveSecretGatePolicy(gate: grandfatheredGate, launchers: [unhardenedLauncher])?.protection == .readOnly,
           matchingSecretGate(request: readOnlyGh, signing: ghSigning, hardeners: [ghMetadata])?.id == "gh",
           matchingSecretGate(request: ghRequest(keys: ["OTHER_TOKEN"]), signing: ghSigning, hardeners: [ghMetadata]) == nil,
           matchingSecretGate(request: ghRequest(keys: []), signing: ghSigning, hardeners: [ghMetadata]) == nil,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3080,15 +3080,7 @@ private struct StaticSigningInfo {
 }
 
 private func runtimeProtection(_ dictionary: [CFString: Any]) -> LauncherRuntimeProtection {
-    let signatureFlags = (dictionary[kSecCodeInfoFlags] as? NSNumber)?.uint32Value ?? 0
-    let entitlements = dictionary[kSecCodeInfoEntitlementsDict] as? [String: Any] ?? [:]
-    let enabledEntitlements = Set(entitlements.compactMap { key, value in
-        (value as? NSNumber)?.boolValue == true ? key : nil
-    })
-    return launcherRuntimeProtection(
-        signatureFlags: signatureFlags,
-        enabledEntitlements: enabledEntitlements
-    )
+    launcherRuntimeProtection(signingInformation: dictionary)
 }
 
 private struct LauncherAppVerificationFailure {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -424,7 +424,6 @@ public enum LauncherRuntimeProtection: Equatable, Sendable {
 
 private let unsafeLauncherRuntimeEntitlements: Set<String> = [
     "com.apple.security.cs.allow-dyld-environment-variables",
-    "com.apple.security.cs.allow-unsigned-executable-memory",
     "com.apple.security.cs.disable-executable-page-protection",
     "com.apple.security.cs.disable-library-validation",
     "com.apple.security.get-task-allow",

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -399,12 +399,46 @@ public struct SecretGatePolicy: Equatable, Sendable {
     public let bundleIdentifier: String
     public let requirement: String
     public let protection: SecretGateProtection
+    public let requiresHardenedRuntime: Bool
 
-    public init(bundleIdentifier: String, requirement: String, protection: SecretGateProtection) {
+    public init(
+        bundleIdentifier: String,
+        requirement: String,
+        protection: SecretGateProtection,
+        requiresHardenedRuntime: Bool = false
+    ) {
         self.bundleIdentifier = bundleIdentifier
         self.requirement = requirement
         self.protection = protection
+        self.requiresHardenedRuntime = requiresHardenedRuntime
     }
+}
+
+public enum LauncherRuntimeProtection: Equatable, Sendable {
+    case hardened
+    case hardenedRuntimeMissing
+    case unsafeEntitlements([String])
+
+    public var allowsSecretGateAccess: Bool { self == .hardened }
+}
+
+private let unsafeLauncherRuntimeEntitlements: Set<String> = [
+    "com.apple.security.cs.allow-dyld-environment-variables",
+    "com.apple.security.cs.allow-unsigned-executable-memory",
+    "com.apple.security.cs.disable-executable-page-protection",
+    "com.apple.security.cs.disable-library-validation",
+    "com.apple.security.get-task-allow",
+]
+
+public func launcherRuntimeProtection(
+    signatureFlags: UInt32,
+    enabledEntitlements: Set<String>
+) -> LauncherRuntimeProtection {
+    guard signatureFlags & SecCodeSignatureFlags.runtime.rawValue != 0 else {
+        return .hardenedRuntimeMissing
+    }
+    let unsafe = enabledEntitlements.intersection(unsafeLauncherRuntimeEntitlements).sorted()
+    return unsafe.isEmpty ? .hardened : .unsafeEntitlements(unsafe)
 }
 
 public struct SecretGate: Equatable, Identifiable, Sendable {
@@ -718,7 +752,8 @@ public func loadSecretGates(
                     SecretGatePolicy(
                         bundleIdentifier: appIdentifier(from: $0) ?? "unknown",
                         requirement: $0,
-                        protection: prototype.normalizedProtection(record.protection)
+                        protection: prototype.normalizedProtection(record.protection),
+                        requiresHardenedRuntime: record.requiresHardenedRuntime == true
                     )
                 }
             }.uniqueSorted()
@@ -785,12 +820,18 @@ public func setSecretGateAppProtection(
     requirement: String,
     protection: SecretGateProtection,
     for gate: SecretGate,
+    requiresHardenedRuntime: Bool = true,
     service: String = secretGatePoliciesKeychainService,
     account: String = secretGatePoliciesKeychainAccount
 ) -> OSStatus {
     let protection = gate.normalizedProtection(protection)
     return setSecretGatePolicyRecord(
-        SecretGatePolicyRecord(gateID: gate.id, requirement: requirement, protection: protection),
+        SecretGatePolicyRecord(
+            gateID: gate.id,
+            requirement: requirement,
+            protection: protection,
+            requiresHardenedRuntime: requiresHardenedRuntime
+        ),
         service: service,
         account: account
     )
@@ -827,6 +868,19 @@ private struct SecretGatePolicyRecord: Codable, Equatable {
     let gateID: String
     let requirement: String?
     let protection: SecretGateProtection
+    let requiresHardenedRuntime: Bool?
+
+    init(
+        gateID: String,
+        requirement: String?,
+        protection: SecretGateProtection,
+        requiresHardenedRuntime: Bool? = nil
+    ) {
+        self.gateID = gateID
+        self.requirement = requirement
+        self.protection = protection
+        self.requiresHardenedRuntime = requiresHardenedRuntime
+    }
 }
 
 private enum SecretGatePolicyRecordsLoad {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -440,6 +440,20 @@ public func launcherRuntimeProtection(
     return unsafe.isEmpty ? .hardened : .unsafeEntitlements(unsafe)
 }
 
+public func launcherRuntimeProtection(
+    signingInformation: [CFString: Any]
+) -> LauncherRuntimeProtection {
+    let signatureFlags = (signingInformation[kSecCodeInfoFlags] as? NSNumber)?.uint32Value ?? 0
+    let entitlements = signingInformation[kSecCodeInfoEntitlementsDict] as? [String: Any] ?? [:]
+    let enabledEntitlements = Set(entitlements.compactMap { key, value in
+        (value as? NSNumber)?.boolValue == true ? key : nil
+    })
+    return launcherRuntimeProtection(
+        signatureFlags: signatureFlags,
+        enabledEntitlements: enabledEntitlements
+    )
+}
+
 public struct SecretGate: Equatable, Identifiable, Sendable {
     public let id: String
     public let keyPatterns: [String]

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -378,6 +378,7 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     ).first)
     #expect(gate.defaultProtection == .fullExceptSecretDumps)
     #expect(gate.appPolicies.first?.protection == .fullExceptSecretDumps)
+    #expect(gate.appPolicies.first?.requiresHardenedRuntime == false)
 
     #expect(setSecretGateDefaultProtection(
         .readOnly,
@@ -458,15 +459,28 @@ func protectionPolicyMatrix(
         requirement: requirement,
         protection: .noAccess,
         for: gate,
+        requiresHardenedRuntime: true,
         service: service,
         account: account
     ) == errSecSuccess)
     gate = try #require(loadSecretGates(hardeners: [metadata], service: service, account: account).first)
     let appPolicy = try #require(gate.appPolicies.first)
     #expect(appPolicy.protection == .noAccess)
+    #expect(appPolicy.requiresHardenedRuntime)
     #expect(gate.defaultPolicyLabel == "All Other Apps")
     #expect(secretGateProtection(for: requirement, in: gate).protection == .noAccess)
     #expect(secretGateProtection(for: #"identifier "com.other.app""#, in: gate).protection == .fullExceptSecretDumps)
+
+    #expect(setSecretGateAppProtection(
+        requirement: appPolicy.requirement,
+        protection: .readOnly,
+        for: gate,
+        requiresHardenedRuntime: appPolicy.requiresHardenedRuntime,
+        service: service,
+        account: account
+    ) == errSecSuccess)
+    gate = try #require(loadSecretGates(hardeners: [metadata], service: service, account: account).first)
+    #expect(gate.appPolicies.first?.requiresHardenedRuntime == true)
 
     #expect(removeSecretGateAppPolicy(appPolicy, from: gate, service: service, account: account) == errSecSuccess)
     gate = try #require(loadSecretGates(hardeners: [metadata], service: service, account: account).first)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
@@ -1,0 +1,32 @@
+import Security
+import Testing
+@testable import MenubarHelperCore
+
+@Test func hardenedRuntimeIsRequiredForNewSecretGateLaunchers() {
+    #expect(launcherRuntimeProtection(
+        signatureFlags: 0,
+        enabledEntitlements: []
+    ) == .hardenedRuntimeMissing)
+    #expect(launcherRuntimeProtection(
+        signatureFlags: SecCodeSignatureFlags.runtime.rawValue,
+        enabledEntitlements: []
+    ) == .hardened)
+    #expect(launcherRuntimeProtection(
+        signatureFlags: SecCodeSignatureFlags.runtime.rawValue,
+        enabledEntitlements: ["com.apple.security.cs.allow-jit"]
+    ) == .hardened)
+}
+
+@Test func hardenedRuntimeExceptionsPreventSecretGateAdmission() {
+    let unsafe: Set<String> = [
+        "com.apple.security.cs.allow-dyld-environment-variables",
+        "com.apple.security.cs.allow-unsigned-executable-memory",
+        "com.apple.security.cs.disable-executable-page-protection",
+        "com.apple.security.cs.disable-library-validation",
+        "com.apple.security.get-task-allow",
+    ]
+    #expect(launcherRuntimeProtection(
+        signatureFlags: SecCodeSignatureFlags.runtime.rawValue,
+        enabledEntitlements: unsafe
+    ) == .unsafeEntitlements(unsafe.sorted()))
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
@@ -13,14 +13,16 @@ import Testing
     ) == .hardened)
     #expect(launcherRuntimeProtection(
         signatureFlags: SecCodeSignatureFlags.runtime.rawValue,
-        enabledEntitlements: ["com.apple.security.cs.allow-jit"]
+        enabledEntitlements: [
+            "com.apple.security.cs.allow-jit",
+            "com.apple.security.cs.allow-unsigned-executable-memory",
+        ]
     ) == .hardened)
 }
 
 @Test func hardenedRuntimeExceptionsPreventSecretGateAdmission() {
     let unsafe: Set<String> = [
         "com.apple.security.cs.allow-dyld-environment-variables",
-        "com.apple.security.cs.allow-unsigned-executable-memory",
         "com.apple.security.cs.disable-executable-page-protection",
         "com.apple.security.cs.disable-library-validation",
         "com.apple.security.get-task-allow",

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
@@ -32,3 +32,13 @@ import Testing
         enabledEntitlements: unsafe
     ) == .unsafeEntitlements(unsafe.sorted()))
 }
+
+@Test func signingInformationUsesOnlyEnabledRuntimeExceptions() {
+    #expect(launcherRuntimeProtection(signingInformation: [
+        kSecCodeInfoFlags: SecCodeSignatureFlags.runtime.rawValue,
+        kSecCodeInfoEntitlementsDict: [
+            "com.apple.security.cs.allow-dyld-environment-variables": false,
+            "com.apple.security.cs.disable-library-validation": true,
+        ],
+    ]) == .unsafeEntitlements(["com.apple.security.cs.disable-library-validation"]))
+}


### PR DESCRIPTION
## Summary

- require Hardened Runtime before a launcher can be newly added to a secret gate
- allow the `allow-jit` and `allow-unsigned-executable-memory` compatibility exceptions used by JIT runtimes such as ChatGPT's bundled Codex launcher
- reject launchers that enable direct injection or debugging escapes through DYLD environment variables, disabled executable-page protection, disabled library validation, or debugger attachment
- persist the requirement on newly admitted policies and recheck the live launcher on every match
- leave existing stored launcher allowances grandfathered and unchanged

## Security model

Enrollment validates the app's strict nested code signature, Hardened Runtime flag, and entitlements before writing the allowance.

New policy records carry a `requiresHardenedRuntime` marker. At runtime, Automic reads the live ancestor executable's signature flags and entitlements. If its posture is no longer acceptable, the policy resolves to `no-access` even when the designated requirement still matches.

Older records have no marker and decode as grandfathered. Editing an existing allowance preserves that state; removing and re-adding it applies the new checks.

JIT executable-memory entitlements weaken W^X protections but do not by themselves permit another process to inject code or attach a debugger, so they remain compatible with admission. The following enabled entitlements prevent new secret-gate access:

- `com.apple.security.cs.allow-dyld-environment-variables`
- `com.apple.security.cs.disable-executable-page-protection`
- `com.apple.security.cs.disable-library-validation`
- `com.apple.security.get-task-allow`

## Validation

- `swift test --package-path src/menu-helper` (52 tests)
- `AutomicVaultMenubar --self-check-approvals`
- `cargo test --all-targets --all-features --locked` (771 unit tests plus integration targets)
- `git diff --check`
