### PR TITLE
Fix mixed-store GitHub credential migration

### DIFF
--- a/src/isotopes/detectors/gh_cli/mod.rs
+++ b/src/isotopes/detectors/gh_cli/mod.rs
@@ -115,6 +115,29 @@ pub(crate) fn keychain_services_allow_security_tool(_services: &[String]) -> Res
     Ok(false)
 }
 
+#[cfg(target_os = "macos")]
+pub(crate) use macos_keychain::{LegacyKeychainItem, legacy_keychain_items};
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) struct LegacyKeychainItem {
+    pub service: String,
+    pub account: String,
+}
+
+#[cfg(not(target_os = "macos"))]
+impl LegacyKeychainItem {
+    pub(crate) fn delete(self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn legacy_keychain_items(
+    _services: &[String],
+) -> Result<Vec<LegacyKeychainItem>, String> {
+    Ok(Vec::new())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,6 +275,7 @@ mod macos_keychain {
     const CSSM_ACL_AUTHORIZATION_ANY: i32 = 1;
     const CSSM_ACL_AUTHORIZATION_DECRYPT: i32 = 24;
     const SEC_GENERIC_PASSWORD_ITEM_CLASS: u32 = u32::from_be_bytes(*b"genp");
+    const SEC_ACCOUNT_ITEM_ATTR: u32 = u32::from_be_bytes(*b"acct");
     const SEC_SERVICE_ITEM_ATTR: u32 = u32::from_be_bytes(*b"svce");
     const SECURITY_TOOL_PATH: &[u8] = b"/usr/bin/security";
 
@@ -278,6 +302,13 @@ mod macos_keychain {
         attr: *mut SecKeychainAttribute,
     }
 
+    #[repr(C)]
+    struct SecKeychainAttributeInfo {
+        count: u32,
+        tag: *mut u32,
+        format: *mut u32,
+    }
+
     #[link(name = "CoreFoundation", kind = "framework")]
     unsafe extern "C" {
         fn CFArrayGetCount(array: CFArrayRef) -> isize;
@@ -298,6 +329,19 @@ mod macos_keychain {
         fn SecACLGetAuthorizations(acl: SecACLRef, tags: *mut i32, tag_count: *mut u32) -> i32;
         fn SecAccessCopyACLList(access: SecAccessRef, acl_list: *mut CFArrayRef) -> i32;
         fn SecKeychainItemCopyAccess(item: SecKeychainItemRef, access: *mut SecAccessRef) -> i32;
+        fn SecKeychainItemCopyAttributesAndData(
+            item: SecKeychainItemRef,
+            info: *mut SecKeychainAttributeInfo,
+            item_class: *mut u32,
+            attr_list: *mut *mut SecKeychainAttributeList,
+            length: *mut u32,
+            data: *mut *mut c_void,
+        ) -> i32;
+        fn SecKeychainItemDelete(item: SecKeychainItemRef) -> i32;
+        fn SecKeychainItemFreeAttributesAndData(
+            attr_list: *mut SecKeychainAttributeList,
+            data: *mut c_void,
+        ) -> i32;
         fn SecKeychainSearchCopyNext(
             search: SecKeychainSearchRef,
             item: *mut SecKeychainItemRef,
@@ -323,7 +367,50 @@ mod macos_keychain {
         Ok(false)
     }
 
+    pub(crate) struct LegacyKeychainItem {
+        pub service: String,
+        pub account: String,
+        item: ScopedCf<c_void>,
+    }
+
+    impl LegacyKeychainItem {
+        pub(crate) fn delete(self) -> Result<(), String> {
+            check_status(
+                unsafe { SecKeychainItemDelete(self.item.0) },
+                &format!(
+                    "delete legacy keychain item (service {:?}, account {:?})",
+                    self.service, self.account
+                ),
+            )
+        }
+    }
+
+    pub(crate) fn legacy_keychain_items(
+        services: &[String],
+    ) -> Result<Vec<LegacyKeychainItem>, String> {
+        let mut found = Vec::new();
+        for service in services {
+            for item in service_items(service)? {
+                found.push(LegacyKeychainItem {
+                    service: service.clone(),
+                    account: item_account(item.0)?,
+                    item,
+                });
+            }
+        }
+        Ok(found)
+    }
+
     fn service_allows_security_tool(service: &str) -> Result<bool, String> {
+        for item in service_items(service)? {
+            if item_allows_security_tool(item.0)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn service_items(service: &str) -> Result<Vec<ScopedCf<c_void>>, String> {
         let mut service_bytes = service.as_bytes().to_vec();
         let mut attr = SecKeychainAttribute {
             tag: SEC_SERVICE_ITEM_ATTR,
@@ -344,23 +431,68 @@ mod macos_keychain {
             )
         };
         if status == ERR_SEC_ITEM_NOT_FOUND {
-            return Ok(false);
+            return Ok(Vec::new());
         }
         check_status(status, "create keychain search")?;
         let _search_ref = ScopedCf(search);
+        let mut items = Vec::new();
 
         loop {
             let mut item = ptr::null();
             let status = unsafe { SecKeychainSearchCopyNext(search, &mut item) };
             if status == ERR_SEC_ITEM_NOT_FOUND {
-                return Ok(false);
+                return Ok(items);
             }
             check_status(status, "copy next keychain item")?;
-            let _item_ref = ScopedCf(item);
-            if item_allows_security_tool(item)? {
-                return Ok(true);
-            }
+            items.push(ScopedCf(item));
         }
+    }
+
+    fn item_account(item: SecKeychainItemRef) -> Result<String, String> {
+        let mut tag = SEC_ACCOUNT_ITEM_ATTR;
+        let mut info = SecKeychainAttributeInfo {
+            count: 1,
+            tag: &mut tag,
+            format: ptr::null_mut(),
+        };
+        let mut attributes = ptr::null_mut();
+        check_status(
+            unsafe {
+                SecKeychainItemCopyAttributesAndData(
+                    item,
+                    &mut info,
+                    ptr::null_mut(),
+                    &mut attributes,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                )
+            },
+            "copy keychain item account",
+        )?;
+        let account = if attributes.is_null() || unsafe { (*attributes).count } != 1 {
+            Err("legacy keychain item has no account".to_string())
+        } else if let Some(attribute) = unsafe { (*attributes).attr.as_ref() } {
+            if attribute.data.is_null() && attribute.length != 0 {
+                Err("legacy keychain item has an invalid account".to_string())
+            } else {
+                let bytes = if attribute.length == 0 {
+                    &[]
+                } else {
+                    unsafe {
+                        std::slice::from_raw_parts(attribute.data.cast(), attribute.length as usize)
+                    }
+                };
+                String::from_utf8(bytes.to_vec())
+                    .map_err(|_| "legacy keychain item account is not UTF-8".to_string())
+            }
+        } else {
+            Err("legacy keychain item has no account".to_string())
+        };
+        check_status(
+            unsafe { SecKeychainItemFreeAttributesAndData(attributes, ptr::null_mut()) },
+            "free keychain item account",
+        )?;
+        account
     }
 
     fn item_allows_security_tool(item: SecKeychainItemRef) -> Result<bool, String> {

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -46,7 +46,7 @@ mod firebase_cli;
 mod flyctl;
 mod gallery_dl;
 mod gcli;
-mod gh_cli;
+pub(crate) mod gh_cli;
 mod git;
 mod glab;
 mod goat;

--- a/src/isotopes/hardeners/gh_cli.rs
+++ b/src/isotopes/hardeners/gh_cli.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -33,13 +34,18 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
     }
 
     let hosts_paths = gh_hosts_paths()?;
-    let mut credentials = Vec::new();
+    let configured_hosts = configured_hosts(&hosts_paths);
+    let mut plaintext_credentials = Vec::new();
     for path in &hosts_paths {
-        credentials.extend(read_plaintext_credentials(path)?);
+        plaintext_credentials.extend(read_plaintext_credentials(path)?);
     }
-    if credentials.is_empty() {
-        credentials.extend(read_legacy_keychain_credentials(&hosts_paths));
-    }
+    let legacy_credentials = read_legacy_keychain_credentials(&configured_hosts)?;
+    let mut credentials = plaintext_credentials.clone();
+    credentials.extend(
+        legacy_credentials
+            .iter()
+            .map(|credential| credential.credential.clone()),
+    );
 
     writeln!(stdout, "╭─ harden gh").ok();
     writeln!(stdout, "│").ok();
@@ -49,32 +55,44 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
         return Ok(());
     }
 
+    let destinations = migration_destinations(&credentials, &configured_hosts)?;
+    preflight_destinations(&destinations)?;
+
     writeln!(
         stdout,
         "├─ migrate {} GitHub token(s) into Automic Vault",
         credentials.len()
     )
     .ok();
-    writeln!(
-        stdout,
-        "├─ remove plaintext oauth_token entries from hosts.yml"
-    )
-    .ok();
+    if !plaintext_credentials.is_empty() {
+        writeln!(
+            stdout,
+            "├─ delete plaintext oauth_token entries from hosts.yml"
+        )
+        .ok();
+    }
+    if !legacy_credentials.is_empty() {
+        writeln!(
+            stdout,
+            "├─ delete {} exact legacy GitHub Keychain item(s)",
+            legacy_credentials.len()
+        )
+        .ok();
+    }
     writeln!(stdout, "│").ok();
     if !confirm(stdout, yes)? {
         writeln!(stdout, "╰─ cancelled").ok();
         return Ok(());
     }
 
-    for credential in &credentials {
-        store_gh_credential(credential)?;
-    }
+    store_and_verify_destinations(&destinations)?;
     for path in &hosts_paths {
         remove_plaintext_tokens(path)?;
     }
-    for credential in &credentials {
-        delete_legacy_keychain_tokens(&credential.host, credential.user.as_deref())?;
+    for credential in legacy_credentials {
+        credential.delete()?;
     }
+    verify_postconditions()?;
     writeln!(stdout, "╰─ migrated gh credentials").ok();
     super::write_secret_gate_notice(stdout, "gh");
     Ok(())
@@ -178,11 +196,11 @@ fn parse_hosts_credentials(contents: &str) -> Vec<GhCredential> {
         if indent <= 4 {
             user_context = None;
         }
-        if indent == 4 {
-            if let Some(value) = yaml_string_value(trimmed, "user") {
-                active_user = Some(value.to_string());
-                continue;
-            }
+        if indent == 4
+            && let Some(value) = yaml_string_value(trimmed, "user")
+        {
+            active_user = Some(value.to_string());
+            continue;
         }
         if indent >= 8 && trimmed.ends_with(':') {
             user_context = trimmed.strip_suffix(':').map(str::to_string);
@@ -211,19 +229,72 @@ fn yaml_string_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
     Some(value.trim().trim_matches('"').trim_matches('\''))
 }
 
-fn read_legacy_keychain_credentials(hosts_paths: &[PathBuf]) -> Vec<GhCredential> {
-    let hosts = configured_hosts(hosts_paths);
-    let mut credentials = Vec::new();
-    for (host, user) in hosts {
-        if let Some(token) = legacy_token(&host, user.as_deref()) {
-            credentials.push(GhCredential { host, user, token });
-        }
-    }
-    credentials
+struct LegacyCredential {
+    credential: GhCredential,
+    item: Option<crate::isotopes::detectors::gh_cli::LegacyKeychainItem>,
 }
 
-fn configured_hosts(hosts_paths: &[PathBuf]) -> Vec<(String, Option<String>)> {
-    let mut hosts = vec![("github.com".to_string(), None)];
+impl LegacyCredential {
+    fn delete(self) -> Result<(), String> {
+        self.item.map_or(Ok(()), |item| item.delete())
+    }
+}
+
+fn read_legacy_keychain_credentials(
+    hosts: &BTreeMap<String, Option<String>>,
+) -> Result<Vec<LegacyCredential>, String> {
+    if let Some(token) = crate::test_env_string("AUTOMIC_VAULT_TEST_GH_LEGACY_TOKEN") {
+        return Ok(hosts
+            .iter()
+            .map(|(host, user)| LegacyCredential {
+                credential: GhCredential {
+                    host: host.clone(),
+                    user: user.clone(),
+                    token: token.clone(),
+                },
+                item: None,
+            })
+            .collect());
+    }
+    if crate::test_keychain_dir().is_some() {
+        return Ok(Vec::new());
+    }
+
+    let services = hosts
+        .keys()
+        .map(|host| format!("gh:{host}"))
+        .collect::<Vec<_>>();
+    let items = crate::isotopes::detectors::gh_cli::legacy_keychain_items(&services)?;
+    let mut identities = BTreeSet::new();
+    let mut credentials = Vec::new();
+    for item in items {
+        if !identities.insert((item.service.clone(), item.account.clone())) {
+            return Err(format!(
+                "refusing ambiguous duplicate legacy keychain items (service {:?}, account {:?})",
+                item.service, item.account
+            ));
+        }
+        let token = security_find_generic_password_result(&item.service, Some(&item.account))?
+            .ok_or_else(|| {
+                format!(
+                    "failed to read legacy keychain item (service {:?}, account {:?})",
+                    item.service, item.account
+                )
+            })?;
+        credentials.push(LegacyCredential {
+            credential: GhCredential {
+                host: item.service.trim_start_matches("gh:").to_string(),
+                user: (!item.account.is_empty()).then(|| item.account.clone()),
+                token,
+            },
+            item: Some(item),
+        });
+    }
+    Ok(credentials)
+}
+
+fn configured_hosts(hosts_paths: &[PathBuf]) -> BTreeMap<String, Option<String>> {
+    let mut hosts = BTreeMap::from([("github.com".to_string(), None)]);
     for path in hosts_paths {
         let Ok(contents) = fs::read_to_string(path) else {
             continue;
@@ -235,53 +306,59 @@ fn configured_hosts(hosts_paths: &[PathBuf]) -> Vec<(String, Option<String>)> {
             let trimmed = line.trim();
             if indent == 0 {
                 if let Some(previous) = host.take() {
-                    hosts.push((previous, active_user.take()));
+                    hosts.insert(previous, active_user.take());
                 }
                 host = trimmed.strip_suffix(':').map(str::to_string);
-            } else if indent == 4 {
-                if let Some(value) = yaml_string_value(trimmed, "user") {
-                    active_user = Some(value.to_string());
-                }
+            } else if indent == 4
+                && let Some(value) = yaml_string_value(trimmed, "user")
+            {
+                active_user = Some(value.to_string());
             }
         }
         if let Some(previous) = host {
-            hosts.push((previous, active_user));
+            hosts.insert(previous, active_user);
         }
     }
-    hosts.sort();
-    hosts.dedup();
     hosts
-}
-
-fn legacy_token(host: &str, user: Option<&str>) -> Option<String> {
-    if let Some(token) = crate::test_env_string("AUTOMIC_VAULT_TEST_GH_LEGACY_TOKEN") {
-        return Some(token);
-    }
-    let service = format!("gh:{host}");
-    if let Some(user) = user {
-        if let Some(token) = security_find_generic_password(&service, Some(user)) {
-            return Some(token);
-        }
-    }
-    security_find_generic_password(&service, Some(""))
-        .or_else(|| security_find_generic_password(&service, None))
 }
 
 pub(super) fn security_find_generic_password(
     service: &str,
     account: Option<&str>,
 ) -> Option<String> {
+    security_find_generic_password_result(service, account)
+        .ok()
+        .flatten()
+}
+
+fn security_find_generic_password_result(
+    service: &str,
+    account: Option<&str>,
+) -> Result<Option<String>, String> {
     let mut command = Command::new(security_path());
     command.args(["find-generic-password", "-s", service]);
     if let Some(account) = account {
         command.args(["-a", account]);
     }
     command.arg("-w");
-    let output = command.output().ok()?;
+    let output = command
+        .output()
+        .map_err(|err| format!("failed to run security: {err}"))?;
     if !output.status.success() {
-        return None;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("could not be found")
+            || stderr.contains("The specified item could not be found")
+        {
+            return Ok(None);
+        }
+        return Err(format!(
+            "failed to read legacy keychain item (service {service:?}, account {account:?}): {}",
+            stderr.trim()
+        ));
     }
-    decode_legacy_keychain_password(String::from_utf8_lossy(&output.stdout).trim())
+    Ok(decode_legacy_keychain_password(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
 }
 
 fn decode_legacy_keychain_password(value: &str) -> Option<String> {
@@ -363,12 +440,127 @@ fn decode_hex(value: &str) -> Option<Vec<u8>> {
         .collect()
 }
 
-fn store_gh_credential(credential: &GhCredential) -> Result<(), String> {
-    crate::secrets::store_secret(&vault_key(&credential.host, None), &credential.token)?;
-    if let Some(user) = &credential.user {
-        crate::secrets::store_secret(&vault_key(&credential.host, Some(user)), &credential.token)?;
+fn migration_destinations(
+    credentials: &[GhCredential],
+    active_users: &BTreeMap<String, Option<String>>,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut destinations = BTreeMap::new();
+    for credential in credentials {
+        if let Some(user) = credential.user.as_deref().filter(|user| !user.is_empty()) {
+            insert_destination(
+                &mut destinations,
+                vault_key(&credential.host, Some(user)),
+                &credential.token,
+            )?;
+        } else {
+            insert_destination(
+                &mut destinations,
+                vault_key(&credential.host, None),
+                &credential.token,
+            )?;
+        }
+
+        if active_users
+            .get(&credential.host)
+            .and_then(|user| user.as_deref())
+            == credential.user.as_deref()
+        {
+            insert_destination(
+                &mut destinations,
+                vault_key(&credential.host, None),
+                &credential.token,
+            )?;
+        }
+    }
+
+    for (host, active_user) in active_users {
+        if active_user.is_some() || destinations.contains_key(&vault_key(host, None)) {
+            continue;
+        }
+        let mut tokens = credentials
+            .iter()
+            .filter(|credential| credential.host == *host)
+            .map(|credential| credential.token.as_str());
+        if let Some(token) = tokens
+            .next()
+            .filter(|token| tokens.all(|other| other == *token))
+        {
+            insert_destination(&mut destinations, vault_key(host, None), token)?;
+        }
+    }
+    Ok(destinations)
+}
+
+fn insert_destination(
+    destinations: &mut BTreeMap<String, String>,
+    key: String,
+    token: &str,
+) -> Result<(), String> {
+    if let Some(existing) = destinations.get(&key) {
+        if existing != token {
+            return Err(format!(
+                "refusing ambiguous GitHub credential destination {key}"
+            ));
+        }
+    } else {
+        destinations.insert(key, token.to_string());
     }
     Ok(())
+}
+
+fn preflight_destinations(destinations: &BTreeMap<String, String>) -> Result<(), String> {
+    let existing = crate::secrets::list_secret_names()?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    for (key, expected) in destinations {
+        if existing.contains(key) && crate::secrets::load_secret(key)? != *expected {
+            return Err(format!(
+                "refusing to replace differing existing GitHub credential {key}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn store_and_verify_destinations(destinations: &BTreeMap<String, String>) -> Result<(), String> {
+    for (key, token) in destinations {
+        crate::secrets::store_secret_if_absent_or_equal(key, token)?;
+    }
+    for (key, expected) in destinations {
+        if crate::secrets::load_secret(key)? != *expected {
+            return Err(format!("failed to verify GitHub credential {key}"));
+        }
+    }
+    Ok(())
+}
+
+fn verify_postconditions() -> Result<(), String> {
+    let hosts_token =
+        crate::isotopes::detectors::gh_cli::hosts_token::install_insecurity_reasons()?;
+    let keychain_access = if crate::test_keychain_dir().is_some() {
+        Vec::new()
+    } else {
+        crate::isotopes::detectors::gh_cli::keychain_access::install_insecurity_reasons()?
+    };
+    ensure_postconditions(&hosts_token, &keychain_access)
+}
+
+fn ensure_postconditions(hosts_token: &[String], keychain_access: &[String]) -> Result<(), String> {
+    let mut failed = Vec::new();
+    if !hosts_token.is_empty() {
+        failed.push("gh-cli-hosts-token");
+    }
+    if !keychain_access.is_empty() {
+        failed.push("gh-cli-keychain-access");
+    }
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "GitHub migration postcondition failed: {}",
+            failed.join(", ")
+        ))
+    }
 }
 
 fn remove_plaintext_tokens(path: &Path) -> Result<(), String> {
@@ -386,17 +578,6 @@ fn remove_plaintext_tokens(path: &Path) -> Result<(), String> {
             .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
     }
     Ok(())
-}
-
-fn delete_legacy_keychain_tokens(host: &str, user: Option<&str>) -> Result<(), String> {
-    if crate::test_env_var("AUTOMIC_VAULT_TEST_GH_LEGACY_TOKEN").is_some() {
-        return Ok(());
-    }
-    let service = format!("gh:{host}");
-    if let Some(user) = user {
-        security_delete_generic_password(&service, Some(user))?;
-    }
-    security_delete_generic_password(&service, Some(""))
 }
 
 pub(super) fn security_delete_generic_password(
@@ -559,13 +740,12 @@ mod tests {
     }
 
     #[test]
-    fn harden_decodes_go_keyring_legacy_token() {
+    fn harden_imports_legacy_keychain_token() {
         let _guard = crate::global_test_env_lock().lock().unwrap();
-        let dir = temp_path("gh-go-keyring-import");
+        let dir = temp_path("gh-keychain-import");
         let config = dir.join("config");
         let keychain = dir.join("keychain");
         let gh = dir.join("gh");
-        let security = dir.join("security");
         fs::create_dir_all(&config).unwrap();
         fs::write(&gh, "").unwrap();
         fs::write(
@@ -573,27 +753,27 @@ mod tests {
             "github.com:\n    users:\n        mxcl:\n    user: mxcl\n",
         )
         .unwrap();
-        fs::write(
-            &security,
-            "#!/bin/sh\nprintf '%s\\n' 'go-keyring-base64:Z2hvX3NlY3JldA=='\n",
-        )
-        .unwrap();
-        fs::set_permissions(&security, fs::Permissions::from_mode(0o700)).unwrap();
         unsafe {
             std::env::set_var("GH_CONFIG_DIR", &config);
             std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
             std::env::set_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH", &gh);
-            std::env::set_var("AUTOMIC_VAULT_TEST_SECURITY_PATH", &security);
+            std::env::set_var("AUTOMIC_VAULT_TEST_GH_LEGACY_TOKEN", "gho_secret");
         }
 
-        run(&mut Vec::new(), true).unwrap();
+        let mut output = Vec::new();
+        run(&mut output, true).unwrap();
 
         unsafe {
             std::env::remove_var("GH_CONFIG_DIR");
             std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
             std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
-            std::env::remove_var("AUTOMIC_VAULT_TEST_SECURITY_PATH");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_GH_LEGACY_TOKEN");
         }
+        assert!(
+            String::from_utf8(output)
+                .unwrap()
+                .contains("delete 1 exact legacy")
+        );
         assert_eq!(
             fs::read_to_string(keychain.join("GH_TOKEN_GITHUB_COM")).unwrap(),
             "gho_secret"
@@ -603,6 +783,125 @@ mod tests {
             "gho_secret"
         );
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn migration_destinations_union_multiple_accounts() {
+        let credentials = vec![
+            GhCredential {
+                host: "github.com".into(),
+                user: Some("monalisa".into()),
+                token: "active-token".into(),
+            },
+            GhCredential {
+                host: "github.com".into(),
+                user: Some("hubot".into()),
+                token: "other-token".into(),
+            },
+        ];
+        let active_users =
+            BTreeMap::from([("github.com".to_string(), Some("monalisa".to_string()))]);
+
+        assert_eq!(
+            migration_destinations(&credentials, &active_users).unwrap(),
+            BTreeMap::from([
+                (
+                    "GH_TOKEN_GITHUB_COM".to_string(),
+                    "active-token".to_string()
+                ),
+                (
+                    "GH_TOKEN_GITHUB_COM_HUBOT".to_string(),
+                    "other-token".to_string(),
+                ),
+                (
+                    "GH_TOKEN_GITHUB_COM_MONALISA".to_string(),
+                    "active-token".to_string(),
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn migration_rejects_ambiguous_destination() {
+        let credentials = vec![
+            GhCredential {
+                host: "github.com".into(),
+                user: Some("mona-lisa".into()),
+                token: "first".into(),
+            },
+            GhCredential {
+                host: "github.com".into(),
+                user: Some("mona_lisa".into()),
+                token: "second".into(),
+            },
+        ];
+
+        let error = migration_destinations(
+            &credentials,
+            &BTreeMap::from([("github.com".to_string(), None)]),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("refusing ambiguous GitHub credential destination"));
+    }
+
+    #[test]
+    fn harden_preserves_sources_and_destination_on_conflict() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_path("gh-destination-conflict");
+        let config = dir.join("config");
+        let keychain = dir.join("keychain");
+        let gh = dir.join("gh");
+        fs::create_dir_all(&config).unwrap();
+        fs::create_dir_all(&keychain).unwrap();
+        fs::write(&gh, "").unwrap();
+        fs::write(
+            config.join("hosts.yml"),
+            "github.com:\n    user: monalisa\n    oauth_token: incoming\n",
+        )
+        .unwrap();
+        fs::write(keychain.join("GH_TOKEN_GITHUB_COM"), "working").unwrap();
+        unsafe {
+            std::env::set_var("GH_CONFIG_DIR", &config);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+            std::env::set_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH", &gh);
+        }
+
+        let error = run(&mut Vec::new(), true).unwrap_err();
+
+        unsafe {
+            std::env::remove_var("GH_CONFIG_DIR");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
+        }
+        assert!(
+            matches!(error, HardenError::Other(message) if message.contains("refusing to replace"))
+        );
+        assert_eq!(
+            fs::read_to_string(keychain.join("GH_TOKEN_GITHUB_COM")).unwrap(),
+            "working"
+        );
+        assert!(
+            fs::read_to_string(config.join("hosts.yml"))
+                .unwrap()
+                .contains("oauth_token: incoming")
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verifies_both_detector_postconditions() {
+        assert!(ensure_postconditions(&[], &[]).is_ok());
+        assert!(
+            ensure_postconditions(&["plaintext".into()], &[])
+                .unwrap_err()
+                .contains("gh-cli-hosts-token")
+        );
+        assert!(
+            ensure_postconditions(&[], &["keychain".into()])
+                .unwrap_err()
+                .contains("gh-cli-keychain-access")
+        );
     }
 
     #[test]

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1252,6 +1252,7 @@ private struct ApprovalRequest {
 
 enum SecretMutation {
     case save(account: String, value: String, accessibility: StoredSecretAccessibility)
+    case saveIfAbsentOrEqual(account: String, value: String, accessibility: StoredSecretAccessibility)
     case delete(account: String)
     case rename(account: String, newAccount: String)
     case setAccessibility(account: String, accessibility: StoredSecretAccessibility)
@@ -1263,6 +1264,11 @@ enum SecretMutation {
             properties = (
                 "save", [account], ["save", account], "Store \(account)?",
                 "This will create or replace a secret in Automic Vault."
+            )
+        case .saveIfAbsentOrEqual(let account, _, _):
+            properties = (
+                "save-if-absent", [account], ["save-if-absent", account], "Store \(account)?",
+                "This will create the secret only if no differing value already exists."
             )
         case .delete(let account):
             properties = (
@@ -1305,6 +1311,12 @@ enum SecretMutation {
         switch self {
         case .save(let account, let value, let accessibility):
             saveStoredSecret(account: account, value: value, accessibility: accessibility)
+        case .saveIfAbsentOrEqual(let account, let value, let accessibility):
+            saveStoredSecretIfAbsentOrEqual(
+                account: account,
+                value: value,
+                accessibility: accessibility
+            )
         case .delete(let account):
             deleteStoredSecret(account: account)
         case .rename(let account, let newAccount):
@@ -1800,6 +1812,14 @@ private final class ApprovalServer: @unchecked Sendable {
             )
         case "save" where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
+        case "save-if-absent" where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleSave(
+                message,
+                on: peer,
+                cancellation: cancellation,
+                caller: mutationCaller,
+                ifAbsentOrEqual: true
+            )
         case "load" where isTrustedAvCaller(path: callerPath, signing: signing):
             handleLoad(message, on: peer)
         case "bless" where isTrustedAvCaller(path: callerPath, signing: signing):
@@ -2542,7 +2562,8 @@ private final class ApprovalServer: @unchecked Sendable {
         _ message: xpc_object_t,
         on peer: xpc_connection_t,
         cancellation: ApprovalCancellation,
-        caller: MutationCaller
+        caller: MutationCaller,
+        ifAbsentOrEqual: Bool = false
     ) {
         guard let keyPointer = xpc_dictionary_get_string(message, "key"),
               let valuePointer = xpc_dictionary_get_string(message, "value")
@@ -2556,8 +2577,11 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         let value = String(cString: valuePointer)
+        let mutation: SecretMutation = ifAbsentOrEqual
+            ? .saveIfAbsentOrEqual(account: key, value: value, accessibility: .whenUnlocked)
+            : .save(account: key, value: value, accessibility: .whenUnlocked)
         handleMutation(
-            .save(account: key, value: value, accessibility: .whenUnlocked),
+            mutation,
             on: peer,
             message: message,
             cancellation: cancellation,
@@ -2763,7 +2787,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             switch mutation {
-            case .save(let account, _, _):
+            case .save(let account, _, _), .saveIfAbsentOrEqual(let account, _, _):
                 if status == errSecSuccess {
                     self.reply(peer, to: message, ok: true, error: nil)
                 } else {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1252,7 +1252,7 @@ private struct ApprovalRequest {
 
 enum SecretMutation {
     case save(account: String, value: String, accessibility: StoredSecretAccessibility)
-    case saveIfAbsentOrEqual(account: String, value: String, accessibility: StoredSecretAccessibility)
+    case saveIfAbsentOrEqual(account: String, value: String)
     case delete(account: String)
     case rename(account: String, newAccount: String)
     case setAccessibility(account: String, accessibility: StoredSecretAccessibility)
@@ -1265,7 +1265,7 @@ enum SecretMutation {
                 "save", [account], ["save", account], "Store \(account)?",
                 "This will create or replace a secret in Automic Vault."
             )
-        case .saveIfAbsentOrEqual(let account, _, _):
+        case .saveIfAbsentOrEqual(let account, _):
             properties = (
                 "save-if-absent", [account], ["save-if-absent", account], "Store \(account)?",
                 "This will create the secret only if no differing value already exists."
@@ -1311,12 +1311,8 @@ enum SecretMutation {
         switch self {
         case .save(let account, let value, let accessibility):
             saveStoredSecret(account: account, value: value, accessibility: accessibility)
-        case .saveIfAbsentOrEqual(let account, let value, let accessibility):
-            saveStoredSecretIfAbsentOrEqual(
-                account: account,
-                value: value,
-                accessibility: accessibility
-            )
+        case .saveIfAbsentOrEqual(let account, let value):
+            saveStoredSecretIfAbsentOrEqual(account: account, value: value)
         case .delete(let account):
             deleteStoredSecret(account: account)
         case .rename(let account, let newAccount):
@@ -2578,7 +2574,7 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         let value = String(cString: valuePointer)
         let mutation: SecretMutation = ifAbsentOrEqual
-            ? .saveIfAbsentOrEqual(account: key, value: value, accessibility: .whenUnlocked)
+            ? .saveIfAbsentOrEqual(account: key, value: value)
             : .save(account: key, value: value, accessibility: .whenUnlocked)
         handleMutation(
             mutation,
@@ -2787,7 +2783,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             switch mutation {
-            case .save(let account, _, _), .saveIfAbsentOrEqual(let account, _, _):
+            case .save(let account, _, _), .saveIfAbsentOrEqual(let account, _):
                 if status == errSecSuccess {
                     self.reply(peer, to: message, ok: true, error: nil)
                 } else {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1228,14 +1228,12 @@ public func saveStoredSecret(
 public func saveStoredSecretIfAbsentOrEqual(
     account: String,
     value: String,
-    accessibility: StoredSecretAccessibility = .whenUnlocked,
     service: String = automicVaultKeychainService
 ) -> OSStatus {
     saveKeychainDataIfAbsentOrEqual(
         Data(value.utf8),
         service: service,
-        account: account,
-        accessibility: accessibility
+        account: account
     )
 }
 
@@ -1373,8 +1371,7 @@ func saveKeychainData(
 func saveKeychainDataIfAbsentOrEqual(
     _ data: Data,
     service: String,
-    account: String,
-    accessibility: StoredSecretAccessibility = .whenUnlocked
+    account: String
 ) -> OSStatus {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
@@ -1382,7 +1379,7 @@ func saveKeychainDataIfAbsentOrEqual(
         kSecAttrAccount as String: account,
         kSecUseDataProtectionKeychain as String: true,
         kSecValueData as String: data,
-        kSecAttrAccessible as String: accessibility.keychainValue,
+        kSecAttrAccessible as String: StoredSecretAccessibility.whenUnlocked.keychainValue,
     ]
     addCanonicalAccessGroup(to: &query)
     let status = SecItemAdd(query as CFDictionary, nil)

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1225,6 +1225,20 @@ public func saveStoredSecret(
     )
 }
 
+public func saveStoredSecretIfAbsentOrEqual(
+    account: String,
+    value: String,
+    accessibility: StoredSecretAccessibility = .whenUnlocked,
+    service: String = automicVaultKeychainService
+) -> OSStatus {
+    saveKeychainDataIfAbsentOrEqual(
+        Data(value.utf8),
+        service: service,
+        account: account,
+        accessibility: accessibility
+    )
+}
+
 public func setStoredSecretAccessibility(
     account: String,
     accessibility: StoredSecretAccessibility,
@@ -1354,6 +1368,31 @@ func saveKeychainData(
     addQuery[kSecValueData as String] = data
     addQuery[kSecAttrAccessible as String] = accessibility.keychainValue
     return SecItemAdd(addQuery as CFDictionary, nil)
+}
+
+func saveKeychainDataIfAbsentOrEqual(
+    _ data: Data,
+    service: String,
+    account: String,
+    accessibility: StoredSecretAccessibility = .whenUnlocked
+) -> OSStatus {
+    var query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+        kSecUseDataProtectionKeychain as String: true,
+        kSecValueData as String: data,
+        kSecAttrAccessible as String: accessibility.keychainValue,
+    ]
+    addCanonicalAccessGroup(to: &query)
+    let status = SecItemAdd(query as CFDictionary, nil)
+    guard status == errSecDuplicateItem else { return status }
+    guard case .success(let existing) = loadKeychainDataResult(service: service, account: account),
+          existing == data
+    else {
+        return errSecDuplicateItem
+    }
+    return errSecSuccess
 }
 
 private func addCanonicalAccessGroup(to query: inout [String: Any]) {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -544,6 +544,18 @@ func protectionPolicyMatrix(
     #expect(keychainAccessibility(account: "API_TOKEN", service: service) == kSecAttrAccessibleWhenUnlocked as String)
 }
 
+@Test func conditionalSecretSaveNeverReplacesDifferingValue() {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.conditional-save.\(UUID().uuidString)"
+    let account = "TOKEN"
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+
+    #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "first", service: service) == errSecSuccess)
+    #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "first", service: service) == errSecSuccess)
+    #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "second", service: service) == errSecDuplicateItem)
+    #expect(loadStoredSecret(account: account, service: service) == "first")
+}
+
 @Test func storedSecretAccessibilityCanChangeWithoutChangingValue() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.\(UUID().uuidString)"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -551,9 +551,26 @@ func protectionPolicyMatrix(
     defer { _ = deleteStoredSecret(account: account, service: service) }
 
     #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "first", service: service) == errSecSuccess)
+    #expect(keychainAccessibility(account: account, service: service) == kSecAttrAccessibleWhenUnlocked as String)
     #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "first", service: service) == errSecSuccess)
     #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "second", service: service) == errSecDuplicateItem)
     #expect(loadStoredSecret(account: account, service: service) == "first")
+}
+
+@Test func conditionalSecretSavePreservesExistingAccessibility() {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.conditional-save.\(UUID().uuidString)"
+    let account = "TOKEN"
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+
+    #expect(saveStoredSecret(
+        account: account,
+        value: "first",
+        accessibility: .afterFirstUnlock,
+        service: service
+    ) == errSecSuccess)
+    #expect(saveStoredSecretIfAbsentOrEqual(account: account, value: "first", service: service) == errSecSuccess)
+    #expect(keychainAccessibility(account: account, service: service) == kSecAttrAccessibleAfterFirstUnlock as String)
 }
 
 @Test func storedSecretAccessibilityCanChangeWithoutChangingValue() throws {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -24,6 +24,41 @@ pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
     .map(|_| ())
 }
 
+pub(crate) fn store_secret_if_absent_or_equal(account: &str, value: &str) -> Result<(), String> {
+    if let Some(dir) = crate::test_keychain_dir() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|err| format!("failed to create test keychain dir: {err}"))?;
+        let path = PathBuf::from(dir).join(account);
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                use std::io::Write;
+                file.write_all(value.as_bytes())
+                    .map_err(|err| format!("failed to write {}: {err}", path.display()))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                let existing = std::fs::read_to_string(&path)
+                    .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+                (existing == value)
+                    .then_some(())
+                    .ok_or_else(|| format!("refusing to replace existing isotope key {account}"))
+            }
+            Err(err) => Err(format!("failed to create {}: {err}", path.display())),
+        }
+    } else {
+        xpc_request(
+            "save-if-absent",
+            Some((b"key\0", account)),
+            Some((b"value\0", value)),
+            None,
+        )
+        .map(|_| ())
+    }
+}
+
 pub(crate) fn load_secret(account: &str) -> Result<String, String> {
     if let Some(dir) = crate::test_keychain_dir() {
         let path = PathBuf::from(dir).join(account);
@@ -47,8 +82,12 @@ pub(crate) fn bless_script(path: &str, endorse_caller: bool) -> Result<bool, Str
 
 pub(crate) fn list_secret_names() -> Result<Vec<String>, String> {
     if let Some(dir) = crate::test_keychain_dir() {
-        let mut names = std::fs::read_dir(dir)
-            .map_err(|err| format!("failed to list test keychain: {err}"))?
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(format!("failed to list test keychain: {err}")),
+        };
+        let mut names = entries
             .filter_map(|entry| entry.ok())
             .filter_map(|entry| entry.file_type().ok()?.is_file().then(|| entry.file_name()))
             .filter_map(|name| name.into_string().ok())


### PR DESCRIPTION
Fixes #133

## What changed

- Union plaintext hosts.yml credentials with every legacy GitHub Keychain account.
- Preserve active-user routing while storing additional accounts under scoped keys.
- Preflight destination equality and use an atomic insert-or-equal XPC operation.
- Verify every destination before removing plaintext or deleting retained exact Keychain items.
- Disclose exact Keychain deletion in the attended prompt and verify both GitHub detector postconditions.

## Root cause

The hardener treated plaintext and Keychain discovery as alternatives, performed at most one fallback Keychain lookup per host, discarded the actual account on unscoped reads, and used an upsert that could replace a differing destination.

## Security impact

Differing or ambiguous destinations now fail closed before source mutation. Concurrent destination creation also cannot be overwritten. Source deletion happens only after all destination values have been verified, and legacy Keychain deletion targets the exact enumerated item reference.

## Validation

- cargo test --all-targets --no-fail-fast (810 tests)
- swift test in src/menu-helper (67 tests)
- cargo test gh_cli -- --test-threads=1 (20 focused tests)
- git diff --check