### PR TITLE
Support hardening without Homebrew

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,69 @@ version = "3.0.0"
 dependencies = [
  "libc",
  "serde_json",
+ "ureq",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "itoa"
@@ -23,10 +85,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "proc-macro2"
@@ -44,6 +124,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -89,6 +218,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +245,140 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 libc = "0.2"
 serde_json = "1"
+ureq = { version = "3.3", default-features = false, features = ["rustls"] }
 
 [lib]
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@
   # ^^ read it first
   ```
 
-> [!NOTE]
-> At this time *some* parts of Automic Vault *require* Homebrew to be installed.
-> We intend to loosen this restriction in the future. If you don’t use Homebrew
-> much of Automic Vault will still work, but some hardening features will not be
-> available.
-
 > [!IMPORTANT]
 > Automic Vault is not associated or affiliated with any cryptocurrency or “token”.
 
@@ -61,8 +55,9 @@ The primary adversary is untrusted or compromised code already running with your
   Automic Vault is not a security layer for UNIX.
   It is an adapter for the macOS GUI security model applied to the command line.
 
-> † we patch tools to make them more secure and provide a [homebrew tap] to
-> install them. We install stubs in `/usr/local/bin` that federate access to
+> † we patch tools to make them more secure and distribute them through our
+> [homebrew tap] or directly through `av harden`. We install stubs in
+> `/usr/local/bin` that federate access to
 > secrets using the full breadth of the macOS security model, including
 > code signing, notarization, XPC, TCC and the keychain.
 
@@ -334,8 +329,9 @@ But we aren’t going to lie: it’s more friction than now. We minimize:
   - Though when security requires more, we say so: AWS hardening uses a native
     credential helper to convert your too-powerful AWS keys into short-lived
     session tokens for each invocation.
-  - Some tools need more, so we patch them and provide a homebrew tap to install
-    them (`gh`, `stripe`, `supabase` etc.). We try to upstream these patches.
+  - Some tools need more, so we patch them and let `av harden` install the
+    signed Isotope directly or through Homebrew (`gh`, `stripe`, `supabase`
+    etc.). We try to upstream these patches.
 - We make approval gates rare and specific.
   - By default, Secret Gates automically authorize recognized read-only commands.
   - Writes and sensitive secret operations require Approval unless the chosen

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ Detectors inspect the developer environment without changing it. A Scan produces
 
 ### Tool Hardening
 
-Hardeners move supported Tools into a declared Hardened State. Doctor verifies the installed intervention and its dependencies. An Isotope supplies an Automic Vault-compatible build or wrapper where upstream behavior cannot support the required boundary.
+Hardeners move supported Tools into a declared Hardened State. Doctor verifies the installed intervention and its dependencies. An Isotope supplies an Automic Vault-compatible build or wrapper where upstream behavior cannot support the required boundary. The Hardener delegates Isotope updates to Homebrew when the Isotope came from the tap. For a direct install, it verifies the release digest and Automic Vault code signature, installs into `/usr/local/bin`, and Doctor directs the user back to the Hardener when the tap publishes a new digest.
 
 ### Secret Custody
 
@@ -46,7 +46,10 @@ Script Blessings bind a canonical path, exact contents, Script Declaration, capa
 
 ### Distribution
 
-The app, CLI, signed helpers, Isotopes tap, website, and companion app distribute and present the system. Distribution supports the security contexts but does not define competing domain language or policy semantics.
+The app, CLI, signed helpers, Isotopes tap and signed direct Isotope releases,
+website, and companion app distribute and present the system. Distribution
+supports the security contexts but does not define competing domain language or
+policy semantics.
 
 ## Authorization flow
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -207,7 +207,10 @@ A verifier for Automic Vault's intervention. Doctor checks declared invariants s
 
 ### Isotope
 
-An Automic Vault-compatible build or wrapper of a third-party Tool, distributed through the Isotopes Homebrew tap in most cases. An Isotope is not a Detector, Hardener, or Secret.
+An Automic Vault-compatible build or wrapper of a third-party Tool. A Hardener
+installs an Isotope through the Isotopes Homebrew tap when Homebrew is available,
+or installs the same signed release directly and assumes responsibility for its
+updates. An Isotope is not a Detector, Hardener, or Secret.
 
 ## Reviewed automation
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -8,6 +8,7 @@ use std::process::{Command, Stdio};
 
 use crate::isotopes::hardeners::{
     self, HardenerCommand, HardenerMetadata, RequiredExecutable, StubRequirements, executable,
+    isotope,
 };
 
 use super::scan::Style;
@@ -315,7 +316,96 @@ fn diagnose_command(hardener: &str, command: &HardenerCommand, path: &OsStr) -> 
             issues.extend(path_issue(command, path));
         }
     }
+    if let Some(isotope) = &command.isotope {
+        if let Some(issue) = isotope_path_issue(command, path, |path, identifier| {
+            isotope::signature_valid(path, identifier)
+        }) {
+            issues.push(issue);
+        }
+        if let Some(issue) = isotope_update_issue(command, isotope) {
+            issues.push(issue);
+        }
+    }
     issues
+}
+
+fn isotope_path_issue(
+    command: &HardenerCommand,
+    path: &OsStr,
+    signature_valid: impl Fn(&Path, &str) -> bool,
+) -> Option<DoctorIssue> {
+    let isotope = command.isotope.as_ref()?;
+    let resolved = resolve(&command.name, path);
+    if resolved.as_deref().is_some_and(|path| {
+        path.file_name().and_then(|name| name.to_str()) == Some(command.name.as_str())
+            && signature_valid(path, isotope.identifier)
+    }) {
+        return None;
+    }
+    let resolved_path = resolved.as_ref().map(|path| path.display().to_string());
+    let message = resolved_path.as_ref().map_or_else(
+        || format!("{} is not available through PATH", command.name),
+        |resolved| {
+            format!(
+                "{} resolves to {resolved}, which is not the signed Automic Vault isotope",
+                command.name
+            )
+        },
+    );
+    Some(DoctorIssue {
+        kind: "isotope_not_first_on_path",
+        command: Some(command.name.clone()),
+        message,
+        remediation: format!(
+            "Put the signed Automic Vault `{}` isotope first in PATH, then rerun `av doctor {}`.",
+            command.name, command.name
+        ),
+        stub_path: command.stub_path.clone(),
+        target_path: Some(command.target_path.clone()),
+        resolved_path,
+    })
+}
+
+fn isotope_update_issue(
+    command: &HardenerCommand,
+    doctor: &isotope::Doctor,
+) -> Option<DoctorIssue> {
+    let receipt = doctor.receipt_path.as_deref()?;
+    let installed = fs::read_to_string(receipt).ok();
+    let current = isotope::current_sha(&doctor.formula_url);
+    match (installed.as_deref().map(str::trim), current) {
+        (Some(installed), Ok(current)) if installed == current => None,
+        (_, Ok(_)) => Some(DoctorIssue {
+            kind: "isotope_update_required",
+            command: Some(command.name.clone()),
+            message: format!(
+                "the directly installed {} isotope has an update available",
+                command.name
+            ),
+            remediation: format!(
+                "Run `av harden {}` to install the current signed isotope.",
+                command.name
+            ),
+            stub_path: command.stub_path.clone(),
+            target_path: Some(command.target_path.clone()),
+            resolved_path: None,
+        }),
+        (_, Err(error)) => Some(DoctorIssue {
+            kind: "isotope_update_check_failed",
+            command: Some(command.name.clone()),
+            message: format!(
+                "could not check the {} isotope for updates: {error}",
+                command.name
+            ),
+            remediation: format!(
+                "Check the network connection and rerun `av doctor {}`.",
+                command.name
+            ),
+            stub_path: command.stub_path.clone(),
+            target_path: Some(command.target_path.clone()),
+            resolved_path: None,
+        }),
+    }
 }
 
 fn target_issue(hardener: &str, command: &HardenerCommand) -> DoctorIssue {
@@ -1281,7 +1371,65 @@ mod tests {
             stub_requirements: None,
             injected_keys: Vec::new(),
             assignment_keys: Vec::new(),
+            isotope: None,
         }
+    }
+
+    #[test]
+    fn isotope_path_check_requires_the_signed_basename_on_path() {
+        let directory = temp_dir("isotope-path");
+        let gh = executable_file(&directory.join("gh"));
+        let mut command = command("gh", true, gh.to_str().unwrap(), gh.to_str().unwrap());
+        command.isotope = Some(isotope::Doctor {
+            identifier: "gh",
+            formula_url: "https://example.invalid/gh-cli.rb".into(),
+            receipt_path: None,
+        });
+        assert!(
+            isotope_path_issue(&command, directory.as_os_str(), |_, identifier| identifier
+                == "gh")
+            .is_none()
+        );
+        assert_eq!(
+            isotope_path_issue(&command, directory.as_os_str(), |_, _| false)
+                .unwrap()
+                .kind,
+            "isotope_not_first_on_path"
+        );
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn direct_isotope_update_check_uses_the_formula_digest() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let directory = temp_dir("isotope-update");
+        let receipt = directory.join("gh-cli.sha256");
+        let hash = "29e7f73c54cc1c278b7431bc04d581b468ca033d1782c39c87034515ae5d7070";
+        fs::write(&receipt, format!("{hash}\n")).unwrap();
+        unsafe {
+            std::env::set_var(
+                "AUTOMIC_VAULT_TEST_ISOTOPE_FORMULA",
+                format!(
+                    "url \"https://github.com/automic-vault/gh-cli/releases/download/v1/cli.tgz\"\nsha256 \"{hash}\"\n"
+                ),
+            );
+        }
+        let command = command("gh", true, "/usr/local/bin/gh", "/usr/local/bin/gh");
+        let doctor = isotope::Doctor {
+            identifier: "gh",
+            formula_url: "https://example.invalid/gh-cli.rb".into(),
+            receipt_path: Some(receipt.display().to_string()),
+        };
+        assert!(isotope_update_issue(&command, &doctor).is_none());
+        fs::write(&receipt, "different\n").unwrap();
+        assert_eq!(
+            isotope_update_issue(&command, &doctor).unwrap().kind,
+            "isotope_update_required"
+        );
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ISOTOPE_FORMULA");
+        }
+        let _ = fs::remove_dir_all(directory);
     }
 
     fn executable_file(path: &Path) -> PathBuf {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
 
 mod aws;
 mod bless;
@@ -193,12 +194,13 @@ where
                 }
             }
         }
-        Some("__install-env-wrapper") if rest.len() == 1 => {
+        Some("__install-env-wrapper") if rest.len() >= 2 => {
             let Some(target) = rest[0].to_str() else {
                 let _ = writeln!(stderr, "av: invalid env-wrapper hardener name");
                 return 2;
             };
-            match hardeners::env_wrapper::install_target(target) {
+            let paths = rest[1..].iter().map(PathBuf::from).collect::<Vec<_>>();
+            match hardeners::env_wrapper::install_target(target, &paths) {
                 Ok(()) => 0,
                 Err(err) => {
                     let _ = writeln!(stderr, "av: {err}");
@@ -660,7 +662,7 @@ mod tests {
         assert_eq!(
             stderr,
             format!(
-                "av harden: flyctl is not installed at {}\n",
+                "av harden: flyctl is not an executable file: {}\n",
                 targets.join("flyctl").display()
             )
         );
@@ -826,8 +828,12 @@ mod tests {
 
     #[test]
     fn private_env_wrapper_installer_rejects_unknown_targets() {
-        let (code, stdout, stderr) =
-            run_args(&["av", "__install-env-wrapper", "definitely-not-a-hardener"]);
+        let (code, stdout, stderr) = run_args(&[
+            "av",
+            "__install-env-wrapper",
+            "definitely-not-a-hardener",
+            "/nix/store/example/bin/tool",
+        ]);
 
         assert_eq!(code, 1);
         assert_eq!(stdout, "");
@@ -852,7 +858,12 @@ mod tests {
         let _guard = crate::global_test_env_lock().lock().unwrap();
         unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_EUID", "501") };
 
-        let (code, stdout, stderr) = run_args(&["av", "__install-env-wrapper", "doctl"]);
+        let (code, stdout, stderr) = run_args(&[
+            "av",
+            "__install-env-wrapper",
+            "doctl",
+            "/nix/store/example/bin/doctl",
+        ]);
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_EUID") };
         assert_eq!(code, 1);
@@ -867,7 +878,12 @@ mod tests {
             std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", "/tmp/stubs");
         }
 
-        let (code, stdout, stderr) = run_args(&["av", "__install-env-wrapper", "doctl"]);
+        let (code, stdout, stderr) = run_args(&[
+            "av",
+            "__install-env-wrapper",
+            "doctl",
+            "/nix/store/example/bin/doctl",
+        ]);
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         assert_eq!(code, 1);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,7 +39,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 15;
+pub(crate) const INSTALL_REVISION: u32 = 16;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -208,6 +208,24 @@ where
                 }
             }
         }
+        Some("__install-isotope") if rest.len() == 3 => {
+            let Some(hardener) = rest[0].to_str() else {
+                let _ = writeln!(stderr, "av: invalid isotope hardener name");
+                return 2;
+            };
+            let Some(sha256) = rest[1].to_str() else {
+                let _ = writeln!(stderr, "av: invalid isotope digest");
+                return 2;
+            };
+            let archive = PathBuf::from(&rest[2]);
+            match hardeners::isotope::install_privileged(hardener, sha256, &archive) {
+                Ok(()) => 0,
+                Err(err) => {
+                    let _ = writeln!(stderr, "av: {err}");
+                    1
+                }
+            }
+        }
         Some("scan") if rest.is_empty() => scan::run(stdout, style, false),
         Some("scan") if rest == [OsString::from("--show-all")] => scan::run(stdout, style, true),
         Some("scan") if rest == [OsString::from("--json")] => scan::run_json(stdout),
@@ -259,48 +277,12 @@ where
                 return finish_hardening(result, "aws", stdout, stderr);
             }
             if target == "gh" || target == "gh-cli" {
-                return match hardeners::gh_cli::run(stdout, yes) {
-                    Ok(()) => {
-                        print_hardening_followup(stdout, "gh");
-                        0
-                    }
-                    Err(hardeners::gh_cli::HardenError::GhCliNotInstalled) => {
-                        print_isotope_install_guidance(
-                            stderr,
-                            style,
-                            "gh",
-                            "gh-cli",
-                            hardeners::gh_cli::INSTALL_COMMAND,
-                        );
-                        1
-                    }
-                    Err(hardeners::gh_cli::HardenError::Other(err)) => {
-                        let _ = writeln!(stderr, "av harden: {err}");
-                        1
-                    }
-                };
+                let result = hardeners::gh_cli::run(stdout, yes);
+                return finish_hardening(result, "gh", stdout, stderr);
             }
             if target == "stripe" || target == "stripe-cli" {
-                return match hardeners::stripe_cli::run(stdout, yes) {
-                    Ok(()) => {
-                        print_hardening_followup(stdout, "stripe");
-                        0
-                    }
-                    Err(hardeners::stripe_cli::HardenError::StripeCliNotInstalled) => {
-                        print_isotope_install_guidance(
-                            stderr,
-                            style,
-                            "stripe",
-                            "stripe-cli",
-                            hardeners::stripe_cli::INSTALL_COMMAND,
-                        );
-                        1
-                    }
-                    Err(hardeners::stripe_cli::HardenError::Other(err)) => {
-                        let _ = writeln!(stderr, "av harden: {err}");
-                        1
-                    }
-                };
+                let result = hardeners::stripe_cli::run(stdout, yes);
+                return finish_hardening(result, "stripe", stdout, stderr);
             }
             if target == "brew" || target == "homebrew" {
                 let result = hardeners::homebrew::run(stdout, yes);
@@ -379,25 +361,6 @@ fn write_help(stdout: &mut dyn Write, style: scan::Style) {
             );
         }
     }
-}
-
-fn print_isotope_install_guidance(
-    stderr: &mut dyn Write,
-    style: scan::Style,
-    target: &str,
-    package: &str,
-    install_command: &str,
-) {
-    let _ = writeln!(stderr, "╭─ harden {target}");
-    let _ = writeln!(stderr, "│");
-    let _ = writeln!(
-        stderr,
-        "◆ {}",
-        style.paint("33", &format!("{package} is not installed"))
-    );
-    let _ = writeln!(stderr, "│");
-    let _ = writeln!(stderr, "├─ 1. run: `{install_command}`");
-    let _ = writeln!(stderr, "╰─ 2. run: `av harden {target}` again");
 }
 
 fn print_hardening_followup(stdout: &mut dyn Write, target: &str) {
@@ -544,49 +507,6 @@ mod tests {
 
         assert_eq!(code, 0);
         assert_eq!(stderr, "");
-    }
-
-    #[test]
-    fn harden_gh_tells_user_to_install_isotope() {
-        let _guard = crate::global_test_env_lock().lock().unwrap();
-        let missing = std::env::temp_dir().join(format!("av-missing-gh-{}", std::process::id()));
-        unsafe {
-            std::env::set_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH", &missing);
-        }
-
-        let (code, stdout, stderr) = run_args(&["av", "harden", "gh"]);
-
-        unsafe {
-            std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
-        }
-        assert_eq!(code, 1);
-        assert_eq!(stdout, "");
-        assert_eq!(
-            stderr,
-            "╭─ harden gh\n│\n◆ gh-cli is not installed\n│\n├─ 1. run: `brew install automic-vault/isotopes/gh-cli`\n╰─ 2. run: `av harden gh` again\n"
-        );
-    }
-
-    #[test]
-    fn harden_stripe_tells_user_to_install_isotope() {
-        let _guard = crate::global_test_env_lock().lock().unwrap();
-        let missing =
-            std::env::temp_dir().join(format!("av-missing-stripe-{}", std::process::id()));
-        unsafe {
-            std::env::set_var("AUTOMIC_VAULT_TEST_STRIPE_CLI_PATH", &missing);
-        }
-
-        let (code, stdout, stderr) = run_args(&["av", "harden", "stripe"]);
-
-        unsafe {
-            std::env::remove_var("AUTOMIC_VAULT_TEST_STRIPE_CLI_PATH");
-        }
-        assert_eq!(code, 1);
-        assert_eq!(stdout, "");
-        assert_eq!(
-            stderr,
-            "╭─ harden stripe\n│\n◆ stripe-cli is not installed\n│\n├─ 1. run: `brew install automic-vault/isotopes/stripe-cli`\n╰─ 2. run: `av harden stripe` again\n"
-        );
     }
 
     #[test]

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -395,8 +395,9 @@ fn find_target(stub: &StubSpec) -> Result<PathBuf, String> {
                 )
             });
     }
-    if let Some(target) =
-        embedded_target(&stub_path(stub.command)).filter(|path| super::executable(path))
+    let launcher = stub_path(stub.command);
+    if let Some(target) = embedded_target(&launcher)
+        .filter(|path| !same_path(path, &launcher) && super::executable(path))
     {
         return Ok(target);
     }
@@ -715,6 +716,34 @@ mod tests {
             std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
         }
         assert_eq!(targets[0].path, hcloud);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn ignores_a_stub_that_embeds_itself_as_the_target() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let previous_path = std::env::var_os("PATH");
+        let dir = temp_dir("env-wrapper-self-target");
+        fs::create_dir_all(&dir).unwrap();
+        let launcher = dir.join("hcloud");
+        let spec = &wrapper("hcloud").unwrap().primary;
+        fs::write(&launcher, stub_script(spec, &launcher)).unwrap();
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755)).unwrap();
+        unsafe {
+            std::env::set_var("PATH", "");
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+        }
+
+        let error = resolve_targets(wrapper("hcloud").unwrap()).err().unwrap();
+
+        unsafe {
+            match previous_path {
+                Some(path) => std::env::set_var("PATH", path),
+                None => std::env::remove_var("PATH"),
+            }
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        }
+        assert_eq!(error, "hcloud is not installed on PATH");
         fs::remove_dir_all(dir).unwrap();
     }
 

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -11,11 +11,10 @@ use super::{
 
 const MARKER: &str = "AUTOMIC_VAULT_ENV_WRAPPER_STUB_V2";
 const STUB_DIR: &str = "/usr/local/bin";
-const TARGET_DIR: &str = "/opt/homebrew/bin";
 const AV_PATH: &str = "/usr/local/bin/av";
 const SUDO_PATH: &str = "/usr/bin/sudo";
 const PRIVILEGE_MODE: super::PrivilegeMode = super::PrivilegeMode::Mixed;
-const DOCUMENTATION: &str = "# Environment Wrapper\n\nMigrates supported existing credentials into Automic Vault, then runs the target tool through `av inject --allow-missing-keys` with those secrets. Automic Vault requests elevation only to install the launcher stub. This does not protect the target executable; anything that can replace it can read the injected credentials. Run `av scan` after hardening to find unsupported credentials or secrets written later.\n";
+const DOCUMENTATION: &str = "# Environment Wrapper\n\nUses the target executable selected by your current `PATH`, shows its exact path for confirmation, and embeds that path in a launcher stub. Then it migrates supported existing credentials into Automic Vault and runs the target through `av inject --allow-missing-keys` with those secrets. Automic Vault requests elevation only to install the launcher stub. This does not protect the target executable; anything that can replace it can read the injected credentials. Run `av scan` after hardening to find unsupported credentials or secrets written later.\n";
 
 unsafe extern "C" {
     fn geteuid() -> u32;
@@ -29,17 +28,18 @@ pub(crate) fn run_target(
     Some(run(wrapper(target)?, stdout, yes))
 }
 
-pub(crate) fn install_target(target: &str) -> Result<(), String> {
-    let wrapper = wrapper(target).ok_or_else(|| format!("unknown hardener `{target}`"))?;
+pub(crate) fn install_target(name: &str, targets: &[PathBuf]) -> Result<(), String> {
+    let wrapper = wrapper(name).ok_or_else(|| format!("unknown hardener `{name}`"))?;
     if test_stub_dir().is_some() || test_target_dir().is_some() {
         return Err("test path overrides are forbidden during privileged installation".into());
     }
     if actual_uid() != 0 {
         return Err("env-wrapper installation requires root".into());
     }
-    preflight(wrapper)?;
-    for stub in stubs(wrapper) {
-        install_stub(stub)?;
+    let resolved = supplied_targets(wrapper, targets)?;
+    preflight(&resolved)?;
+    for target in &resolved {
+        install_stub(target.stub, &target.path)?;
     }
     Ok(())
 }
@@ -83,15 +83,17 @@ fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
 
 fn run(wrapper: &EnvWrapper, stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     PRIVILEGE_MODE.require_user(wrapper.name, test_stub_dir().is_some())?;
-    preflight(wrapper)?;
+    let targets = resolve_targets(wrapper)?;
+    preflight(&targets)?;
 
     writeln!(stdout, "╭─ harden {}", wrapper.name).ok();
     writeln!(stdout, "│").ok();
-    for stub in stubs(wrapper) {
+    for target in &targets {
+        writeln!(stdout, "├─ target {}", target.path.display()).ok();
         writeln!(
             stdout,
-            "├─ run sudo to write {}",
-            stub_path(stub.command).display()
+            "├─ install launcher {}",
+            stub_path(target.stub.command).display()
         )
         .ok();
     }
@@ -101,7 +103,7 @@ fn run(wrapper: &EnvWrapper, stdout: &mut dyn Write, yes: bool) -> Result<(), St
         return Ok(());
     }
 
-    install_privileged(wrapper)?;
+    install_privileged(wrapper, &targets)?;
     writeln!(stdout, "├─ migrate existing credentials").ok();
     super::migrations::run(wrapper.name)
         .ok_or_else(|| format!("no credential migration registered for {}", wrapper.name))??;
@@ -110,18 +112,24 @@ fn run(wrapper: &EnvWrapper, stdout: &mut dyn Write, yes: bool) -> Result<(), St
     Ok(())
 }
 
-fn preflight(wrapper: &EnvWrapper) -> Result<(), String> {
-    for stub in stubs(wrapper) {
-        let target = target_path(stub);
-        if !target.exists() {
+fn preflight(targets: &[ResolvedStub<'_>]) -> Result<(), String> {
+    for target in targets {
+        if !valid_target_path(&target.path, target.stub.command) {
             return Err(format!(
-                "{} is not installed at {}",
-                wrapper.name,
-                target.display()
+                "invalid target for {}: {}",
+                target.stub.command,
+                target.path.display()
             ));
         }
-        let stub_path = stub_path(stub.command);
-        if stub_path.exists() && !is_managed_stub(&stub_path, stub) {
+        if !super::executable(&target.path) {
+            return Err(format!(
+                "{} is not an executable file: {}",
+                target.stub.command,
+                target.path.display()
+            ));
+        }
+        let stub_path = stub_path(target.stub.command);
+        if stub_path.exists() && !is_managed_stub(&stub_path, target.stub) {
             return Err(format!(
                 "{} already exists and is not an Automic Vault env-wrapper stub",
                 stub_path.display()
@@ -131,16 +139,19 @@ fn preflight(wrapper: &EnvWrapper) -> Result<(), String> {
     Ok(())
 }
 
-fn install_privileged(wrapper: &EnvWrapper) -> Result<(), String> {
+fn install_privileged(wrapper: &EnvWrapper, targets: &[ResolvedStub<'_>]) -> Result<(), String> {
     if test_stub_dir().is_some() {
-        for stub in stubs(wrapper) {
-            install_stub(stub)?;
+        for target in targets {
+            install_stub(target.stub, &target.path)?;
         }
         return Ok(());
     }
     validate_privileged_av(Path::new(AV_PATH))?;
-    let status = Command::new(SUDO_PATH)
+    let mut command = Command::new(SUDO_PATH);
+    command
         .args([AV_PATH, "__install-env-wrapper", wrapper.name])
+        .args(targets.iter().map(|target| &target.path));
+    let status = command
         .status()
         .map_err(|err| format!("failed to run sudo: {err}"))?;
     if status.success() {
@@ -175,13 +186,19 @@ fn detect(wrapper: &EnvWrapper) -> HardenerDetection {
     let commands = stubs(wrapper)
         .map(|stub| {
             let path = stub_path(stub.command);
-            let stub_valid = is_current_stub(&path, stub);
+            let target = embedded_target(&path).or_else(|| find_target_on_path(stub.command));
+            let stub_valid = target.as_deref().is_some_and(|target| {
+                super::executable(target) && is_current_stub(&path, stub, target)
+            });
             HardenerCommand {
                 name: stub.command.to_string(),
                 hardened: stub_valid,
                 stub_valid,
                 stub_path: Some(path.display().to_string()),
-                target_path: target_path(stub).display().to_string(),
+                target_path: target
+                    .unwrap_or_else(|| PathBuf::from(stub.command))
+                    .display()
+                    .to_string(),
                 required_paths: if test_stub_dir().is_some() {
                     Vec::new()
                 } else {
@@ -240,11 +257,11 @@ fn root_stub_requirements(path: &Path) -> StubRequirements {
 
 fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String> {
     if yes {
-        writeln!(stdout, "◇ Continue? yes (--yes)").ok();
+        writeln!(stdout, "◇ Use these targets? yes (--yes)").ok();
         return Ok(true);
     }
 
-    write!(stdout, "◇ Continue? [y/N] ").ok();
+    write!(stdout, "◇ Use these targets? [y/N] ").ok();
     stdout
         .flush()
         .map_err(|err| format!("failed to flush prompt: {err}"))?;
@@ -261,31 +278,29 @@ fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String> {
     ))
 }
 
-fn install_stub(stub: &StubSpec) -> Result<(), String> {
+fn install_stub(stub: &StubSpec, target: &Path) -> Result<(), String> {
     let path = stub_path(stub.command);
-    fs::write(&path, stub_script(stub))
+    fs::write(&path, stub_script(stub, target))
         .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
     fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
         .map_err(|err| format!("failed to chmod {}: {err}", path.display()))
 }
 
 fn is_managed_stub(path: &Path, stub: &StubSpec) -> bool {
-    fs::read_to_string(path)
-        .map(|contents| {
-            contents.contains(MARKER)
-                && contents.contains(&format!(
-                    "original='{}'",
-                    shell_single_argument(&target_path(stub))
-                ))
-        })
-        .unwrap_or(false)
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Some(target) = embedded_target_from_contents(&contents) else {
+        return false;
+    };
+    contents == stub_script(stub, &target)
 }
 
-fn is_current_stub(path: &Path, stub: &StubSpec) -> bool {
-    fs::read_to_string(path).is_ok_and(|contents| contents == stub_script(stub))
+fn is_current_stub(path: &Path, stub: &StubSpec, target: &Path) -> bool {
+    fs::read_to_string(path).is_ok_and(|contents| contents == stub_script(stub, target))
 }
 
-fn stub_script(stub: &StubSpec) -> String {
+fn stub_script(stub: &StubSpec, target: &Path) -> String {
     let keys = stub
         .keys
         .iter()
@@ -296,7 +311,7 @@ fn stub_script(stub: &StubSpec) -> String {
 set -eu\n\
 # {MARKER}\n\
 original='{}'\n",
-        shell_single_argument(&target_path(stub))
+        shell_single_argument(target)
     );
     for key in stub.assignment_keys {
         script.push_str(&format!(
@@ -311,14 +326,112 @@ fn shell_single_argument(path: &Path) -> String {
     path.to_string_lossy().replace('\'', r#"'\''"#)
 }
 
+fn embedded_target(path: &Path) -> Option<PathBuf> {
+    embedded_target_from_contents(&fs::read_to_string(path).ok()?)
+}
+
+fn embedded_target_from_contents(contents: &str) -> Option<PathBuf> {
+    if !contents.lines().any(|line| line == format!("# {MARKER}")) {
+        return None;
+    }
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix("original='")?.strip_suffix('\''))
+        .map(PathBuf::from)
+}
+
 fn wrapper(name: &str) -> Option<&'static EnvWrapper> {
     WRAPPERS.iter().find(|wrapper| wrapper.name == name)
 }
 
-fn target_path(stub: &StubSpec) -> PathBuf {
-    test_target_dir()
-        .map(|dir| dir.join(stub.command))
-        .unwrap_or_else(|| Path::new(TARGET_DIR).join(stub.command))
+fn resolve_targets(wrapper: &EnvWrapper) -> Result<Vec<ResolvedStub<'_>>, String> {
+    stubs(wrapper)
+        .map(|stub| find_target(stub).map(|path| ResolvedStub { stub, path }))
+        .collect()
+}
+
+fn supplied_targets<'a>(
+    wrapper: &'a EnvWrapper,
+    targets: &[PathBuf],
+) -> Result<Vec<ResolvedStub<'a>>, String> {
+    if targets.len() != stubs(wrapper).count() {
+        return Err(format!("invalid target count for {}", wrapper.name));
+    }
+    stubs(wrapper)
+        .zip(targets)
+        .map(|(stub, path)| {
+            if !valid_target_path(path, stub.command) {
+                return Err(format!(
+                    "invalid target for {}: {}",
+                    stub.command,
+                    path.display()
+                ));
+            }
+            if same_path(path, &stub_path(stub.command)) {
+                return Err(format!(
+                    "{} target cannot be its launcher stub",
+                    stub.command
+                ));
+            }
+            Ok(ResolvedStub {
+                stub,
+                path: path.clone(),
+            })
+        })
+        .collect()
+}
+
+fn find_target(stub: &StubSpec) -> Result<PathBuf, String> {
+    if let Some(directory) = test_target_dir() {
+        let path = directory.join(stub.command);
+        return super::executable(&path)
+            .then_some(path.clone())
+            .ok_or_else(|| {
+                format!(
+                    "{} is not an executable file: {}",
+                    stub.command,
+                    path.display()
+                )
+            });
+    }
+    if let Some(target) =
+        embedded_target(&stub_path(stub.command)).filter(|path| super::executable(path))
+    {
+        return Ok(target);
+    }
+    find_target_on_path(stub.command)
+        .ok_or_else(|| format!("{} is not installed on PATH", stub.command))
+}
+
+fn find_target_on_path(command: &str) -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|directory| {
+            let directory = if directory.is_absolute() {
+                directory
+            } else {
+                cwd.join(directory)
+            };
+            directory.join(command)
+        })
+        .find(|candidate| candidate != &stub_path(command) && super::executable(candidate))
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    left == right
+        || left
+            .canonicalize()
+            .ok()
+            .zip(right.canonicalize().ok())
+            .is_some_and(|(left, right)| left == right)
+}
+
+fn valid_target_path(path: &Path, command: &str) -> bool {
+    path.is_absolute()
+        && path.file_name() == Some(command.as_ref())
+        && path
+            .to_str()
+            .is_some_and(|path| !path.contains(['\'', '\n', '\r']))
 }
 
 fn stub_path(command: &str) -> PathBuf {
@@ -351,6 +464,11 @@ struct StubSpec {
     command: &'static str,
     keys: &'static [&'static str],
     assignment_keys: &'static [&'static str],
+}
+
+struct ResolvedStub<'a> {
+    stub: &'a StubSpec,
+    path: PathBuf,
 }
 
 fn stubs(wrapper: &EnvWrapper) -> impl Iterator<Item = &StubSpec> {
@@ -523,16 +641,9 @@ mod tests {
     #[test]
     fn flyctl_wraps_both_commands() {
         let wrapper = wrapper("flyctl").unwrap();
-        let commands = stubs(wrapper)
-            .map(|stub| (stub.command, target_path(stub)))
-            .collect::<Vec<_>>();
-
         assert_eq!(
-            commands,
-            [
-                ("flyctl", PathBuf::from("/opt/homebrew/bin/flyctl")),
-                ("fly", PathBuf::from("/opt/homebrew/bin/fly")),
-            ]
+            stubs(wrapper).map(|stub| stub.command).collect::<Vec<_>>(),
+            ["flyctl", "fly"]
         );
     }
 
@@ -546,6 +657,7 @@ mod tests {
         fs::create_dir_all(&target_dir).unwrap();
         fs::create_dir_all(&stub_dir).unwrap();
         fs::write(target_dir.join("doctl"), "").unwrap();
+        fs::set_permissions(target_dir.join("doctl"), fs::Permissions::from_mode(0o755)).unwrap();
         unsafe {
             std::env::set_var("HOME", &dir);
             std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_TARGET_DIR", &target_dir);
@@ -569,21 +681,52 @@ mod tests {
         assert!(script.contains(MARKER));
         assert!(script.contains("+DIGITALOCEAN_ACCESS_TOKEN"));
         assert!(script.contains("exec \"$original\" \"$@\""));
-        assert!(
-            String::from_utf8(output)
-                .unwrap()
-                .contains("run sudo to write")
-        );
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains(&format!("target {}", target_dir.join("doctl").display())));
+        assert!(output.contains("install launcher"));
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn resolves_target_from_the_users_path() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let previous_path = std::env::var_os("PATH");
+        let dir = temp_dir("env-wrapper-path");
+        let bin = dir.join("nix-profile/bin");
+        let stubs = dir.join("stubs");
+        fs::create_dir_all(&bin).unwrap();
+        fs::create_dir_all(&stubs).unwrap();
+        let hcloud = bin.join("hcloud");
+        fs::write(&hcloud, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&hcloud, fs::Permissions::from_mode(0o755)).unwrap();
+        unsafe {
+            std::env::set_var("PATH", &bin);
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &stubs);
+        }
+
+        let targets = resolve_targets(wrapper("hcloud").unwrap()).unwrap();
+
+        unsafe {
+            match previous_path {
+                Some(path) => std::env::set_var("PATH", path),
+                None => std::env::remove_var("PATH"),
+            }
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        }
+        assert_eq!(targets[0].path, hcloud);
         fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
     fn assignment_keys_are_exported() {
-        let script = stub_script(&stub(
-            "akamai",
-            &["AKAMAI_ENV_ASSIGNMENTS"],
-            &["AKAMAI_ENV_ASSIGNMENTS"],
-        ));
+        let script = stub_script(
+            &stub(
+                "akamai",
+                &["AKAMAI_ENV_ASSIGNMENTS"],
+                &["AKAMAI_ENV_ASSIGNMENTS"],
+            ),
+            Path::new("/nix/store/example/bin/akamai"),
+        );
 
         assert!(script.contains("+AKAMAI_ENV_ASSIGNMENTS"));
         assert!(script.contains("for assignment in ${AKAMAI_ENV_ASSIGNMENTS-}"));
@@ -593,14 +736,19 @@ mod tests {
     #[test]
     fn current_stub_validation_rejects_marker_preserving_edits() {
         let spec = stub("tool", &["TOOL_TOKEN"], &[]);
+        let target = Path::new("/nix/store/example/bin/tool");
         let path = temp_dir("env-wrapper-exact").join("tool");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, stub_script(&spec)).unwrap();
-        assert!(is_current_stub(&path, &spec));
+        fs::write(&path, stub_script(&spec, target)).unwrap();
+        assert!(is_current_stub(&path, &spec, target));
 
-        fs::write(&path, format!("{}\n# modified\n", stub_script(&spec))).unwrap();
-        assert!(is_managed_stub(&path, &spec));
-        assert!(!is_current_stub(&path, &spec));
+        fs::write(
+            &path,
+            format!("{}\n# modified\n", stub_script(&spec, target)),
+        )
+        .unwrap();
+        assert!(!is_managed_stub(&path, &spec));
+        assert!(!is_current_stub(&path, &spec, target));
         let _ = fs::remove_dir_all(path.parent().unwrap());
     }
 
@@ -613,6 +761,7 @@ mod tests {
         fs::create_dir_all(&target_dir).unwrap();
         fs::create_dir_all(&stub_dir).unwrap();
         fs::write(target_dir.join("doctl"), "").unwrap();
+        fs::set_permissions(target_dir.join("doctl"), fs::Permissions::from_mode(0o755)).unwrap();
         fs::write(stub_dir.join("doctl"), "#!/bin/sh\n").unwrap();
         unsafe {
             std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_TARGET_DIR", &target_dir);
@@ -648,7 +797,7 @@ mod tests {
     #[test]
     fn install_entrypoint_rejects_unknown_hardeners() {
         assert_eq!(
-            install_target("not-a-hardener").unwrap_err(),
+            install_target("not-a-hardener", &[]).unwrap_err(),
             "unknown hardener `not-a-hardener`"
         );
     }

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -220,6 +220,7 @@ fn detect(wrapper: &EnvWrapper) -> HardenerDetection {
                     .iter()
                     .map(|key| (*key).to_string())
                     .collect(),
+                isotope: None,
             }
         })
         .collect::<Vec<_>>();

--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -2,8 +2,9 @@
 
 ## How Automic Vault Hardens `gh`
 
-We provide a [patched version] of `gh` via our [tap]. The patches are concerned
-with:
+We provide a [patched version] of `gh`. `av harden gh` installs it from our
+[tap] when Homebrew is available, or installs the same signed release directly
+at `/usr/local/bin/gh`. The patches are concerned with:
 
 1. Is codesigned such that `gh` (and only `gh`) can access its
    secure credentials.
@@ -15,7 +16,9 @@ with:
 
 ## Credential Migration
 
-Use `av harden gh` to migrate existing `gh` credentials into Automic Vault.
+Use `av harden gh` to install the Isotope and migrate existing `gh` credentials
+into Automic Vault. Direct installs are updated by running the same command when
+`av doctor gh` reports a new release.
 
 ## Secret Gate
 

--- a/src/isotopes/hardeners/gh_cli.rs
+++ b/src/isotopes/hardeners/gh_cli.rs
@@ -4,23 +4,9 @@ use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::{HardenerDetection, SecretGateDescriptor, SecretGateRoute};
+use super::{HardenerDetection, SecretGateDescriptor, SecretGateRoute, isotope};
 
 const PRIVILEGE_MODE: super::PrivilegeMode = super::PrivilegeMode::UserOnly;
-const GH_CLI_PATH: &str = "/opt/homebrew/opt/gh-cli/bin/gh";
-pub(crate) const INSTALL_COMMAND: &str = "brew install automic-vault/isotopes/gh-cli";
-
-#[derive(Debug)]
-pub(crate) enum HardenError {
-    GhCliNotInstalled,
-    Other(String),
-}
-
-impl From<String> for HardenError {
-    fn from(error: String) -> Self {
-        Self::Other(error)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct GhCredential {
@@ -29,11 +15,9 @@ struct GhCredential {
     token: String,
 }
 
-pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> {
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     PRIVILEGE_MODE.require_user("gh", false)?;
-    if !gh_cli_path().exists() {
-        return Err(HardenError::GhCliNotInstalled);
-    }
+    let install = isotope::plan(isotope::GH)?;
 
     let hosts_paths = gh_hosts_paths()?;
     let configured_hosts = configured_hosts(&hosts_paths);
@@ -51,7 +35,8 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
 
     writeln!(stdout, "╭─ harden gh").ok();
     writeln!(stdout, "│").ok();
-    if credentials.is_empty() {
+    install.write(stdout, isotope::GH);
+    if credentials.is_empty() && !install.needed() {
         writeln!(stdout, "╰─ no legacy gh credentials found").ok();
         super::write_secret_gate_notice(stdout, "gh");
         return Ok(());
@@ -60,12 +45,16 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
     let destinations = migration_destinations(&credentials, &configured_hosts)?;
     preflight_destinations(&destinations)?;
 
-    writeln!(
-        stdout,
-        "├─ migrate {} GitHub token(s) into Automic Vault",
-        credentials.len()
-    )
-    .ok();
+    if credentials.is_empty() {
+        writeln!(stdout, "├─ no legacy gh credentials found").ok();
+    } else {
+        writeln!(
+            stdout,
+            "├─ migrate {} GitHub token(s) into Automic Vault",
+            credentials.len()
+        )
+        .ok();
+    }
     if !plaintext_credentials.is_empty() {
         writeln!(
             stdout,
@@ -87,6 +76,12 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
         return Ok(());
     }
 
+    install.apply(isotope::GH)?;
+    if credentials.is_empty() {
+        writeln!(stdout, "╰─ installed gh isotope").ok();
+        super::write_secret_gate_notice(stdout, "gh");
+        return Ok(());
+    }
     store_and_verify_destinations(&destinations)?;
     for path in &hosts_paths {
         remove_plaintext_tokens(path)?;
@@ -101,10 +96,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
 }
 
 pub(crate) fn detect() -> HardenerDetection {
-    let path = gh_cli_path();
-    let exists = path.exists();
-    let path = path.display().to_string();
-    HardenerDetection::command(exists, "gh", Some(path.clone()), path)
+    isotope::detect(isotope::GH)
 }
 
 pub(crate) fn secret_gate() -> SecretGateDescriptor {
@@ -114,7 +106,7 @@ pub(crate) fn secret_gate() -> SecretGateDescriptor {
         routes: vec![SecretGateRoute {
             operation: "keys",
             script_path: None,
-            target_path: gh_cli_path().display().to_string(),
+            target_path: isotope::target(isotope::GH).display().to_string(),
             caller_identifiers: vec!["gh", "com.github.cli"],
             key_patterns: vec!["GH_TOKEN_*".to_string()],
             replace_existing_env: true,
@@ -144,12 +136,6 @@ pub(super) fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String>
         input.trim().to_ascii_lowercase().as_str(),
         "y" | "yes"
     ))
-}
-
-fn gh_cli_path() -> PathBuf {
-    crate::test_env_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| Path::new(GH_CLI_PATH).to_path_buf())
 }
 
 fn gh_hosts_paths() -> Result<Vec<PathBuf>, String> {
@@ -646,22 +632,6 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn missing_gh_cli_tells_user_to_install_isotope() {
-        let _guard = crate::global_test_env_lock().lock().unwrap();
-        let missing = temp_path("missing-gh-cli");
-        unsafe {
-            std::env::set_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH", &missing);
-        }
-
-        let err = run(&mut Vec::new(), true).err().unwrap();
-
-        unsafe {
-            std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
-        }
-        assert!(matches!(err, HardenError::GhCliNotInstalled));
-    }
-
-    #[test]
     fn detect_reports_full_gh_path() {
         let _guard = crate::global_test_env_lock().lock().unwrap();
         let missing = temp_path("missing-gh-cli-detect");
@@ -876,9 +846,7 @@ mod tests {
             std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
             std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
         }
-        assert!(
-            matches!(error, HardenError::Other(message) if message.contains("refusing to replace"))
-        );
+        assert!(error.contains("refusing to replace"));
         assert_eq!(
             fs::read_to_string(keychain.join("GH_TOKEN_GITHUB_COM")).unwrap(),
             "working"

--- a/src/isotopes/hardeners/isotope.rs
+++ b/src/isotopes/hardeners/isotope.rs
@@ -1,0 +1,697 @@
+use std::collections::BTreeSet;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::{HardenerDetection, executable};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const CURL_PATH: &str = "/usr/bin/curl";
+const SUDO_PATH: &str = "/usr/bin/sudo";
+const TEAM_IDENTIFIER: &str = "ZU76A67LGU";
+const TAP_FORMULA_ROOT: &str =
+    "https://raw.githubusercontent.com/automic-vault/homebrew-isotopes/main/Formula";
+
+pub(crate) const GH: Spec = Spec {
+    hardener: "gh",
+    formula: "gh-cli",
+    repository: "gh-cli",
+    primary: "gh",
+    binaries: &["gh"],
+    test_path: "AUTOMIC_VAULT_TEST_GH_CLI_PATH",
+};
+pub(crate) const STRIPE: Spec = Spec {
+    hardener: "stripe",
+    formula: "stripe-cli",
+    repository: "stripe-cli",
+    primary: "stripe",
+    binaries: &["stripe"],
+    test_path: "AUTOMIC_VAULT_TEST_STRIPE_CLI_PATH",
+};
+pub(crate) const SUPABASE: Spec = Spec {
+    hardener: "supabase",
+    formula: "supabase-cli",
+    repository: "supabase-cli",
+    primary: "supabase",
+    binaries: &["supabase-go", "supabase"],
+    test_path: "AUTOMIC_VAULT_TEST_SUPABASE_CLI_PATH",
+};
+
+#[derive(Clone, Copy)]
+pub(crate) struct Spec {
+    pub(crate) hardener: &'static str,
+    formula: &'static str,
+    repository: &'static str,
+    primary: &'static str,
+    binaries: &'static [&'static str],
+    test_path: &'static str,
+}
+
+#[derive(Clone)]
+pub(crate) struct Doctor {
+    pub(crate) identifier: &'static str,
+    pub(crate) formula_url: String,
+    pub(crate) receipt_path: Option<String>,
+}
+
+pub(crate) enum InstallPlan {
+    Ready,
+    Homebrew { brew: PathBuf },
+    Direct { manifest: Manifest, update: bool },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Manifest {
+    url: String,
+    sha256: String,
+}
+
+impl InstallPlan {
+    pub(crate) fn needed(&self) -> bool {
+        !matches!(self, Self::Ready)
+    }
+
+    pub(crate) fn write(&self, stdout: &mut dyn Write, spec: Spec) {
+        match self {
+            Self::Ready => {}
+            Self::Homebrew { brew } => {
+                writeln!(
+                    stdout,
+                    "├─ run `{} install automic-vault/isotopes/{}`",
+                    brew.display(),
+                    spec.formula
+                )
+                .ok();
+            }
+            Self::Direct { update, .. } => {
+                let verb = if *update { "update" } else { "install" };
+                for binary in spec.binaries {
+                    writeln!(stdout, "├─ {verb} /usr/local/bin/{binary}").ok();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn apply(self, spec: Spec) -> Result<(), String> {
+        match self {
+            Self::Ready => Ok(()),
+            Self::Homebrew { brew } => install_with_homebrew(spec, &brew),
+            Self::Direct { manifest, .. } => install_direct(spec, &manifest),
+        }
+    }
+}
+
+pub(crate) fn plan(spec: Spec) -> Result<InstallPlan, String> {
+    let target = target(spec);
+    if installed(spec, &target) {
+        if is_direct_target(spec, &target) {
+            let manifest = current_manifest(spec)?;
+            let current = fs::read_to_string(receipt_path(spec)).ok();
+            if current.as_deref().map(str::trim) != Some(manifest.sha256.as_str()) {
+                return Ok(InstallPlan::Direct {
+                    manifest,
+                    update: true,
+                });
+            }
+        }
+        return Ok(InstallPlan::Ready);
+    }
+    if let Some(brew) = brew_path() {
+        return Ok(InstallPlan::Homebrew { brew });
+    }
+    Ok(InstallPlan::Direct {
+        manifest: current_manifest(spec)?,
+        update: false,
+    })
+}
+
+pub(crate) fn target(spec: Spec) -> PathBuf {
+    if let Some(path) = crate::test_env_var(spec.test_path) {
+        return path.into();
+    }
+    brew_targets(spec)
+        .into_iter()
+        .find(|path| executable(path))
+        .or_else(|| executable(&direct_target(spec)).then(|| direct_target(spec)))
+        .unwrap_or_else(|| {
+            if brew_path().is_some() {
+                brew_targets(spec).remove(0)
+            } else {
+                direct_target(spec)
+            }
+        })
+}
+
+pub(crate) fn detect(spec: Spec) -> HardenerDetection {
+    let target = target(spec);
+    let exists = installed(spec, &target);
+    let target_text = target.display().to_string();
+    let mut detection =
+        HardenerDetection::command(exists, spec.primary, Some(target_text.clone()), target_text);
+    detection.commands[0].isotope = Some(Doctor {
+        identifier: spec.primary,
+        formula_url: formula_url(spec),
+        receipt_path: is_direct_target(spec, &target)
+            .then(|| receipt_path(spec).display().to_string()),
+    });
+    detection
+}
+
+pub(crate) fn current_sha(formula_url: &str) -> Result<String, String> {
+    let formula = fetch(formula_url, 5)?;
+    parse_formula(&formula, None).map(|manifest| manifest.sha256)
+}
+
+pub(crate) fn signature_valid(path: &Path, identifier: &str) -> bool {
+    if crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR").is_some() {
+        return executable(path);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let requirement = format!(
+            "=identifier \"{identifier}\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{TEAM_IDENTIFIER}\""
+        );
+        Command::new("/usr/bin/codesign")
+            .args(["--verify", "--strict", "-R", &requirement])
+            .arg(path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
+}
+
+pub(crate) fn install_privileged(
+    hardener: &str,
+    sha256: &str,
+    archive: &Path,
+) -> Result<(), String> {
+    let spec = spec(hardener).ok_or_else(|| format!("unknown isotope `{hardener}`"))?;
+    if crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR").is_none()
+        && super::effective_uid() != 0
+    {
+        return Err("isotope installation requires root".into());
+    }
+    validate_sha256(sha256)?;
+    let bin_dir = direct_bin_dir();
+    let receipt_dir = direct_receipt_dir();
+    prepare_install_directory(&bin_dir)?;
+    prepare_install_directory(&receipt_dir)?;
+    let suffix = format!("{}.{}", std::process::id(), now_nanos());
+    let root_stage = TemporaryDirectory::new_in(&receipt_dir, spec.hardener)?;
+    let trusted_archive = root_stage.path.join("isotope.tgz");
+    copy_new(archive, &trusted_archive)?;
+    let actual = sha256_file(&trusted_archive)?;
+    if actual != sha256 {
+        return Err(format!(
+            "downloaded {} digest {actual}, expected {sha256}",
+            spec.formula
+        ));
+    }
+    let sources = extract_and_verify(spec, &trusted_archive, &root_stage.path)?;
+    let mut staged = Vec::new();
+    for (source, binary) in sources.iter().zip(spec.binaries) {
+        if source.file_name().and_then(|name| name.to_str()) != Some(*binary) {
+            return Err(format!(
+                "refusing isotope binary with unexpected basename: {}",
+                source.display()
+            ));
+        }
+        let stage = bin_dir.join(format!(".{binary}.av-{suffix}"));
+        copy_new(source, &stage)?;
+        fs::set_permissions(&stage, fs::Permissions::from_mode(0o755))
+            .map_err(|err| format!("failed to protect {}: {err}", stage.display()))?;
+        if !signature_valid(&stage, binary) {
+            let _ = fs::remove_file(&stage);
+            return Err(format!(
+                "refusing {} because its Automic Vault code signature is invalid",
+                source.display()
+            ));
+        }
+        staged.push((stage, bin_dir.join(binary)));
+    }
+    for (stage, destination) in &staged {
+        fs::rename(stage, destination).map_err(|err| {
+            format!(
+                "failed to install {} at {}: {err}",
+                stage.display(),
+                destination.display()
+            )
+        })?;
+    }
+    let receipt = receipt_path(spec);
+    let staged_receipt = receipt_dir.join(format!(".{}.sha256.av-{suffix}", spec.formula));
+    fs::write(&staged_receipt, format!("{sha256}\n"))
+        .map_err(|err| format!("failed to write {}: {err}", staged_receipt.display()))?;
+    fs::set_permissions(&staged_receipt, fs::Permissions::from_mode(0o644))
+        .map_err(|err| format!("failed to protect {}: {err}", staged_receipt.display()))?;
+    fs::rename(&staged_receipt, &receipt)
+        .map_err(|err| format!("failed to install {}: {err}", receipt.display()))?;
+    Ok(())
+}
+
+fn install_with_homebrew(spec: Spec, brew: &Path) -> Result<(), String> {
+    let package = format!("automic-vault/isotopes/{}", spec.formula);
+    let status = Command::new(brew)
+        .args(["install", &package])
+        .status()
+        .map_err(|err| format!("failed to run {}: {err}", brew.display()))?;
+    if !status.success() {
+        return Err(format!("Homebrew isotope installation failed: {status}"));
+    }
+    let target = target(spec);
+    if !executable(&target) || !signature_valid(&target, spec.primary) {
+        return Err(format!(
+            "Homebrew installed {}, but {} is missing or has an invalid Automic Vault code signature",
+            spec.formula,
+            target.display()
+        ));
+    }
+    Ok(())
+}
+
+fn install_direct(spec: Spec, manifest: &Manifest) -> Result<(), String> {
+    let temporary = TemporaryDirectory::new(spec.hardener)?;
+    let archive = temporary.path.join("isotope.tgz");
+    download(&manifest.url, &archive)?;
+    let actual = sha256_file(&archive)?;
+    if actual != manifest.sha256 {
+        return Err(format!(
+            "downloaded {} digest {actual}, expected {}",
+            spec.formula, manifest.sha256
+        ));
+    }
+    extract_and_verify(spec, &archive, &temporary.path)?;
+    if crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR").is_some() {
+        return install_privileged(spec.hardener, &manifest.sha256, &archive);
+    }
+    super::env_wrapper::validate_privileged_av(Path::new(AV_PATH))?;
+    let status = Command::new(SUDO_PATH)
+        .args([
+            AV_PATH,
+            "__install-isotope",
+            spec.hardener,
+            &manifest.sha256,
+        ])
+        .arg(archive)
+        .status()
+        .map_err(|err| format!("failed to run sudo: {err}"))?;
+    if !status.success() {
+        return Err(format!("isotope installation failed: {status}"));
+    }
+    Ok(())
+}
+
+fn extract_and_verify(
+    spec: Spec,
+    archive: &Path,
+    destination: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    let expected = spec
+        .binaries
+        .iter()
+        .map(|binary| format!("bin/{binary}"))
+        .collect::<BTreeSet<_>>();
+    let listing = Command::new("/usr/bin/tar")
+        .args(["-tzf"])
+        .arg(archive)
+        .output()
+        .map_err(|err| format!("failed to inspect {}: {err}", archive.display()))?;
+    if !listing.status.success() {
+        return Err(format!("invalid isotope archive: {}", archive.display()));
+    }
+    let entries = String::from_utf8(listing.stdout)
+        .map_err(|_| "isotope archive contains non-UTF-8 paths".to_string())?
+        .lines()
+        .filter(|entry| *entry != "bin/")
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    if entries != expected {
+        return Err("isotope archive contains unexpected paths".into());
+    }
+    let status = Command::new("/usr/bin/tar")
+        .args(["-xzf"])
+        .arg(archive)
+        .arg("-C")
+        .arg(destination)
+        .status()
+        .map_err(|err| format!("failed to unpack isotope archive: {err}"))?;
+    if !status.success() {
+        return Err(format!("failed to unpack isotope archive: {status}"));
+    }
+    let sources = spec
+        .binaries
+        .iter()
+        .map(|binary| destination.join("bin").join(binary))
+        .collect::<Vec<_>>();
+    for (source, binary) in sources.iter().zip(spec.binaries) {
+        if !source
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.file_type().is_file())
+            || !signature_valid(source, binary)
+        {
+            return Err(format!(
+                "refusing {} because its Automic Vault code signature is invalid",
+                source.display()
+            ));
+        }
+    }
+    Ok(sources)
+}
+
+fn current_manifest(spec: Spec) -> Result<Manifest, String> {
+    let formula = fetch(&formula_url(spec), 15)?;
+    parse_formula(&formula, Some(spec))
+}
+
+fn parse_formula(contents: &str, spec: Option<Spec>) -> Result<Manifest, String> {
+    let values = |prefix: &str| {
+        contents
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix(prefix))
+            .filter_map(|value| value.strip_suffix('"'))
+            .collect::<Vec<_>>()
+    };
+    let urls = values("url \"");
+    let hashes = values("sha256 \"");
+    if urls.len() != 1 || hashes.len() != 1 {
+        return Err("isotope formula must contain exactly one URL and SHA-256".into());
+    }
+    let url = urls[0];
+    if let Some(spec) = spec {
+        let prefix = format!(
+            "https://github.com/automic-vault/{}/releases/download/",
+            spec.repository
+        );
+        if !url.starts_with(&prefix) || !url.ends_with(".tgz") {
+            return Err(format!("refusing unexpected isotope URL: {url}"));
+        }
+    } else if !url.starts_with("https://github.com/automic-vault/") || !url.ends_with(".tgz") {
+        return Err(format!("refusing unexpected isotope URL: {url}"));
+    }
+    validate_sha256(hashes[0])?;
+    Ok(Manifest {
+        url: url.to_string(),
+        sha256: hashes[0].to_string(),
+    })
+}
+
+fn fetch(url: &str, timeout: u32) -> Result<String, String> {
+    if let Some(contents) = crate::test_env_string("AUTOMIC_VAULT_TEST_ISOTOPE_FORMULA") {
+        return Ok(contents);
+    }
+    let output = Command::new(CURL_PATH)
+        .args([
+            "-fsSL",
+            "--proto",
+            "=https",
+            "--tlsv1.2",
+            "--max-time",
+            &timeout.to_string(),
+            url,
+        ])
+        .output()
+        .map_err(|err| format!("failed to fetch {url}: {err}"))?;
+    if !output.status.success() {
+        return Err(format!("failed to fetch {url}: {}", output.status));
+    }
+    String::from_utf8(output.stdout).map_err(|_| format!("{url} returned non-UTF-8 data"))
+}
+
+fn download(url: &str, destination: &Path) -> Result<(), String> {
+    let status = Command::new(CURL_PATH)
+        .args(["-fsSL", "--proto", "=https", "--tlsv1.2", "-o"])
+        .arg(destination)
+        .arg(url)
+        .status()
+        .map_err(|err| format!("failed to download {url}: {err}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("failed to download {url}: {status}"))
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let output = Command::new("/usr/bin/shasum")
+        .args(["-a", "256"])
+        .arg(path)
+        .output()
+        .map_err(|err| format!("failed to hash {}: {err}", path.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to hash {}: {}",
+            path.display(),
+            output.status
+        ));
+    }
+    let hash = String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    validate_sha256(&hash)?;
+    Ok(hash)
+}
+
+fn validate_sha256(value: &str) -> Result<(), String> {
+    if value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err("invalid isotope SHA-256".into())
+    }
+}
+
+fn brew_path() -> Option<PathBuf> {
+    if let Some(path) = crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_BREW_PATH") {
+        return (!path.is_empty()).then(|| path.into());
+    }
+    ["/usr/local/bin/brew", "/opt/homebrew/bin/brew"]
+        .map(PathBuf::from)
+        .into_iter()
+        .find(|path| executable(path))
+}
+
+fn brew_targets(spec: Spec) -> Vec<PathBuf> {
+    ["/opt/homebrew/opt", "/usr/local/opt"]
+        .map(|root| {
+            Path::new(root)
+                .join(spec.formula)
+                .join("bin")
+                .join(spec.primary)
+        })
+        .to_vec()
+}
+
+fn direct_target(spec: Spec) -> PathBuf {
+    direct_bin_dir().join(spec.primary)
+}
+
+fn direct_bin_dir() -> PathBuf {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/usr/local/bin"))
+}
+
+fn direct_receipt_dir() -> PathBuf {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR")
+        .map(PathBuf::from)
+        .map(|path| path.join(".automic-vault-isotopes"))
+        .unwrap_or_else(|| PathBuf::from("/usr/local/share/automic-vault/isotopes"))
+}
+
+fn receipt_path(spec: Spec) -> PathBuf {
+    direct_receipt_dir().join(format!("{}.sha256", spec.formula))
+}
+
+fn is_direct_target(spec: Spec, path: &Path) -> bool {
+    path == direct_target(spec)
+}
+
+fn installed(spec: Spec, path: &Path) -> bool {
+    executable(path) || crate::test_env_var(spec.test_path).is_some() && path.exists()
+}
+
+fn formula_url(spec: Spec) -> String {
+    format!("{TAP_FORMULA_ROOT}/{}.rb", spec.formula)
+}
+
+fn spec(hardener: &str) -> Option<Spec> {
+    [GH, STRIPE, SUPABASE]
+        .into_iter()
+        .find(|spec| spec.hardener == hardener)
+}
+
+fn prepare_install_directory(path: &Path) -> Result<(), String> {
+    if crate::test_env_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR").is_some() {
+        fs::create_dir_all(path)
+            .map_err(|err| format!("failed to create {}: {err}", path.display()))?;
+        return Ok(());
+    }
+    for ancestor in path.ancestors().collect::<Vec<_>>().into_iter().rev() {
+        match fs::symlink_metadata(ancestor) {
+            Ok(metadata)
+                if metadata.file_type().is_dir()
+                    && metadata.uid() == 0
+                    && metadata.permissions().mode() & 0o022 == 0 => {}
+            Ok(_) => {
+                return Err(format!(
+                    "refusing to install through unsafe directory {}",
+                    ancestor.display()
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(ancestor)
+                    .map_err(|err| format!("failed to create {}: {err}", ancestor.display()))?;
+                fs::set_permissions(ancestor, fs::Permissions::from_mode(0o755))
+                    .map_err(|err| format!("failed to protect {}: {err}", ancestor.display()))?;
+            }
+            Err(err) => return Err(format!("cannot trust {}: {err}", ancestor.display())),
+        }
+    }
+    Ok(())
+}
+
+fn copy_new(source: &Path, destination: &Path) -> Result<(), String> {
+    let mut input = fs::File::open(source)
+        .map_err(|err| format!("failed to open {}: {err}", source.display()))?;
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+        .map_err(|err| format!("failed to create {}: {err}", destination.display()))?;
+    std::io::copy(&mut input, &mut output)
+        .map_err(|err| format!("failed to copy {}: {err}", source.display()))?;
+    output
+        .sync_all()
+        .map_err(|err| format!("failed to sync {}: {err}", destination.display()))
+}
+
+struct TemporaryDirectory {
+    path: PathBuf,
+}
+
+impl TemporaryDirectory {
+    fn new(label: &str) -> Result<Self, String> {
+        Self::new_in(&std::env::temp_dir(), label)
+    }
+
+    fn new_in(parent: &Path, label: &str) -> Result<Self, String> {
+        let path = parent.join(format!(
+            "av-isotope-{label}-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::create_dir(&path)
+            .map_err(|err| format!("failed to create {}: {err}", path.display()))?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+            .map_err(|err| format!("failed to protect {}: {err}", path.display()))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TemporaryDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn now_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formula_parser_accepts_only_the_expected_release_and_digest() {
+        let formula = r#"
+          url "https://github.com/automic-vault/gh-cli/releases/download/v2.97.0/cli-2.97.0.tgz"
+          sha256 "29e7f73c54cc1c278b7431bc04d581b468ca033d1782c39c87034515ae5d7070"
+        "#;
+        assert_eq!(
+            parse_formula(formula, Some(GH)).unwrap(),
+            Manifest {
+                url: "https://github.com/automic-vault/gh-cli/releases/download/v2.97.0/cli-2.97.0.tgz".into(),
+                sha256: "29e7f73c54cc1c278b7431bc04d581b468ca033d1782c39c87034515ae5d7070".into(),
+            }
+        );
+        assert!(
+            parse_formula(
+                &formula.replace("automic-vault/gh-cli", "evil/gh-cli"),
+                Some(GH)
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn missing_isotope_with_homebrew_plans_the_tap_install() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let missing = std::env::temp_dir().join("av-test-missing-gh-isotope");
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH", &missing);
+            std::env::set_var("AUTOMIC_VAULT_TEST_ISOTOPE_BREW_PATH", "/test/bin/brew");
+        }
+        let plan = plan(GH).unwrap();
+        let mut output = Vec::new();
+        plan.write(&mut output, GH);
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ISOTOPE_BREW_PATH");
+        }
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "├─ run `/test/bin/brew install automic-vault/isotopes/gh-cli`\n"
+        );
+    }
+
+    #[test]
+    fn privileged_installer_binds_the_receipt_to_the_archive() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let directory = TemporaryDirectory::new("install-test").unwrap();
+        let source = directory.path.join("source");
+        let bin = source.join("bin");
+        let destination = directory.path.join("destination");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("gh"), "#!/bin/sh\n").unwrap();
+        fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
+        let archive = directory.path.join("gh.tgz");
+        let status = Command::new("/usr/bin/tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .arg("-C")
+            .arg(&source)
+            .arg("bin")
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let digest = sha256_file(&archive).unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR", &destination);
+        }
+        install_privileged("gh", &digest, &archive).unwrap();
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ISOTOPE_DIRECT_DIR");
+        }
+        assert!(executable(&destination.join("gh")));
+        assert_eq!(
+            fs::read_to_string(
+                destination
+                    .join(".automic-vault-isotopes")
+                    .join("gh-cli.sha256")
+            )
+            .unwrap(),
+            format!("{digest}\n")
+        );
+    }
+}

--- a/src/isotopes/hardeners/isotope.rs
+++ b/src/isotopes/hardeners/isotope.rs
@@ -1,15 +1,14 @@
 use std::collections::BTreeSet;
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::{HardenerDetection, executable};
 
 const AV_PATH: &str = "/usr/local/bin/av";
-const CURL_PATH: &str = "/usr/bin/curl";
 const SUDO_PATH: &str = "/usr/bin/sudo";
 const TEAM_IDENTIFIER: &str = "ZU76A67LGU";
 const TAP_FORMULA_ROOT: &str =
@@ -406,36 +405,38 @@ fn fetch(url: &str, timeout: u32) -> Result<String, String> {
     if let Some(contents) = crate::test_env_string("AUTOMIC_VAULT_TEST_ISOTOPE_FORMULA") {
         return Ok(contents);
     }
-    let output = Command::new(CURL_PATH)
-        .args([
-            "-fsSL",
-            "--proto",
-            "=https",
-            "--tlsv1.2",
-            "--max-time",
-            &timeout.to_string(),
-            url,
-        ])
-        .output()
-        .map_err(|err| format!("failed to fetch {url}: {err}"))?;
-    if !output.status.success() {
-        return Err(format!("failed to fetch {url}: {}", output.status));
-    }
-    String::from_utf8(output.stdout).map_err(|_| format!("{url} returned non-UTF-8 data"))
+    get(url, timeout)?
+        .into_with_config()
+        .limit(64 * 1024)
+        .read_to_string()
+        .map_err(|err| format!("failed to read {url}: {err}"))
 }
 
 fn download(url: &str, destination: &Path) -> Result<(), String> {
-    let status = Command::new(CURL_PATH)
-        .args(["-fsSL", "--proto", "=https", "--tlsv1.2", "-o"])
-        .arg(destination)
-        .arg(url)
-        .status()
-        .map_err(|err| format!("failed to download {url}: {err}"))?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!("failed to download {url}: {status}"))
-    }
+    let mut body = get(url, 120)?.into_reader();
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+        .map_err(|err| format!("failed to create {}: {err}", destination.display()))?;
+    io::copy(&mut body, &mut output).map_err(|err| format!("failed to download {url}: {err}"))?;
+    output
+        .sync_all()
+        .map_err(|err| format!("failed to sync {}: {err}", destination.display()))
+}
+
+fn get(url: &str, timeout_secs: u32) -> Result<ureq::Body, String> {
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .https_only(true)
+        .max_redirects(5)
+        .timeout_global(Some(Duration::from_secs(timeout_secs.into())))
+        .build()
+        .into();
+    agent
+        .get(url)
+        .call()
+        .map(|response| response.into_body())
+        .map_err(|err| format!("failed to fetch {url}: {err}"))
 }
 
 fn sha256_file(path: &Path) -> Result<String, String> {
@@ -611,6 +612,11 @@ fn now_nanos() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn isotope_downloads_require_https() {
+        assert!(get("http://example.com/isotope.tgz", 1).is_err());
+    }
 
     #[test]
     fn formula_parser_accepts_only_the_expected_release_and_digest() {

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod codex;
 pub(crate) mod env_wrapper;
 pub(crate) mod gh_cli;
 pub(crate) mod homebrew;
+pub(crate) mod isotope;
 mod migrations;
 pub(crate) mod stripe_cli;
 pub(crate) mod sudo;
@@ -96,6 +97,7 @@ pub(crate) struct HardenerCommand {
     pub(crate) stub_requirements: Option<StubRequirements>,
     pub(crate) injected_keys: Vec<String>,
     pub(crate) assignment_keys: Vec<String>,
+    pub(crate) isotope: Option<isotope::Doctor>,
 }
 
 #[derive(Clone)]
@@ -156,6 +158,7 @@ impl HardenerDetection {
                 stub_requirements: None,
                 injected_keys: Vec::new(),
                 assignment_keys: Vec::new(),
+                isotope: None,
             }],
             diagnostics: Vec::new(),
         }

--- a/src/isotopes/hardeners/stripe_cli.md
+++ b/src/isotopes/hardeners/stripe_cli.md
@@ -2,16 +2,19 @@
 
 ## How Automic Vault Hardens `stripe`
 
-Install the patched [Stripe CLI fork] from the Automic Vault Isotopes tap. On
-macOS it stores and retrieves Stripe CLI credentials through the authenticated
-Automic Vault XPC broker instead of Keychain or plaintext fallback files.
+`av harden stripe` installs the patched [Stripe CLI fork] from the Automic Vault
+Isotopes tap when Homebrew is available. Without Homebrew it installs the same
+signed release at `/usr/local/bin/stripe`; `av doctor stripe` reports direct
+install updates. On macOS it stores and retrieves Stripe CLI credentials through
+the authenticated Automic Vault XPC broker instead of Keychain or plaintext
+fallback files.
 
-Credential reads use the Stripe Secret Gate, so the configured per-app policy,
-human approval, and access audit apply to each use.
+Credential reads use the Stripe Secret Gate, so the configured per-Launcher
+policy, Approval, and Authorization History apply to each use.
 
-After installing the isotope, run `av harden stripe`. Existing API keys,
-sessions, and user access tokens are moved from the `StripeCLI` Keychain
-service or `credentials.json`; plaintext API keys in `config.toml` are
-replaced with redacted markers only after the Vault writes succeed.
+Existing API keys, sessions, and user access tokens are moved from the
+`StripeCLI` Keychain service or `credentials.json`; plaintext API keys in
+`config.toml` are replaced with redacted markers only after the Vault writes
+succeed.
 
 [Stripe CLI fork]: https://github.com/automic-vault/stripe-cli

--- a/src/isotopes/hardeners/stripe_cli.rs
+++ b/src/isotopes/hardeners/stripe_cli.rs
@@ -3,25 +3,11 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use super::{HardenerDetection, SecretGateDescriptor, SecretGateRoute};
+use super::{HardenerDetection, SecretGateDescriptor, SecretGateRoute, isotope};
 
 const PRIVILEGE_MODE: super::PrivilegeMode = super::PrivilegeMode::UserOnly;
-const STRIPE_CLI_PATH: &str = "/opt/homebrew/opt/stripe-cli/bin/stripe";
 const KEYCHAIN_SERVICE: &str = "StripeCLI";
-pub(crate) const INSTALL_COMMAND: &str = "brew install automic-vault/isotopes/stripe-cli";
 const API_KEY_FIELDS: [&str; 2] = ["test_mode_api_key", "live_mode_api_key"];
-
-#[derive(Debug)]
-pub(crate) enum HardenError {
-    StripeCliNotInstalled,
-    Other(String),
-}
-
-impl From<String> for HardenError {
-    fn from(error: String) -> Self {
-        Self::Other(error)
-    }
-}
 
 #[derive(Clone)]
 struct Credential {
@@ -29,11 +15,9 @@ struct Credential {
     legacy_accounts: BTreeSet<String>,
 }
 
-pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> {
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     PRIVILEGE_MODE.require_user("stripe", false)?;
-    if !stripe_cli_path().exists() {
-        return Err(HardenError::StripeCliNotInstalled);
-    }
+    let install = isotope::plan(isotope::STRIPE)?;
 
     let config_dir = stripe_config_dir()?;
     let config_path = config_dir.join("config.toml");
@@ -42,7 +26,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
         Ok(config) => config,
         Err(err) if err.kind() == io::ErrorKind::NotFound => String::new(),
         Err(err) => {
-            return Err(format!("failed to read {}: {err}", config_path.display()).into());
+            return Err(format!("failed to read {}: {err}", config_path.display()));
         }
     };
     let profiles = parse_profiles(&config);
@@ -93,25 +77,37 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
 
     writeln!(stdout, "╭─ harden stripe").ok();
     writeln!(stdout, "│").ok();
-    if credentials.is_empty() {
+    install.write(stdout, isotope::STRIPE);
+    if credentials.is_empty() && !install.needed() {
         remove_fallback(&credentials_path)?;
         writeln!(stdout, "╰─ no legacy Stripe credentials found").ok();
         super::write_secret_gate_notice(stdout, "stripe");
         return Ok(());
     }
-    writeln!(
-        stdout,
-        "├─ migrate {} Stripe credential(s) into Automic Vault",
-        credentials.len()
-    )
-    .ok();
-    writeln!(stdout, "├─ remove legacy Keychain and plaintext copies").ok();
+    if credentials.is_empty() {
+        writeln!(stdout, "├─ no legacy Stripe credentials found").ok();
+    } else {
+        writeln!(
+            stdout,
+            "├─ migrate {} Stripe credential(s) into Automic Vault",
+            credentials.len()
+        )
+        .ok();
+        writeln!(stdout, "├─ remove legacy Keychain and plaintext copies").ok();
+    }
     writeln!(stdout, "│").ok();
     if !super::gh_cli::confirm(stdout, yes)? {
         writeln!(stdout, "╰─ cancelled").ok();
         return Ok(());
     }
 
+    install.apply(isotope::STRIPE)?;
+    if credentials.is_empty() {
+        remove_fallback(&credentials_path)?;
+        writeln!(stdout, "╰─ installed stripe isotope").ok();
+        super::write_secret_gate_notice(stdout, "stripe");
+        return Ok(());
+    }
     for (key, credential) in &credentials {
         crate::secrets::store_secret(key, &credential.value)?;
     }
@@ -128,10 +124,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), HardenError> 
 }
 
 pub(crate) fn detect() -> HardenerDetection {
-    let path = stripe_cli_path();
-    let exists = path.exists();
-    let path = path.display().to_string();
-    HardenerDetection::command(exists, "stripe", Some(path.clone()), path)
+    isotope::detect(isotope::STRIPE)
 }
 
 pub(crate) fn secret_gate() -> SecretGateDescriptor {
@@ -141,19 +134,13 @@ pub(crate) fn secret_gate() -> SecretGateDescriptor {
         routes: vec![SecretGateRoute {
             operation: "keys",
             script_path: None,
-            target_path: stripe_cli_path().display().to_string(),
+            target_path: isotope::target(isotope::STRIPE).display().to_string(),
             caller_identifiers: vec!["stripe"],
             key_patterns: vec!["STRIPE_CLI_*".to_string()],
             replace_existing_env: true,
             allow_missing_keys: false,
         }],
     }
-}
-
-fn stripe_cli_path() -> PathBuf {
-    crate::test_env_var("AUTOMIC_VAULT_TEST_STRIPE_CLI_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| Path::new(STRIPE_CLI_PATH).to_path_buf())
 }
 
 fn stripe_config_dir() -> Result<PathBuf, String> {

--- a/src/isotopes/hardeners/supabase.md
+++ b/src/isotopes/hardeners/supabase.md
@@ -1,4 +1,7 @@
 ## What it Does
 
-Moves legacy Supabase CLI access tokens into Automic Vault and removes the
-plaintext fallback token files used by older Supabase CLI releases.
+`av harden supabase` installs the signed Supabase Isotope from the Automic Vault
+tap when Homebrew is available. Without Homebrew it installs `supabase` and
+`supabase-go` in `/usr/local/bin`; `av doctor supabase` reports direct install
+updates. It then moves legacy Supabase CLI access tokens into Automic Vault and
+removes the plaintext fallback token files used by older Supabase CLI releases.

--- a/src/isotopes/hardeners/supabase.rs
+++ b/src/isotopes/hardeners/supabase.rs
@@ -3,22 +3,16 @@ use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::{HardenerDetection, SecretGateDescriptor, SecretGateRoute};
+use super::{HardenerDetection, SecretGateDescriptor, SecretGateRoute, isotope};
 
 const PRIVILEGE_MODE: super::PrivilegeMode = super::PrivilegeMode::UserOnly;
-const SUPABASE_CLI_PATH: &str = "/opt/homebrew/opt/supabase-cli/bin/supabase";
-const INSTALL_COMMAND: &str = "brew install automic-vault/isotopes/supabase-cli";
 const VAULT_KEY: &str = "SUPABASE_ACCESS_TOKEN";
 const KEYCHAIN_SERVICE: &str = "Supabase CLI";
 const KEYCHAIN_ACCOUNTS: &[&str] = &["supabase", "access-token"];
 
 pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     PRIVILEGE_MODE.require_user("supabase", false)?;
-    if !supabase_cli_path().exists() {
-        return Err(format!(
-            "supabase is not installed; run `{INSTALL_COMMAND}`"
-        ));
-    }
+    let install = isotope::plan(isotope::SUPABASE)?;
 
     let token_paths = supabase_token_paths()?;
     let mut tokens = read_plaintext_tokens(&token_paths)?;
@@ -30,7 +24,8 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
 
     writeln!(stdout, "╭─ harden supabase").ok();
     writeln!(stdout, "│").ok();
-    if tokens.is_empty() {
+    install.write(stdout, isotope::SUPABASE);
+    if tokens.is_empty() && !install.needed() {
         writeln!(stdout, "╰─ no legacy Supabase credentials found").ok();
         super::write_secret_gate_notice(stdout, "supabase");
         return Ok(());
@@ -41,18 +36,28 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
         );
     }
 
-    writeln!(
-        stdout,
-        "├─ migrate Supabase access token into Automic Vault"
-    )
-    .ok();
-    writeln!(stdout, "├─ remove plaintext fallback access-token files").ok();
+    if tokens.is_empty() {
+        writeln!(stdout, "├─ no legacy Supabase credentials found").ok();
+    } else {
+        writeln!(
+            stdout,
+            "├─ migrate Supabase access token into Automic Vault"
+        )
+        .ok();
+        writeln!(stdout, "├─ remove plaintext fallback access-token files").ok();
+    }
     writeln!(stdout, "│").ok();
     if !confirm(stdout, yes)? {
         writeln!(stdout, "╰─ cancelled").ok();
         return Ok(());
     }
 
+    install.apply(isotope::SUPABASE)?;
+    if tokens.is_empty() {
+        writeln!(stdout, "╰─ installed supabase isotope").ok();
+        super::write_secret_gate_notice(stdout, "supabase");
+        return Ok(());
+    }
     crate::secrets::store_secret(VAULT_KEY, &tokens[0])?;
     for path in &token_paths {
         remove_plaintext_token(path)?;
@@ -66,10 +71,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
 }
 
 pub(crate) fn detect() -> HardenerDetection {
-    let path = supabase_cli_path();
-    let exists = path.exists();
-    let path = path.display().to_string();
-    HardenerDetection::command(exists, "supabase", Some(path.clone()), path)
+    isotope::detect(isotope::SUPABASE)
 }
 
 pub(crate) fn secret_gate() -> SecretGateDescriptor {
@@ -79,7 +81,7 @@ pub(crate) fn secret_gate() -> SecretGateDescriptor {
         routes: vec![SecretGateRoute {
             operation: "keys",
             script_path: None,
-            target_path: supabase_cli_path().display().to_string(),
+            target_path: isotope::target(isotope::SUPABASE).display().to_string(),
             caller_identifiers: vec!["supabase", "supabase-go", "com.supabase.cli"],
             key_patterns: vec![VAULT_KEY.to_string()],
             replace_existing_env: true,
@@ -108,12 +110,6 @@ fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String> {
         input.trim().to_ascii_lowercase().as_str(),
         "y" | "yes"
     ))
-}
-
-fn supabase_cli_path() -> PathBuf {
-    crate::test_env_var("AUTOMIC_VAULT_TEST_SUPABASE_CLI_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| Path::new(SUPABASE_CLI_PATH).to_path_buf())
 }
 
 fn supabase_token_paths() -> Result<Vec<PathBuf>, String> {

--- a/tests/harden_cli.rs
+++ b/tests/harden_cli.rs
@@ -158,6 +158,11 @@ fn prepare(root: &Path, command: &str) {
     fs::create_dir_all(root.join("stubs")).unwrap();
     fs::create_dir_all(root.join("home")).unwrap();
     fs::write(root.join("targets").join(command), "#!/bin/sh\n").unwrap();
+    fs::set_permissions(
+        root.join("targets").join(command),
+        fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
 }
 
 fn stderr(output: &Output) -> String {


### PR DESCRIPTION
## What changed

- Resolve simple hardener targets from PATH and embed the confirmed executable target in the installed stub.
- Reject an existing launcher stub that points its embedded target back to itself.
- Use the Automic Vault Homebrew tap automatically when Homebrew is available.
- Install supported isotope binaries in /usr/local/bin when Homebrew is unavailable.
- Download isotope metadata and archives in-process with ureq and Rustls, HTTPS-only redirects, and bounded timeouts.
- Report direct-install isotope updates through doctor and validate PATH candidates with code-signing checks.
- Remove the top-level Homebrew requirement from the README.

## Why

Nix and other non-Homebrew users should be able to harden existing tools without adopting a second package manager. Homebrew users should not need to type installation pre-steps manually.

## Impact

The hardening flow now previews the concrete installation or stub target, asks for confirmation, and performs the selected installation. Homebrew-managed isotopes continue to rely on Homebrew for updates; direct installs are updated by running av harden again.

## Validation

- cargo test --workspace
- 822 library tests plus CLI and integration tests passed
- Focused HTTPS-only and recursive-stub regression tests passed
- cargo fmt --check
- git diff --check
