### PR TITLE
Publish the scanner as a local website artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
       COMMIT: ${{ inputs.commit }}
       ASSET_DIR: target/release-assets
       DMG_NAME: Automic-Vault-${{ inputs.version }}.dmg
-      SCANNER_NAME: scanner.tgz
       SBOM_NAME: Automic-Vault-${{ inputs.version }}.spdx.json
       IMMUTABLE_RELEASES_ENABLED: ${{ vars.IMMUTABLE_RELEASES_ENABLED }}
       RUST_TOOLCHAIN: 1.96.0
@@ -196,11 +195,6 @@ jobs:
           codesign --verify --deep --strict "target/swift/Automic Vault.app"
           codesign --verify "$dmg"
           xcrun stapler validate "$dmg"
-          scanner_dir="$RUNNER_TEMP/scanner"
-          mkdir "$scanner_dir"
-          tar -xzf "target/$SCANNER_NAME" -C "$scanner_dir"
-          requirement='=anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = "ZU76A67LGU" and identifier "com.automicvault.scanner"'
-          codesign --verify --strict -R "$requirement" "$scanner_dir/scanner"
 
       - name: Stage release inputs
         shell: bash
@@ -208,7 +202,6 @@ jobs:
           set -euo pipefail
           mkdir -p "$ASSET_DIR" target/sbom-input
           cp "target/swift/$DMG_NAME" "$ASSET_DIR/$DMG_NAME"
-          cp "target/$SCANNER_NAME" "$ASSET_DIR/$SCANNER_NAME"
           cp Cargo.toml Cargo.lock target/sbom-input/
           cp src/menu-helper/Package.swift \
             src/menu-helper/Package.resolved \
@@ -231,18 +224,13 @@ jobs:
           set -euo pipefail
           (
             cd "$ASSET_DIR"
-            shasum -a 256 "$DMG_NAME" "$SCANNER_NAME" "$SBOM_NAME" >SHA256SUMS
+            shasum -a 256 "$DMG_NAME" "$SBOM_NAME" >SHA256SUMS
           )
 
       - name: Attest build provenance
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
         with:
           subject-path: ${{ env.ASSET_DIR }}/${{ env.DMG_NAME }}
-
-      - name: Attest scanner build provenance
-        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
-        with:
-          subject-path: ${{ env.ASSET_DIR }}/${{ env.SCANNER_NAME }}
 
       - name: Attest the SBOM
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
@@ -258,7 +246,6 @@ jobs:
           printf '%s\n' "$RELEASE_NOTES" >"$notes"
           gh release create "$VERSION" \
             "$ASSET_DIR/$DMG_NAME" \
-            "$ASSET_DIR/$SCANNER_NAME" \
             "$ASSET_DIR/$SBOM_NAME" \
             "$ASSET_DIR/SHA256SUMS" \
             --repo "$GITHUB_REPOSITORY" \

--- a/scripts/build-scanner.sh
+++ b/scripts/build-scanner.sh
@@ -7,6 +7,10 @@ IDENTITY="${SCANNER_CODESIGN_IDENTITY:--}"
 TARGET="$ROOT/target/scanner-build"
 SCANNER="$TARGET/release/scanner"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/av-scanner-package.XXXXXX")"
+CARGO=(cargo)
+if [[ -n "${SCANNER_RUST_TOOLCHAIN:-}" ]]; then
+  CARGO=(rustup run "$SCANNER_RUST_TOOLCHAIN" cargo)
+fi
 trap 'rm -rf "$TMP"' EXIT
 
 MACOSX_DEPLOYMENT_TARGET=14.0 \
@@ -17,7 +21,7 @@ CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
 CARGO_PROFILE_RELEASE_STRIP=symbols \
 CARGO_PROFILE_RELEASE_PANIC=abort \
 RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-dead_strip" \
-  cargo build --release --locked --bin scanner --manifest-path "$ROOT/Cargo.toml"
+  "${CARGO[@]}" build --release --locked --bin scanner --manifest-path "$ROOT/Cargo.toml"
 
 codesign_args=(--force --sign "$IDENTITY" --options runtime)
 if [[ "$IDENTITY" != "-" ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -178,9 +178,6 @@ fi
 
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$ROOT/target/release/av"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$ROOT/target/release/av-brew-stub"
-if [[ "$release_artifact" -eq 1 ]]; then
-  SCANNER_CODESIGN_IDENTITY="$identity" "$ROOT/scripts/build-scanner.sh"
-fi
 cp "$ROOT/target/release/av" "$MACOS/av"
 cp "$ROOT/target/release/av-brew-stub" "$MACOS/av-brew-stub"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$MACOS/av"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -32,6 +32,8 @@ TAP_ROOT="${AUTOMIC_VAULT_REPO_CACHE:-$ROOT/../homebrew-isotopes}"
 WEBSITE_BUCKET="${AUTOMIC_VAULT_WEBSITE_BUCKET:-automicvault.com}"
 WEBSITE_ALIAS="${AUTOMIC_VAULT_WEBSITE_DOMAIN:-automicvault.com}"
 WEBSITE_DISTRIBUTION_ID="${AUTOMIC_VAULT_CLOUDFRONT_DISTRIBUTION_ID:-}"
+SCANNER_RUST_TOOLCHAIN="1.96.0"
+SCANNER_CODESIGN_IDENTITY=""
 CURRENT_VERSION="$(
   awk -F '"' '
     /^\[package\]/ { package = 1; next }
@@ -315,8 +317,26 @@ prepare_cask_publish() {
 }
 
 prepare_website_publish() {
+  local rustc_version
   if ! command -v aws >/dev/null 2>&1; then
     echo "error: publish requires aws" >&2
+    exit 64
+  fi
+  if ! command -v rustup >/dev/null 2>&1; then
+    echo "error: publishing the scanner requires rustup" >&2
+    exit 64
+  fi
+  rustc_version="$(rustup run "$SCANNER_RUST_TOOLCHAIN" rustc --version 2>/dev/null || true)"
+  if [[ "$rustc_version" != "rustc $SCANNER_RUST_TOOLCHAIN "* ]]; then
+    echo "error: install Rust $SCANNER_RUST_TOOLCHAIN before publishing the scanner" >&2
+    exit 64
+  fi
+  SCANNER_CODESIGN_IDENTITY="$(
+    security find-identity -v -p codesigning |
+      awk -F '"' '$2 ~ /^Developer ID Application:/ && $2 ~ /\(ZU76A67LGU\)$/ { print $2 }'
+  )"
+  if [[ -z "$SCANNER_CODESIGN_IDENTITY" || "$SCANNER_CODESIGN_IDENTITY" == *$'\n'* ]]; then
+    echo "error: publishing the scanner requires exactly one Developer ID Application identity for ZU76A67LGU" >&2
     exit 64
   fi
   if [[ ! "$WEBSITE_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ||
@@ -344,28 +364,21 @@ prepare_website_publish() {
 publish_website_assets() (
   set -euo pipefail
   umask 077
-  local version="$1"
-  local tmp archive expected actual scanner requirement
+  local expected_head="$1"
+  local tmp archive scanner requirement
+  if [[ "$(git -C "$ROOT" rev-parse HEAD)" != "$expected_head" ||
+    -n "$(git -C "$ROOT" status --porcelain --untracked-files=all)" ]]; then
+    echo "error: scanner must be built from the clean release commit" >&2
+    exit 1
+  fi
   tmp="$(mktemp -d "$ROOT/target/av-website-publish.XXXXXX")"
   trap 'rm -rf "$tmp"' EXIT
   archive="$tmp/scanner.tgz"
   scanner="$tmp/scanner"
 
-  gh release download "$version" \
-    --repo "$REPOSITORY" \
-    --pattern scanner.tgz \
-    --dir "$tmp"
-  expected="$(
-    gh release view "$version" \
-      --repo "$REPOSITORY" \
-      --json assets \
-      --jq '.assets[] | select(.name == "scanner.tgz") | .digest'
-  )"
-  actual="sha256:$(shasum -a 256 "$archive" | awk '{print $1}')"
-  if [[ ! "$expected" =~ ^sha256:[0-9a-f]{64}$ || "$actual" != "$expected" ]]; then
-    echo "error: scanner archive does not match GitHub's digest" >&2
-    exit 1
-  fi
+  SCANNER_RUST_TOOLCHAIN="$SCANNER_RUST_TOOLCHAIN" \
+    SCANNER_CODESIGN_IDENTITY="$SCANNER_CODESIGN_IDENTITY" \
+    "$ROOT/scripts/build-scanner.sh" "$archive"
   if [[ "$(tar -tzf "$archive")" != scanner ]]; then
     echo "error: scanner archive has unexpected contents" >&2
     exit 1
@@ -636,7 +649,7 @@ if [[ "$is_draft" != "false" || "$is_immutable" != "true" || "$target_commitish"
   echo "error: published release is not immutable or targets the wrong commit" >&2
   exit 1
 fi
-publish_website_assets "$VERSION"
+publish_website_assets "$head"
 digest="$(
   gh release view "$VERSION" \
     --repo "$REPOSITORY" \

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -131,14 +131,21 @@ fn release_actions_delegate_website_publication_to_the_local_script() {
     assert!(PUBLISH_SCRIPT.contains("gh release edit"));
     assert!(PUBLISH_SCRIPT.contains("Update Automic Vault cask to $version"));
     assert!(PUBLISH_SCRIPT.contains("Homebrew tap main must match origin/main"));
-    assert!(PUBLISH_SCRIPT.contains("publish_website_assets \"$VERSION\""));
+    assert!(PUBLISH_SCRIPT.contains("publish_website_assets \"$head\""));
     assert!(PUBLISH_SCRIPT.contains("contains(Aliases.Items, '$WEBSITE_ALIAS')"));
     assert!(!PUBLISH_SCRIPT.contains("contains(join(',', Aliases.Items)"));
+    assert!(PUBLISH_SCRIPT.contains("SCANNER_RUST_TOOLCHAIN=\"1.96.0\""));
+    assert!(
+        PUBLISH_SCRIPT.contains("exactly one Developer ID Application identity for ZU76A67LGU")
+    );
+    assert!(PUBLISH_SCRIPT.contains("$ROOT/scripts/build-scanner.sh"));
+    assert!(PUBLISH_SCRIPT.contains("scanner must be built from the clean release commit"));
+    assert!(!PUBLISH_SCRIPT.contains("--pattern scanner.tgz"));
     assert!(PUBLISH_SCRIPT.contains("$ROOT/scripts/dist/install.sh"));
     assert!(PUBLISH_SCRIPT.contains("$ROOT/scripts/dist/scanner.sh"));
     assert!(PUBLISH_SCRIPT.contains("s3://$WEBSITE_BUCKET/install.sh"));
     assert!(PUBLISH_SCRIPT.contains("s3://$WEBSITE_BUCKET/scanner.tgz"));
-    assert!(PUBLISH_SCRIPT.contains("scanner archive does not match GitHub's digest"));
+    assert!(PUBLISH_SCRIPT.contains("scanner archive has unexpected contents"));
     assert!(PUBLISH_SCRIPT.contains("codesign --verify --strict -R \"$requirement\" \"$scanner\""));
     assert!(RELEASE_WORKFLOW.contains("DMG_NAME: Automic-Vault-${{ inputs.version }}.dmg"));
 }
@@ -174,6 +181,7 @@ fn scanner_is_small_signed_and_read_only() {
     ] {
         assert!(BUILD_SCANNER_SCRIPT.contains(setting));
     }
+    assert!(BUILD_SCANNER_SCRIPT.contains("rustup run \"$SCANNER_RUST_TOOLCHAIN\" cargo"));
     assert!(SCANNER_SCRIPT.contains("https://www.automicvault.com/scanner.tgz"));
     assert!(SCANNER_SCRIPT.contains("--proto '=https'"));
     assert!(SCANNER_SCRIPT.contains("--proto-redir '=https'"));

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -145,6 +145,14 @@ fn release_actions_delegate_website_publication_to_the_local_script() {
     assert!(PUBLISH_SCRIPT.contains("scanner archive has unexpected contents"));
     assert!(PUBLISH_SCRIPT.contains("codesign --verify --strict -R \"$requirement\" \"$scanner\""));
     assert!(RELEASE_WORKFLOW.contains("DMG_NAME: Automic-Vault-${{ inputs.version }}.dmg"));
+    let build = PUBLISH_SCRIPT
+        .find("$ROOT/scripts/build-scanner.sh")
+        .unwrap();
+    let verify = PUBLISH_SCRIPT
+        .find("codesign --verify --strict -R \"$requirement\" \"$scanner\"")
+        .unwrap();
+    let upload = PUBLISH_SCRIPT.find("aws s3 cp \"$archive\"").unwrap();
+    assert!(build < verify && verify < upload);
 }
 
 #[test]

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -17,7 +17,7 @@ fn release_workflow_binds_the_dmg_to_reviewed_source() {
     assert!(RELEASE_WORKFLOW.contains("--target \"$GITHUB_SHA\""));
     assert!(RELEASE_WORKFLOW.contains("targetCommitish"));
     assert!(RELEASE_WORKFLOW.contains("actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"));
-    assert_eq!(RELEASE_WORKFLOW.matches("uses: actions/attest@").count(), 3);
+    assert_eq!(RELEASE_WORKFLOW.matches("uses: actions/attest@").count(), 2);
     assert!(RELEASE_WORKFLOW.contains("sbom-path:"));
     assert!(RELEASE_WORKFLOW.contains("SHA256SUMS"));
     assert!(RELEASE_WORKFLOW.contains("RUST_TOOLCHAIN: 1.96.0"));
@@ -38,11 +38,8 @@ fn release_assets_are_immutable_and_never_replaced() {
     assert!(!BUILD_SCRIPT.contains("--clobber"));
     assert!(!PUBLISH_SCRIPT.contains("--clobber"));
     assert!(!PUBLISH_SCRIPT.contains("gh release create"));
-    assert!(RELEASE_WORKFLOW.contains("SCANNER_NAME: scanner.tgz"));
-    assert!(
-        RELEASE_WORKFLOW
-            .contains("codesign --verify --strict -R \"$requirement\" \"$scanner_dir/scanner\"")
-    );
+    assert!(!RELEASE_WORKFLOW.contains("SCANNER_NAME"));
+    assert!(!RELEASE_WORKFLOW.contains("scanner.tgz"));
 }
 
 #[test]
@@ -96,7 +93,7 @@ fn release_builds_are_actions_only_and_fail_closed() {
     ));
     assert!(BUILD_SCRIPT.contains("requires a Developer ID Application identity"));
     assert!(BUILD_SCRIPT.contains("requires the Developer ID provisioning profile"));
-    assert!(BUILD_SCRIPT.contains("SCANNER_CODESIGN_IDENTITY=\"$identity\""));
+    assert!(!BUILD_SCRIPT.contains("build-scanner.sh"));
     assert!(NOTARIZE_SCRIPT.starts_with("#!/bin/sh\n"));
     assert!(!NOTARIZE_SCRIPT.contains("/usr/local/bin/av"));
     for secret in ["APPLE_USERNAME", "APPLE_PASSWORD", "APPLE_TEAM_ID"] {


### PR DESCRIPTION
## What changed

- build and Developer ID-sign `scanner.tgz` in the local website publication flow
- require the clean release commit, Rust 1.96.0, and exactly one signing identity for team `ZU76A67LGU`
- verify the archive shape and designated code-signing requirement before uploading it
- remove the scanner from GitHub release assets, release checksums, and provenance attestations

## Why

The scanner is an experimental marketing entrypoint, not a versioned product deliverable. Publishing it beside the DMG made it appear to carry the same release and support status. It now remains a website-only artifact built and uploaded locally with the human-readable `scanner.sh`.

## Validation

- full Rust suite passes: 772 unit tests plus all integration tests
- release workflow contract tests pass
- shell scripts pass syntax checks and ShellCheck
- release workflow YAML parses successfully
- a real Rust 1.96.0 local build produced a 767,856-byte scanner and passed the expected Developer ID designated requirement
