### PR TITLE
Show canceled approvals in menu bar

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -700,7 +700,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func didRecordAccessRequest(_ record: AccessRequestRecord) {
-        if record.decision == "Denied", let menuRecord = autoApprovalRecord(record) {
+        if ["Canceled", "Denied"].contains(record.decision), let menuRecord = autoApprovalRecord(record) {
             recordMenuAccess(menuRecord)
             if shouldShowAutomaticAccessToast(record) {
                 showAutomaticAccessToast(menuRecord, below: statusItem.button)
@@ -771,11 +771,12 @@ private struct AutoApprovalRecord {
     let tool: String
     let command: String
     let keys: [String]
+    let wasCanceled: Bool
     let wasDenied: Bool
 }
 
 private func autoApprovalTitle(_ record: AutoApprovalRecord, formatter: DateFormatter) -> String {
-    let action = record.wasDenied ? "was denied use of" : "used"
+    let action = record.wasCanceled ? "canceled its request to use" : record.wasDenied ? "was denied use of" : "used"
     return "\(formatter.string(from: record.date)) – \(record.launcher) \(action) \(record.tool)"
 }
 
@@ -799,13 +800,15 @@ private func autoApprovalRecord(
         tool: autoApprovalToolName(request, scriptPath: script?.path),
         command: autoApprovalCommand(request, scriptPath: script?.path),
         keys: request.keys,
+        wasCanceled: false,
         wasDenied: false
     )
 }
 
 private func autoApprovalRecord(_ record: AccessRequestRecord) -> AutoApprovalRecord? {
+    let wasCanceled = record.decision == "Canceled"
     let wasDenied = record.decision == "Denied"
-    guard wasDenied || (record.decision == "Approved" && record.approvalSourceLabel == "Auto") else { return nil }
+    guard wasCanceled || wasDenied || (record.decision == "Approved" && record.approvalSourceLabel == "Auto") else { return nil }
     return AutoApprovalRecord(
         accessRequestID: record.id,
         date: record.date,
@@ -814,6 +817,7 @@ private func autoApprovalRecord(_ record: AccessRequestRecord) -> AutoApprovalRe
         tool: record.tool,
         command: record.command,
         keys: record.keys,
+        wasCanceled: wasCanceled,
         wasDenied: wasDenied
     )
 }
@@ -5477,6 +5481,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
                   tool: "aws",
                   command: "aws s3 ls",
                   keys: ["AWS_SECRET_ACCESS_KEY"],
+                  wasCanceled: false,
                   wasDenied: false
               ),
               formatter: formatter
@@ -5495,6 +5500,21 @@ private func runMenuStatusSelfCheck() -> Int32 {
               decision: "Denied",
               approvalSource: "Manual",
               reason: "Denied in prompt",
+              launcher: recordedApproval.launcher,
+              callerPath: recordedApproval.callerPath,
+              target: recordedApproval.target,
+              cwd: recordedApproval.cwd,
+              keys: recordedApproval.keys,
+              detail: recordedApproval.detail
+          )),
+          let restoredCancellation = autoApprovalRecord(AccessRequestRecord(
+              id: recordedApproval.id,
+              date: recordedApproval.date,
+              tool: "gh",
+              command: "gh pr create",
+              decision: "Canceled",
+              approvalSource: "Manual",
+              reason: "Caller exited",
               launcher: recordedApproval.launcher,
               callerPath: recordedApproval.callerPath,
               target: recordedApproval.target,
@@ -5531,6 +5551,9 @@ private func runMenuStatusSelfCheck() -> Int32 {
               detail: recordedApproval.detail
           )),
           restoredDenial.wasDenied,
+          restoredCancellation.wasCanceled,
+          autoApprovalTitle(restoredCancellation, formatter: formatter)
+              == "5:15 AM – Codex canceled its request to use gh",
           automaticAccessDecisionLabel(wasDenied: restoredDenial.wasDenied) == "AUTO REJECTED",
           automaticAccessDecisionSymbol(wasDenied: restoredDenial.wasDenied) == "xmark.shield.fill",
           automaticAccessDecisionLabel(wasDenied: restoredApproval.wasDenied) == "AUTO APPROVED",


### PR DESCRIPTION
## Summary

- show canceled approval requests in the menu bar history
- distinguish canceled requests from denied requests in menu item titles
- restore canceled entries from the persisted access log after relaunch

## Root cause

PR #114 recorded caller exits as `Canceled`, but the menu bar projection only admitted `Denied` and automatic `Approved` records. Its live update callback also explicitly ignored every decision except `Denied`.

## Validation

- `swift build --package-path src/menu-helper`
- `swift test --package-path src/menu-helper --disable-automatic-resolution` (57 tests)
- `AutomicVaultMenubar --self-check-menu-status`
- `git diff --check`
