### PR TITLE
Add explicit launcher access continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,3 +443,5 @@ For more ephemeral discussion,
 
 > We provide a Discord server as a more convenient way to engage in
 > *ephemeral* discussion. Hardly anybody is there and that is *fine*.
+
+[Documentation index](docs/index.md)

--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ review.
 Launcher Endorsement can make the exact Blessed Script automically authorized
 for a specific Verified Launcher.
 
+> [!NOTE]
+> Blessed Scripts are designed for well-defined usage scenarios: they run a
+> reviewed set of steps and then exit, so you can reason about which Tools they
+> run and where they apply Secrets. Do not use them to inject Secrets into
+> long-running Tools. Use Authorization Gates with Verified Launchers:
+> [Hardened Tools](#hardening) for long-running use, or Blessed Scripts for
+> bounded automation. In rare cases, add Direct Access Rules for exact Secret
+> Names and specific Verified Launchers.
+
 > [!TIP]
 > Allowing specific signed launchers is powerful but requires careful
 > consideration. Potential uses:

--- a/docs/adr/0006-direct-secret-access.md
+++ b/docs/adr/0006-direct-secret-access.md
@@ -1,0 +1,46 @@
+# ADR 0006: Direct Secret Access
+
+- Status: Accepted
+- Date: 2026-08-07
+
+## Context
+
+A Verified Launcher can submit a complete direct `av inject` request without a
+Tool-specific Secret Gate. Approval can authorize that request once, but the
+existing durable policies require either a Hardener-provided gate or an exact
+Blessed Script. Some stable Developer ID-signed launchers need repeated access
+to a small set of named Secrets while selecting commands dynamically.
+
+Treating this as Secret Availability would conflate Keychain accessibility with
+authorization. Attaching it to an unrelated Tool gate would misrepresent both
+the Target and the granted authority.
+
+## Decision
+
+Automic Vault has one built-in Direct Secret Gate whose default Access Level is
+Approval Required. A Direct Access Rule binds one exact Secret Name to one
+Verified Launcher identity and permits Unconstrained Secret Application through
+direct `av inject`.
+
+Rules store the Launcher’s designated requirement, not its path or display name.
+Every request revalidates the live code signature and required runtime
+protections. Every requested Secret Name must have a matching rule for the same
+Verified Launcher. Rules never apply to Secret Disclosure, Secret Name listing,
+Secret mutation, or Tool-specific Gate Client requests.
+
+The UI requires a fresh acknowledgement of the broader delegation before every
+attempt to add a rule. Renaming or deleting a Secret revokes its Direct Access
+Rules. Authorization Record persistence remains mandatory before Secret
+Application.
+
+## Consequences
+
+- A permitted Launcher may choose any Target and arguments and can therefore
+  cause the Secret to be disclosed after application.
+- Tool-specific Hardening and Blessed Scripts remain the preferred alternatives
+  because they constrain more of the Authorization Request.
+- Invalid identity, unsafe runtime protection, malformed policy, incomplete
+  Secret matching, or failed Authorization Record persistence cannot produce
+  automic authorization.
+- A Direct Access Rule does not propagate to another Secret Name, Launcher, or
+  Gate Client.

--- a/docs/adr/0007-retained-launcher-provenance.md
+++ b/docs/adr/0007-retained-launcher-provenance.md
@@ -1,0 +1,59 @@
+# ADR 0007: Retain Launcher Provenance for Detached Processes
+
+- Status: Accepted
+- Date: 2026-08-07
+
+## Context
+
+Long-lived developer harnesses can outlive the Verified Launcher that started
+them. macOS may reparent a server under a terminal or app to PID 1 after its
+parent exits. Later Gate Clients remain descendants of the same server process,
+but ordinary process ancestry no longer proves which Verified Launcher supplied
+policy.
+
+Remembering a prior Approval would be incorrect: Approval authorizes one complete
+Authorization Request. Remembering PID and start time alone would also be
+unsafe because `exec` preserves both while replacing the executable image.
+
+## Decision
+
+Automic Vault may retain ephemeral Launcher provenance after a successful
+automic authorization. One record binds:
+
+- one Authorization Gate;
+- the exact Verified Launcher that supplied authority;
+- one signed intermediary process execution identified by PID, PID version,
+  start time, user and audit session, and live code identity.
+
+Automic Vault creates a provenance record only after it persists the required
+Authorization Record. Human Approval never creates Retained Launcher
+Provenance. Automic Vault keeps provenance in memory, revalidates it before every
+use, and removes it when the process execution or menu bar helper exits.
+
+When normal ancestry cannot supply authority, a matching record may restore the
+original Launcher attribution only for its recorded gate. Automic Vault then
+classifies the complete current Authorization Request and applies the gate's
+current policy. It does not reuse the earlier Authorization Decision. Policy
+changes and revocation therefore take effect immediately, Unknown still requires
+Approval, and every allowed Secret Use still requires a new Authorization
+Record.
+
+A global **Keep Launcher Access for Detached Processes** setting controls the
+behavior and defaults to off. Automic Vault may keep non-authorizing shadow
+records while the setting is off so an Approval window can explain when the
+setting would have permitted the current request.
+
+## Consequences
+
+- Portal, herdr, and similar harnesses use one generic process-provenance model;
+  no product name or executable basename becomes an identity.
+- A process cannot inherit provenance after PID reuse, `exec`, code replacement,
+  another user session, menu bar helper restart, or use at another gate.
+- Enabling the setting extends a Launcher's gate-specific authority beyond the
+  lifetime of its visible parent chain. A process can intentionally detach and
+  retain that attribution until its exact execution exits.
+- Ad-hoc signed processes remain more exposed to same-user code injection than
+  Hardened Runtime launchers. The UI recommends a Secure Launcher for recurring
+  harness use.
+- If supported macOS APIs cannot establish the exact process execution or live
+  code identity, Automic Vault fails closed and does not retain or reuse it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,10 @@ Unknown operation risk requires Approval. Missing or invalid identity, integrity
 
 Policies bind a Gate and Verified Launcher. Approval binds one complete request and process. Blessings bind exact script contents and a complete declaration.
 
+Optional Retained Launcher Provenance binds one Authorization Gate, one Verified
+Launcher, and one exact live process execution. It preserves attribution after
+ancestry loss; it does not preserve an Authorization Decision.
+
 ### The system is zeroconf above its boundary
 
 Developer tools and agent harnesses use their existing commands. Automic Vault discovers and hardens integrations beneath that interface. Configuration remains where user intent or a security tradeoff requires it.
@@ -72,9 +76,23 @@ flowchart LR
 
 The Authorization Request is immutable across this flow. A cached decision may be reused only for the same live process and complete request identity. Reuse still requires an Authorization Record before Secret Application.
 
+After a successful policy decision, Automic Vault may record Retained Launcher
+Provenance for signed intermediary process executions.
+If ordinary ancestry later disappears, that provenance may restore the original
+Launcher only at the same Authorization Gate. The complete later request is
+classified against current policy and receives a new Authorization Decision and
+Authorization Record.
+
 ## Identity model
 
 The policy identity is the Launcher's designated requirement, checked against the live process and its launch chain. Paths, process identifiers, names, and icons help the user recognize software but do not establish identity. Hardened Runtime requirements and rejected entitlements form part of launcher eligibility.
+
+Retained Launcher Provenance identifies an intermediary by its macOS process
+execution identity, including PID version and process start time, and by its live
+code identity. PID alone, PID plus start time, a pathname, or a basename is not
+sufficient: `exec` preserves PID and start time while changing the executable
+generation. Retained records are memory-only, are revalidated before use, and
+expire when the process execution or menu bar helper exits.
 
 The Gate Client and Target remain separate roles. A signed client submits the request. The Target performs the operation and may receive the Secret. Conflating them hides confused-deputy and target-substitution risks.
 
@@ -139,6 +157,14 @@ The Direct Secret Gate starts at Approval Required and has no broad default.
 Adding each Direct Access Rule requires an explicit warning and acknowledgement.
 Runtime signature or Hardened Runtime verification failure disables automic
 authorization and falls back to Approval when human approval is available.
+
+Detached-process access is off by default. While it is off, Retained Launcher
+Provenance may be observed in memory only to explain an Approval that the setting
+would have avoided; shadow records cannot authorize. Enabling the setting
+extends a verified Launcher's gate-specific attribution through a live signed
+descendant after its original parent chain exits. The UI must explain that this
+widens the lifetime of authority and that a Secure Launcher is safer for a
+recurring mutable or injectable harness.
 
 ## Source of truth
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,11 @@ Automic Vault stores named opaque Secrets in the macOS Data Protection Keychain.
 
 Authorization Gates verify the Launcher, bind the Gate Client and Target, classify the complete operation, apply the gate's Authorization Policy, request Approval when policy cannot allow it, and enforce the Authorization Decision.
 
+The Direct Secret Gate handles direct `av inject` requests that do not match a
+Tool-specific gate. It defaults to Approval Required. A user may add a Direct
+Access Rule for one exact Secret Name and Verified Launcher, knowingly allowing
+that Launcher to select the Target and arguments on future requests.
+
 ### Reviewed Automation
 
 Script Blessings bind a canonical path, exact contents, Script Declaration, capabilities, and optional Launcher Endorsements. Execution uses a verified snapshot so file edits cannot race authorization.
@@ -84,7 +89,12 @@ Each Authorization Gate owns one Authorization Policy:
 5. Policy must permit every characteristic for automic authorization.
 6. Unknown prevents automic authorization.
 
-Access Levels are named presets over operation characteristics. The user sees a small set of presets and concrete Approval reasons. The policy engine's target model keeps Homebrew Update, Local Write, System Write, Remote Write, Elevated Secret Application, and Secret Disclosure distinct.
+Access Levels are named presets over operation characteristics. The user sees a small set of presets and concrete Approval reasons. The policy engine's target model keeps Homebrew Update, Local Write, System Write, Remote Write, Elevated Secret Application, Unconstrained Secret Application, and Secret Disclosure distinct.
+
+Direct Access is available only at the Direct Secret Gate. It permits
+Unconstrained Secret Application for exact Secret Names in the matching
+Launcher’s Direct Access Rules. It does not turn unknown Tool operations into
+recognized operations and does not apply to Tool-specific Gate Clients.
 
 ### Current compatibility model
 
@@ -103,6 +113,10 @@ The Homebrew migration intentionally broadens persisted `readOnly` rules to allo
 
 Secret bytes stay in the app's private Keychain access group. Gate policy and Authorization History use separate services. Availability controls whether Keychain may return a Secret while the device is locked. Authorization controls whether the operation may receive it. Both checks must pass.
 
+Direct Access Rules are authorization policy, not Secret Availability. They are
+stored separately from Secret bytes. Renaming or deleting a Secret revokes its
+rules so recreating an old Secret Name cannot silently restore authority.
+
 Human Approval requires an active user session and awake displays. Requests that still need a human decision are denied if the session becomes inactive or the displays sleep. Policy-authorized requests may proceed while locked only when every requested Secret has Available While Locked enabled.
 
 ## Recording before release
@@ -120,6 +134,11 @@ After Secret Application, the Target controls its own memory, plugins, helpers, 
 ## Secure defaults
 
 New Secret Gates start at Read Only. The Homebrew Execution Gate starts at Read & Update, which adds `brew update` without authorizing installation, upgrade, reinstall, removal, or other writes. Unknown operations and unverifiable Launchers require a human decision or denial according to the failed check. Every default and Launcher-specific rule is explicit and persisted.
+
+The Direct Secret Gate starts at Approval Required and has no broad default.
+Adding each Direct Access Rule requires an explicit warning and acknowledgement.
+Runtime signature or Hardened Runtime verification failure disables automic
+authorization and falls back to Approval when human approval is available.
 
 ## Source of truth
 

--- a/docs/direct-secret-access.md
+++ b/docs/direct-secret-access.md
@@ -1,0 +1,55 @@
+# Direct Secret Access
+
+Direct Secret Access lets one Verified Launcher use one exact Secret Name in
+future direct `av inject` requests without asking for Approval each time.
+
+This is intentionally not the preferred way to use Automic Vault. The Launcher
+may select any Target and arguments, and the Target receives the Secret. Code
+signing establishes the Launcher's identity and integrity; it does not prove the
+Launcher's intent or make the selected Target trustworthy.
+
+## Safer alternatives
+
+Choose the narrowest option that works:
+
+1. **Harden the Tool.** A Tool-specific Secret Gate recognizes its Target and
+   operations, allowing policy to distinguish read-only work, writes, elevated
+   credentials, and Secret Disclosure.
+2. **Bless an exact script.** A Blessing binds the script’s canonical path,
+   contents, declared Secret Names, Target, injection options, and Gate
+   capabilities. A Launcher Endorsement can then authorize that reviewed script.
+3. **Approve each request.** Approval binds one complete request and live process
+   and creates no durable delegation.
+
+Direct Secret Access is appropriate only when commands must be selected
+dynamically, no suitable Hardener exists, and an exact Blessed Script is too
+restrictive.
+
+## What a rule permits
+
+A Direct Access Rule binds:
+
+- one exact Secret Name;
+- one designated requirement for a Verified Launcher; and
+- direct `av inject` Secret Application.
+
+It does not permit listing Secret Names, reading a raw Secret from Automic Vault,
+changing or deleting Secrets, using sibling Launchers, or bypassing another Gate
+Client’s policy. A request for several Secrets is automically authorized only
+when the same Verified Launcher has a rule for every requested Secret Name.
+
+The live Launcher must continue to pass code-signature, identity, Hardened
+Runtime, and entitlement checks. A path, filename, icon, process identifier, or
+bundle display name is not an identity.
+
+## Adding and removing access
+
+Select a Secret in the Automic Vault app and use **Allow Launcher** under Direct
+Secret Access. The app requires a fresh acknowledgement every time, verifies the
+selected signed app or executable, and shows the identity before saving it.
+
+Remove a Launcher from the same Secret to revoke the rule. Renaming or deleting
+the Secret also revokes every Direct Access Rule for that Secret Name.
+
+All allowed uses still require a persisted Authorization Record before Automic
+Vault releases the Secret.

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -31,6 +31,17 @@ A boundary that decides whether an operation may proceed. Every gate owns one Au
 - A **Secret Gate** controls the application or disclosure of protected secrets.
 - An **Execution Gate** controls an operation without requiring a secret. Homebrew is the current example.
 
+### Direct Secret Gate
+
+The built-in Secret Gate for direct `av inject` requests that do not belong to a
+Tool-specific Secret Gate. Its default Access Level is Approval Required.
+
+A **Direct Access Rule** binds one exact Secret Name to one Verified Launcher and
+grants Direct Access. It does not use patterns and does not authorize Secret
+Disclosure, listing Secret Names, changing Secrets, or sibling Launchers. Because
+the Launcher may choose any Target and arguments for each request, Direct Access
+delegates more authority than a Tool-specific Secret Gate or Blessed Script.
+
 ### Local Execution Boundary
 
 The point on the Mac where Automic Vault decides whether a Verified Launcher may apply a protected Secret or perform a gated operation through a Target. Secret storage, identity verification, policy evaluation, enforcement, and Authorization History remain on the Mac. A companion device may carry an Approval, but the Mac enforces the resulting Authorization Decision.
@@ -143,6 +154,7 @@ The policy engine's target model describes an operation with a set of characteri
 - **System Write:** changes shared machine state, installed software, protected locations, or configuration outside the user's local project state.
 - **Remote Write:** changes state in a remote service.
 - **Elevated Secret Application:** applies a more powerful or reusable credential than the operation normally receives.
+- **Unconstrained Secret Application:** applies a Secret through direct `av inject` to a Target and arguments selected by the Verified Launcher, without Tool-specific operation policy.
 - **Secret Disclosure:** returns a raw Secret value to a general-purpose destination.
 - **Unknown:** the Tool policy cannot establish the operation's characteristics.
 
@@ -162,6 +174,7 @@ An **Access Level** is a named policy preset for one Launcher at one Authorizati
 | **Local Write** | Recognized Read Only and Local Write operations. |
 | **Write Access** | Recognized read and write operations. Elevated Secret Application and Secret Disclosure still require Approval. |
 | **Full Access** | Recognized operations, including Elevated Secret Application and Secret Disclosure. Unknown operations still require Approval. |
+| **Direct Access** | Unconstrained Secret Application for exact Secret Names named by Direct Access Rules. Available only at the Direct Secret Gate. |
 
 Every requested characteristic must fit the selected preset. Gates may omit presets that do not describe their operation set.
 
@@ -241,7 +254,12 @@ Automic Vault persists and verifies a record of allowed Secret Use before releas
 
 ## Least Authority
 
-Durable trust binds one Authorization Gate to one Verified Launcher. A Blessing binds one exact script and its capabilities. Approval binds one complete request and process. Authority does not propagate to sibling Launchers, changed scripts, or a broader operation.
+Durable trust binds one Authorization Gate to one Verified Launcher. A Direct
+Access Rule additionally binds one exact Secret Name, but intentionally leaves
+the Target and arguments under that Launcher’s control. A Blessing binds one
+exact script and its capabilities. Approval binds one complete request and
+process. Authority does not propagate to sibling Launchers, changed scripts, or
+a broader operation.
 
 ## Zeroconf above the security boundary
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -64,6 +64,20 @@ A live Launcher whose code signature, designated requirement, and runtime protec
 
 The designated requirement stored when the user establishes trust and revalidated for each request. A path, display name, process identifier, or icon is metadata, not identity.
 
+### Retained Launcher Provenance
+
+Ephemeral evidence that Automic Vault recorded one exact live process execution
+between a Gate Client and a Verified Launcher during a successful automic
+authorization at one Authorization Gate. If the original parent chain later
+disappears, detached-process access can recover the same Launcher attribution at
+the same gate.
+
+Retained Launcher Provenance is not an Approval, Authorization Policy, or new
+Launcher Identity. Every later request is classified again under the gate's
+current policy. It does not apply to another gate, process execution, user
+session, or system boot, and uncertainty about the live process execution denies
+reuse.
+
 ### Gate Client
 
 The signed component that submits an Authorization Request, such as `av`, a patched `gh`, or the Homebrew stub.
@@ -258,7 +272,10 @@ Durable trust binds one Authorization Gate to one Verified Launcher. A Direct
 Access Rule additionally binds one exact Secret Name, but intentionally leaves
 the Target and arguments under that Launcher’s control. A Blessing binds one
 exact script and its capabilities. Approval binds one complete request and
-process. Authority does not propagate to sibling Launchers, changed scripts, or
+process. When detached-process access is enabled, Retained Launcher Provenance
+may preserve the same gate-and-Launcher attribution for one exact live process
+execution after its parent chain disappears. Authority does not propagate to
+sibling Launchers, changed scripts, another gate, a later process execution, or
 a broader operation.
 
 ## Zeroconf above the security boundary

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# Documentation
+
+## Security model
+
+- [Domain Language](domain-language.md) — canonical product and security terms
+- [Architecture](architecture.md) — contexts, invariants, and authorization flow
+- [Architecture Decisions](adr/) — accepted security and design decisions
+- [Secret Gate Security Audit](secret-gate-security-audit.md) — mediation limits and reviewed risks
+
+## Using Automic Vault
+
+- [Direct Secret Access](direct-secret-access.md) — broad per-Secret Launcher access and safer alternatives
+- [Signed CLI Launchers](signed-cli-launchers.md) — signature requirements and verification
+- [Securing Git](securing-git.md) — protected Git credentials
+
+## Development
+
+- [Releasing](releasing.md) — release, notarization, and publication process

--- a/src/menu-helper/Package.swift
+++ b/src/menu-helper/Package.swift
@@ -20,7 +20,11 @@ let package = Package(
                 .product(name: "GraphQL", package: "GraphQL"),
             ]
         ),
-        .target(name: "CProcessInfo", publicHeadersPath: "include"),
+        .target(
+            name: "CProcessInfo",
+            publicHeadersPath: "include",
+            linkerSettings: [.linkedLibrary("bsm")]
+        ),
         .executableTarget(
             name: "MenubarHelper",
             dependencies: [

--- a/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
+++ b/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
@@ -1,6 +1,9 @@
 #include "CProcessInfo.h"
 
+#include <bsm/libbsm.h>
 #include <libproc.h>
+#include <mach/mach.h>
+#include <mach/task_info.h>
 #include <string.h>
 #include <sys/sysctl.h>
 #include <sys/socket.h>
@@ -28,6 +31,19 @@ bool av_process_identity(pid_t pid, AVProcessIdentity *identity_out) {
     identity_out->start_usec =
         ((uint64_t)info.kp_proc.p_starttime.tv_sec * 1000000ULL) +
         (uint64_t)info.kp_proc.p_starttime.tv_usec;
+    identity_out->euid = info.kp_eproc.e_ucred.cr_uid;
+
+    mach_port_name_t task = MACH_PORT_NULL;
+    if (task_name_for_pid(mach_task_self(), pid, &task) == KERN_SUCCESS) {
+        audit_token_t token = {0};
+        mach_msg_type_number_t count = TASK_AUDIT_TOKEN_COUNT;
+        if (task_info(task, TASK_AUDIT_TOKEN, (task_info_t)&token, &count) == KERN_SUCCESS) {
+            identity_out->pidversion = audit_token_to_pidversion(token);
+            identity_out->euid = audit_token_to_euid(token);
+            identity_out->audit_session_id = audit_token_to_asid(token);
+        }
+        mach_port_deallocate(mach_task_self(), task);
+    }
     proc_pidpath(pid, identity_out->path, sizeof(identity_out->path));
     return true;
 }

--- a/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
+++ b/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
@@ -14,6 +14,9 @@ typedef struct {
     pid_t ppid;
     pid_t sid;
     uint64_t start_usec;
+    int pidversion;
+    uid_t euid;
+    uint32_t audit_session_id;
     char path[PROC_PIDPATHINFO_MAXSIZE];
 } AVProcessIdentity;
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -6,6 +6,9 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 let automaticApprovalFeedbackDefaultsKey = "automaticApprovalFeedback"
+private let directAccessDocumentationURL = URL(
+    string: "https://github.com/automic-vault/automic-vault/blob/main/docs/direct-secret-access.md#safer-alternatives"
+)!
 
 enum AutomaticApprovalFeedback: String, CaseIterable, Identifiable {
     case notification
@@ -557,6 +560,34 @@ final class DashboardModel: ObservableObject {
         return false
     }
 
+    func addDirectAccessLauncher(to secret: StoredSecret) {
+        chooseLauncher { [weak self] signing in
+            guard let self, let signing else { return }
+            guard signing.runtimeProtection.allowsSecretGateAccess else {
+                self.errorMessage = secretGateAdmissionError(
+                    appName: signing.identifier,
+                    protection: signing.runtimeProtection
+                )
+                return
+            }
+            let launcher = BlessedScriptLauncher(
+                bundleIdentifier: signing.identifier,
+                requirement: signing.requirement
+            )
+            self.finishPolicyUpdate(
+                allowDirectAccess(to: secret.account, for: launcher),
+                error: "Could not allow \(signing.identifier) to use \(secret.account)"
+            )
+        }
+    }
+
+    func removeDirectAccessLauncher(_ launcher: BlessedScriptLauncher, from secret: StoredSecret) {
+        finishPolicyUpdate(
+            removeDirectAccess(to: secret.account, for: launcher),
+            error: "Could not remove \(launcher.bundleIdentifier) from \(secret.account)"
+        )
+    }
+
     func deleteSecret(account: String) {
         let result = performInAppSecretMutation(.delete(account: account))
         guard let status = result.status else {
@@ -956,7 +987,14 @@ func runDashboardSearchSelfCheck() -> Int32 {
         ],
         secretGates: [],
         secrets: [
-            StoredSecret(account: "AWS_TOKEN", accessibility: .afterFirstUnlock),
+            StoredSecret(
+                account: "AWS_TOKEN",
+                accessibility: .afterFirstUnlock,
+                directAccessLaunchers: [BlessedScriptLauncher(
+                    bundleIdentifier: "com.example.launcher",
+                    requirement: #"identifier "com.example.launcher" and anchor apple generic"#
+                )]
+            ),
             StoredSecret(account: "GITHUB_TOKEN"),
         ],
         accessRequests: [accessRequest],
@@ -1000,6 +1038,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
           model.count(for: .allSecrets) == 2,
           model.count(for: .secretUsage) == 1,
           model.selectedStoredSecret?.accessibility == .afterFirstUnlock,
+          model.selectedStoredSecret?.directAccessLaunchers.count == 1,
           gateHeight > 0,
           secretDetailHeight.map({ $0 > 0 }) == true,
           aboutHeight > 0,
@@ -1614,6 +1653,7 @@ private struct StoredSecretDetailView: View {
     let secret: StoredSecret
     @State private var isAvailableWhileLocked: Bool
     @State private var isConfirmingDelete = false
+    @State private var isConfirmingDirectAccess = false
 
     init(model: DashboardModel, secret: StoredSecret) {
         self.model = model
@@ -1642,6 +1682,34 @@ private struct StoredSecretDetailView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                launcherList(
+                    secret.directAccessLaunchers,
+                    title: "Direct Secret Access",
+                    empty: "No Launchers have Direct Access to this Secret."
+                ) {
+                    model.removeDirectAccessLauncher($0, from: secret)
+                }
+                Button {
+                    isConfirmingDirectAccess = true
+                } label: {
+                    Label("Allow Launcher…", systemImage: "app.badge.checkmark")
+                }
+                .buttonStyle(.bordered)
+                Text("Hardening a Tool or blessing an exact script grants narrower authority.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Link("Read the safer alternatives", destination: directAccessDocumentationURL)
+                    .font(.caption)
             }
             .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1681,6 +1749,12 @@ private struct StoredSecretDetailView: View {
         } message: {
             Text("This secret will be permanently deleted.")
         }
+        .sheet(isPresented: $isConfirmingDirectAccess) {
+            DirectAccessAcknowledgementView(secretName: secret.account) {
+                isConfirmingDirectAccess = false
+                model.addDirectAccessLauncher(to: secret)
+            }
+        }
     }
 
     private var availabilityBinding: Binding<Bool> {
@@ -1695,6 +1769,53 @@ private struct StoredSecretDetailView: View {
             if !model.setAccessibility(accessibility, for: secret) {
                 isAvailableWhileLocked = previous
             }
+        }
+    }
+}
+
+private struct DirectAccessAcknowledgementView: View {
+    let secretName: String
+    let confirm: () -> Void
+    @State private var understandsRisk = false
+    @State private var readAlternatives = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Label("This grants broad authority", systemImage: "exclamationmark.shield.fill")
+                    .font(.headline)
+                    .foregroundStyle(.orange)
+                Text("The verified Launcher will be able to apply \(secretName) to any Target and arguments it chooses through direct av inject requests.")
+                    .fixedSize(horizontal: false, vertical: true)
+                Toggle(
+                    "I understand that Direct Secret Access is not the most secure way to use Automic Vault.",
+                    isOn: $understandsRisk
+                )
+                Toggle(
+                    "I have read the safer alternatives and determined they do not fit this use.",
+                    isOn: $readAlternatives
+                )
+                Link("Read the safer alternatives", destination: directAccessDocumentationURL)
+                    .font(.callout)
+                Spacer(minLength: 0)
+            }
+            .padding(22)
+            .frame(width: 470, height: 260, alignment: .topLeading)
+            .navigationTitle("Allow Direct Secret Access?")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Continue") { confirm() }
+                        .disabled(!understandsRisk || !readAlternatives)
+                }
+            }
+        }
+        .onAppear {
+            understandsRisk = false
+            readAlternatives = false
         }
     }
 }
@@ -2313,8 +2434,15 @@ private func launcherList(
         }
         ForEach(launchers, id: \.requirement) { launcher in
             HStack {
-                Text(launcher.bundleIdentifier)
-                    .textSelection(.enabled)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(launcher.bundleIdentifier)
+                        .textSelection(.enabled)
+                    Text(codeSigningTeamIdentifier(from: launcher.requirement).map { "Team \($0)" }
+                        ?? "Verified designated requirement")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
                 Spacer()
                 Button {
                     remove(launcher)
@@ -2322,7 +2450,7 @@ private func launcherList(
                     Image(systemName: "minus.circle")
                 }
                 .buttonStyle(.plain)
-                .help("Remove Calling App")
+                .help("Remove Launcher")
             }
             .padding(10)
             .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 8))

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -6,8 +6,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 let automaticApprovalFeedbackDefaultsKey = "automaticApprovalFeedback"
+let keepLauncherAccessForDetachedProcessesDefaultsKey = "keepLauncherAccessForDetachedProcesses"
 private let directAccessDocumentationURL = URL(
     string: "https://github.com/automic-vault/automic-vault/blob/main/docs/direct-secret-access.md#safer-alternatives"
+)!
+private let secureLauncherDocumentationURL = URL(
+    string: "https://github.com/automic-vault/automic-vault/blob/main/docs/signed-cli-launchers.md"
 )!
 
 enum AutomaticApprovalFeedback: String, CaseIterable, Identifiable {
@@ -231,6 +235,12 @@ final class DashboardModel: ObservableObject {
                     title: "Automic Authorization",
                     subtitle: "Choose subtle feedback or none",
                     detail: "Control visual feedback after policy authorizes an operation."
+                ),
+                DashboardItem(
+                    id: "detached-process-access",
+                    title: "Detached Processes",
+                    subtitle: "Keep Launcher attribution after ancestry loss",
+                    detail: "Allow an exact live process execution to retain gate-specific Launcher attribution after its parent chain exits."
                 ),
                 DashboardItem(
                     id: "secret-name-access",
@@ -1031,6 +1041,9 @@ func runDashboardSearchSelfCheck() -> Int32 {
         NSHostingView(rootView: StoredSecretDetailView(model: model, secret: $0)).fittingSize.height
     }
     let aboutHeight = NSHostingView(rootView: AboutSettingsView(guiPath: "/usr/bin:/bin")).fittingSize.height
+    let detachedProcessAccessHeight = NSHostingView(
+        rootView: DetachedProcessAccessSettingsView()
+    ).fittingSize.height
     guard DashboardSection.allCases.last == .settings,
           model.count(for: .detectors) == 3,
           model.count(for: .doctor) == 1,
@@ -1042,6 +1055,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
           gateHeight > 0,
           secretDetailHeight.map({ $0 > 0 }) == true,
           aboutHeight > 0,
+          detachedProcessAccessHeight > 0,
           appRowHeight < 140
     else { return 1 }
     guard model.items.first(where: { $0.id == "aws" })?.isHardened == true,
@@ -1117,7 +1131,12 @@ func runDashboardSearchSelfCheck() -> Int32 {
     else { return 1 }
     model.searchText = ""
     model.selectSection(.settings)
-    guard model.items.map(\.id) == ["automatic-approval-feedback", "secret-name-access", "about"],
+    guard model.items.map(\.id) == [
+        "automatic-approval-feedback",
+        "detached-process-access",
+        "secret-name-access",
+        "about",
+    ],
           guiPATH(environment: ["PATH": "/usr/bin:/bin"]) == "/usr/bin:/bin",
           guiPATH(environment: [:]) == "<unset>"
     else { return 1 }
@@ -1436,6 +1455,12 @@ private struct DashboardDetailView: View {
             } else if model.selectedSection == .settings {
                 if model.selectedItem?.id == "automatic-approval-feedback" {
                     AutomaticApprovalFeedbackSettingsView()
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else if model.selectedItem?.id == "detached-process-access" {
+                    DetachedProcessAccessSettingsView()
                         .padding(.horizontal, 22)
                         .padding(.top, 32)
                         .padding(.bottom, 28)
@@ -2507,6 +2532,37 @@ private struct AutomaticApprovalFeedbackSettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct DetachedProcessAccessSettingsView: View {
+    @AppStorage(keepLauncherAccessForDetachedProcessesDefaultsKey)
+    private var keepsLauncherAccess = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Detached Processes")
+                    .font(.system(size: 24, weight: .semibold))
+                Text("Control whether a live process keeps its verified Launcher attribution after its parent chain exits.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            Toggle(
+                "Keep Launcher Access for Detached Processes",
+                isOn: $keepsLauncherAccess
+            )
+            Text("Off by default. When enabled, an exact signed process execution that participates in an automically authorized operation may continue using that Launcher’s current policy at the same Authorization Gate until the process or Automic Vault exits. New processes and other gates are not included.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            InfoBlock(
+                title: "Security tradeoff",
+                text: "This extends authority after the verified parent chain disappears. Ad-hoc signed tools can still be modified in memory by other same-user processes. A Secure Launcher with Hardened Runtime is safer for a recurring harness."
+            )
+            Link("Learn about Secure Launchers", destination: secureLauncherDocumentationURL)
+                .font(.caption)
         }
     }
 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1300,9 +1300,9 @@ enum SecretMutation {
         case .saveIfAbsentOrEqual(let account, let value):
             saveStoredSecretIfAbsentOrEqual(account: account, value: value)
         case .delete(let account):
-            deleteStoredSecret(account: account)
+            deleteStoredSecretRevokingDirectAccess(account: account)
         case .rename(let account, let newAccount):
-            renameStoredSecret(account: account, to: newAccount)
+            renameStoredSecretRevokingDirectAccess(account: account, to: newAccount)
         case .setAccessibility(let account, let accessibility):
             setStoredSecretAccessibility(account: account, accessibility: accessibility)
         }
@@ -2095,6 +2095,13 @@ private final class ApprovalServer: @unchecked Sendable {
             signing: signing,
             hardeners: metadata
         )
+        let directAccessLauncher = matchingDirectAccessLauncher(
+            request: request,
+            configuredGate: configuredGate,
+            trustedAVGateClient: isTrustedAvCaller(path: callerPath, signing: signing),
+            launchers: launchers,
+            rules: loadDirectAccessRules()
+        )
         let resolvedPolicy = configuredGate.flatMap { resolveSecretGatePolicy(gate: $0, launchers: launchers) }
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
@@ -2117,6 +2124,54 @@ private final class ApprovalServer: @unchecked Sendable {
             automaticApprovalExplanation = failure.explanation
         } else {
             automaticApprovalExplanation = nil
+        }
+        if activeBlessing == nil, let directAccessLauncher {
+            do {
+                let payload = try approvedPayload(
+                    for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
+                )
+                let accessRequestID = UUID()
+                let record = accessRequestRecord(
+                    id: accessRequestID,
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Approved",
+                    approvalSource: "Auto",
+                    reason: "Direct Access from \(shortAppName(directAccessLauncher.identifier))",
+                    launcher: directAccessLauncher
+                )
+                guard onAccessRequest(record) else {
+                    reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                    return
+                }
+                Task { @MainActor in
+                    self.onAutoApproval(autoApprovalRecord(
+                        accessRequestID: accessRequestID,
+                        request: request,
+                        script: scriptApproval,
+                        launcher: directAccessLauncher
+                    ))
+                }
+                reply(
+                    peer,
+                    to: message,
+                    ok: true,
+                    error: nil,
+                    secrets: payload.secrets,
+                    value: payload.value
+                )
+            } catch {
+                _ = onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Failed",
+                    approvalSource: "Auto",
+                    reason: error.localizedDescription,
+                    launcher: directAccessLauncher
+                ))
+                reply(peer, to: message, ok: false, error: error.localizedDescription)
+            }
+            return
         }
         if activeBlessing == nil,
            let configuredGate,
@@ -3176,6 +3231,24 @@ private final class ApprovalServer: @unchecked Sendable {
         let message = xpc_dictionary_create_empty()
         event.withCString { xpc_dictionary_set_string(message, "event", $0) }
         xpc_connection_send_message(peer, message)
+    }
+}
+
+private func matchingDirectAccessLauncher(
+    request: ApprovalRequest,
+    configuredGate: SecretGate?,
+    trustedAVGateClient: Bool,
+    launchers: [LauncherIdentity],
+    rules: [DirectAccessRule]
+) -> LauncherIdentity? {
+    guard request.op == "inject", configuredGate == nil, trustedAVGateClient else { return nil }
+    return launchers.first {
+        directAccessAllows(
+            secretNames: request.keys,
+            launcherRequirement: $0.designatedRequirement,
+            runtimeProtection: $0.runtimeProtection,
+            rules: rules
+        )
     }
 }
 
@@ -5481,6 +5554,28 @@ private func runApprovalSelfCheck() -> Int32 {
             detail: nil
         )
     }
+    let directRequest = ApprovalRequest(
+        op: "inject",
+        keys: ["HCLOUD_TOKEN"],
+        target: "/bin/sh",
+        args: ["-c", "hcloud server list"],
+        cwd: "/tmp",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        envConflicts: [],
+        shebangScript: nil,
+        scriptData: nil,
+        tool: nil,
+        title: nil,
+        detail: nil
+    )
+    let directRules = [DirectAccessRule(
+        secretName: "HCLOUD_TOKEN",
+        launcher: BlessedScriptLauncher(
+            bundleIdentifier: blockedLauncher.identifier,
+            requirement: blockedLauncher.designatedRequirement
+        )
+    )]
     guard resolveSecretGatePolicy(gate: policyGate, launchers: []) == nil,
           resolveSecretGatePolicy(gate: policyGate, launchers: [blockedLauncher])?.protection == .noAccess,
           resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [blockedLauncher])?.protection == .readOnly,
@@ -5512,6 +5607,34 @@ private func runApprovalSelfCheck() -> Int32 {
           classifySecretGateRequest(gateID: "flyctl", request: flyRequest(["apps", "list"])) == .readOnly,
           classifySecretGateRequest(gateID: "flyctl", request: flyRequest(["deploy"])) == .mutating,
           classifySecretGateRequest(gateID: "flyctl", request: flyRequest(["auth", "token"])) == .secretDump,
+          matchingDirectAccessLauncher(
+              request: directRequest,
+              configuredGate: nil,
+              trustedAVGateClient: true,
+              launchers: [blockedLauncher],
+              rules: directRules
+          )?.designatedRequirement == blockedLauncher.designatedRequirement,
+          matchingDirectAccessLauncher(
+              request: directRequest,
+              configuredGate: policyGate,
+              trustedAVGateClient: true,
+              launchers: [blockedLauncher],
+              rules: directRules
+          ) == nil,
+          matchingDirectAccessLauncher(
+              request: directRequest,
+              configuredGate: nil,
+              trustedAVGateClient: false,
+              launchers: [blockedLauncher],
+              rules: directRules
+          ) == nil,
+          matchingDirectAccessLauncher(
+              request: directRequest,
+              configuredGate: nil,
+              trustedAVGateClient: true,
+              launchers: [unhardenedLauncher],
+              rules: directRules
+          ) == nil,
           isTrustedStripeCaller(
               path: "/opt/homebrew/opt/stripe-cli/bin/stripe",
               signing: stripeSigning

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1518,6 +1518,77 @@ private struct TransientApprovalCache {
     }
 }
 
+private enum RetainedAuthorizationGate: Hashable {
+    case blessing(path: String, checksum: String)
+    case directSecret
+    case secretGate(String)
+}
+
+private struct RetainedProcessExecution: Hashable {
+    let pid: Int32
+    let pidVersion: Int32
+    let startUsec: UInt64
+    let effectiveUserID: UInt32
+    let auditSessionID: UInt32
+    let codeIdentity: Data
+}
+
+private struct RetainedProcessChainNode {
+    let pid: Int32
+    let path: String
+    let execution: RetainedProcessExecution?
+}
+
+private struct RetainedProcessProvenanceMatch {
+    let launcher: LauncherIdentity
+    let processPath: String
+    let execution: RetainedProcessExecution
+}
+
+private struct RetainedProcessProvenanceStore {
+    private var records: [RetainedAuthorizationGate: [RetainedProcessExecution: LauncherIdentity]] = [:]
+
+    mutating func remember(
+        _ executions: [RetainedProcessExecution],
+        at gate: RetainedAuthorizationGate,
+        launcher: LauncherIdentity,
+        isLive: (RetainedProcessExecution) -> Bool = retainedProcessExecutionIsLive
+    ) {
+        prune(isLive: isLive)
+        guard !executions.isEmpty else { return }
+        for execution in executions where isLive(execution) {
+            records[gate, default: [:]][execution] = launcher
+        }
+    }
+
+    mutating func match(
+        at gate: RetainedAuthorizationGate,
+        in chains: [[RetainedProcessChainNode]],
+        isLive: (RetainedProcessExecution) -> Bool = retainedProcessExecutionIsLive
+    ) -> RetainedProcessProvenanceMatch? {
+        prune(isLive: isLive)
+        guard let gateRecords = records[gate] else { return nil }
+        for node in chains.joined() {
+            guard let execution = node.execution,
+                  let launcher = gateRecords[execution]
+            else { continue }
+            return RetainedProcessProvenanceMatch(
+                launcher: launcher,
+                processPath: node.path,
+                execution: execution
+            )
+        }
+        return nil
+    }
+
+    private mutating func prune(isLive: (RetainedProcessExecution) -> Bool) {
+        records = records.compactMapValues { gateRecords in
+            let live = gateRecords.filter { isLive($0.key) }
+            return live.isEmpty ? nil : live
+        }
+    }
+}
+
 private struct SigningInfo {
     let identifier: String
     let teamIdentifier: String
@@ -1653,8 +1724,10 @@ private final class ApprovalServer: @unchecked Sendable {
     ) -> Void
     private let canRequestHumanApproval: @MainActor () -> Bool
     private var listener: xpc_connection_t?
-    // ponytail: in-memory per-process cache; use persistent approvals for cross-process trust.
+    // ponytail: helper-lifetime caches; persistent policy remains the cross-restart trust boundary.
     private var transientApprovals = TransientApprovalCache()
+    private let retainedProcessProvenanceLock = NSLock()
+    private var retainedProcessProvenance = RetainedProcessProvenanceStore()
     private let blessedExecutionsLock = NSLock()
     private var blessedExecutions: [BlessedExecutionKey: BlessedScript] = [:]
     private let awsRegistrationsLock = NSLock()
@@ -1716,6 +1789,29 @@ private final class ApprovalServer: @unchecked Sendable {
         if let listener {
             xpc_connection_cancel(listener)
             self.listener = nil
+        }
+    }
+
+    private func retainedProvenanceMatch(
+        at gate: RetainedAuthorizationGate,
+        in chains: [[RetainedProcessChainNode]]
+    ) -> RetainedProcessProvenanceMatch? {
+        retainedProcessProvenanceLock.withLock {
+            retainedProcessProvenance.match(at: gate, in: chains)
+        }
+    }
+
+    private func rememberRetainedProvenance(
+        at gate: RetainedAuthorizationGate,
+        launcher: LauncherIdentity,
+        chains: [[RetainedProcessChainNode]],
+        retainedMatch: RetainedProcessProvenanceMatch? = nil
+    ) {
+        let executions = retainedMatch.map {
+            retainedExecutions(leadingTo: $0.execution, in: chains)
+        } ?? retainedExecutions(leadingTo: launcher.pid, in: chains)
+        retainedProcessProvenanceLock.withLock {
+            retainedProcessProvenance.remember(executions, at: gate, launcher: launcher)
         }
     }
 
@@ -2005,6 +2101,10 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         let scriptApproval = scriptApproval(for: request)
+        let processChains = retainedProcessChains(for: identity)
+        let keepsDetachedProcessAccess = UserDefaults.standard.bool(
+            forKey: keepLauncherAccessForDetachedProcessesDefaultsKey
+        )
         var launchers = launcherIdentities(for: identity)
         let ancestorFallbackPath = launcherFallbackPath(for: identity)
         let launcherFallbackPath = ancestorFallbackPath ?? callerPath
@@ -2035,14 +2135,30 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
         }
+        let blessingGate = scriptApproval.map {
+            RetainedAuthorizationGate.blessing(path: $0.path, checksum: $0.checksum)
+        }
+        let retainedBlessingProvenance = blessingGate.flatMap {
+            retainedProvenanceMatch(at: $0, in: processChains)
+        }
+        let currentBlessingMatch = scriptApproval.flatMap {
+            matchingBlessedScript(request: request, approval: $0, launchers: launchers)
+        }
+        let retainedBlessingMatch = scriptApproval.flatMap { approval in
+            retainedBlessingProvenance.flatMap {
+                matchingBlessedScript(
+                    request: request,
+                    approval: approval,
+                    launchers: [$0.launcher]
+                )
+            }
+        }
+        let effectiveBlessingMatch = currentBlessingMatch
+            ?? (keepsDetachedProcessAccess ? retainedBlessingMatch : nil)
         if let scriptApproval,
-           let match = matchingBlessedScript(
-               request: request,
-               approval: scriptApproval,
-               launchers: launchers
-           )
+           let blessingGate,
+           let (script, matchedLauncher) = effectiveBlessingMatch
         {
-            let (script, _) = match
             do {
                 let payload = try approvedPayload(
                     for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
@@ -2055,22 +2171,26 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Approved",
                     approvalSource: "Auto",
                     reason: "Blessed script \(script.path)",
-                    launcher: launcher
+                    launcher: matchedLauncher
                 )
                 guard onAccessRequest(record) else {
                     reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                     return
                 }
                 registerBlessedExecution(script, pid: pid, identity: identity)
-                if let launcher {
-                    Task { @MainActor in
-                        self.onAutoApproval(autoApprovalRecord(
-                            accessRequestID: accessRequestID,
-                            request: request,
-                            script: scriptApproval,
-                            launcher: launcher
-                        ))
-                    }
+                rememberRetainedProvenance(
+                    at: blessingGate,
+                    launcher: matchedLauncher,
+                    chains: processChains,
+                    retainedMatch: currentBlessingMatch == nil ? retainedBlessingProvenance : nil
+                )
+                Task { @MainActor in
+                    self.onAutoApproval(autoApprovalRecord(
+                        accessRequestID: accessRequestID,
+                        request: request,
+                        script: scriptApproval,
+                        launcher: matchedLauncher
+                    ))
                 }
                 reply(peer, to: message, ok: true, error: nil, secrets: payload.secrets, value: payload.value)
             } catch {
@@ -2080,7 +2200,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Failed",
                     approvalSource: "Auto",
                     reason: error.localizedDescription,
-                    launcher: launcher
+                    launcher: matchedLauncher
                 ))
                 reply(peer, to: message, ok: false, error: error.localizedDescription)
             }
@@ -2095,16 +2215,68 @@ private final class ApprovalServer: @unchecked Sendable {
             signing: signing,
             hardeners: metadata
         )
+        let authorizationGate = configuredGate.map {
+            RetainedAuthorizationGate.secretGate($0.id)
+        } ?? .directSecret
+        let retainedGateProvenance = retainedProvenanceMatch(
+            at: authorizationGate,
+            in: processChains
+        )
+        var policyLaunchers = launchers
+        if keepsDetachedProcessAccess,
+           let retainedLauncher = retainedGateProvenance?.launcher,
+           !policyLaunchers.contains(where: {
+               $0.designatedRequirement == retainedLauncher.designatedRequirement
+           })
+        {
+            policyLaunchers.append(retainedLauncher)
+        }
+        let policyLauncher = executionOrigin(
+            among: policyLaunchers,
+            callerPID: pid,
+            ancestorFallbackPath: ancestorFallbackPath
+        ) ?? launcher
+        let directAccessRules = loadDirectAccessRules()
         let directAccessLauncher = matchingDirectAccessLauncher(
             request: request,
             configuredGate: configuredGate,
             trustedAVGateClient: isTrustedAvCaller(path: callerPath, signing: signing),
-            launchers: launchers,
-            rules: loadDirectAccessRules()
+            launchers: policyLaunchers,
+            rules: directAccessRules
         )
-        let resolvedPolicy = configuredGate.flatMap { resolveSecretGatePolicy(gate: $0, launchers: launchers) }
+        let resolvedPolicy = configuredGate.flatMap {
+            resolveSecretGatePolicy(gate: $0, launchers: policyLaunchers)
+        }
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
+        }
+        let retainedProcessExplanation: String?
+        if !keepsDetachedProcessAccess,
+           retainedBlessingMatch != nil,
+           let retainedBlessingProvenance
+        {
+            retainedProcessExplanation = retainedProcessApprovalExplanation(
+                match: retainedBlessingProvenance,
+                gateName: "this Blessing"
+            )
+        } else if !keepsDetachedProcessAccess,
+                  activeBlessing == nil,
+                  let retainedGateProvenance,
+                  retainedProvenanceWouldAuthorize(
+                      request: request,
+                      configuredGate: configuredGate,
+                      classification: classification,
+                      launcher: retainedGateProvenance.launcher,
+                      directAccessRules: directAccessRules,
+                      trustedAVGateClient: isTrustedAvCaller(path: callerPath, signing: signing)
+                  )
+        {
+            retainedProcessExplanation = retainedProcessApprovalExplanation(
+                match: retainedGateProvenance,
+                gateName: configuredGate.map { "the \($0.id) gate" } ?? "the Direct Secret Gate"
+            )
+        } else {
+            retainedProcessExplanation = nil
         }
         let automaticApprovalExplanation: String?
         if let configuredGate,
@@ -2144,6 +2316,14 @@ private final class ApprovalServer: @unchecked Sendable {
                     reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                     return
                 }
+                rememberRetainedProvenance(
+                    at: authorizationGate,
+                    launcher: directAccessLauncher,
+                    chains: processChains,
+                    retainedMatch: launchers.contains(where: {
+                        $0.designatedRequirement == directAccessLauncher.designatedRequirement
+                    }) ? nil : retainedGateProvenance
+                )
                 Task { @MainActor in
                     self.onAutoApproval(autoApprovalRecord(
                         accessRequestID: accessRequestID,
@@ -2182,6 +2362,7 @@ private final class ApprovalServer: @unchecked Sendable {
                classification: classification
            )
         {
+            let authorizingLauncher = resolvedPolicy.launcher ?? policyLauncher
             do {
                 let payload = try approvedPayload(
                     for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
@@ -2195,19 +2376,27 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Approved",
                     approvalSource: "Auto",
                     reason: reason,
-                    launcher: launcher
+                    launcher: authorizingLauncher
                 )
                 guard onAccessRequest(record) else {
                     reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                     return
                 }
-                if let launcher {
+                if let authorizingLauncher {
+                    rememberRetainedProvenance(
+                        at: authorizationGate,
+                        launcher: authorizingLauncher,
+                        chains: processChains,
+                        retainedMatch: launchers.contains(where: {
+                            $0.designatedRequirement == authorizingLauncher.designatedRequirement
+                        }) ? nil : retainedGateProvenance
+                    )
                     Task { @MainActor in
                         self.onAutoApproval(autoApprovalRecord(
                             accessRequestID: accessRequestID,
                             request: request,
                             script: scriptApproval,
-                            launcher: launcher
+                            launcher: authorizingLauncher
                         ))
                     }
                 }
@@ -2219,12 +2408,13 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Failed",
                     approvalSource: "Auto",
                     reason: error.localizedDescription,
-                    launcher: launcher
+                    launcher: authorizingLauncher
                 ))
                 reply(peer, to: message, ok: false, error: error.localizedDescription)
             }
             return
         }
+        let promptLauncher = policyLauncher
         let transientApproval = TransientApprovalKey(
             pid: pid,
             startUsec: identity.start_usec,
@@ -2280,7 +2470,7 @@ private final class ApprovalServer: @unchecked Sendable {
         DispatchQueue.main.async {
             if cancellation.isCanceled {
                 _ = self.onAccessRequest(canceledAccessRequestRecord(
-                    request: request, callerPath: callerPath, launcher: launcher
+                    request: request, callerPath: callerPath, launcher: promptLauncher
                 ))
                 return
             }
@@ -2295,7 +2485,7 @@ private final class ApprovalServer: @unchecked Sendable {
                         decision: "Denied",
                         approvalSource: "Auto",
                         reason: "Reused recent denial",
-                        launcher: launcher
+                        launcher: promptLauncher
                     ))
                     self.reply(peer, to: message, ok: false, error: "\(request.op) denied")
                     return
@@ -2310,7 +2500,7 @@ private final class ApprovalServer: @unchecked Sendable {
                         decision: "Approved",
                         approvalSource: "Auto",
                         reason: "Reused recent approval",
-                        launcher: launcher
+                        launcher: promptLauncher
                     )
                     guard self.onAccessRequest(record) else {
                         self.reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
@@ -2324,7 +2514,7 @@ private final class ApprovalServer: @unchecked Sendable {
                         decision: "Failed",
                         approvalSource: "Auto",
                         reason: error.localizedDescription,
-                        launcher: launcher
+                        launcher: promptLauncher
                     ))
                     self.reply(peer, to: message, ok: false, error: error.localizedDescription)
                 }
@@ -2338,7 +2528,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Denied",
                     approvalSource: "Auto",
                     reason: "Human approval unavailable",
-                    launcher: launcher
+                    launcher: promptLauncher
                 ))
                 self.reply(
                     peer,
@@ -2356,15 +2546,16 @@ private final class ApprovalServer: @unchecked Sendable {
                 signing: signing,
                 scriptApproval: scriptApproval,
                 blessing: promptBlessing,
-                launcher: launcher,
+                launcher: promptLauncher,
                 launcherFallbackPath: launcherFallbackPath,
                 automaticApprovalExplanation: lostBlessingExplanation(for: scriptApproval)
+                    ?? retainedProcessExplanation
                     ?? automaticApprovalExplanation,
                 cancellation: cancellation
             )
             if decision == .canceled {
                 _ = self.onAccessRequest(canceledAccessRequestRecord(
-                    request: request, callerPath: callerPath, launcher: launcher
+                    request: request, callerPath: callerPath, launcher: promptLauncher
                 ))
                 return
             }
@@ -2378,7 +2569,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Denied",
                     approvalSource: "Manual",
                     reason: "Denied in prompt",
-                    launcher: launcher
+                    launcher: promptLauncher
                 ))
                 self.reply(
                     peer,
@@ -2399,7 +2590,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Approved",
                     approvalSource: "Manual",
                     reason: "Approved in prompt",
-                    launcher: launcher
+                    launcher: promptLauncher
                 )
                 guard self.onAccessRequest(record) else {
                     self.reply(
@@ -2439,7 +2630,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     decision: "Failed",
                     approvalSource: "Manual",
                     reason: error.localizedDescription,
-                    launcher: launcher
+                    launcher: promptLauncher
                 ))
                 self.reply(
                     peer,
@@ -3252,6 +3443,43 @@ private func matchingDirectAccessLauncher(
     }
 }
 
+private func retainedProvenanceWouldAuthorize(
+    request: ApprovalRequest,
+    configuredGate: SecretGate?,
+    classification: SecretGateRequestClassification?,
+    launcher: LauncherIdentity,
+    directAccessRules: [DirectAccessRule],
+    trustedAVGateClient: Bool
+) -> Bool {
+    if let configuredGate, let classification {
+        guard let policy = resolveSecretGatePolicy(
+            gate: configuredGate,
+            launchers: [launcher]
+        ) else { return false }
+        return secretGateProtectionAllows(
+            policy.protection,
+            classification: classification
+        )
+    }
+    return matchingDirectAccessLauncher(
+        request: request,
+        configuredGate: nil,
+        trustedAVGateClient: trustedAVGateClient,
+        launchers: [launcher],
+        rules: directAccessRules
+    ) != nil
+}
+
+private func retainedProcessApprovalExplanation(
+    match: RetainedProcessProvenanceMatch,
+    gateName: String
+) -> String {
+    let name = URL(fileURLWithPath: match.processPath).lastPathComponent
+    let process = name.isEmpty ? "detached" : name
+    let launcher = shortAppName(match.launcher.identifier)
+    return "Automic Vault previously verified this running \(process) process under \(launcher), but that parent chain is no longer available. Keep Launcher Access for Detached Processes is off; enabling it would have automically authorized this request under the current \(gateName) policy."
+}
+
 private func isAllowedCaller(path: String, signing: SigningInfo) -> Bool {
     if isTrustedAvCaller(path: path, signing: signing) {
         return true
@@ -4044,6 +4272,91 @@ private func launcherAncestorStartPIDs(_ identity: AVProcessIdentity) -> [pid_t]
     return [identity.ppid, identity.sid].filter { $0 > 1 && seen.insert($0).inserted }
 }
 
+private func retainedProcessChains(for identity: AVProcessIdentity) -> [[RetainedProcessChainNode]] {
+    launcherAncestorStartPIDs(identity).map { startPID in
+        var nodes: [RetainedProcessChainNode] = []
+        var pid = startPID
+        var seen = Set<pid_t>()
+        for _ in 0..<32 {
+            guard pid > 1, seen.insert(pid).inserted else { break }
+            var current = AVProcessIdentity()
+            guard av_process_identity(pid, &current) else { break }
+            nodes.append(RetainedProcessChainNode(
+                pid: pid,
+                path: pathString(current),
+                execution: retainedProcessExecution(pid: pid, identity: current)
+            ))
+            pid = current.ppid
+        }
+        return nodes
+    }
+}
+
+private func retainedProcessExecution(
+    pid: pid_t,
+    identity: AVProcessIdentity
+) -> RetainedProcessExecution? {
+    guard identity.pidversion > 0,
+          identity.euid == geteuid(),
+          let codeIdentity = liveCodeIdentity(pid: pid)
+    else { return nil }
+
+    var current = AVProcessIdentity()
+    guard av_process_identity(pid, &current),
+          current.pidversion == identity.pidversion,
+          current.start_usec == identity.start_usec,
+          current.euid == identity.euid,
+          current.audit_session_id == identity.audit_session_id
+    else { return nil }
+
+    return RetainedProcessExecution(
+        pid: pid,
+        pidVersion: identity.pidversion,
+        startUsec: identity.start_usec,
+        effectiveUserID: identity.euid,
+        auditSessionID: identity.audit_session_id,
+        codeIdentity: codeIdentity
+    )
+}
+
+private func retainedProcessExecutionIsLive(_ execution: RetainedProcessExecution) -> Bool {
+    func matches(_ identity: AVProcessIdentity) -> Bool {
+        identity.pidversion == execution.pidVersion
+            && identity.start_usec == execution.startUsec
+            && identity.euid == execution.effectiveUserID
+            && identity.audit_session_id == execution.auditSessionID
+    }
+    var before = AVProcessIdentity()
+    guard av_process_identity(execution.pid, &before),
+          matches(before),
+          liveCodeIdentity(pid: execution.pid) == execution.codeIdentity
+    else { return false }
+    var after = AVProcessIdentity()
+    return av_process_identity(execution.pid, &after) && matches(after)
+}
+
+private func retainedExecutions(
+    leadingTo launcherPID: pid_t,
+    in chains: [[RetainedProcessChainNode]]
+) -> [RetainedProcessExecution] {
+    guard let chain = chains.first(where: { $0.contains(where: { $0.pid == launcherPID }) }),
+          let launcherIndex = chain.firstIndex(where: { $0.pid == launcherPID })
+    else { return [] }
+    return chain[..<launcherIndex].compactMap(\.execution)
+}
+
+private func retainedExecutions(
+    leadingTo retainedExecution: RetainedProcessExecution,
+    in chains: [[RetainedProcessChainNode]]
+) -> [RetainedProcessExecution] {
+    guard let chain = chains.first(where: {
+        $0.contains(where: { $0.execution == retainedExecution })
+    }),
+    let retainedIndex = chain.firstIndex(where: { $0.execution == retainedExecution })
+    else { return [] }
+    return chain[...retainedIndex].compactMap(\.execution)
+}
+
 private func executionOrigin(
     among launchers: [LauncherIdentity],
     callerPID: pid_t,
@@ -4261,6 +4574,25 @@ private func liveSigningInfo(pid: pid_t) -> LiveSigningInfo? {
             SecCodeCheckValidity(code, [], $0)
         }
     )
+}
+
+private func liveCodeIdentity(pid: pid_t) -> Data? {
+    var code: SecCode?
+    let attributes = [kSecGuestAttributePid as String: NSNumber(value: pid)] as CFDictionary
+    guard SecCodeCopyGuestWithAttributes(nil, attributes, [], &code) == errSecSuccess,
+          let code,
+          SecCodeCheckValidity(code, [], nil) == errSecSuccess
+    else { return nil }
+
+    var staticCode: SecStaticCode?
+    guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess,
+          let staticCode
+    else { return nil }
+    var info: CFDictionary?
+    guard SecCodeCopySigningInformation(staticCode, [], &info) == errSecSuccess,
+          let dictionary = info as? [CFString: Any]
+    else { return nil }
+    return dictionary[kSecCodeInfoUnique] as? Data
 }
 
 private func executableSigningInfo(path: String) -> LiveSigningInfo? {
@@ -6295,6 +6627,124 @@ private func runTransientApprovalSelfCheck() -> Int32 {
     return 0
 }
 
+private func runRetainedProcessProvenanceSelfCheck() -> Int32 {
+    var currentIdentity = AVProcessIdentity()
+    guard av_process_identity(getpid(), &currentIdentity),
+          currentIdentity.pidversion > 0,
+          currentIdentity.euid == geteuid(),
+          let currentExecution = retainedProcessExecution(
+              pid: getpid(),
+              identity: currentIdentity
+          ),
+          retainedProcessExecutionIsLive(currentExecution)
+    else { return 1 }
+
+    let launcher = LauncherIdentity(
+        pid: 300,
+        path: "/Applications/Ghostty.app/Contents/MacOS/ghostty",
+        identifier: "com.mitchellh.ghostty",
+        teamIdentifier: "TEAM",
+        designatedRequirement: #"identifier "com.mitchellh.ghostty" and anchor apple generic"#,
+        runtimeProtection: .hardened
+    )
+    let herdr = RetainedProcessExecution(
+        pid: 200,
+        pidVersion: 9,
+        startUsec: 123,
+        effectiveUserID: 501,
+        auditSessionID: 10,
+        codeIdentity: Data([1, 2, 3])
+    )
+    let replacedHerdr = RetainedProcessExecution(
+        pid: herdr.pid,
+        pidVersion: herdr.pidVersion + 1,
+        startUsec: herdr.startUsec,
+        effectiveUserID: herdr.effectiveUserID,
+        auditSessionID: herdr.auditSessionID,
+        codeIdentity: herdr.codeIdentity
+    )
+    let chains = [[RetainedProcessChainNode(
+        pid: herdr.pid,
+        path: "/usr/local/bin/herdr",
+        execution: herdr
+    )]]
+    let request = ApprovalRequest(
+        op: "keys",
+        keys: ["GH_TOKEN_GITHUB_COM"],
+        target: "/opt/homebrew/bin/gh",
+        args: ["repo", "view"],
+        cwd: "/tmp",
+        replaceExistingEnv: true,
+        allowMissingKeys: false,
+        envConflicts: [],
+        shebangScript: nil,
+        scriptData: nil,
+        tool: "gh",
+        title: nil,
+        detail: nil
+    )
+    let gate = SecretGate(
+        id: "gh",
+        keyPatterns: ["GH_TOKEN_*"],
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: [SecretGatePolicy(
+            bundleIdentifier: launcher.identifier,
+            requirement: launcher.designatedRequirement,
+            protection: .readOnly
+        )]
+    )
+    var store = RetainedProcessProvenanceStore()
+    store.remember(
+        [herdr],
+        at: .secretGate("gh"),
+        launcher: launcher,
+        isLive: { _ in true }
+    )
+    guard store.match(
+        at: .secretGate("gh"),
+        in: chains,
+        isLive: { _ in true }
+    )?.launcher.designatedRequirement == launcher.designatedRequirement,
+    retainedProvenanceWouldAuthorize(
+        request: request,
+        configuredGate: gate,
+        classification: .readOnly,
+        launcher: launcher,
+        directAccessRules: [],
+        trustedAVGateClient: false
+    ),
+    !retainedProvenanceWouldAuthorize(
+        request: request,
+        configuredGate: gate,
+        classification: .mutating,
+        launcher: launcher,
+        directAccessRules: [],
+        trustedAVGateClient: false
+    ),
+    store.match(
+        at: .directSecret,
+        in: chains,
+        isLive: { _ in true }
+    ) == nil,
+    store.match(
+        at: .secretGate("gh"),
+        in: [[RetainedProcessChainNode(
+            pid: replacedHerdr.pid,
+            path: "/usr/local/bin/herdr",
+            execution: replacedHerdr
+        )]],
+        isLive: { _ in true }
+    ) == nil,
+    store.match(
+        at: .secretGate("gh"),
+        in: chains,
+        isLive: { _ in false }
+    ) == nil
+    else { return 1 }
+    return 0
+}
+
 private func runLaunchAgentHandoffSelfCheck() -> Int32 {
     let template = try! PropertyListSerialization.data(
         fromPropertyList: [
@@ -6770,6 +7220,10 @@ if CommandLine.arguments.contains("--self-check-brew-read-only") {
 
 if CommandLine.arguments.contains("--self-check-transient-approvals") {
     exit(runTransientApprovalSelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-retained-provenance") {
+    exit(runRetainedProcessProvenanceSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-dashboard-search") {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -8,6 +8,8 @@ public let secretGatePoliciesKeychainService = "com.automicvault.gate-policies"
 public let secretGatePoliciesKeychainAccount = "SecretGatePoliciesV2"
 public let secretNameAccessKeychainService = "com.automicvault.secret-name-access"
 public let secretNameAccessKeychainAccount = "SecretNameAccessV1"
+public let directAccessKeychainService = "com.automicvault.direct-secret-access"
+public let directAccessKeychainAccount = "DirectAccessRulesV1"
 public let accessRequestLogDefaultsKey = "AccessRequestLog"
 public let accessRequestLogKeychainService = "com.automicvault.access-log"
 private let accessRequestLogLock = NSLock()
@@ -83,7 +85,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             ghCLIURL: ghCLIURL,
             metadata: hardenerMetadata
         )
-        let secrets = loadStoredSecrets()
+        let secrets = loadStoredSecrets(directAccessRules: loadDirectAccessRules())
         return DashboardSnapshot(
             detectors: loadDetectorMetadata(avExecutableURL: avExecutableURL),
             detectorFindings: scanDetectorFindings(avExecutableURL: avExecutableURL),
@@ -562,15 +564,18 @@ public struct StoredSecret: Equatable, Sendable {
     public let account: String
     public let accessibility: StoredSecretAccessibility
     public let keychainProperties: [String]
+    public let directAccessLaunchers: [BlessedScriptLauncher]
 
     public init(
         account: String,
         accessibility: StoredSecretAccessibility = .whenUnlocked,
-        keychainProperties: [String] = []
+        keychainProperties: [String] = [],
+        directAccessLaunchers: [BlessedScriptLauncher] = []
     ) {
         self.account = account
         self.accessibility = accessibility
         self.keychainProperties = keychainProperties
+        self.directAccessLaunchers = directAccessLaunchers
     }
 
     public var subtitle: String {
@@ -1152,7 +1157,11 @@ public func appendAccessRequestRecord(
     return loadAccessRequestRecords(defaults: defaults, key: key, service: service).first?.id == record.id
 }
 
-public func loadStoredSecrets(service: String = automicVaultKeychainService) -> [StoredSecret] {
+public func loadStoredSecrets(
+    service: String = automicVaultKeychainService,
+    directAccessRules: [DirectAccessRule] = []
+) -> [StoredSecret] {
+    let directAccess = Dictionary(grouping: directAccessRules, by: \.secretName)
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: service,
@@ -1174,7 +1183,12 @@ public func loadStoredSecrets(service: String = automicVaultKeychainService) -> 
             accessibility: StoredSecretAccessibility(
                 keychainValue: item[kSecAttrAccessible as String]
             ),
-            keychainProperties: keychainProperties(for: item, dataProtection: true)
+            keychainProperties: keychainProperties(for: item, dataProtection: true),
+            directAccessLaunchers: (directAccess[account] ?? [])
+                .map(\.launcher)
+                .sorted {
+                    $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending
+                }
         )
     }
     .sorted { $0.account.localizedStandardCompare($1.account) == .orderedAscending }
@@ -1278,6 +1292,22 @@ public func renameStoredSecret(account: String, to newAccount: String, service: 
     return SecItemUpdate(query as CFDictionary, [kSecAttrAccount as String: newAccount] as CFDictionary)
 }
 
+public func renameStoredSecretRevokingDirectAccess(
+    account: String,
+    to newAccount: String,
+    service: String = automicVaultKeychainService,
+    directAccessService: String = directAccessKeychainService,
+    directAccessAccount: String = directAccessKeychainAccount
+) -> OSStatus {
+    let status = revokeDirectAccess(
+        to: account,
+        service: directAccessService,
+        account: directAccessAccount
+    )
+    guard status == errSecSuccess else { return status }
+    return renameStoredSecret(account: account, to: newAccount, service: service)
+}
+
 public func deleteStoredSecret(account: String, service: String = automicVaultKeychainService) -> OSStatus {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
@@ -1287,6 +1317,21 @@ public func deleteStoredSecret(account: String, service: String = automicVaultKe
     ]
     addCanonicalAccessGroup(to: &query)
     return SecItemDelete(query as CFDictionary)
+}
+
+public func deleteStoredSecretRevokingDirectAccess(
+    account: String,
+    service: String = automicVaultKeychainService,
+    directAccessService: String = directAccessKeychainService,
+    directAccessAccount: String = directAccessKeychainAccount
+) -> OSStatus {
+    let status = revokeDirectAccess(
+        to: account,
+        service: directAccessService,
+        account: directAccessAccount
+    )
+    guard status == errSecSuccess else { return status }
+    return deleteStoredSecret(account: account, service: service)
 }
 
 public func loadStoredSecret(account: String, service: String = automicVaultKeychainService) -> String? {
@@ -1330,12 +1375,15 @@ public func migrateBackgroundKeychainItems(
     accessLogService: String = accessRequestLogKeychainService,
     accessLogAccount: String = accessRequestLogDefaultsKey,
     secretNameAccessService: String = secretNameAccessKeychainService,
-    secretNameAccessAccount: String = secretNameAccessKeychainAccount
+    secretNameAccessAccount: String = secretNameAccessKeychainAccount,
+    directAccessService: String = directAccessKeychainService,
+    directAccessAccount: String = directAccessKeychainAccount
 ) -> OSStatus {
     for (service, account) in [
         (policyService, policyAccount),
         (accessLogService, accessLogAccount),
         (secretNameAccessService, secretNameAccessAccount),
+        (directAccessService, directAccessAccount),
     ] {
         let status = setKeychainAccessibility(.afterFirstUnlock, service: service, account: account)
         if status != errSecSuccess && status != errSecItemNotFound {
@@ -1343,6 +1391,148 @@ public func migrateBackgroundKeychainItems(
         }
     }
     return errSecSuccess
+}
+
+public struct DirectAccessRule: Codable, Equatable, Sendable {
+    public let secretName: String
+    public let launcher: BlessedScriptLauncher
+
+    public init(secretName: String, launcher: BlessedScriptLauncher) {
+        self.secretName = secretName
+        self.launcher = launcher
+    }
+}
+
+public func loadDirectAccessRules(
+    service: String = directAccessKeychainService,
+    account: String = directAccessKeychainAccount
+) -> [DirectAccessRule] {
+    guard case .success(let rules) = loadDirectAccessRulesResult(service: service, account: account)
+    else { return [] }
+    return rules.sorted(by: directAccessRulePrecedes)
+}
+
+public func allowDirectAccess(
+    to secretName: String,
+    for launcher: BlessedScriptLauncher,
+    service: String = directAccessKeychainService,
+    account: String = directAccessKeychainAccount
+) -> OSStatus {
+    guard !secretName.isEmpty, !launcher.requirement.isEmpty else { return errSecParam }
+    var rules: [DirectAccessRule]
+    switch loadDirectAccessRulesResult(service: service, account: account) {
+    case .success(let loaded): rules = loaded
+    case .failure(let status): return status
+    }
+    rules.removeAll {
+        $0.secretName == secretName && $0.launcher.requirement == launcher.requirement
+    }
+    rules.append(DirectAccessRule(secretName: secretName, launcher: launcher))
+    return saveDirectAccessRules(rules, service: service, account: account)
+}
+
+public func removeDirectAccess(
+    to secretName: String,
+    for launcher: BlessedScriptLauncher,
+    service: String = directAccessKeychainService,
+    account: String = directAccessKeychainAccount
+) -> OSStatus {
+    mutateDirectAccessRules(service: service, account: account) { rules in
+        rules.removeAll { rule in
+            rule.secretName == secretName && rule.launcher.requirement == launcher.requirement
+        }
+    }
+}
+
+public func revokeDirectAccess(
+    to secretName: String,
+    service: String = directAccessKeychainService,
+    account: String = directAccessKeychainAccount
+) -> OSStatus {
+    mutateDirectAccessRules(service: service, account: account) { rules in
+        rules.removeAll { $0.secretName == secretName }
+    }
+}
+
+public func directAccessAllows(
+    secretNames: [String],
+    launcherRequirement: String,
+    runtimeProtection: LauncherRuntimeProtection,
+    rules: [DirectAccessRule]
+) -> Bool {
+    guard !secretNames.isEmpty,
+          !launcherRequirement.isEmpty,
+          runtimeProtection.allowsSecretGateAccess
+    else { return false }
+    return Set(secretNames).allSatisfy { secretName in
+        rules.contains {
+            $0.secretName == secretName && $0.launcher.requirement == launcherRequirement
+        }
+    }
+}
+
+private enum DirectAccessRulesLoad {
+    case success([DirectAccessRule])
+    case failure(OSStatus)
+}
+
+private func loadDirectAccessRulesResult(service: String, account: String) -> DirectAccessRulesLoad {
+    switch loadKeychainDataResult(service: service, account: account) {
+    case .notFound:
+        return .success([])
+    case .failure(let status):
+        return .failure(status)
+    case .success(let data):
+        do {
+            return .success(try JSONDecoder().decode([DirectAccessRule].self, from: data))
+        } catch {
+            return .failure(errSecDecode)
+        }
+    }
+}
+
+private func mutateDirectAccessRules(
+    service: String,
+    account: String,
+    mutate: (inout [DirectAccessRule]) -> Void
+) -> OSStatus {
+    var rules: [DirectAccessRule]
+    switch loadDirectAccessRulesResult(service: service, account: account) {
+    case .success(let loaded): rules = loaded
+    case .failure(let status): return status
+    }
+    mutate(&rules)
+    return saveDirectAccessRules(rules, service: service, account: account)
+}
+
+private func saveDirectAccessRules(
+    _ rules: [DirectAccessRule],
+    service: String,
+    account: String
+) -> OSStatus {
+    if rules.isEmpty {
+        let status = deleteStoredSecret(account: account, service: service)
+        return status == errSecItemNotFound ? errSecSuccess : status
+    }
+    do {
+        return saveKeychainData(
+            try JSONEncoder().encode(rules.sorted(by: directAccessRulePrecedes)),
+            service: service,
+            account: account,
+            accessibility: .afterFirstUnlock
+        )
+    } catch {
+        return errSecParam
+    }
+}
+
+private func directAccessRulePrecedes(_ lhs: DirectAccessRule, _ rhs: DirectAccessRule) -> Bool {
+    [lhs.secretName, lhs.launcher.bundleIdentifier, lhs.launcher.requirement]
+        .joined(separator: "\u{1f}")
+        .localizedStandardCompare(
+            [rhs.secretName, rhs.launcher.bundleIdentifier, rhs.launcher.requirement]
+                .joined(separator: "\u{1f}")
+        ) == .orderedAscending
 }
 
 private func setKeychainAccessibility(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -386,6 +386,142 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(loadStoredSecret(account: account, service: service) == "not json")
 }
 
+@Test func directAccessRequiresEveryExactSecretAndHardenedRuntime() {
+    let launcher = BlessedScriptLauncher(
+        bundleIdentifier: "com.example.launcher",
+        requirement: "designated requirement"
+    )
+    let rules = [
+        DirectAccessRule(secretName: "ALPHA_TOKEN", launcher: launcher),
+        DirectAccessRule(secretName: "BETA_TOKEN", launcher: launcher),
+    ]
+
+    #expect(directAccessAllows(
+        secretNames: ["ALPHA_TOKEN", "BETA_TOKEN"],
+        launcherRequirement: launcher.requirement,
+        runtimeProtection: .hardened,
+        rules: rules
+    ))
+    #expect(!directAccessAllows(
+        secretNames: ["ALPHA_TOKEN", "OTHER_TOKEN"],
+        launcherRequirement: launcher.requirement,
+        runtimeProtection: .hardened,
+        rules: rules
+    ))
+    #expect(!directAccessAllows(
+        secretNames: ["ALPHA_TOKEN"],
+        launcherRequirement: "another requirement",
+        runtimeProtection: .hardened,
+        rules: rules
+    ))
+    #expect(!directAccessAllows(
+        secretNames: ["ALPHA_TOKEN"],
+        launcherRequirement: launcher.requirement,
+        runtimeProtection: .hardenedRuntimeMissing,
+        rules: rules
+    ))
+    #expect(!directAccessAllows(
+        secretNames: [],
+        launcherRequirement: launcher.requirement,
+        runtimeProtection: .hardened,
+        rules: rules
+    ))
+}
+
+@Test func directAccessRulesArePersistedWithSecretsAndRevocable() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let secretService = "com.automicvault.tests.secret.\(UUID().uuidString)"
+    let policyService = "com.automicvault.tests.direct.\(UUID().uuidString)"
+    let policyAccount = "rules"
+    let zeta = BlessedScriptLauncher(bundleIdentifier: "com.example.zeta", requirement: "zeta")
+    let alpha = BlessedScriptLauncher(bundleIdentifier: "com.example.alpha", requirement: "alpha")
+    defer { _ = deleteStoredSecret(account: "API_TOKEN", service: secretService) }
+    defer { _ = deleteStoredSecret(account: policyAccount, service: policyService) }
+
+    #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: secretService) == errSecSuccess)
+    #expect(allowDirectAccess(
+        to: "API_TOKEN", for: zeta, service: policyService, account: policyAccount
+    ) == errSecSuccess)
+    #expect(allowDirectAccess(
+        to: "API_TOKEN", for: alpha, service: policyService, account: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).map(\.launcher) == [alpha, zeta])
+    #expect(loadStoredSecrets(
+        service: secretService,
+        directAccessRules: loadDirectAccessRules(service: policyService, account: policyAccount)
+    ).first?.directAccessLaunchers == [alpha, zeta])
+    #expect(keychainAccessibility(account: policyAccount, service: policyService) == kSecAttrAccessibleAfterFirstUnlock as String)
+
+    #expect(removeDirectAccess(
+        to: "API_TOKEN", for: alpha, service: policyService, account: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).map(\.launcher) == [zeta])
+    #expect(revokeDirectAccess(
+        to: "API_TOKEN", service: policyService, account: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).isEmpty)
+}
+
+@Test func malformedDirectAccessPolicyFailsClosedAndIsNotReplaced() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.direct.\(UUID().uuidString)"
+    let secretService = "com.automicvault.tests.secret.\(UUID().uuidString)"
+    let account = "rules"
+    let launcher = BlessedScriptLauncher(bundleIdentifier: "com.example.app", requirement: "requirement")
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+    defer { _ = deleteStoredSecret(account: "API_TOKEN", service: secretService) }
+    #expect(saveStoredSecret(account: account, value: "not json", service: service) == errSecSuccess)
+    #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: secretService) == errSecSuccess)
+
+    #expect(loadDirectAccessRules(service: service, account: account).isEmpty)
+    #expect(allowDirectAccess(
+        to: "API_TOKEN", for: launcher, service: service, account: account
+    ) == errSecDecode)
+    #expect(deleteStoredSecretRevokingDirectAccess(
+        account: "API_TOKEN",
+        service: secretService,
+        directAccessService: service,
+        directAccessAccount: account
+    ) == errSecDecode)
+    #expect(storedSecretExists(account: "API_TOKEN", service: secretService))
+    #expect(loadStoredSecret(account: account, service: service) == "not json")
+}
+
+@Test func deletingOrRenamingASecretRevokesDirectAccessFirst() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let secretService = "com.automicvault.tests.secret.\(UUID().uuidString)"
+    let policyService = "com.automicvault.tests.direct.\(UUID().uuidString)"
+    let policyAccount = "rules"
+    let launcher = BlessedScriptLauncher(bundleIdentifier: "com.example.app", requirement: "requirement")
+    defer { _ = deleteStoredSecret(account: "OLD_TOKEN", service: secretService) }
+    defer { _ = deleteStoredSecret(account: "NEW_TOKEN", service: secretService) }
+    defer { _ = deleteStoredSecret(account: policyAccount, service: policyService) }
+
+    #expect(saveStoredSecret(account: "OLD_TOKEN", value: "secret", service: secretService) == errSecSuccess)
+    #expect(allowDirectAccess(
+        to: "OLD_TOKEN", for: launcher, service: policyService, account: policyAccount
+    ) == errSecSuccess)
+    #expect(renameStoredSecretRevokingDirectAccess(
+        account: "OLD_TOKEN",
+        to: "NEW_TOKEN",
+        service: secretService,
+        directAccessService: policyService,
+        directAccessAccount: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).isEmpty)
+
+    #expect(allowDirectAccess(
+        to: "NEW_TOKEN", for: launcher, service: policyService, account: policyAccount
+    ) == errSecSuccess)
+    #expect(deleteStoredSecretRevokingDirectAccess(
+        account: "NEW_TOKEN",
+        service: secretService,
+        directAccessService: policyService,
+        directAccessAccount: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).isEmpty)
+}
+
 @Test func secretlessGateNormalizesLegacyFullPolicy() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.\(UUID().uuidString)"


### PR DESCRIPTION
## What changed

- Add Direct Access Rules that bind exact Secret Names to verified, Hardened Runtime launchers.
- Add the required repeated security acknowledgement and documentation for safer alternatives.
- Add default-off Retained Launcher Provenance for exact live process executions whose verified parent chain disappears.
- Re-evaluate every retained request against current gate policy and write a new authorization record.
- Show a non-authorizing explanation in Approval while retained access is disabled.
- Define both security boundaries in ADR 0006 and ADR 0007 and update canonical domain language.

## Why

Long-lived harnesses such as herdr and Portal can outlive the launcher that established their policy attribution. Users also need an explicit escape hatch for exact named secrets when normal Authorization Gates do not fit.

## Security impact

Both features default to fail closed. Direct Access requires an exact secret, verified launcher identity, and Hardened Runtime. Retained provenance is memory-only, gate-scoped, bound to one live process execution and code identity, and never reuses a prior authorization decision.

Context: #73

## Validation

- swift test --package-path src/menu-helper
- 73 Swift tests passed
- Retained-provenance and dashboard self-checks passed
- git diff --check
