### PR TITLE
Add fail-closed Varlock dotenv blessings

### DIFF
--- a/src/cli/dotenv.rs
+++ b/src/cli/dotenv.rs
@@ -1,0 +1,111 @@
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::PathBuf;
+
+const USAGE: &str = "usage: av dotenv resolve --schema PATH --item NAME --key NAME";
+
+struct Options {
+    schema: PathBuf,
+    item: String,
+    key: String,
+}
+
+pub(super) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    let options = match parse(args) {
+        Ok(options) => options,
+        Err(err) => {
+            let _ = writeln!(stderr, "av dotenv: {err}\n{USAGE}");
+            return 2;
+        }
+    };
+    match crate::secrets::resolve_dotenv_secret(
+        &options.schema.to_string_lossy(),
+        &options.item,
+        &options.key,
+    ) {
+        Ok(value) => match stdout.write_all(value.as_bytes()) {
+            Ok(()) => 0,
+            Err(err) => {
+                let _ = writeln!(stderr, "av dotenv: failed to write resolved value: {err}");
+                1
+            }
+        },
+        Err(err) => {
+            let _ = writeln!(stderr, "av dotenv: {err}");
+            1
+        }
+    }
+}
+
+fn parse(args: Vec<OsString>) -> Result<Options, String> {
+    let mut args = args.into_iter();
+    if args.next().as_deref() != Some(std::ffi::OsStr::new("resolve")) {
+        return Err("expected `resolve`".into());
+    }
+    let mut schema = None;
+    let mut item = None;
+    let mut key = None;
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .ok_or_else(|| format!("missing value for {}", flag.to_string_lossy()))?;
+        match flag.to_str() {
+            Some("--schema") if schema.is_none() => schema = Some(value),
+            Some("--item") if item.is_none() => item = value.into_string().ok(),
+            Some("--key") if key.is_none() => key = value.into_string().ok(),
+            _ => return Err(format!("unexpected option {}", flag.to_string_lossy())),
+        }
+    }
+    let schema = std::fs::canonicalize(schema.ok_or_else(|| "missing --schema".to_string())?)
+        .map_err(|err| format!("failed to resolve schema: {err}"))?;
+    if schema.file_name().and_then(|name| name.to_str()) != Some(".env.schema") || !schema.is_file()
+    {
+        return Err("schema must be a regular file named .env.schema".into());
+    }
+    let item = item.ok_or_else(|| "missing or invalid --item".to_string())?;
+    let key = key.ok_or_else(|| "missing or invalid --key".to_string())?;
+    super::inject::validate_key_name(&item)?;
+    super::inject::validate_key_name(&key)?;
+    Ok(Options { schema, item, key })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_requires_a_real_root_schema_and_static_keys() {
+        let dir = std::env::temp_dir().join(format!("av-dotenv-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let schema = dir.join(".env.schema");
+        std::fs::write(&schema, "SECRET=av()\n").unwrap();
+
+        let options = parse(vec![
+            "resolve".into(),
+            "--schema".into(),
+            schema.as_os_str().into(),
+            "--item".into(),
+            "SECRET".into(),
+            "--key".into(),
+            "VAULT_SECRET".into(),
+        ])
+        .unwrap();
+        assert_eq!(options.schema, std::fs::canonicalize(&schema).unwrap());
+        assert_eq!(options.item, "SECRET");
+        assert_eq!(options.key, "VAULT_SECRET");
+        assert!(
+            parse(vec![
+                "resolve".into(),
+                "--schema".into(),
+                schema.as_os_str().into(),
+                "--item".into(),
+                "dynamic-name".into(),
+                "--key".into(),
+                "SECRET".into(),
+            ])
+            .is_err()
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod aws;
 mod bless;
 pub(crate) mod docker_credential;
 pub(crate) mod doctor;
+mod dotenv;
 mod inject;
 mod launcher_bundle;
 mod list;
@@ -26,6 +27,7 @@ commands:
   $ av detectors --json                   # print detector metadata
   $ av hardeners --json                   # print hardener metadata
   $ av bless [--endorse-launcher] <path>  # review a script for secret access
+  $ av dotenv resolve ...                 # resolve a blessed Varlock dotenv item
   $ av inject +KEY... [--] <command>      # inject secrets into a command
   $ av inject -- <command>                # run an approved script
   $ av list                               # list saved secret names
@@ -390,6 +392,7 @@ where
             aws::credentials(Some("official-v2"), stdout, stderr)
         }
         Some("docker-credential") => docker_credential::run(rest, stdout, stderr),
+        Some("dotenv") => dotenv::run(rest, stdout, stderr),
         Some("list" | "ls") => list::run(rest, stdout, stderr),
         Some("bless") => bless::run(rest, stderr),
         Some("open") => {

--- a/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
+++ b/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
@@ -74,20 +74,26 @@ bool av_process_arguments(pid_t pid, char *out, size_t out_len) {
     while (cursor < end && *cursor == '\0') cursor++;
 
     size_t written = 0;
-    for (int i = 0; i < argc && cursor < end && written + 1 < out_len; i++) {
-        size_t arg_len = strnlen(cursor, (size_t)(end - cursor));
-        if (arg_len == 0) {
-            break;
+    for (int i = 0; i < argc; i++) {
+        if (cursor >= end) {
+            return false;
         }
-        if (i > 0 && written + 1 < out_len) {
+        size_t arg_len = strnlen(cursor, (size_t)(end - cursor));
+        if (cursor + arg_len >= end) {
+            return false;
+        }
+        if (memchr(cursor, '\n', arg_len) != NULL) {
+            return false;
+        }
+        size_t required = arg_len + (i > 0 ? 1 : 0);
+        if (required > out_len - written - 1) {
+            return false;
+        }
+        if (i > 0) {
             out[written++] = '\n';
         }
-        size_t copy_len = arg_len;
-        if (copy_len > out_len - written - 1) {
-            copy_len = out_len - written - 1;
-        }
-        memcpy(out + written, cursor, copy_len);
-        written += copy_len;
+        memcpy(out + written, cursor, arg_len);
+        written += arg_len;
         cursor += arg_len + 1;
     }
     out[written] = '\0';
@@ -179,5 +185,23 @@ bool av_process_environment_value(pid_t pid, const char *key, char *out, size_t 
     memcpy(out, match, match_len);
     out[match_len] = '\0';
     free(buffer);
+    return true;
+}
+
+bool av_process_cwd(pid_t pid, char *out, size_t out_len) {
+    if (out_len == 0) {
+        return false;
+    }
+    struct proc_vnodepathinfo info;
+    memset(&info, 0, sizeof(info));
+    int size = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info, sizeof(info));
+    if (size != sizeof(info) || info.pvi_cdir.vip_path[0] == '\0') {
+        return false;
+    }
+    size_t len = strnlen(info.pvi_cdir.vip_path, sizeof(info.pvi_cdir.vip_path));
+    if (len >= out_len) {
+        return false;
+    }
+    memcpy(out, info.pvi_cdir.vip_path, len + 1);
     return true;
 }

--- a/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
+++ b/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
@@ -24,3 +24,4 @@ bool av_peer_pid(int fd, pid_t *pid_out);
 bool av_process_identity(pid_t pid, AVProcessIdentity *identity_out);
 bool av_process_arguments(pid_t pid, char *out, size_t out_len);
 bool av_process_environment_value(pid_t pid, const char *key, char *out, size_t out_len);
+bool av_process_cwd(pid_t pid, char *out, size_t out_len);

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -234,6 +234,7 @@ final class DashboardModel: ObservableObject {
             }
         case .blessedScripts:
             blessedScriptItems(snapshot.blessedScripts, pending: pendingBlessing)
+                + snapshot.blessedDotenvs.map(blessedDotenvItem)
         case .launcherBundles:
             launcherBundles.map {
                 DashboardItem(
@@ -312,15 +313,17 @@ final class DashboardModel: ObservableObject {
     }
 
     var selectedBlessedScript: BlessedScript? {
-        if let selectedItemID,
-           let script = snapshot.blessedScripts.first(where: { $0.path == selectedItemID }) {
-            return script
-        }
-        return snapshot.blessedScripts.first
+        guard let id = selectedItem?.id else { return nil }
+        return snapshot.blessedScripts.first { "script:\($0.path)" == id }
+    }
+
+    var selectedBlessedDotenv: BlessedDotenv? {
+        guard let id = selectedItem?.id else { return nil }
+        return snapshot.blessedDotenvs.first { "dotenv:\($0.id)" == id }
     }
 
     var selectedPendingBlessing: BlessedScriptReviewRequest? {
-        guard pendingBlessing?.path == selectedItem?.id else { return nil }
+        guard pendingBlessing.map({ "script:\($0.path)" }) == selectedItem?.id else { return nil }
         return pendingBlessing
     }
 
@@ -360,7 +363,7 @@ final class DashboardModel: ObservableObject {
         case .hardenedTools: snapshot.hardenedTools.count
         case .secretGates: snapshot.secretGates.count
         case .blessedScripts:
-            snapshot.blessedScripts.count
+            snapshot.blessedScripts.count + snapshot.blessedDotenvs.count
                 + (pendingBlessing.map { pending in
                     snapshot.blessedScripts.contains { $0.path == pending.path } ? 0 : 1
                 } ?? 0)
@@ -415,7 +418,7 @@ final class DashboardModel: ObservableObject {
         )
         blessingCompletion = completion
         selectedSection = .blessedScripts
-        selectedItemID = request.path
+        selectedItemID = "script:\(request.path)"
     }
 
     func approvePendingBlessing() {
@@ -438,7 +441,7 @@ final class DashboardModel: ObservableObject {
             return
         }
         finishPendingBlessing(.approved)
-        selectedItemID = script.path
+        selectedItemID = "script:\(script.path)"
         reload()
     }
 
@@ -481,6 +484,22 @@ final class DashboardModel: ObservableObject {
         }
     }
 
+    func addApp(to dotenv: BlessedDotenv) {
+        chooseLauncherApp { [weak self] launcher in
+            guard let self, let launcher,
+                  !dotenv.launchers.contains(where: { $0.requirement == launcher.requirement })
+            else { return }
+            let updated = BlessedDotenv(
+                path: dotenv.path,
+                checksum: dotenv.checksum,
+                processes: dotenv.processes,
+                launchers: dotenv.launchers + [launcher],
+                blessedAt: dotenv.blessedAt
+            )
+            self.finishPolicyUpdate(saveBlessedDotenv(updated), error: "Could not add calling app")
+        }
+    }
+
     func addSecretNameAccessApp() {
         chooseLauncherApp { [weak self] launcher in
             guard let self, let launcher else { return }
@@ -515,8 +534,29 @@ final class DashboardModel: ObservableObject {
         finishPolicyUpdate(saveBlessedScript(updated), error: "Could not remove calling app")
     }
 
+    func removeLauncher(_ launcher: BlessedScriptLauncher, from dotenv: BlessedDotenv) {
+        let updated = BlessedDotenv(
+            path: dotenv.path,
+            checksum: dotenv.checksum,
+            processes: dotenv.processes,
+            launchers: dotenv.launchers.filter { $0.requirement != launcher.requirement },
+            blessedAt: dotenv.blessedAt
+        )
+        finishPolicyUpdate(saveBlessedDotenv(updated), error: "Could not remove calling app")
+    }
+
     func revoke(_ script: BlessedScript) {
         let status = removeBlessedScript(path: script.path)
+        if status == errSecSuccess {
+            selectedItemID = nil
+            reload()
+        } else {
+            errorMessage = "Could not revoke blessing: \(status)"
+        }
+    }
+
+    func revoke(_ dotenv: BlessedDotenv) {
+        let status = removeBlessedDotenv(id: dotenv.id)
         if status == errSecSuccess {
             selectedItemID = nil
             reload()
@@ -962,8 +1002,9 @@ private func blessedScriptItem(_ script: BlessedScript) -> DashboardItem {
     let currentChecksum = isGone ? nil : try? blessedScriptDeclaration(data: readBlessedScript(path: script.path)).checksum
     let status = isGone ? "Gone" : currentChecksum == script.checksum ? "Blessed" : "Changed"
     return DashboardItem(
-        id: script.path,
+        id: "script:\(script.path)",
         title: URL(fileURLWithPath: script.path).lastPathComponent,
+        kind: "Script",
         subtitle: blessedScriptDirectory(script.path),
         detail: script.path,
         blessingStatus: status
@@ -975,11 +1016,12 @@ private func blessedScriptItems(
     pending: BlessedScriptReviewRequest?
 ) -> [DashboardItem] {
     let scripts = blessed.map(blessedScriptItem)
-    guard let pending, !scripts.contains(where: { $0.id == pending.path }) else { return scripts }
+    guard let pending, !scripts.contains(where: { $0.id == "script:\(pending.path)" }) else { return scripts }
     return [
         DashboardItem(
-            id: pending.path,
+            id: "script:\(pending.path)",
             title: URL(fileURLWithPath: pending.path).lastPathComponent,
+            kind: "Script",
             subtitle: blessedScriptDirectory(pending.path),
             detail: pending.path,
             blessingStatus: "Pending review"
@@ -989,6 +1031,18 @@ private func blessedScriptItems(
 
 private func blessedScriptDirectory(_ path: String) -> String {
     NSString(string: URL(fileURLWithPath: path).deletingLastPathComponent().path).abbreviatingWithTildeInPath
+}
+
+private func blessedDotenvItem(_ dotenv: BlessedDotenv) -> DashboardItem {
+    let data = try? readBlessedScript(path: dotenv.path)
+    let status = data.map(dotenvSchemaChecksum) == dotenv.checksum ? "Blessed" : "Stale"
+    return DashboardItem(
+        id: "dotenv:\(dotenv.id)",
+        title: URL(fileURLWithPath: dotenv.path).deletingLastPathComponent().lastPathComponent,
+        kind: "Dotenv",
+        subtitle: status,
+        detail: dotenv.path
+    )
 }
 
 private func detectorSeveritySortPriority(_ severity: String?) -> Int {
@@ -1464,6 +1518,8 @@ struct DashboardRootView: View {
                                 model.addAppToPendingBlessing()
                             } else if let script = model.selectedBlessedScript {
                                 model.addApp(to: script)
+                            } else if let dotenv = model.selectedBlessedDotenv {
+                                model.addApp(to: dotenv)
                             }
                         } label: {
                             Image(systemName: "plus")
@@ -1583,7 +1639,12 @@ private struct DashboardListView: View {
                 }
             } else {
                 List(selection: itemSelection) {
-                    rows(items)
+                    if model.selectedSection == .blessedScripts {
+                        Section("Scripts") { rows(model.items.filter { $0.kind == "Script" }) }
+                        Section("Dotenvs") { rows(model.items.filter { $0.kind == "Dotenv" }) }
+                    } else {
+                        rows(model.items)
+                    }
                 }
                 .listStyle(.inset)
             }
@@ -1630,6 +1691,13 @@ private struct DashboardDetailView: View {
             } else if model.selectedSection == .blessedScripts,
                       let script = model.selectedBlessedScript {
                 BlessedScriptDetailView(model: model, script: script)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 32)
+                    .padding(.bottom, 28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if model.selectedSection == .blessedScripts,
+                      let dotenv = model.selectedBlessedDotenv {
+                BlessedDotenvDetailView(model: model, dotenv: dotenv)
                     .padding(.horizontal, 22)
                     .padding(.top, 32)
                     .padding(.bottom, 28)
@@ -3058,6 +3126,51 @@ private struct BlessedScriptDetailView: View {
             return "Changed"
         }
         return checksum == script.checksum ? "Blessed" : "Changed"
+    }
+}
+
+private struct BlessedDotenvDetailView: View {
+    @ObservedObject var model: DashboardModel
+    let dotenv: BlessedDotenv
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(URL(fileURLWithPath: dotenv.path).deletingLastPathComponent().lastPathComponent)
+                    .font(.system(size: 24, weight: .semibold))
+                Text(status)
+                    .font(.system(size: 13))
+                    .foregroundStyle(status == "Blessed" ? .green : .orange)
+            }
+            VStack(alignment: .leading, spacing: 10) {
+                SecretGateField("Path", dotenv.path)
+                SecretGateField("SHA-256", dotenv.checksum, monospaced: true)
+                SecretGateField("Secrets", declarations.map { "\($0.item) → \($0.secret)" }.joined(separator: ", "))
+                ForEach(Array(dotenv.processes.enumerated()), id: \.offset) { index, process in
+                    SecretGateField(
+                        index == 0 ? "Entrypoint" : "Parent \(index)",
+                        ([process.path] + process.arguments.dropFirst()).joined(separator: " ") + "\nwd: \(process.cwd)",
+                        monospaced: true
+                    )
+                }
+            }
+            launcherList(dotenv.launchers) {
+                model.removeLauncher($0, from: dotenv)
+            }
+            HStack {
+                Spacer()
+                Button("Revoke Blessing", role: .destructive) { model.revoke(dotenv) }
+            }
+            if let error = model.errorMessage {
+                InfoBlock(title: "Error", text: error)
+            }
+        }
+    }
+
+    private var data: Data? { try? readBlessedScript(path: dotenv.path) }
+    private var status: String { data.map(dotenvSchemaChecksum) == dotenv.checksum ? "Blessed" : "Stale" }
+    private var declarations: [DotenvSecretDeclaration] {
+        data.map(dotenvSchemaDeclarations) ?? []
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3858,9 +3858,8 @@ private final class ApprovalServer: @unchecked Sendable {
             processes: processes,
             launchers: []
         ).id }
-        let launchers = (existing?.launchers ?? []).contains(launcherRecord)
-            ? existing!.launchers
-            : (existing?.launchers ?? []) + [launcherRecord]
+        var launchers = existing?.launchers ?? []
+        if !launchers.contains(launcherRecord) { launchers.append(launcherRecord) }
         let blessing = BlessedDotenv(
             path: path,
             checksum: checksum,
@@ -3910,7 +3909,9 @@ private final class ApprovalServer: @unchecked Sendable {
 
         if persistent {
             discloseDotenvSecret(
+                item: item,
                 key: key,
+                execution: execution,
                 request: request,
                 callerPath: callerPath,
                 launcher: launcher,
@@ -3927,7 +3928,9 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             discloseDotenvSecret(
+                item: item,
                 key: key,
+                execution: execution,
                 request: request,
                 callerPath: callerPath,
                 launcher: launcher,
@@ -3979,7 +3982,9 @@ private final class ApprovalServer: @unchecked Sendable {
                 }
             }
             self.discloseDotenvSecret(
+                item: item,
                 key: key,
+                execution: execution,
                 request: request,
                 callerPath: callerPath,
                 launcher: launcher,
@@ -3992,7 +3997,9 @@ private final class ApprovalServer: @unchecked Sendable {
     }
 
     private func discloseDotenvSecret(
+        item: String,
         key: String,
+        execution: DotenvExecutionKey,
         request: ApprovalRequest,
         callerPath: String,
         launcher: LauncherIdentity,
@@ -4001,6 +4008,21 @@ private final class ApprovalServer: @unchecked Sendable {
         peer: xpc_connection_t,
         message: xpc_object_t
     ) {
+        guard let path = request.dotenvPath,
+              let checksum = request.dotenvChecksum,
+              let data = try? readBlessedScript(path: path),
+              dotenvSchemaChecksum(data) == checksum,
+              dotenvSchemaDeclaration(data: data, item: item, secret: key) != nil,
+              let parent = processIdentity(execution.pid),
+              parent.start_usec == execution.startUsec,
+              dotenvProcessChain(startingAt: parent, launcherPID: launcher.pid) == execution.processes,
+              launcherIdentities(startingAt: parent.pid).contains(where: {
+                  $0.pid == launcher.pid && $0.designatedRequirement == launcher.designatedRequirement
+              })
+        else {
+            reply(peer, to: message, ok: false, error: "dotenv authorization changed before disclosure")
+            return
+        }
         guard let value = loadStoredSecret(account: key) else {
             reply(peer, to: message, ok: false, error: "failed to load Secret Value for \(key): \(errSecItemNotFound)")
             return

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1586,6 +1586,9 @@ private struct ApprovalRequest {
     let dockerServerURL: String?
     let dockerParent: DockerCredentialParent?
     let selectedValues: [String: StoredSecretValue]
+    let dotenvPath: String?
+    let dotenvChecksum: String?
+    let dotenvProcesses: [BlessedDotenvProcess]
 
     init(
         op: String,
@@ -1604,7 +1607,10 @@ private struct ApprovalRequest {
         detail: String?,
         dockerServerURL: String? = nil,
         dockerParent: DockerCredentialParent? = nil,
-        selectedValues: [String: StoredSecretValue] = [:]
+        selectedValues: [String: StoredSecretValue] = [:],
+        dotenvPath: String? = nil,
+        dotenvChecksum: String? = nil,
+        dotenvProcesses: [BlessedDotenvProcess] = []
     ) {
         self.op = op
         self.keys = keys
@@ -1623,6 +1629,9 @@ private struct ApprovalRequest {
         self.dockerServerURL = dockerServerURL
         self.dockerParent = dockerParent
         self.selectedValues = selectedValues
+        self.dotenvPath = dotenvPath
+        self.dotenvChecksum = dotenvChecksum
+        self.dotenvProcesses = dotenvProcesses
     }
 
     func selecting(_ values: [String: StoredSecretValue]) -> ApprovalRequest {
@@ -1643,7 +1652,10 @@ private struct ApprovalRequest {
             detail: detail,
             dockerServerURL: dockerServerURL,
             dockerParent: dockerParent,
-            selectedValues: values
+            selectedValues: values,
+            dotenvPath: dotenvPath,
+            dotenvChecksum: dotenvChecksum,
+            dotenvProcesses: dotenvProcesses
         )
     }
 }
@@ -2385,6 +2397,14 @@ private struct ApprovedPayload {
     let value: String?
 }
 
+private struct DotenvExecutionKey: Hashable {
+    let pid: Int32
+    let startUsec: UInt64
+    let path: String
+    let checksum: String
+    let processes: [BlessedDotenvProcess]
+}
+
 private final class ApprovalServer: @unchecked Sendable {
     private let serviceName: String
     private let teamIdentifier: String
@@ -2408,6 +2428,7 @@ private final class ApprovalServer: @unchecked Sendable {
     private var blessedExecutions: [BlessedExecutionKey: BlessedScript] = [:]
     private let awsRegistrationsLock = NSLock()
     private var awsRegistrations: [BlessedExecutionKey: AWSRegistration] = [:]
+    private var dotenvExecutions: [DotenvExecutionKey: ApprovalDecision] = [:]
 
     init(
         serviceName: String,
@@ -2612,6 +2633,15 @@ private final class ApprovalServer: @unchecked Sendable {
             )
         case .bless where isTrustedAvCaller(path: callerPath, signing: signing):
             handleBless(message, on: peer, identity: identity)
+        case .dotenv where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleDotenv(
+                message,
+                on: peer,
+                pid: pid,
+                identity: identity,
+                callerPath: callerPath,
+                signing: signing
+            )
         case .delete where isTrustedAvCaller(path: callerPath, signing: signing):
             handleDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
         case .save where isTrustedGhCaller(path: callerPath, signing: signing):
@@ -3776,6 +3806,229 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
         }
         return true
+    }
+
+    private func handleDotenv(
+        _ message: xpc_object_t,
+        on peer: xpc_connection_t,
+        pid: pid_t,
+        identity: AVProcessIdentity,
+        callerPath: String,
+        signing: SigningInfo
+    ) {
+        guard let schemaPointer = xpc_dictionary_get_string(message, "schema"),
+              let itemPointer = xpc_dictionary_get_string(message, "item"),
+              let keyPointer = xpc_dictionary_get_string(message, "key")
+        else {
+            reply(peer, to: message, ok: false, error: "invalid dotenv request")
+            return
+        }
+        let path = String(cString: schemaPointer)
+        let item = String(cString: itemPointer)
+        let key = String(cString: keyPointer)
+        let url = URL(fileURLWithPath: path)
+        guard validSecretKeyName(item), validSecretKeyName(key),
+              path.hasPrefix("/"), url.lastPathComponent == ".env.schema",
+              url.standardizedFileURL.path == path,
+              url.resolvingSymlinksInPath().path == path,
+              let data = try? readBlessedScript(path: path),
+              dotenvSchemaDeclaration(data: data, item: item, secret: key) != nil,
+              storedSecretExists(account: key)
+        else {
+            reply(peer, to: message, ok: false, error: "dotenv request is not declared by a canonical .env.schema")
+            return
+        }
+        guard let launcher = launcherIdentities(startingAt: identity.ppid).first,
+              let parentIdentity = processIdentity(identity.ppid),
+              let processes = dotenvProcessChain(startingAt: parentIdentity, launcherPID: launcher.pid),
+              !processes.isEmpty
+        else {
+            reply(peer, to: message, ok: false, error: "dotenv launcher ancestry could not be verified")
+            return
+        }
+
+        let checksum = dotenvSchemaChecksum(data)
+        let launcherRecord = BlessedScriptLauncher(
+            bundleIdentifier: launcher.identifier,
+            requirement: launcher.designatedRequirement
+        )
+        let existing = loadBlessedDotenvs().first { $0.id == BlessedDotenv(
+            path: path,
+            checksum: checksum,
+            processes: processes,
+            launchers: []
+        ).id }
+        let launchers = (existing?.launchers ?? []).contains(launcherRecord)
+            ? existing!.launchers
+            : (existing?.launchers ?? []) + [launcherRecord]
+        let blessing = BlessedDotenv(
+            path: path,
+            checksum: checksum,
+            processes: processes,
+            launchers: launchers
+        )
+        let request = ApprovalRequest(
+            op: "dotenv",
+            keys: [key],
+            target: processes.last?.path ?? callerPath,
+            args: processes.last?.arguments ?? [],
+            cwd: processes.first?.cwd ?? "",
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "Varlock",
+            title: "Allow \(item) from this dotenv?",
+            detail: "The verified process tree will receive \(key) through Varlock.",
+            dotenvPath: path,
+            dotenvChecksum: checksum,
+            dotenvProcesses: processes
+        )
+        let execution = DotenvExecutionKey(
+            pid: parentIdentity.pid,
+            startUsec: parentIdentity.start_usec,
+            path: path,
+            checksum: checksum,
+            processes: processes
+        )
+        let persistent = loadBlessedDotenvs().contains {
+            $0.matches(
+                path: path,
+                checksum: checksum,
+                processes: processes,
+                launcherRequirement: launcher.designatedRequirement
+            )
+        }
+        blessedExecutionsLock.lock()
+        dotenvExecutions = dotenvExecutions.filter { execution, _ in
+            guard let current = processIdentity(execution.pid) else { return false }
+            return current.start_usec == execution.startUsec
+        }
+        let transient = dotenvExecutions[execution]
+        blessedExecutionsLock.unlock()
+
+        if persistent {
+            discloseDotenvSecret(
+                key: key,
+                request: request,
+                callerPath: callerPath,
+                launcher: launcher,
+                approvalSource: "Auto",
+                reason: "Blessed dotenv \(path)",
+                peer: peer,
+                message: message
+            )
+            return
+        }
+        if let transient {
+            guard transient == .approved else {
+                reply(peer, to: message, ok: false, error: "dotenv access denied for this process")
+                return
+            }
+            discloseDotenvSecret(
+                key: key,
+                request: request,
+                callerPath: callerPath,
+                launcher: launcher,
+                approvalSource: "Auto",
+                reason: "Allowed once for this process tree",
+                peer: peer,
+                message: message
+            )
+            return
+        }
+
+        DispatchQueue.main.async {
+            guard self.canRequestHumanApproval() else {
+                self.reply(peer, to: message, ok: false, error: "dotenv approval is unavailable")
+                return
+            }
+            let decision = showApprovalAlert(
+                request: request,
+                callerPath: callerPath,
+                pid: pid,
+                signing: signing,
+                scriptApproval: nil,
+                launcher: launcher,
+                launcherFallbackPath: launcher.path,
+                automaticApprovalExplanation: nil,
+                allowsPersistentApproval: true,
+                persistentApprovalTitle: "Bless for \(approvalPromptRequester(launcher: launcher, fallback: launcher.path).name)"
+            )
+            self.blessedExecutionsLock.lock()
+            self.dotenvExecutions[execution] = decision
+            self.blessedExecutionsLock.unlock()
+            guard decision != .denied else {
+                _ = self.onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Denied",
+                    approvalSource: "Manual",
+                    reason: "Denied in prompt",
+                    launcher: launcher
+                ))
+                self.reply(peer, to: message, ok: false, error: "dotenv access denied")
+                return
+            }
+            if decision == .alwaysApproved {
+                let status = saveBlessedDotenv(blessing)
+                guard status == errSecSuccess else {
+                    self.reply(peer, to: message, ok: false, error: "failed to save dotenv blessing: \(status)")
+                    return
+                }
+            }
+            self.discloseDotenvSecret(
+                key: key,
+                request: request,
+                callerPath: callerPath,
+                launcher: launcher,
+                approvalSource: "Manual",
+                reason: decision == .alwaysApproved ? "Blessed in prompt" : "Allowed once in prompt",
+                peer: peer,
+                message: message
+            )
+        }
+    }
+
+    private func discloseDotenvSecret(
+        key: String,
+        request: ApprovalRequest,
+        callerPath: String,
+        launcher: LauncherIdentity,
+        approvalSource: String,
+        reason: String,
+        peer: xpc_connection_t,
+        message: xpc_object_t
+    ) {
+        guard let value = loadStoredSecret(account: key) else {
+            reply(peer, to: message, ok: false, error: "failed to load Secret Value for \(key): \(errSecItemNotFound)")
+            return
+        }
+        let id = UUID()
+        guard onAccessRequest(accessRequestRecord(
+            id: id,
+            request: request,
+            callerPath: callerPath,
+            decision: "Approved",
+            approvalSource: approvalSource,
+            reason: reason,
+            launcher: launcher
+        )) else {
+            reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+            return
+        }
+        if approvalSource == "Auto" {
+            Task { @MainActor in
+                self.onAutoApproval(autoApprovalRecord(
+                    accessRequestID: id,
+                    request: request,
+                    script: nil,
+                    launcher: launcher
+                ))
+            }
+        }
+        reply(peer, to: message, ok: true, error: nil, value: value)
     }
 
     private func handleSave(
@@ -5713,6 +5966,53 @@ private func pathString(_ identity: AVProcessIdentity) -> String {
     }
 }
 
+private func processIdentity(_ pid: pid_t) -> AVProcessIdentity? {
+    var identity = AVProcessIdentity()
+    return av_process_identity(pid, &identity) ? identity : nil
+}
+
+private func dotenvProcessChain(
+    startingAt start: AVProcessIdentity,
+    launcherPID: pid_t
+) -> [BlessedDotenvProcess]? {
+    var identity = start
+    var seen = Set<pid_t>()
+    var processes: [BlessedDotenvProcess] = []
+    for _ in 0..<32 {
+        guard seen.insert(identity.pid).inserted else { return nil }
+        if identity.pid == launcherPID { return processes }
+        guard let arguments = processArguments(identity.pid),
+              let cwd = processCWD(identity.pid),
+              !pathString(identity).isEmpty
+        else {
+            return nil
+        }
+        processes.append(BlessedDotenvProcess(
+            path: pathString(identity),
+            arguments: arguments,
+            cwd: cwd
+        ))
+        guard identity.ppid > 1, let parent = processIdentity(identity.ppid) else { return nil }
+        identity = parent
+    }
+    return nil
+}
+
+private func processArguments(_ pid: pid_t) -> [String]? {
+    var buffer = [CChar](repeating: 0, count: 8192)
+    guard av_process_arguments(pid, &buffer, buffer.count) else { return nil }
+    guard let end = buffer.firstIndex(of: 0) else { return nil }
+    guard let value = String(bytes: buffer[..<end].map(UInt8.init(bitPattern:)), encoding: .utf8) else { return nil }
+    return value.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+}
+
+private func processCWD(_ pid: pid_t) -> String? {
+    var buffer = [CChar](repeating: 0, count: 4096)
+    guard av_process_cwd(pid, &buffer, buffer.count) else { return nil }
+    guard let end = buffer.firstIndex(of: 0) else { return nil }
+    return String(bytes: buffer[..<end].map(UInt8.init(bitPattern:)), encoding: .utf8)
+}
+
 private func signingInfo(path: String) -> SigningInfo {
     var staticCode: SecStaticCode?
     let url = URL(fileURLWithPath: path) as CFURL
@@ -6413,6 +6713,7 @@ private func showApprovalAlert(
     automaticApprovalExplanation: String?,
     temporaryGrantCandidate: TemporaryAccessGrantCandidate? = nil,
     allowsPersistentApproval: Bool = false,
+    persistentApprovalTitle: String = "Always Allow",
     cancellation: ApprovalCancellation? = nil
 ) -> ApprovalDecision {
     guard cancellation?.isCanceled != true else { return .canceled }
@@ -6449,6 +6750,7 @@ private func showApprovalAlert(
             maximumHeight: maximumHeight,
             allowsPersistentApproval: allowsPersistentApproval,
             temporaryGrantCandidate: temporaryGrantCandidate,
+            persistentApprovalTitle: persistentApprovalTitle,
             decide: {
                 decision = $0
                 #if !DEBUG
@@ -6586,6 +6888,20 @@ private func approvalPromptSections(
         ]))
     }
 
+    if let path = request.dotenvPath, let checksum = request.dotenvChecksum {
+        var rows = [
+            ApprovalPromptRow("Path", path),
+            ApprovalPromptRow("SHA-256", checksum),
+        ]
+        rows.append(contentsOf: request.dotenvProcesses.enumerated().map { index, process in
+            ApprovalPromptRow(
+                index == 0 ? "Entrypoint" : "Parent \(index)",
+                ([process.path] + process.arguments.dropFirst()).joined(separator: " ") + "\nwd: \(process.cwd)"
+            )
+        })
+        sections.append(ApprovalPromptSection("Dotenv", "doc.badge.key", rows))
+    }
+
     return sections
 }
 
@@ -6647,6 +6963,7 @@ private struct ApprovalPromptView: View {
     var maximumHeight: CGFloat? = nil
     var allowsPersistentApproval = false
     let temporaryGrantCandidate: TemporaryAccessGrantCandidate?
+    var persistentApprovalTitle = "Always Allow"
     let decide: (ApprovalDecision) -> Void
     let contentSizeDidChange: () -> Void
     @State private var showsDetails = false
@@ -6755,7 +7072,7 @@ private struct ApprovalPromptView: View {
                     .frame(maxWidth: .infinity)
                     .keyboardShortcut(.defaultAction)
                 if allowsPersistentApproval {
-                    Button("Always Allow") { decide(.alwaysApproved) }
+                    Button(persistentApprovalTitle) { decide(.alwaysApproved) }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.large)
                         .tint(.blue)
@@ -6788,7 +7105,7 @@ private struct ApprovalPromptView: View {
             }
 
             Text(allowsPersistentApproval
-                ? "Always Allow trusts this verified app until removed in Settings"
+                ? "Persistent access remains until its Blessing is removed."
                 : "Automic Authorization can be configured for Verified Launchers in the Automic Vault app.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -12,6 +12,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case save
     case saveIfAbsentOrEqual = "save-if-absent"
     case bless
+    case dotenv
     case delete
     case openWindow = "open-window"
     case ghSave = "gh-save"

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedDotenvs.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedDotenvs.swift
@@ -35,7 +35,16 @@ public struct BlessedDotenv: Codable, Equatable, Identifiable, Sendable {
     public let blessedAt: Date
 
     public var id: String {
-        ([path] + processes.flatMap { [$0.path, $0.cwd] + $0.arguments }).joined(separator: "\u{1f}")
+        var data = Data()
+        appendIdentity(path, to: &data)
+        appendIdentity(String(processes.count), to: &data)
+        for process in processes {
+            appendIdentity(process.path, to: &data)
+            appendIdentity(process.cwd, to: &data)
+            appendIdentity(String(process.arguments.count), to: &data)
+            process.arguments.forEach { appendIdentity($0, to: &data) }
+        }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     public init(
@@ -63,6 +72,12 @@ public struct BlessedDotenv: Codable, Equatable, Identifiable, Sendable {
             && self.processes == processes
             && launchers.contains { $0.requirement == launcherRequirement }
     }
+}
+
+private func appendIdentity(_ value: String, to data: inout Data) {
+    var length = UInt64(value.utf8.count).bigEndian
+    withUnsafeBytes(of: &length) { data.append(contentsOf: $0) }
+    data.append(contentsOf: value.utf8)
 }
 
 public func dotenvSchemaDeclaration(

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedDotenvs.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedDotenvs.swift
@@ -1,0 +1,166 @@
+import CryptoKit
+import Foundation
+import Security
+
+public let blessedDotenvsKeychainService = "com.automicvault.blessed-dotenvs"
+public let blessedDotenvsKeychainAccount = "BlessedDotenvsV1"
+
+public struct DotenvSecretDeclaration: Equatable, Sendable {
+    public let item: String
+    public let secret: String
+
+    public init(item: String, secret: String) {
+        self.item = item
+        self.secret = secret
+    }
+}
+
+public struct BlessedDotenvProcess: Codable, Equatable, Hashable, Sendable {
+    public let path: String
+    public let arguments: [String]
+    public let cwd: String
+
+    public init(path: String, arguments: [String], cwd: String) {
+        self.path = path
+        self.arguments = arguments
+        self.cwd = cwd
+    }
+}
+
+public struct BlessedDotenv: Codable, Equatable, Identifiable, Sendable {
+    public let path: String
+    public let checksum: String
+    public let processes: [BlessedDotenvProcess]
+    public let launchers: [BlessedScriptLauncher]
+    public let blessedAt: Date
+
+    public var id: String {
+        ([path] + processes.flatMap { [$0.path, $0.cwd] + $0.arguments }).joined(separator: "\u{1f}")
+    }
+
+    public init(
+        path: String,
+        checksum: String,
+        processes: [BlessedDotenvProcess],
+        launchers: [BlessedScriptLauncher],
+        blessedAt: Date = Date()
+    ) {
+        self.path = path
+        self.checksum = checksum
+        self.processes = processes
+        self.launchers = launchers
+        self.blessedAt = blessedAt
+    }
+
+    public func matches(
+        path: String,
+        checksum: String,
+        processes: [BlessedDotenvProcess],
+        launcherRequirement: String
+    ) -> Bool {
+        self.path == path
+            && self.checksum == checksum
+            && self.processes == processes
+            && launchers.contains { $0.requirement == launcherRequirement }
+    }
+}
+
+public func dotenvSchemaDeclaration(
+    data: Data,
+    item requestedItem: String,
+    secret requestedSecret: String
+) -> DotenvSecretDeclaration? {
+    dotenvSchemaDeclarations(data: data).first {
+        $0.item == requestedItem && $0.secret == requestedSecret
+    }
+}
+
+public func dotenvSchemaDeclarations(data: Data) -> [DotenvSecretDeclaration] {
+    guard let source = String(data: data, encoding: .utf8) else { return [] }
+    return source.split(separator: "\n", omittingEmptySubsequences: false).compactMap { rawLine in
+        let line = rawLine.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            .trimmingCharacters(in: .whitespaces)
+        guard let separator = line.firstIndex(of: "=") else { return nil }
+        let item = line[..<separator].trimmingCharacters(in: .whitespaces)
+        guard validDotenvKey(item) else { return nil }
+
+        let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+        guard value.hasPrefix("av("), value.hasSuffix(")") else { return nil }
+        var argument = value.dropFirst(3).dropLast().trimmingCharacters(in: .whitespaces)
+        if argument.count >= 2,
+           let first = argument.first,
+           first == argument.last,
+           first == "\"" || first == "'"
+        {
+            argument = String(argument.dropFirst().dropLast())
+        }
+        let secret = argument.isEmpty ? item : argument
+        guard validDotenvKey(secret) else { return nil }
+        return DotenvSecretDeclaration(item: item, secret: secret)
+    }
+}
+
+public func dotenvSchemaChecksum(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+}
+
+private func validDotenvKey(_ key: String) -> Bool {
+    guard let first = key.first, first == "_" || first.isASCII && first.isLetter else { return false }
+    return key.dropFirst().allSatisfy { $0 == "_" || $0.isASCII && ($0.isLetter || $0.isNumber) }
+}
+
+public func loadBlessedDotenvs(
+    service: String = blessedDotenvsKeychainService,
+    account: String = blessedDotenvsKeychainAccount
+) -> [BlessedDotenv] {
+    guard case .success(let data) = loadKeychainDataResult(service: service, account: account),
+          let dotenvs = try? JSONDecoder().decode([BlessedDotenv].self, from: data)
+    else {
+        return []
+    }
+    return dotenvs.sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+}
+
+@discardableResult
+public func saveBlessedDotenv(
+    _ dotenv: BlessedDotenv,
+    service: String = blessedDotenvsKeychainService,
+    account: String = blessedDotenvsKeychainAccount
+) -> OSStatus {
+    var dotenvs = loadBlessedDotenvs(service: service, account: account)
+    dotenvs.removeAll { $0.id == dotenv.id }
+    dotenvs.append(dotenv)
+    return saveBlessedDotenvs(dotenvs, service: service, account: account)
+}
+
+@discardableResult
+public func removeBlessedDotenv(
+    id: String,
+    service: String = blessedDotenvsKeychainService,
+    account: String = blessedDotenvsKeychainAccount
+) -> OSStatus {
+    let dotenvs = loadBlessedDotenvs(service: service, account: account).filter { $0.id != id }
+    if dotenvs.isEmpty {
+        let status = deleteStoredSecret(account: account, service: service)
+        return status == errSecItemNotFound ? errSecSuccess : status
+    }
+    return saveBlessedDotenvs(dotenvs, service: service, account: account)
+}
+
+private func saveBlessedDotenvs(
+    _ dotenvs: [BlessedDotenv],
+    service: String,
+    account: String
+) -> OSStatus {
+    guard let data = try? JSONEncoder().encode(dotenvs.sorted {
+        $0.id.localizedStandardCompare($1.id) == .orderedAscending
+    }) else {
+        return errSecParam
+    }
+    return saveKeychainData(
+        data,
+        service: service,
+        account: account,
+        accessibility: .afterFirstUnlock
+    )
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -25,6 +25,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
     public var hardeners: [HardenerMetadata]
     public var secretGates: [SecretGate]
     public var blessedScripts: [BlessedScript]
+    public var blessedDotenvs: [BlessedDotenv]
     public var secretNameAccessApps: [BlessedScriptLauncher]
     public var secrets: [StoredSecret]
     public var accessRequests: [AccessRequestRecord]
@@ -37,6 +38,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         hardeners: [HardenerMetadata] = [],
         secretGates: [SecretGate],
         blessedScripts: [BlessedScript] = [],
+        blessedDotenvs: [BlessedDotenv] = [],
         secretNameAccessApps: [BlessedScriptLauncher] = [],
         secrets: [StoredSecret],
         accessRequests: [AccessRequestRecord] = [],
@@ -48,6 +50,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         self.hardeners = hardeners
         self.secretGates = secretGates
         self.blessedScripts = blessedScripts
+        self.blessedDotenvs = blessedDotenvs
         self.secretNameAccessApps = secretNameAccessApps
         self.secrets = secrets
         self.accessRequests = accessRequests
@@ -61,6 +64,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         hardeners: [],
         secretGates: [],
         blessedScripts: [],
+        blessedDotenvs: [],
         secretNameAccessApps: [],
         secrets: [],
         accessRequests: [],
@@ -97,6 +101,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             hardeners: hardenerMetadata,
             secretGates: loadSecretGates(hardeners: hardenerMetadata, service: policyService),
             blessedScripts: loadBlessedScripts(),
+            blessedDotenvs: loadBlessedDotenvs(),
             secretNameAccessApps: loadSecretNameAccessApps(),
             secrets: secrets,
             accessRequests: loadAccessRequestRecords(),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedDotenvsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedDotenvsTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import MenubarHelperCore
+import Testing
+
+@Test func dotenvSchemaDeclarationsAreStaticAndDirect() {
+    let schema = Data("""
+    # @plugin(@automic-vault/varlock-plugin)
+    DATABASE_URL=av()
+    STRIPE_API_KEY = av(STRIPE_PROD_API_KEY) # @sensitive
+    QUOTED=av("QUOTED_SECRET")
+    DYNAMIC=av(ref(SECRET_NAME))
+    # COMMENTED=av(COMMENTED_SECRET)
+    """.utf8)
+
+    #expect(dotenvSchemaDeclarations(data: schema) == [
+        DotenvSecretDeclaration(item: "DATABASE_URL", secret: "DATABASE_URL"),
+        DotenvSecretDeclaration(item: "STRIPE_API_KEY", secret: "STRIPE_PROD_API_KEY"),
+        DotenvSecretDeclaration(item: "QUOTED", secret: "QUOTED_SECRET"),
+    ])
+    #expect(dotenvSchemaDeclaration(
+        data: schema,
+        item: "STRIPE_API_KEY",
+        secret: "STRIPE_PROD_API_KEY"
+    ) != nil)
+    #expect(dotenvSchemaDeclaration(data: schema, item: "DYNAMIC", secret: "SECRET_NAME") == nil)
+}
+
+@Test func blessedDotenvMatchesHashProcessChainAndLauncher() {
+    let process = BlessedDotenvProcess(
+        path: "/opt/homebrew/bin/node",
+        arguments: ["node", "src/release.js"],
+        cwd: "/repo"
+    )
+    let dotenv = BlessedDotenv(
+        path: "/repo/.env.schema",
+        checksum: "abc",
+        processes: [process],
+        launchers: [BlessedScriptLauncher(bundleIdentifier: "com.openai.codex", requirement: "codex")]
+    )
+
+    #expect(dotenv.matches(
+        path: "/repo/.env.schema",
+        checksum: "abc",
+        processes: [process],
+        launcherRequirement: "codex"
+    ))
+    #expect(!dotenv.matches(
+        path: "/repo/.env.schema",
+        checksum: "changed",
+        processes: [process],
+        launcherRequirement: "codex"
+    ))
+    #expect(!dotenv.matches(
+        path: "/repo/.env.schema",
+        checksum: "abc",
+        processes: [BlessedDotenvProcess(
+            path: process.path,
+            arguments: ["node", "src/other.js"],
+            cwd: process.cwd
+        )],
+        launcherRequirement: "codex"
+    ))
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedDotenvsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedDotenvsTests.swift
@@ -60,4 +60,17 @@ import Testing
         )],
         launcherRequirement: "codex"
     ))
+    let embeddedSeparator = BlessedDotenv(
+        path: dotenv.path,
+        checksum: dotenv.checksum,
+        processes: [BlessedDotenvProcess(path: process.path, arguments: ["a\u{1f}b"], cwd: process.cwd)],
+        launchers: []
+    )
+    let separateArguments = BlessedDotenv(
+        path: dotenv.path,
+        checksum: dotenv.checksum,
+        processes: [BlessedDotenvProcess(path: process.path, arguments: ["a", "b"], cwd: process.cwd)],
+        launchers: []
+    )
+    #expect(embeddedSeparator.id != separateArguments.id)
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -112,6 +112,22 @@ pub(crate) fn bless_script(path: &str, endorse_launcher: bool) -> Result<bool, S
     .map(|reply| reply.value.as_deref() == Some("already blessed"))
 }
 
+pub(crate) fn resolve_dotenv_secret(schema: &str, item: &str, key: &str) -> Result<String, String> {
+    xpc_request_fields(
+        "dotenv",
+        &[
+            Some((b"schema\0", schema)),
+            Some((b"item\0", item)),
+            Some((b"key\0", key)),
+        ],
+        None,
+        None,
+        None,
+    )?
+    .value
+    .ok_or_else(|| format!("failed to resolve dotenv key {item}"))
+}
+
 pub(crate) fn list_secret_names() -> Result<Vec<String>, String> {
     if let Some(dir) = crate::test_keychain_dir() {
         let entries = match std::fs::read_dir(dir) {
@@ -212,6 +228,23 @@ fn xpc_request_with_project_directory(
     uint_field: Option<(&'static [u8], u64)>,
     project_directory: Option<&str>,
 ) -> Result<XpcReply, String> {
+    xpc_request_fields(
+        operation,
+        &[field, extra],
+        bool_field,
+        uint_field,
+        project_directory,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn xpc_request_fields(
+    operation: &str,
+    fields: &[Option<(&'static [u8], &str)>],
+    bool_field: Option<&'static [u8]>,
+    uint_field: Option<(&'static [u8], u64)>,
+    project_directory: Option<&str>,
+) -> Result<XpcReply, String> {
     use std::ffi::CString;
     use std::os::raw::{c_char, c_int, c_void};
 
@@ -288,11 +321,8 @@ fn xpc_request_with_project_directory(
 
     unsafe {
         set_string(message, b"op\0", operation)?;
-        if let Some((field, value)) = field {
+        for (field, value) in fields.iter().flatten() {
             set_string(message, field, value)?;
-        }
-        if let Some((extra_field, value)) = extra {
-            set_string(message, extra_field, value)?;
         }
         if let Some(bool_field) = bool_field {
             xpc_dictionary_set_bool(message, bool_field.as_ptr().cast(), true);
@@ -401,6 +431,17 @@ fn xpc_request(
     _extra: Option<(&'static [u8], &str)>,
     _bool_field: Option<&'static [u8]>,
     _uint_field: Option<(&'static [u8], u64)>,
+) -> Result<XpcReply, String> {
+    Err("the Automic Vault menu bar approval service is only available on macOS".to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn xpc_request_fields(
+    _operation: &str,
+    _fields: &[Option<(&'static [u8], &str)>],
+    _bool_field: Option<&'static [u8]>,
+    _uint_field: Option<(&'static [u8], u64)>,
+    _project_directory: Option<&str>,
 ) -> Result<XpcReply, String> {
     Err("the Automic Vault menu bar approval service is only available on macOS".to_string())
 }


### PR DESCRIPTION
Adds a signed `av dotenv resolve` path and persistent Dotenv blessings under the renamed Blessings UI.

Authorization binds the canonical root `.env.schema` SHA-256, direct static `av()` declaration, live parent process metadata, and signed launcher. Schema and ancestry are revalidated immediately before disclosure; failures deny without fallback.

Also adds Keychain persistence, stale blessing display/revocation, launcher configuration, and focused Swift/Rust checks.

Companion plugin: https://github.com/automic-vault/varlock-plugin