### PR TITLE
Add automatic approval feedback setting

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -5,6 +5,22 @@ import Security
 import SwiftUI
 import UniformTypeIdentifiers
 
+let automaticApprovalFeedbackDefaultsKey = "automaticApprovalFeedback"
+
+enum AutomaticApprovalFeedback: String, CaseIterable, Identifiable {
+    case none
+    case menuBarFlash
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .none: "Show Nothing"
+        case .menuBarFlash: "Flash Menu Bar"
+        }
+    }
+}
+
 struct BlessedScriptReviewRequest: Sendable {
     let path: String
     let declaration: BlessedScriptDeclaration
@@ -188,12 +204,20 @@ final class DashboardModel: ObservableObject {
                 )
             }
         case .settings:
-            [DashboardItem(
-                id: "secret-name-access",
-                title: "Secret Name Access",
-                subtitle: "Apps allowed to run av list",
-                detail: "Manage verified apps that may list saved secret names without prompting."
-            )]
+            [
+                DashboardItem(
+                    id: "automatic-approval-feedback",
+                    title: "Automatic Approvals",
+                    subtitle: "Choose subtle feedback or none",
+                    detail: "Control visual feedback after an automatic approval."
+                ),
+                DashboardItem(
+                    id: "secret-name-access",
+                    title: "Secret Name Access",
+                    subtitle: "Apps allowed to run av list",
+                    detail: "Manage verified apps that may list saved secret names without prompting."
+                ),
+            ]
         }
         let query = searchQuery
         guard !query.isEmpty else { return base }
@@ -1125,7 +1149,8 @@ struct DashboardRootView: View {
                         }
                         .help("Add Calling App")
                     }
-                    if model.selectedSection == .settings {
+                    if model.selectedSection == .settings,
+                       model.selectedItem?.id == "secret-name-access" {
                         Button {
                             model.addSecretNameAccessApp()
                         } label: {
@@ -1284,11 +1309,19 @@ private struct DashboardDetailView: View {
                     .padding(.bottom, 28)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else if model.selectedSection == .settings {
-                SecretNameAccessSettingsView(model: model)
-                    .padding(.horizontal, 22)
-                    .padding(.top, 32)
-                    .padding(.bottom, 28)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if model.selectedItem?.id == "automatic-approval-feedback" {
+                    AutomaticApprovalFeedbackSettingsView()
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    SecretNameAccessSettingsView(model: model)
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             } else if model.selectedSection == .detectors, let item = model.selectedItem {
                 ReferenceDetailView(
                     item: item,
@@ -2193,6 +2226,33 @@ private struct SecretNameAccessSettingsView: View {
             if let error = model.errorMessage {
                 InfoBlock(title: "Error", text: error)
             }
+        }
+    }
+}
+
+private struct AutomaticApprovalFeedbackSettingsView: View {
+    @AppStorage(automaticApprovalFeedbackDefaultsKey)
+    private var feedback = AutomaticApprovalFeedback.menuBarFlash
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Automatic Approvals")
+                    .font(.system(size: 24, weight: .semibold))
+                Text("Choose what appears when access is approved automatically.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            Picker("Feedback", selection: $feedback) {
+                ForEach(AutomaticApprovalFeedback.allCases) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+            .pickerStyle(.radioGroup)
+            Text("Automatic approvals are always recorded in Secret Usage. Approval prompts and automatic rejection notifications are unaffected.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -9,8 +9,8 @@ let automaticApprovalFeedbackDefaultsKey = "automaticApprovalFeedback"
 
 enum AutomaticApprovalFeedback: String, CaseIterable, Identifiable {
     case notification
-    case none
     case menuBarFlash
+    case none
 
     var id: Self { self }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -8,6 +8,7 @@ import UniformTypeIdentifiers
 let automaticApprovalFeedbackDefaultsKey = "automaticApprovalFeedback"
 
 enum AutomaticApprovalFeedback: String, CaseIterable, Identifiable {
+    case notification
     case none
     case menuBarFlash
 
@@ -15,6 +16,7 @@ enum AutomaticApprovalFeedback: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
+        case .notification: "Show Notification"
         case .none: "Show Nothing"
         case .menuBarFlash: "Flash Menu Bar"
         }
@@ -2232,7 +2234,7 @@ private struct SecretNameAccessSettingsView: View {
 
 private struct AutomaticApprovalFeedbackSettingsView: View {
     @AppStorage(automaticApprovalFeedbackDefaultsKey)
-    private var feedback = AutomaticApprovalFeedback.menuBarFlash
+    private var feedback = AutomaticApprovalFeedback.notification
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -62,6 +62,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var automaticUpdateCheckTask: Task<Void, Never>?
     private var readyUpdate: Update?
     private var isCheckingForUpdates = false
+    private var automaticApprovalFlashWorkItem: DispatchWorkItem?
+    private var preFlashStatusImage: NSImage?
     #if !DEBUG
     private let postHogTelemetry = PostHogTelemetry.shared
     private var lastTelemetryFindingCount: Int?
@@ -248,6 +250,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func stopServices() {
+        automaticApprovalFlashWorkItem?.cancel()
+        automaticApprovalFlashWorkItem = nil
+        preFlashStatusImage = nil
         scanWorkItem?.cancel()
         scanWorkItem = nil
         scanBurstStartedAt = nil
@@ -608,7 +613,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func recordAutoApproval(_ record: AutoApprovalRecord) {
         recordMenuAccess(record)
-        showAutomaticAccessToast(record, below: statusItem.button)
+        if automaticApprovalFeedback() == .menuBarFlash {
+            flashMenuBarForAutomaticApproval()
+        }
+    }
+
+    private func flashMenuBarForAutomaticApproval() {
+        guard let button = statusItem.button else { return }
+        if automaticApprovalFlashWorkItem == nil {
+            preFlashStatusImage = button.image
+        }
+        automaticApprovalFlashWorkItem?.cancel()
+
+        let flashImage = brandImage(color: .systemGreen.withAlphaComponent(0.65))
+        button.image = flashImage
+        let workItem = DispatchWorkItem { [weak self, weak button] in
+            guard let self else { return }
+            if button?.image === flashImage {
+                button?.image = self.preFlashStatusImage
+            }
+            self.automaticApprovalFlashWorkItem = nil
+            self.preFlashStatusImage = nil
+        }
+        automaticApprovalFlashWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: workItem)
     }
 
     private func recordMenuAccess(_ record: AutoApprovalRecord) {
@@ -741,6 +769,12 @@ private func autoApprovalRecord(_ record: AccessRequestRecord) -> AutoApprovalRe
 
 private func shouldShowAutomaticAccessToast(_ record: AccessRequestRecord) -> Bool {
     record.decision == "Denied" && record.approvalSourceLabel == "Auto"
+}
+
+private func automaticApprovalFeedback(rawValue: String? = UserDefaults.standard.string(
+    forKey: automaticApprovalFeedbackDefaultsKey
+)) -> AutomaticApprovalFeedback {
+    rawValue.flatMap(AutomaticApprovalFeedback.init(rawValue:)) ?? .menuBarFlash
 }
 
 private func accessRequestRecord(
@@ -4962,6 +4996,10 @@ private func runMenuStatusSelfCheck() -> Int32 {
           approvalEvent(for: nil) == humanApprovalRequiredEvent,
           approvalEvent(for: .approved) == nil,
           approvalEvent(for: .denied) == nil,
+          automaticApprovalFeedback(rawValue: nil) == .menuBarFlash,
+          automaticApprovalFeedback(rawValue: "menuBarFlash") == .menuBarFlash,
+          automaticApprovalFeedback(rawValue: "none") == .none,
+          automaticApprovalFeedback(rawValue: "tampered") == .menuBarFlash,
           autoApprovalToolName(request) == "aws",
           approvalCommandPath(request) == "/usr/local/bin/aws",
           approvalCommandPath(envWrapperRequest) == "/usr/local/bin/pulumi",

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -613,8 +613,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func recordAutoApproval(_ record: AutoApprovalRecord) {
         recordMenuAccess(record)
-        if automaticApprovalFeedback() == .menuBarFlash {
+        switch automaticApprovalFeedback() {
+        case .notification:
+            showAutomaticAccessToast(record, below: statusItem.button)
+        case .menuBarFlash:
             flashMenuBarForAutomaticApproval()
+        case .none:
+            break
         }
     }
 
@@ -774,7 +779,7 @@ private func shouldShowAutomaticAccessToast(_ record: AccessRequestRecord) -> Bo
 private func automaticApprovalFeedback(rawValue: String? = UserDefaults.standard.string(
     forKey: automaticApprovalFeedbackDefaultsKey
 )) -> AutomaticApprovalFeedback {
-    rawValue.flatMap(AutomaticApprovalFeedback.init(rawValue:)) ?? .menuBarFlash
+    rawValue.flatMap(AutomaticApprovalFeedback.init(rawValue:)) ?? .notification
 }
 
 private func accessRequestRecord(
@@ -4996,10 +5001,11 @@ private func runMenuStatusSelfCheck() -> Int32 {
           approvalEvent(for: nil) == humanApprovalRequiredEvent,
           approvalEvent(for: .approved) == nil,
           approvalEvent(for: .denied) == nil,
-          automaticApprovalFeedback(rawValue: nil) == .menuBarFlash,
+          automaticApprovalFeedback(rawValue: nil) == .notification,
+          automaticApprovalFeedback(rawValue: "notification") == .notification,
           automaticApprovalFeedback(rawValue: "menuBarFlash") == .menuBarFlash,
           automaticApprovalFeedback(rawValue: "none") == .none,
-          automaticApprovalFeedback(rawValue: "tampered") == .menuBarFlash,
+          automaticApprovalFeedback(rawValue: "tampered") == .notification,
           autoApprovalToolName(request) == "aws",
           approvalCommandPath(request) == "/usr/local/bin/aws",
           approvalCommandPath(envWrapperRequest) == "/usr/local/bin/pulumi",

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -630,7 +630,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         automaticApprovalFlashWorkItem?.cancel()
 
-        let flashImage = brandImage(color: .systemGreen.withAlphaComponent(0.65))
+        // av.www --site-accent (#BEA9F3)
+        let flashImage = brandImage(color: NSColor(
+            srgbRed: 190.0 / 255,
+            green: 169.0 / 255,
+            blue: 243.0 / 255,
+            alpha: 1
+        ))
         button.image = flashImage
         let workItem = DispatchWorkItem { [weak self, weak button] in
             guard let self else { return }
@@ -5001,6 +5007,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
           approvalEvent(for: nil) == humanApprovalRequiredEvent,
           approvalEvent(for: .approved) == nil,
           approvalEvent(for: .denied) == nil,
+          AutomaticApprovalFeedback.allCases == [.notification, .menuBarFlash, .none],
           automaticApprovalFeedback(rawValue: nil) == .notification,
           automaticApprovalFeedback(rawValue: "notification") == .notification,
           automaticApprovalFeedback(rawValue: "menuBarFlash") == .menuBarFlash,


### PR DESCRIPTION
## Summary

- add a setting for automatic-approval feedback
- preserve the existing notification as the default
- offer either no transient UI or a subtle menu-bar flash as alternatives
- preserve audit logging, menu history, approval prompts, and automatic-rejection notifications

Closes #107.

## Security impact

This setting affects presentation only. It does not change access policy decisions, approval behavior, pending-request indicators, or audit records. Missing or invalid stored preference values fall back to the existing notification behavior.

## Validation

- `swift test` (53 tests)
- `AutomicVaultMenubar --self-check-menu-status`