### PR TITLE
Fix menu bar CLI install state refresh

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -225,6 +225,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = migrateBackgroundKeychainItems()
         autoApprovals = loadAccessRequestRecords().compactMap(autoApprovalRecord)
         refreshAutoApprovalMenuItems()
+        refreshCLIInstallState()
         do {
             let approval = try ApprovalServer(serviceName: approvalServiceName) { [weak self] event in
                 self?.recordAutoApproval(event)
@@ -290,6 +291,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func application(_ application: NSApplication, open urls: [URL]) {
         if urls.contains(where: isCLIInstallCompletionURL) {
+            refreshCLIInstallState()
             (mainWindow?.contentViewController as? AutomicVaultMainWindowController)?.reload()
         }
         guard let secretGateID = urls.lazy.compactMap(secretGateID(from:)).first else { return }
@@ -612,6 +614,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func refreshCLIInstallState() {
+        scanQueue.async { [weak self] in
+            let isCurrent = currentCLIInstallState() == .current
+            Task { @MainActor in
+                self?.installCLIItem.isHidden = isCurrent
+            }
+        }
+    }
+
     private func brandImage(color: NSColor? = nil) -> NSImage? {
         let fallback = NSImage(systemSymbolName: "shield.fill", accessibilityDescription: "Automic Vault")
         guard let image = Bundle.main.url(forResource: "NSMenuItem", withExtension: "png")
@@ -757,7 +768,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 extension AppDelegate: NSMenuDelegate {
     func menuWillOpen(_ menu: NSMenu) {
-        installCLIItem.isHidden = currentCLIInstallState() == .current
         refreshAutoApprovalMenuItems()
         refreshDoctorStatus()
     }

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -133,9 +133,10 @@ fn publication_requires_the_previous_app_to_accept_the_draft() {
     assert!(PUBLISH_SCRIPT.contains("AVUpdatePreflightVersion"));
     assert!(PUBLISH_SCRIPT.contains("--verify-update \"$version\""));
     assert!(PUBLISH_SCRIPT.contains("APP_VERSION=\"$previous_version\""));
-    assert!(PUBLISH_SCRIPT.contains(
-        "\"$previous_version\" == \"2.9.0\" || \"$previous_version\" == \"2.10.0\""
-    ));
+    assert!(
+        PUBLISH_SCRIPT
+            .contains("\"$previous_version\" == \"2.9.0\" || \"$previous_version\" == \"2.10.0\"")
+    );
     assert!(PUBLISH_SCRIPT.contains("lacks the updater preflight"));
     assert!(PUBLISH_SCRIPT.contains("downloaded draft DMG does not match GitHub's digest"));
 }


### PR DESCRIPTION
## Summary

- Refresh CLI installation state when the menu bar helper launches.
- Refresh state after CLI installation completion callbacks.
- Remove stale menu-open-only state updates to prevent incorrect menu behavior.

## Testing

Not run (not requested).