### PR TITLE
Open settings with Command-comma

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -66,6 +66,10 @@ final class AutomicVaultMainWindowController: NSHostingController<DashboardRootV
         model.showSecretGate(id: id)
     }
 
+    func showSettings() {
+        model.showSettings()
+    }
+
     func reviewBlessing(
         _ request: BlessedScriptReviewRequest,
         completion: @escaping (String?) -> Void
@@ -95,6 +99,13 @@ final class AutomicVaultWindow: NSWindow {
             return true
         case "h":
             NSApp.hide(nil)
+            return true
+        case ",":
+            guard let controller = contentViewController as? AutomicVaultMainWindowController
+            else {
+                return super.performKeyEquivalent(with: event)
+            }
+            controller.showSettings()
             return true
         default:
             return super.performKeyEquivalent(with: event)
@@ -317,6 +328,11 @@ final class DashboardModel: ObservableObject {
     func showSecretGate(id: String) {
         selectedSection = .secretGates
         selectedItemID = id
+    }
+
+    func showSettings() {
+        selectedSection = .settings
+        selectedItemID = nil
     }
 
     func reviewBlessing(


### PR DESCRIPTION
⌘, opens settings in essentially every other Mac app, and right now it does nothing here. The window already answers ⌘C, ⌘W and ⌘H in `performKeyEquivalent`, so this adds a fourth case alongside them. Since the app runs as an accessory with no menu bar to carry the standard Settings item, the window seemed like the right place for it rather than a menu.

Three small additions, each mirroring the existing `showSecretGate(id:)` path:

- `case ","` in `AutomicVaultWindow.performKeyEquivalent`
- `AutomicVaultMainWindowController.showSettings()`
- `DashboardModel.showSettings()`, setting `selectedSection = .settings` and clearing `selectedItemID`

### One thing I couldn't verify

It builds clean — `swift build -c release` on the whole package with Xcode 27 beta — and `swift test` is green at 60. But I couldn't confirm the pane actually switches at runtime, because I can't produce a signed build: `ApprovalServer.init` requires a team identifier, and running the bare SwiftPM executable exits immediately since it has no bundle identifier. Would you mind giving it a quick try?

If it doesn't behave, my guess at the likely culprit is focus: if the sidebar search field has first responder, the field editor may consume the event before the window sees it. Happy to move the handling if so.

### A question on scope

Right now this only works when the main window is open and key. Would you want ⌘, to also open the window when it's closed — say from the menu bar item — or is window-scoped the right behavior for an accessory app?
