### PR TITLE
Report every pending approval waiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ the approval level for each tool *based on the launcher*:
 Hardened tools request secrets when they need them. Automic Vault releases those
 secrets only when your gate policy allows it or you approve.
 
+> [!IMPORTANT]
+> Human approval is available only while your macOS user session is active and
+> the screens are awake. Automic Vault aborts open approval windows and denies
+> requests that still need a human decision when the session becomes inactive
+> or the screens sleep. Retry when you return; stale approvals are not preserved.
+>
+> Requests already allowed by policy may continue without a prompt, subject to
+> each secret’s **Available While Locked** setting.
+
 > [!NOTE]
 > For launcher-specific policy, we walk the process’s launcher chain, validate its code
 > signature with macOS and match its designated requirement against the identity

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1272,8 +1272,11 @@ func performInAppSecretMutation(
 
 private let humanApprovalRequiredEvent = "human-approval-required"
 
-private func approvalEvent(for cachedDecision: ApprovalDecision?) -> String? {
-    cachedDecision == nil ? humanApprovalRequiredEvent : nil
+private func approvalEvent(
+    for cachedDecision: ApprovalDecision?,
+    humanApprovalAvailable: Bool = true
+) -> String? {
+    humanApprovalAvailable && cachedDecision == nil ? humanApprovalRequiredEvent : nil
 }
 
 private final class ApprovalCancellation: @unchecked Sendable {
@@ -1328,39 +1331,34 @@ private func missingRequiredSecret(
     }
 }
 
-private final class TransientApprovalCache: @unchecked Sendable {
+private struct TransientApprovalCache {
     private enum Key: Hashable {
         case approval(TransientApprovalKey)
         case denial(pid: Int32, startUsec: UInt64)
     }
 
-    private let lock = NSLock()
     private var expirations: [Key: Date] = [:]
 
-    func decision(for key: TransientApprovalKey, now: Date = Date()) -> ApprovalDecision? {
-        lock.withLock {
-            prune(now: now)
-            if expirations[.denial(pid: key.pid, startUsec: key.startUsec)] != nil {
-                return .denied
-            }
-            return expirations[.approval(key)] == nil ? nil : .approved
+    mutating func decision(for key: TransientApprovalKey, now: Date = Date()) -> ApprovalDecision? {
+        prune(now: now)
+        if expirations[.denial(pid: key.pid, startUsec: key.startUsec)] != nil {
+            return .denied
         }
+        return expirations[.approval(key)] == nil ? nil : .approved
     }
 
-    func remember(_ decision: ApprovalDecision, for key: TransientApprovalKey, now: Date = Date()) {
-        lock.withLock {
-            prune(now: now)
-            let cacheKey: Key
-            switch decision {
-            case .canceled: return
-            case .denied: cacheKey = .denial(pid: key.pid, startUsec: key.startUsec)
-            case .approved, .alwaysApproved: cacheKey = .approval(key)
-            }
-            expirations[cacheKey] = now.addingTimeInterval(transientApprovalTTL)
+    mutating func remember(_ decision: ApprovalDecision, for key: TransientApprovalKey, now: Date = Date()) {
+        prune(now: now)
+        let cacheKey: Key
+        switch decision {
+        case .canceled: return
+        case .denied: cacheKey = .denial(pid: key.pid, startUsec: key.startUsec)
+        case .approved, .alwaysApproved: cacheKey = .approval(key)
         }
+        expirations[cacheKey] = now.addingTimeInterval(transientApprovalTTL)
     }
 
-    private func prune(now: Date) {
+    private mutating func prune(now: Date) {
         expirations = expirations.filter { $0.value > now }
     }
 }
@@ -2004,11 +2002,18 @@ private final class ApprovalServer: @unchecked Sendable {
             promptBlessing = nil
         }
         let requiresFreshApproval = awsRequestMayUseLongLivedCredentials(request)
-        let cachedDecision = requiresFreshApproval
-            ? nil
-            : transientApprovals.decision(for: transientApproval)
-        if let event = approvalEvent(for: cachedDecision) {
-            sendEvent(event, to: peer)
+        RunLoop.main.perform(inModes: [.modalPanel, .default]) {
+            MainActor.assumeIsolated {
+                guard !cancellation.isCanceled,
+                      let event = approvalEvent(
+                          for: requiresFreshApproval
+                              ? nil
+                              : self.transientApprovals.decision(for: transientApproval),
+                          humanApprovalAvailable: self.canRequestHumanApproval()
+                      )
+                else { return }
+                self.sendEvent(event, to: peer)
+            }
         }
         DispatchQueue.main.async {
             if cancellation.isCanceled {
@@ -2068,14 +2073,14 @@ private final class ApprovalServer: @unchecked Sendable {
                     callerPath: callerPath,
                     decision: "Denied",
                     approvalSource: "Auto",
-                    reason: "User session is inactive",
+                    reason: "Human approval unavailable",
                     launcher: launcher
                 ))
                 self.reply(
                     peer,
                     to: message,
                     ok: false,
-                    error: "\(request.op) denied while user session is inactive"
+                    error: "human approval unavailable"
                 )
                 return
             }
@@ -5661,7 +5666,7 @@ private func runTransientApprovalSelfCheck() -> Int32 {
         keys: ["GH_TOKEN_GITHUB_COM_MXCL"]
     )
     let fallbackAfterDenial = key(args: ["auth", "token"])
-    let cache = TransientApprovalCache()
+    var cache = TransientApprovalCache()
     cache.remember(.approved, for: approval, now: Date(timeIntervalSince1970: 100))
     guard cache.decision(for: approval, now: Date(timeIntervalSince1970: 200)) == .approved,
           cache.decision(for: fallbackAfterDenial, now: Date(timeIntervalSince1970: 200)) == nil,
@@ -5802,6 +5807,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
           approvalEvent(for: nil) == humanApprovalRequiredEvent,
           approvalEvent(for: .approved) == nil,
           approvalEvent(for: .denied) == nil,
+          approvalEvent(for: nil, humanApprovalAvailable: false) == nil,
           AutomaticApprovalFeedback.allCases == [.notification, .menuBarFlash, .none],
           automaticApprovalFeedback(rawValue: nil) == .notification,
           automaticApprovalFeedback(rawValue: "notification") == .notification,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1328,34 +1328,39 @@ private func missingRequiredSecret(
     }
 }
 
-private struct TransientApprovalCache {
+private final class TransientApprovalCache: @unchecked Sendable {
     private enum Key: Hashable {
         case approval(TransientApprovalKey)
         case denial(pid: Int32, startUsec: UInt64)
     }
 
+    private let lock = NSLock()
     private var expirations: [Key: Date] = [:]
 
-    mutating func decision(for key: TransientApprovalKey, now: Date = Date()) -> ApprovalDecision? {
-        prune(now: now)
-        if expirations[.denial(pid: key.pid, startUsec: key.startUsec)] != nil {
-            return .denied
+    func decision(for key: TransientApprovalKey, now: Date = Date()) -> ApprovalDecision? {
+        lock.withLock {
+            prune(now: now)
+            if expirations[.denial(pid: key.pid, startUsec: key.startUsec)] != nil {
+                return .denied
+            }
+            return expirations[.approval(key)] == nil ? nil : .approved
         }
-        return expirations[.approval(key)] == nil ? nil : .approved
     }
 
-    mutating func remember(_ decision: ApprovalDecision, for key: TransientApprovalKey, now: Date = Date()) {
-        prune(now: now)
-        let cacheKey: Key
-        switch decision {
-        case .canceled: return
-        case .denied: cacheKey = .denial(pid: key.pid, startUsec: key.startUsec)
-        case .approved, .alwaysApproved: cacheKey = .approval(key)
+    func remember(_ decision: ApprovalDecision, for key: TransientApprovalKey, now: Date = Date()) {
+        lock.withLock {
+            prune(now: now)
+            let cacheKey: Key
+            switch decision {
+            case .canceled: return
+            case .denied: cacheKey = .denial(pid: key.pid, startUsec: key.startUsec)
+            case .approved, .alwaysApproved: cacheKey = .approval(key)
+            }
+            expirations[cacheKey] = now.addingTimeInterval(transientApprovalTTL)
         }
-        expirations[cacheKey] = now.addingTimeInterval(transientApprovalTTL)
     }
 
-    private mutating func prune(now: Date) {
+    private func prune(now: Date) {
         expirations = expirations.filter { $0.value > now }
     }
 }
@@ -1998,6 +2003,13 @@ private final class ApprovalServer: @unchecked Sendable {
         } else {
             promptBlessing = nil
         }
+        let requiresFreshApproval = awsRequestMayUseLongLivedCredentials(request)
+        let cachedDecision = requiresFreshApproval
+            ? nil
+            : transientApprovals.decision(for: transientApproval)
+        if let event = approvalEvent(for: cachedDecision) {
+            sendEvent(event, to: peer)
+        }
         DispatchQueue.main.async {
             if cancellation.isCanceled {
                 _ = self.onAccessRequest(canceledAccessRequestRecord(
@@ -2005,7 +2017,6 @@ private final class ApprovalServer: @unchecked Sendable {
                 ))
                 return
             }
-            let requiresFreshApproval = awsRequestMayUseLongLivedCredentials(request)
             let cachedDecision = requiresFreshApproval
                 ? nil
                 : self.transientApprovals.decision(for: transientApproval)
@@ -2069,9 +2080,6 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
 
-            if let event = approvalEvent(for: cachedDecision) {
-                self.sendEvent(event, to: peer)
-            }
             let decision = showApprovalAlert(
                 request: request,
                 callerPath: callerPath,
@@ -5653,7 +5661,7 @@ private func runTransientApprovalSelfCheck() -> Int32 {
         keys: ["GH_TOKEN_GITHUB_COM_MXCL"]
     )
     let fallbackAfterDenial = key(args: ["auth", "token"])
-    var cache = TransientApprovalCache()
+    let cache = TransientApprovalCache()
     cache.remember(.approved, for: approval, now: Date(timeIntervalSince1970: 100))
     guard cache.decision(for: approval, now: Date(timeIntervalSince1970: 200)) == .approved,
           cache.decision(for: fallbackAfterDenial, now: Date(timeIntervalSince1970: 200)) == nil,


### PR DESCRIPTION
## Summary

- send `human-approval-required` before entering the serialized AppKit approval queue
- make the transient approval cache safe for concurrent XPC handlers

## Root cause

The server emitted the status event from the main-queue block immediately before `NSApp.runModal`. While one prompt was active, later waiter blocks could not run, so their clients appeared to hang silently.

The status check now runs after caller validation and automatic-approval checks but before UI serialization. The final cache decision is still rechecked on the main path.

## Security

This does not change caller identity validation, gate policy, approval decisions, secret loading, or audit-before-release behavior. Cache access is serialized with `NSLock` to preserve its existing semantics across concurrent XPC handlers.

## Checks

- `cargo test`
- `swift test` (58 tests)
- `swift run AutomicVaultMenubar --self-check-transient-approvals`

Fixes #54
