### PR TITLE
Skip external Homebrew completion symlinks

### DIFF
--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -730,11 +730,12 @@ fn sync_zsh_completion_mirror(
                 }
             };
             if !target.starts_with(&canonical_prefix) {
-                return Err(format!(
-                    "zsh completion {} resolves outside {}",
+                eprintln!(
+                    "av-brew-stub: skipping zsh completion {} because it resolves outside {}",
                     entry.path().display(),
                     prefix.display()
-                ));
+                );
+                continue;
             }
             let mut file = fs::OpenOptions::new()
                 .read(true)
@@ -1611,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn zsh_completion_mirror_rejects_escape_without_replacing_snapshot() {
+    fn zsh_completion_mirror_omits_escape_and_publishes_safe_files() {
         let prefix = temp_path("zsh-completion-escape");
         let home = temp_path("zsh-completion-escape-home");
         let mirror = home.join(ZSH_COMPLETION_MIRROR);
@@ -1620,22 +1621,23 @@ mod tests {
         fs::create_dir_all(&functions).unwrap();
         fs::create_dir_all(&mirror).unwrap();
         fs::write(mirror.join("_existing"), "safe").unwrap();
+        fs::write(functions.join("_protected"), "#compdef protected").unwrap();
         fs::write(&outside, "unsafe").unwrap();
         std::os::unix::fs::symlink(&outside, functions.join("_escape")).unwrap();
 
-        assert!(
-            sync_zsh_completion_mirror(
-                &prefix,
-                &home,
-                &mirror,
-                fs::metadata(&outside).unwrap().uid(),
-            )
-            .is_err()
-        );
+        sync_zsh_completion_mirror(
+            &prefix,
+            &home,
+            &mirror,
+            fs::metadata(&outside).unwrap().uid(),
+        )
+        .unwrap();
         assert_eq!(
-            fs::read_to_string(mirror.join("_existing")).unwrap(),
-            "safe"
+            fs::read_to_string(mirror.join("_protected")).unwrap(),
+            "#compdef protected"
         );
+        assert!(!mirror.join("_escape").exists());
+        assert!(!mirror.join("_existing").exists());
 
         fs::remove_dir_all(prefix).unwrap();
         fs::remove_dir_all(home).unwrap();

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -731,8 +731,9 @@ fn sync_zsh_completion_mirror(
             };
             if !target.starts_with(&canonical_prefix) {
                 eprintln!(
-                    "av-brew-stub: skipping zsh completion {} because it resolves outside {}",
+                    "av-brew-stub: skipping zsh completion {} (resolves to {}) because it resolves outside {}",
                     entry.path().display(),
+                    target.display(),
                     prefix.display()
                 );
                 continue;

--- a/src/isotopes/hardeners/homebrew.md
+++ b/src/isotopes/hardeners/homebrew.md
@@ -70,7 +70,8 @@ is that solution.
   regular completion files into
   `~/.local/share/automic-vault/homebrew/zsh/site-functions`. The mirror is
   replaced atomically and the original Homebrew completion directory is removed
-  from `fpath` by `brew shellenv zsh`.
+  from `fpath` by `brew shellenv zsh`. Completion symlinks that resolve outside
+  the protected Homebrew prefix are omitted with a warning.
 - A failed refresh leaves the previous mirror intact. It warns without changing
   the result of an ordinary Homebrew command; `brew shellenv zsh` fails instead
   of emitting an unsafe `fpath` when no valid mirror can be published.


### PR DESCRIPTION
## Summary

- skip zsh completion symlinks that resolve outside the protected Homebrew prefix, with a warning
- continue atomically publishing every validated in-prefix completion
- document the external-symlink behavior

## Root cause

The completion scan treated one external cask-managed symlink as fatal, so `brew shellenv zsh` could not publish any otherwise-safe completion mirror. The private-current-directory failure reported in the same issue is already fixed on `main` by `f6d27ffa`.

The skipped target is never opened or copied; all existing ownership, mode, size, and atomic-publication checks remain in force for mirrored files.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked` (799 tests)
- focused completion mirror regression test with an external symlink and a protected completion

Closes #121
