### PR TITLE
Add biometric Full Access Sessions

### DIFF
--- a/docs/adr/0006-biometric-full-access-sessions.md
+++ b/docs/adr/0006-biometric-full-access-sessions.md
@@ -15,21 +15,21 @@ Add an in-memory **Full Access Session**. While active, the policy resolver appl
 
 Only the signed macOS app UI can start a session. Starting requires `deviceOwnerAuthenticationWithBiometrics` through LocalAuthentication, with no password fallback. Authentication cancellation, failure, lockout, or unavailable biometry leaves normal policy active. Gate Clients, Launchers, CLI commands, URL handlers, XPC messages, environment variables, and persisted configuration receive no start mechanism.
 
-A session lasts for at most one hour. It ends earlier when the macOS user session becomes inactive, the displays sleep, the app exits or updates, or the user selects **End Full Access Session**. Ending a session is always available without authentication because it narrows authority. The session is never persisted; app launch always starts under durable policy.
+The user chooses a session lifetime of **1 hour**, **8 hours**, or **Until turned off** before authenticating. Until turned off is the default. Timed sessions expire using both wall-clock and monotonic deadlines. Every session ends when the macOS user session becomes inactive, the displays sleep, the app exits or updates, or the user selects **End Full Access Session**. Ending a session is always available without authentication because it narrows authority. The session and selected lifetime are never persisted; app launch always starts under durable policy with Until turned off selected.
 
 Make the exceptional state conspicuous:
 
-- the menu-bar icon and menu use a warning treatment and show the remaining time;
+- the menu-bar icon and menu use a warning treatment and show the remaining time or Until turned off;
 - the main window shows a persistent warning banner with an End action;
 - Settings explains exactly what Full Access includes and what still fails closed;
 - Authorization History records allowed requests with `Full Access Session` as the policy reason.
 
-The primary action is **Start Full Access Session…**, not a generic “disable approvals” toggle. The confirmation copy states that recognized operations from every Verified Launcher may use or disclose protected Secrets for up to one hour. Touch ID follows that explicit warning. Normal durable policy returns automatically when the session ends.
+The primary action is **Start Full Access Session…**, not a generic “disable approvals” toggle. The main window and menu-bar confirmation offer the lifetime choices before Touch ID. The confirmation copy states that every valid recognized operation from every Verified Launcher may use or disclose protected Secrets for the selected lifetime. Normal durable policy returns automatically when the session ends.
 
 ## Consequences
 
-- A physically present user can authorize a bounded low-friction automation window without rewriting durable gate policy.
+- A physically present user can authorize a low-friction automation window, bounded by the chosen timer or by the local user session and helper lifetime, without rewriting durable gate policy.
 - Agents can open the app or attempt the action, but cannot satisfy local biometric authentication.
 - Full Access Sessions broaden recognized authority intentionally, visibly, and temporarily; they never convert uncertainty into authority.
 - Existing per-gate policy remains the source of truth before and after the session.
-- Tests must cover biometric success and failure, expiry, lock and sleep termination, app-restart reset, verified versus unverifiable Launchers, every recognized Full Access classification, Unknown denial, Authorization History reasons, and the visible warning states.
+- Tests must cover the default Until turned off lifetime, timed expiry, biometric success and failure, lock and sleep termination, app-restart reset, verified versus unverifiable Launchers, every recognized Full Access classification, Unknown denial, Authorization History reasons, and the visible warning states.

--- a/docs/adr/0006-biometric-full-access-sessions.md
+++ b/docs/adr/0006-biometric-full-access-sessions.md
@@ -1,0 +1,35 @@
+# ADR 0006: Offer Biometric Full Access Sessions
+
+- Status: Accepted
+- Date: 2026-08-07
+
+## Context
+
+Users sometimes want an uninterrupted local automation window without changing every Authorization Gate or repeatedly responding to Approval prompts. Quitting the menu-bar helper does not provide that mode: protected Secrets become unavailable, Gate Clients fail, and reopening the app does not express a reviewed authority choice.
+
+A literal “approve everything” switch would violate Automic Vault's fail-closed invariants. Unknown operations, unverifiable Launchers, untrusted Gate Clients or Targets, invalid requests, missing Secrets, and failed required Authorization Records cannot become allowed because a convenience mode is active. A durable global override would also outlive the user's immediate intent and obscure the per-gate policies that normally govern authority.
+
+## Decision
+
+Add an in-memory **Full Access Session**. While active, the policy resolver applies the Full Access Access Level at every Authorization Gate for Verified Launchers. The overlay includes recognized Elevated Secret Application and Secret Disclosure, but Unknown remains ineligible for automic authorization. All existing identity, integrity, request-validation, Secret-matching, and record-before-release requirements remain unchanged.
+
+Only the signed macOS app UI can start a session. Starting requires `deviceOwnerAuthenticationWithBiometrics` through LocalAuthentication, with no password fallback. Authentication cancellation, failure, lockout, or unavailable biometry leaves normal policy active. Gate Clients, Launchers, CLI commands, URL handlers, XPC messages, environment variables, and persisted configuration receive no start mechanism.
+
+A session lasts for at most one hour. It ends earlier when the macOS user session becomes inactive, the displays sleep, the app exits or updates, or the user selects **End Full Access Session**. Ending a session is always available without authentication because it narrows authority. The session is never persisted; app launch always starts under durable policy.
+
+Make the exceptional state conspicuous:
+
+- the menu-bar icon and menu use a warning treatment and show the remaining time;
+- the main window shows a persistent warning banner with an End action;
+- Settings explains exactly what Full Access includes and what still fails closed;
+- Authorization History records allowed requests with `Full Access Session` as the policy reason.
+
+The primary action is **Start Full Access Session…**, not a generic “disable approvals” toggle. The confirmation copy states that recognized operations from every Verified Launcher may use or disclose protected Secrets for up to one hour. Touch ID follows that explicit warning. Normal durable policy returns automatically when the session ends.
+
+## Consequences
+
+- A physically present user can authorize a bounded low-friction automation window without rewriting durable gate policy.
+- Agents can open the app or attempt the action, but cannot satisfy local biometric authentication.
+- Full Access Sessions broaden recognized authority intentionally, visibly, and temporarily; they never convert uncertainty into authority.
+- Existing per-gate policy remains the source of truth before and after the session.
+- Tests must cover biometric success and failure, expiry, lock and sleep termination, app-restart reset, verified versus unverifiable Launchers, every recognized Full Access classification, Unknown denial, Authorization History reasons, and the visible warning states.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,7 +118,7 @@ Unconstrained Secret Application for exact Secret Names in the matching
 Launcher’s Direct Access Rules. It does not turn unknown Tool operations into
 recognized operations and does not apply to Tool-specific Gate Clients.
 
-A Full Access Session is an in-memory policy overlay, not a mutation of the durable per-gate policies. The signed app requires local biometric authentication before creating a session. No Gate Client or automation interface can create one. A session has a one-hour maximum lifetime and is discarded on user-session inactivity, display sleep, app termination, or explicit user action. Required identity, integrity, classification, Secret matching, and Authorization Record checks remain in force.
+A Full Access Session is an in-memory policy overlay, not a mutation of the durable per-gate policies. The signed app requires the user to choose 1 hour, 8 hours, or Until turned off and complete local biometric authentication before creating a session. Until turned off is selected by default. No Gate Client or automation interface can create a session or select its lifetime. Timed sessions expire against wall-clock and monotonic deadlines. Every session is discarded on user-session inactivity, display sleep, app termination, or explicit user action. Required identity, integrity, classification, Secret matching, and Authorization Record checks remain in force.
 
 ### Current compatibility model
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,10 +105,11 @@ Each Authorization Gate owns one Authorization Policy:
 
 1. The gate defines an explicit default Access Level.
 2. Launcher-specific rules override that default for matching Verified Launchers.
-3. An unverifiable Launcher receives no durable policy grant.
-4. The classifier describes the operation's characteristics.
-5. Policy must permit every characteristic for automic authorization.
-6. Unknown prevents automic authorization.
+3. An active Full Access Session temporarily overlays Full Access for Verified Launchers at every gate.
+4. An unverifiable Launcher receives no durable or session policy grant.
+5. The classifier describes the operation's characteristics.
+6. Policy must permit every characteristic for automic authorization.
+7. Unknown prevents automic authorization, including during a Full Access Session.
 
 Access Levels are named presets over operation characteristics. The user sees a small set of presets and concrete Approval reasons. The policy engine's target model keeps Homebrew Update, Local Write, System Write, Remote Write, Elevated Secret Application, Unconstrained Secret Application, and Secret Disclosure distinct.
 
@@ -116,6 +117,8 @@ Direct Access is available only at the Direct Secret Gate. It permits
 Unconstrained Secret Application for exact Secret Names in the matching
 Launcher’s Direct Access Rules. It does not turn unknown Tool operations into
 recognized operations and does not apply to Tool-specific Gate Clients.
+
+A Full Access Session is an in-memory policy overlay, not a mutation of the durable per-gate policies. The signed app requires local biometric authentication before creating a session. No Gate Client or automation interface can create one. A session has a one-hour maximum lifetime and is discarded on user-session inactivity, display sleep, app termination, or explicit user action. Required identity, integrity, classification, Secret matching, and Authorization Record checks remain in force.
 
 ### Current compatibility model
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -194,6 +194,12 @@ Every requested characteristic must fit the selected preset. Gates may omit pres
 
 The Homebrew Execution Gate does not expose Read Only. Homebrew may update itself and its package metadata while running inspection commands, so Automic Vault treats Read Only and Homebrew Update as one indivisible level: Read & Update.
 
+### Full Access Session
+
+A short-lived, device-owner-authorized policy overlay that applies the Full Access level at every Authorization Gate for Verified Launchers. A Full Access Session never authorizes an Unknown operation, an unverifiable Launcher, an untrusted Gate Client or Target, an invalid request, a missing Secret, or a failed required Authorization Record.
+
+Starting a Full Access Session requires local biometric authentication in the signed app. The session ends after one hour, when the user session becomes inactive, when the displays sleep, when the app exits, or when the user ends it. Ending a session restores the durable Authorization Policies immediately and requires no authentication. Full Access Sessions are never persisted and cannot be started by a Gate Client, command-line interface, URL handler, or other automation.
+
 ## Detection and hardening
 
 ### Detector

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -196,9 +196,9 @@ The Homebrew Execution Gate does not expose Read Only. Homebrew may update itsel
 
 ### Full Access Session
 
-A short-lived, device-owner-authorized policy overlay that applies the Full Access level at every Authorization Gate for Verified Launchers. A Full Access Session never authorizes an Unknown operation, an unverifiable Launcher, an untrusted Gate Client or Target, an invalid request, a missing Secret, or a failed required Authorization Record.
+A non-persistent, device-owner-authorized policy overlay that applies the Full Access level at every Authorization Gate for Verified Launchers. A Full Access Session never authorizes an Unknown operation, an unverifiable Launcher, an untrusted Gate Client or Target, an invalid request, a missing Secret, or a failed required Authorization Record.
 
-Starting a Full Access Session requires local biometric authentication in the signed app. The session ends after one hour, when the user session becomes inactive, when the displays sleep, when the app exits, or when the user ends it. Ending a session restores the durable Authorization Policies immediately and requires no authentication. Full Access Sessions are never persisted and cannot be started by a Gate Client, command-line interface, URL handler, or other automation.
+Starting a Full Access Session requires choosing 1 hour, 8 hours, or Until turned off and completing local biometric authentication in the signed app. Until turned off is selected by default. A timed session ends when its duration expires. Every session ends when the user session becomes inactive, when the displays sleep, when the app exits, or when the user ends it. Ending a session restores the durable Authorization Policies immediately and requires no authentication. Full Access Sessions and their selected lifetime are never persisted and cannot be started by a Gate Client, command-line interface, URL handler, or other automation.
 
 ## Detection and hardening
 

--- a/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
+++ b/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
@@ -145,10 +145,42 @@ private enum FullAccessSessionAuthenticationError: LocalizedError {
 
 func fullAccessSessionRemainingLabel(
     _ snapshot: FullAccessSessionSnapshot,
-    at date: Date = Date()
+    at date: Date = Date(),
+    uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
 ) -> String {
-    let remaining = Int(ceil(snapshot.remaining(at: date)))
+    let remaining = Int(ceil(snapshot.remaining(at: date, uptime: uptime)))
     let minutes = remaining / 60
     let seconds = remaining % 60
     return minutes > 0 ? "\(minutes)m \(seconds)s remaining" : "\(seconds)s remaining"
+}
+
+struct FullAccessSessionMenuPresentation: Equatable {
+    let title: String
+    let isEnabled: Bool
+    let showsWarning: Bool
+}
+
+func fullAccessSessionMenuPresentation(
+    snapshot: FullAccessSessionSnapshot?,
+    isAuthenticating: Bool,
+    at date: Date = Date(),
+    uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+) -> FullAccessSessionMenuPresentation {
+    if let snapshot {
+        let remaining = fullAccessSessionRemainingLabel(
+            snapshot,
+            at: date,
+            uptime: uptime
+        )
+        return FullAccessSessionMenuPresentation(
+            title: "End Full Access Session (\(remaining))",
+            isEnabled: true,
+            showsWarning: true
+        )
+    }
+    return FullAccessSessionMenuPresentation(
+        title: isAuthenticating ? "Waiting for Touch ID…" : "Start Full Access Session…",
+        isEnabled: !isAuthenticating,
+        showsWarning: false
+    )
 }

--- a/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
+++ b/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
@@ -3,6 +3,18 @@ import LocalAuthentication
 import MenubarHelperCore
 import SwiftUI
 
+struct FullAccessSessionConfirmationPresentation: Equatable {
+    let title: String
+    let message: String
+    let actionTitle: String
+}
+
+let fullAccessSessionConfirmationPresentation = FullAccessSessionConfirmationPresentation(
+    title: "Start Full Access Session?",
+    message: "For up to one hour, every recognized operation from every verified app may run automatically, including operations that use or disclose protected secrets. Unknown and unverifiable requests still require approval or fail closed.",
+    actionTitle: "Continue to Touch ID"
+)
+
 @MainActor
 final class FullAccessSessionModel: ObservableObject {
     typealias Authenticate = @MainActor () async throws -> Bool

--- a/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
+++ b/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
@@ -11,17 +11,28 @@ struct FullAccessSessionConfirmationPresentation: Equatable {
 
 let fullAccessSessionConfirmationPresentation = FullAccessSessionConfirmationPresentation(
     title: "Start Full Access Session?",
-    message: "For up to one hour, every recognized operation from every verified app may run automatically, including operations that use or disclose protected secrets. Unknown and unverifiable requests still require approval or fail closed.",
+    message: "For the selected duration, every valid recognized operation from every verified app may be automically authorized, including operations that use or disclose protected secrets. Unknown, invalid, and unverifiable requests still require approval or fail closed.",
     actionTitle: "Continue to Touch ID"
 )
 
+extension FullAccessSessionLifetime {
+    var title: String {
+        switch self {
+        case .oneHour: "1 hour"
+        case .eightHours: "8 hours"
+        case .untilEnded: "Until turned off"
+        }
+    }
+}
+
 @MainActor
 final class FullAccessSessionModel: ObservableObject {
-    typealias Authenticate = @MainActor () async throws -> Bool
+    typealias Authenticate = @MainActor (FullAccessSessionLifetime) async throws -> Bool
 
     @Published private(set) var snapshot: FullAccessSessionSnapshot?
     @Published private(set) var isAuthenticating = false
     @Published private(set) var authenticationError: String?
+    @Published var selectedLifetime: FullAccessSessionLifetime = .untilEnded
 
     private let controller: FullAccessSessionController
     private let authenticate: Authenticate
@@ -51,12 +62,13 @@ final class FullAccessSessionModel: ObservableObject {
     func authenticateAndStart() async {
         guard !isActive, !isAuthenticating else { return }
         let attempt = UUID()
+        let lifetime = selectedLifetime
         authenticationAttempt = attempt
         isAuthenticating = true
         authenticationError = nil
         onChange?()
         do {
-            let authenticated = try await authenticate()
+            let authenticated = try await authenticate(lifetime)
             guard authenticationAttempt == attempt, !Task.isCancelled else { return }
             authenticationAttempt = nil
             authenticationTask = nil
@@ -65,7 +77,7 @@ final class FullAccessSessionModel: ObservableObject {
                 onChange?()
                 return
             }
-            guard controller.start() else {
+            guard controller.start(lifetime: lifetime) else {
                 throw FullAccessSessionAuthenticationError.couldNotStart
             }
             isAuthenticating = false
@@ -99,8 +111,8 @@ final class FullAccessSessionModel: ObservableObject {
         let updated = controller.snapshot(at: date)
         guard updated != snapshot else { return }
         snapshot = updated
-        if let updated {
-            scheduleExpiration(at: updated.expiresAt)
+        if let expiresAt = updated?.expiresAt {
+            scheduleExpiration(at: expiresAt)
         } else {
             expirationTask?.cancel()
             expirationTask = nil
@@ -124,7 +136,9 @@ final class FullAccessSessionModel: ObservableObject {
 }
 
 @MainActor
-private func authenticateFullAccessSession() async throws -> Bool {
+private func authenticateFullAccessSession(
+    lifetime: FullAccessSessionLifetime
+) async throws -> Bool {
     let context = LAContext()
     context.localizedFallbackTitle = ""
     context.touchIDAuthenticationAllowableReuseDuration = 0
@@ -137,7 +151,7 @@ private func authenticateFullAccessSession() async throws -> Bool {
     }
     return try await context.evaluatePolicy(
         .deviceOwnerAuthenticationWithBiometrics,
-        localizedReason: "Start a one-hour Full Access Session that automatically authorizes every recognized operation from verified apps."
+        localizedReason: "Start a Full Access Session for \(lifetime.title) that automically authorizes every valid recognized operation from verified apps."
     )
 }
 
@@ -160,9 +174,16 @@ func fullAccessSessionRemainingLabel(
     at date: Date = Date(),
     uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
 ) -> String {
-    let remaining = Int(ceil(snapshot.remaining(at: date, uptime: uptime)))
+    guard let interval = snapshot.remaining(at: date, uptime: uptime) else {
+        return "Until turned off"
+    }
+    let remaining = Int(ceil(interval))
+    let hours = remaining / 3_600
     let minutes = remaining / 60
     let seconds = remaining % 60
+    if hours > 0 {
+        return "\(hours)h \(minutes % 60)m remaining"
+    }
     return minutes > 0 ? "\(minutes)m \(seconds)s remaining" : "\(seconds)s remaining"
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
+++ b/src/menu-helper/Sources/MenubarHelper/FullAccessSessionUI.swift
@@ -1,0 +1,154 @@
+import Foundation
+import LocalAuthentication
+import MenubarHelperCore
+import SwiftUI
+
+@MainActor
+final class FullAccessSessionModel: ObservableObject {
+    typealias Authenticate = @MainActor () async throws -> Bool
+
+    @Published private(set) var snapshot: FullAccessSessionSnapshot?
+    @Published private(set) var isAuthenticating = false
+    @Published private(set) var authenticationError: String?
+
+    private let controller: FullAccessSessionController
+    private let authenticate: Authenticate
+    private var authenticationAttempt: UUID?
+    private var authenticationTask: Task<Void, Never>?
+    private var expirationTask: Task<Void, Never>?
+    var onChange: (() -> Void)?
+
+    init(
+        controller: FullAccessSessionController,
+        authenticate: @escaping Authenticate = authenticateFullAccessSession
+    ) {
+        self.controller = controller
+        self.authenticate = authenticate
+        snapshot = controller.snapshot()
+    }
+
+    var isActive: Bool { snapshot != nil }
+
+    func start() {
+        guard !isActive, !isAuthenticating else { return }
+        authenticationTask = Task { [weak self] in
+            await self?.authenticateAndStart()
+        }
+    }
+
+    func authenticateAndStart() async {
+        guard !isActive, !isAuthenticating else { return }
+        let attempt = UUID()
+        authenticationAttempt = attempt
+        isAuthenticating = true
+        authenticationError = nil
+        onChange?()
+        do {
+            let authenticated = try await authenticate()
+            guard authenticationAttempt == attempt, !Task.isCancelled else { return }
+            authenticationAttempt = nil
+            authenticationTask = nil
+            guard authenticated else {
+                isAuthenticating = false
+                onChange?()
+                return
+            }
+            guard controller.start() else {
+                throw FullAccessSessionAuthenticationError.couldNotStart
+            }
+            isAuthenticating = false
+            refresh()
+        } catch {
+            guard authenticationAttempt == attempt else { return }
+            authenticationAttempt = nil
+            authenticationTask = nil
+            isAuthenticating = false
+            authenticationError = error.localizedDescription
+            onChange?()
+        }
+    }
+
+    func end() {
+        let wasAuthenticating = isAuthenticating
+        authenticationAttempt = nil
+        authenticationTask?.cancel()
+        authenticationTask = nil
+        isAuthenticating = false
+        expirationTask?.cancel()
+        expirationTask = nil
+        controller.end()
+        refresh()
+        if wasAuthenticating, snapshot == nil {
+            onChange?()
+        }
+    }
+
+    func refresh(at date: Date = Date()) {
+        let updated = controller.snapshot(at: date)
+        guard updated != snapshot else { return }
+        snapshot = updated
+        if let updated {
+            scheduleExpiration(at: updated.expiresAt)
+        } else {
+            expirationTask?.cancel()
+            expirationTask = nil
+        }
+        onChange?()
+    }
+
+    func clearAuthenticationError() {
+        authenticationError = nil
+    }
+
+    private func scheduleExpiration(at date: Date) {
+        expirationTask?.cancel()
+        let nanoseconds = UInt64(max(0, date.timeIntervalSinceNow) * 1_000_000_000)
+        expirationTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.refresh()
+        }
+    }
+}
+
+@MainActor
+private func authenticateFullAccessSession() async throws -> Bool {
+    let context = LAContext()
+    context.localizedFallbackTitle = ""
+    context.touchIDAuthenticationAllowableReuseDuration = 0
+    var error: NSError?
+    guard context.canEvaluatePolicy(
+        .deviceOwnerAuthenticationWithBiometrics,
+        error: &error
+    ) else {
+        throw error ?? FullAccessSessionAuthenticationError.biometryUnavailable
+    }
+    return try await context.evaluatePolicy(
+        .deviceOwnerAuthenticationWithBiometrics,
+        localizedReason: "Start a one-hour Full Access Session that automatically authorizes every recognized operation from verified apps."
+    )
+}
+
+private enum FullAccessSessionAuthenticationError: LocalizedError {
+    case biometryUnavailable
+    case couldNotStart
+
+    var errorDescription: String? {
+        switch self {
+        case .biometryUnavailable:
+            "Touch ID is unavailable. Full Access Session was not started."
+        case .couldNotStart:
+            "Full Access Session could not be started."
+        }
+    }
+}
+
+func fullAccessSessionRemainingLabel(
+    _ snapshot: FullAccessSessionSnapshot,
+    at date: Date = Date()
+) -> String {
+    let remaining = Int(ceil(snapshot.remaining(at: date)))
+    let minutes = remaining / 60
+    let seconds = remaining % 60
+    return minutes > 0 ? "\(minutes)m \(seconds)s remaining" : "\(seconds)s remaining"
+}

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -40,12 +40,35 @@ struct BlessedScriptReviewRequest: Sendable {
 final class AutomicVaultMainWindowController: NSHostingController<DashboardRootView> {
     private let model = DashboardModel()
 
-    init(checkForUpdates: @escaping () -> Void) {
-        super.init(rootView: DashboardRootView(model: model, checkForUpdates: checkForUpdates))
+    convenience init(checkForUpdates: @escaping () -> Void) {
+        self.init(
+            fullAccessSession: FullAccessSessionModel(
+                controller: FullAccessSessionController()
+            ),
+            checkForUpdates: checkForUpdates
+        )
+    }
+
+    init(
+        fullAccessSession: FullAccessSessionModel,
+        checkForUpdates: @escaping () -> Void
+    ) {
+        super.init(rootView: DashboardRootView(
+            model: model,
+            fullAccessSession: fullAccessSession,
+            checkForUpdates: checkForUpdates
+        ))
     }
 
     @MainActor @preconcurrency required dynamic init?(coder: NSCoder) {
-        super.init(coder: coder, rootView: DashboardRootView(model: model, checkForUpdates: {}))
+        let fullAccessSession = FullAccessSessionModel(
+            controller: FullAccessSessionController()
+        )
+        super.init(coder: coder, rootView: DashboardRootView(
+            model: model,
+            fullAccessSession: fullAccessSession,
+            checkForUpdates: {}
+        ))
     }
 
     override func viewDidAppear() {
@@ -230,6 +253,12 @@ final class DashboardModel: ObservableObject {
             }
         case .settings:
             [
+                DashboardItem(
+                    id: "full-access-session",
+                    title: "Full Access Session",
+                    subtitle: "Touch ID-only automatic authorization",
+                    detail: "Temporarily authorize every recognized operation from verified apps."
+                ),
                 DashboardItem(
                     id: "automatic-approval-feedback",
                     title: "Automic Authorization",
@@ -1135,6 +1164,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
     model.searchText = ""
     model.selectSection(.settings)
     guard model.items.map(\.id) == [
+        "full-access-session",
         "automatic-approval-feedback",
         "detached-process-access",
         "secret-name-access",
@@ -1228,10 +1258,18 @@ struct DashboardItem: Identifiable, Equatable {
 
 struct DashboardRootView: View {
     @ObservedObject var model: DashboardModel
+    @ObservedObject var fullAccessSession: FullAccessSessionModel
     let checkForUpdates: () -> Void
 
     var body: some View {
-        NavigationSplitView() {
+        VStack(spacing: 0) {
+            if let snapshot = fullAccessSession.snapshot {
+                FullAccessSessionBanner(
+                    snapshot: snapshot,
+                    end: fullAccessSession.end
+                )
+            }
+            NavigationSplitView() {
             DashboardSidebarView(model: model)
                 .navigationSplitViewColumnWidth(min: 186, ideal: 227, max: 250)
         } content: {
@@ -1250,7 +1288,10 @@ struct DashboardRootView: View {
                     }
                 }
         } detail: {
-            DashboardDetailView(model: model)
+            DashboardDetailView(
+                model: model,
+                fullAccessSession: fullAccessSession
+            )
                 .navigationSplitViewColumnWidth(min: 320, ideal: 320)
                 .toolbar {
                     Spacer()
@@ -1307,7 +1348,102 @@ struct DashboardRootView: View {
                     .help("Refresh")
                 }
         }
-        .searchable(text: $model.searchText, placement: .sidebar, prompt: "Search")
+            .searchable(text: $model.searchText, placement: .sidebar, prompt: "Search")
+        }
+    }
+}
+
+private struct FullAccessSessionBanner: View {
+    let snapshot: FullAccessSessionSnapshot
+    let end: () -> Void
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.shield.fill")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Full Access Session is active")
+                        .fontWeight(.semibold)
+                    Text("Recognized operations from verified apps are automatically authorized · \(fullAccessSessionRemainingLabel(snapshot, at: context.date))")
+                        .font(.caption)
+                }
+                Spacer()
+                Button("End", action: end)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .foregroundStyle(.primary)
+            .background(Color.orange.opacity(0.2))
+            .overlay(alignment: .bottom) {
+                Divider().overlay(Color.orange.opacity(0.55))
+            }
+        }
+    }
+}
+
+private struct FullAccessSessionSettingsView: View {
+    @ObservedObject var model: FullAccessSessionModel
+    @State private var showingConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label("Full Access Session", systemImage: "exclamationmark.shield")
+                .font(.title2.weight(.semibold))
+
+            Text("Temporarily authorize every recognized operation from every verified app, including operations that use or disclose protected secrets. Unknown operations, unverifiable apps, invalid requests, missing secrets, and audit-record failures remain blocked or require approval.")
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let snapshot = model.snapshot {
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    Label(
+                        "Active · \(fullAccessSessionRemainingLabel(snapshot, at: context.date))",
+                        systemImage: "lock.open.fill"
+                    )
+                    .foregroundStyle(.orange)
+                    .fontWeight(.semibold)
+                }
+                Button("End Full Access Session", action: model.end)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
+            } else {
+                Button("Start Full Access Session…") {
+                    showingConfirmation = true
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(model.isAuthenticating)
+
+                if model.isAuthenticating {
+                    Label("Waiting for Touch ID…", systemImage: "touchid")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let error = model.authenticationError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Dismiss") {
+                    model.clearAuthenticationError()
+                }
+            }
+
+            Divider()
+            Text("The session is kept only in memory. It ends after one hour, when the Mac locks, when the displays sleep, when Automic Vault exits or updates, or when you end it. Only Touch ID in this app can start it; agents and command-line tools cannot.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .alert("Start Full Access Session?", isPresented: $showingConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Continue to Touch ID") {
+                model.start()
+            }
+        } message: {
+            Text("For up to one hour, every recognized operation from every verified app may run automatically, including operations that use or disclose protected secrets.")
+        }
     }
 }
 
@@ -1426,6 +1562,7 @@ private struct DashboardListView: View {
 
 private struct DashboardDetailView: View {
     @ObservedObject var model: DashboardModel
+    @ObservedObject var fullAccessSession: FullAccessSessionModel
 
     var body: some View {
         ScrollView {
@@ -1456,7 +1593,13 @@ private struct DashboardDetailView: View {
                     .padding(.bottom, 28)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else if model.selectedSection == .settings {
-                if model.selectedItem?.id == "automatic-approval-feedback" {
+                if model.selectedItem?.id == "full-access-session" {
+                    FullAccessSessionSettingsView(model: fullAccessSession)
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else if model.selectedItem?.id == "automatic-approval-feedback" {
                     AutomaticApprovalFeedbackSettingsView()
                         .padding(.horizontal, 22)
                         .padding(.top, 32)

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1436,13 +1436,13 @@ private struct FullAccessSessionSettingsView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .alert("Start Full Access Session?", isPresented: $showingConfirmation) {
+        .alert(fullAccessSessionConfirmationPresentation.title, isPresented: $showingConfirmation) {
             Button("Cancel", role: .cancel) {}
-            Button("Continue to Touch ID") {
+            Button(fullAccessSessionConfirmationPresentation.actionTitle) {
                 model.start()
             }
         } message: {
-            Text("For up to one hour, every recognized operation from every verified app may run automatically, including operations that use or disclose protected secrets.")
+            Text(fullAccessSessionConfirmationPresentation.message)
         }
     }
 }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1364,7 +1364,7 @@ private struct FullAccessSessionBanner: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Full Access Session is active")
                         .fontWeight(.semibold)
-                    Text("Recognized operations from verified apps are automatically authorized · \(fullAccessSessionRemainingLabel(snapshot, at: context.date))")
+                    Text("Every valid recognized operation from verified apps is automically authorized · \(fullAccessSessionRemainingLabel(snapshot, at: context.date))")
                         .font(.caption)
                 }
                 Spacer()
@@ -1392,7 +1392,7 @@ private struct FullAccessSessionSettingsView: View {
             Label("Full Access Session", systemImage: "exclamationmark.shield")
                 .font(.title2.weight(.semibold))
 
-            Text("Temporarily authorize every recognized operation from every verified app, including operations that use or disclose protected secrets. Unknown operations, unverifiable apps, invalid requests, missing secrets, and audit-record failures remain blocked or require approval.")
+            Text("Temporarily authorize every valid recognized operation from every verified app, including operations that use or disclose protected secrets. Unknown operations, unverifiable apps, invalid requests, missing secrets, and audit-record failures remain blocked or require approval.")
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -1409,6 +1409,19 @@ private struct FullAccessSessionSettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(.orange)
             } else {
+                HStack {
+                    Text("Duration")
+                    Spacer()
+                    Picker("Duration", selection: $model.selectedLifetime) {
+                        ForEach(FullAccessSessionLifetime.allCases, id: \.self) { lifetime in
+                            Text(lifetime.title).tag(lifetime)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 170)
+                }
+                .disabled(model.isAuthenticating)
+
                 Button("Start Full Access Session…") {
                     showingConfirmation = true
                 }
@@ -1431,7 +1444,7 @@ private struct FullAccessSessionSettingsView: View {
             }
 
             Divider()
-            Text("The session is kept only in memory. It ends after one hour, when the Mac locks, when the displays sleep, when Automic Vault exits or updates, or when you end it. Only Touch ID in this app can start it; agents and command-line tools cannot.")
+            Text("The session is kept only in memory. A timed session ends when its duration expires. Every session ends when the Mac locks, the displays sleep, Automic Vault exits or updates, or you end it. Only Touch ID in this app can start it; agents and command-line tools cannot.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -440,6 +440,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard alert.runModal() == .alertFirstButtonReturn else { return }
 
             readyUpdate = nil
+            fullAccessSessionModel.end()
             restoreMainWindow = beginUpdating(with: alert)
             updatingAlert = alert
             let prepared = try await update.prepareInstallation()
@@ -709,19 +710,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         automaticApprovalFlashWorkItem?.cancel()
         automaticApprovalFlashWorkItem = nil
         preFlashStatusImage = nil
-        if let snapshot = fullAccessSessionModel.snapshot {
-            fullAccessSessionItem.title = "End Full Access Session (\(fullAccessSessionRemainingLabel(snapshot)))"
-        } else {
-            fullAccessSessionItem.title = fullAccessSessionModel.isAuthenticating
-                ? "Waiting for Touch ID…"
-                : "Start Full Access Session…"
-        }
-        fullAccessSessionItem.isEnabled = !fullAccessSessionModel.isAuthenticating
+        let presentation = fullAccessSessionMenuPresentation(
+            snapshot: fullAccessSessionModel.snapshot,
+            isAuthenticating: fullAccessSessionModel.isAuthenticating
+        )
+        fullAccessSessionItem.title = presentation.title
+        fullAccessSessionItem.isEnabled = presentation.isEnabled
         refreshStatusImage()
     }
 
     private func refreshStatusImage() {
-        statusItem.button?.image = if fullAccessSessionModel.isActive {
+        let showsWarning = fullAccessSessionMenuPresentation(
+            snapshot: fullAccessSessionModel.snapshot,
+            isAuthenticating: fullAccessSessionModel.isAuthenticating
+        ).showsWarning
+        statusItem.button?.image = if showsWarning {
             shieldImage(
                 symbolName: "exclamationmark.shield.fill",
                 color: .systemOrange,
@@ -2330,17 +2333,51 @@ private final class ApprovalServer: @unchecked Sendable {
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
         }
+        let sessionLease = fullAccessSession.lease()
         let sessionPolicy: ResolvedSecretGatePolicy? = if let configuredGate, let classification {
             resolveFullAccessSessionPolicy(
                 gate: configuredGate,
                 launchers: policyLaunchers,
                 classification: classification,
-                sessionActive: fullAccessSession.isActive()
+                sessionActive: sessionLease != nil
             )
         } else {
             nil
         }
-        let resolvedPolicy = sessionPolicy ?? durablePolicy
+        let preferredPolicy = automaticSecretGatePolicy(
+            sessionPolicy: sessionPolicy,
+            durablePolicy: durablePolicy,
+            classification: classification,
+            hasActiveBlessing: activeBlessing != nil
+        )
+        if let configuredGate,
+           let sessionPolicy,
+           preferredPolicy?.origin == .fullAccessSession,
+           let sessionLease
+        {
+            let authorizingLauncher = sessionPolicy.launcher ?? policyLauncher
+            let authorized = fullAccessSession.withActiveLease(sessionLease) {
+                automaticallyAuthorize(
+                    request: request,
+                    awsRegistration: awsRegistration,
+                    pid: pid,
+                    identity: identity,
+                    callerPath: callerPath,
+                    launcher: authorizingLauncher,
+                    scriptApproval: scriptApproval,
+                    gate: configuredGate,
+                    policy: sessionPolicy,
+                    authorizationGate: authorizationGate,
+                    processChains: processChains,
+                    currentLaunchers: launchers,
+                    retainedGateProvenance: retainedGateProvenance,
+                    peer: peer,
+                    message: message
+                )
+                return true
+            } ?? false
+            if authorized { return }
+        }
         let retainedProcessExplanation: String?
         if !keepsDetachedProcessAccess,
            retainedBlessingMatch != nil,
@@ -2371,16 +2408,16 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         let automaticApprovalExplanation: String?
         if let configuredGate,
-           let resolvedPolicy,
+           let durablePolicy,
            let classification,
-           !secretGateProtectionAllows(resolvedPolicy.protection, classification: classification),
+           !secretGateProtectionAllows(durablePolicy.protection, classification: classification),
            let explanation = secretGateAutomaticApprovalExplanation(
                gateID: configuredGate.id,
                request: request
            )
         {
             automaticApprovalExplanation = explanation
-        } else if resolvedPolicy == nil,
+        } else if durablePolicy == nil,
            classification == .readOnly,
            let failure = launcherAppVerificationFailure(for: identity)
         {
@@ -2444,23 +2481,22 @@ private final class ApprovalServer: @unchecked Sendable {
             }
             return
         }
-        if activeBlessing == nil,
-           let configuredGate,
-           let resolvedPolicy,
-           let classification,
-           secretGateProtectionAllows(
-               resolvedPolicy.protection,
-               classification: classification
+        if let configuredGate,
+           let fallbackPolicy = automaticSecretGatePolicy(
+               sessionPolicy: nil,
+               durablePolicy: durablePolicy,
+               classification: classification,
+               hasActiveBlessing: activeBlessing != nil
            )
         {
-            let authorizingLauncher = resolvedPolicy.launcher ?? policyLauncher
+            let authorizingLauncher = fallbackPolicy.launcher ?? policyLauncher
             do {
                 let payload = try approvedPayload(
                     for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
                 )
                 let reason = secretGateAuthorizationReason(
                     gate: configuredGate,
-                    policy: resolvedPolicy
+                    policy: fallbackPolicy
                 )
                 let accessRequestID = UUID()
                 let record = accessRequestRecord(
@@ -2734,6 +2770,83 @@ private final class ApprovalServer: @unchecked Sendable {
                     humanApprovalDecision: "approved"
                 )
             }
+        }
+    }
+
+    private func automaticallyAuthorize(
+        request: ApprovalRequest,
+        awsRegistration: AWSRegistrationCandidate?,
+        pid: pid_t,
+        identity: AVProcessIdentity,
+        callerPath: String,
+        launcher: LauncherIdentity?,
+        scriptApproval: ScriptApproval?,
+        gate: SecretGate,
+        policy: ResolvedSecretGatePolicy,
+        authorizationGate: RetainedAuthorizationGate,
+        processChains: [[RetainedProcessChainNode]],
+        currentLaunchers: [LauncherIdentity],
+        retainedGateProvenance: RetainedProcessProvenanceMatch?,
+        peer: xpc_connection_t,
+        message: xpc_object_t
+    ) {
+        do {
+            let payload = try approvedPayload(
+                for: request,
+                awsRegistration: awsRegistration,
+                pid: pid,
+                identity: identity
+            )
+            let accessRequestID = UUID()
+            let record = accessRequestRecord(
+                id: accessRequestID,
+                request: request,
+                callerPath: callerPath,
+                decision: "Approved",
+                approvalSource: "Auto",
+                reason: secretGateAuthorizationReason(gate: gate, policy: policy),
+                launcher: launcher
+            )
+            guard onAccessRequest(record) else {
+                reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                return
+            }
+            if let launcher {
+                rememberRetainedProvenance(
+                    at: authorizationGate,
+                    launcher: launcher,
+                    chains: processChains,
+                    retainedMatch: currentLaunchers.contains(where: {
+                        $0.designatedRequirement == launcher.designatedRequirement
+                    }) ? nil : retainedGateProvenance
+                )
+                Task { @MainActor in
+                    self.onAutoApproval(autoApprovalRecord(
+                        accessRequestID: accessRequestID,
+                        request: request,
+                        script: scriptApproval,
+                        launcher: launcher
+                    ))
+                }
+            }
+            reply(
+                peer,
+                to: message,
+                ok: true,
+                error: nil,
+                secrets: payload.secrets,
+                value: payload.value
+            )
+        } catch {
+            _ = onAccessRequest(accessRequestRecord(
+                request: request,
+                callerPath: callerPath,
+                decision: "Failed",
+                approvalSource: "Auto",
+                reason: error.localizedDescription,
+                launcher: launcher
+            ))
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
         }
     }
 
@@ -3619,6 +3732,12 @@ private struct ResolvedSecretGatePolicy {
     let protection: SecretGateProtection
     let source: String
     let launcher: LauncherIdentity?
+    let origin: SecretGatePolicyOrigin
+}
+
+private enum SecretGatePolicyOrigin {
+    case durable
+    case fullAccessSession
 }
 
 private func matchingSecretGate(
@@ -3694,7 +3813,8 @@ private func resolveSecretGatePolicy(
                     ? .noAccess
                     : policy.protection,
                 source: shortAppName(launcher.identifier),
-                launcher: launcher
+                launcher: launcher,
+                origin: .durable
             )
         }
     }
@@ -3702,7 +3822,8 @@ private func resolveSecretGatePolicy(
     return ResolvedSecretGatePolicy(
         protection: gate.defaultProtection,
         source: gate.defaultPolicyLabel,
-        launcher: firstLauncher
+        launcher: firstLauncher,
+        origin: .durable
     )
 }
 
@@ -3725,7 +3846,8 @@ private func resolveFullAccessSessionPolicy(
     return ResolvedSecretGatePolicy(
         protection: protection,
         source: "Full Access Session",
-        launcher: launcher
+        launcher: launcher,
+        origin: .fullAccessSession
     )
 }
 
@@ -3753,9 +3875,29 @@ private func secretGateAuthorizationReason(
     gate: SecretGate,
     policy: ResolvedSecretGatePolicy
 ) -> String {
-    policy.source == "Full Access Session"
+    policy.origin == .fullAccessSession
         ? policy.source
         : "\(gate.protectionTitle(policy.protection)) from \(policy.source)"
+}
+
+private func automaticSecretGatePolicy(
+    sessionPolicy: ResolvedSecretGatePolicy?,
+    durablePolicy: ResolvedSecretGatePolicy?,
+    classification: SecretGateRequestClassification?,
+    hasActiveBlessing: Bool
+) -> ResolvedSecretGatePolicy? {
+    if let sessionPolicy { return sessionPolicy }
+    guard !hasActiveBlessing,
+          let durablePolicy,
+          let classification,
+          secretGateProtectionAllows(
+              durablePolicy.protection,
+              classification: classification
+          )
+    else {
+        return nil
+    }
+    return durablePolicy
 }
 
 private func secretGateProtectionAllows(
@@ -7391,6 +7533,22 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
         return 1
     }
 
+    let leasedController = FullAccessSessionController()
+    guard leasedController.start(at: now, uptime: 200, duration: 60),
+          let lease = leasedController.lease(at: now, uptime: 200),
+          leasedController.withActiveLease(lease, at: now, uptime: 200, {
+              "released"
+          }) == "released"
+    else {
+        return 1
+    }
+    leasedController.end()
+    guard leasedController.withActiveLease(lease, at: now, uptime: 200, {
+        "released"
+    }) == nil else {
+        return 1
+    }
+
     let gate = SecretGate(
         id: "gh",
         keyPatterns: ["GH_TOKEN_*"],
@@ -7406,13 +7564,38 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
         designatedRequirement: #"identifier "com.apple.Terminal" and anchor apple"#,
         runtimeProtection: .hardened
     )
-    guard resolveFullAccessSessionPolicy(
+    let fullPolicy = resolveFullAccessSessionPolicy(
         gate: gate,
         launchers: [launcher],
         classification: .secretDump,
         sessionActive: true
-    ).map({ secretGateAuthorizationReason(gate: gate, policy: $0) })
+    )
+    let durablePolicy = ResolvedSecretGatePolicy(
+        protection: .readOnly,
+        source: "All Apps",
+        launcher: launcher,
+        origin: .durable
+    )
+    guard fullPolicy.map({ secretGateAuthorizationReason(gate: gate, policy: $0) })
         == "Full Access Session",
+        automaticSecretGatePolicy(
+            sessionPolicy: fullPolicy,
+            durablePolicy: nil,
+            classification: .secretDump,
+            hasActiveBlessing: true
+        )?.source == "Full Access Session",
+        automaticSecretGatePolicy(
+            sessionPolicy: nil,
+            durablePolicy: durablePolicy,
+            classification: .readOnly,
+            hasActiveBlessing: true
+        ) == nil,
+        automaticSecretGatePolicy(
+            sessionPolicy: nil,
+            durablePolicy: durablePolicy,
+            classification: .readOnly,
+            hasActiveBlessing: false
+        )?.source == "All Apps",
         resolveFullAccessSessionPolicy(
             gate: gate,
             launchers: [launcher],
@@ -7437,7 +7620,19 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
     await authenticated.authenticateAndStart()
     guard authenticated.isActive,
           authenticated.snapshot.map({ fullAccessSessionRemainingLabel($0) })?
-            .contains("remaining") == true
+            .contains("remaining") == true,
+          fullAccessSessionMenuPresentation(
+              snapshot: authenticated.snapshot,
+              isAuthenticating: false
+          ).showsWarning,
+          fullAccessSessionMenuPresentation(
+              snapshot: nil,
+              isAuthenticating: true
+          ) == FullAccessSessionMenuPresentation(
+              title: "Waiting for Touch ID…",
+              isEnabled: false,
+              showsWarning: false
+          )
     else {
         return 1
     }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -7374,12 +7374,19 @@ private func runUpdatePreflight() async -> Int32 {
 private func runFullAccessSessionSelfCheck() async -> Int32 {
     let now = Date(timeIntervalSince1970: 1_000)
     let controller = FullAccessSessionController()
-    guard !controller.isActive(at: now),
-          !controller.start(at: now, duration: 0),
-          controller.start(at: now, duration: fullAccessSessionMaximumDuration * 2),
-          controller.snapshot(at: now)?.expiresAt
+    guard !controller.isActive(at: now, uptime: 100),
+          !controller.start(at: now, uptime: 100, duration: 0),
+          controller.start(
+              at: now,
+              uptime: 100,
+              duration: fullAccessSessionMaximumDuration * 2
+          ),
+          controller.snapshot(at: now, uptime: 100)?.expiresAt
             == now.addingTimeInterval(fullAccessSessionMaximumDuration),
-          !controller.isActive(at: now.addingTimeInterval(fullAccessSessionMaximumDuration))
+          !controller.isActive(
+              at: now.addingTimeInterval(-300),
+              uptime: 100 + fullAccessSessionMaximumDuration
+          )
     else {
         return 1
     }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -377,9 +377,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Start Full Access Session?"
-        alert.informativeText = "For up to one hour, every recognized operation from every verified app may run automatically, including operations that use or disclose protected secrets. Unknown and unverifiable requests still require approval or fail closed."
-        alert.addButton(withTitle: "Continue to Touch ID")
+        alert.messageText = fullAccessSessionConfirmationPresentation.title
+        alert.informativeText = fullAccessSessionConfirmationPresentation.message
+        alert.addButton(withTitle: fullAccessSessionConfirmationPresentation.actionTitle)
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         fullAccessSessionModel.start()
@@ -1790,6 +1790,21 @@ private struct ApprovedPayload {
     let value: String?
 }
 
+private struct AutomaticAuthorizationContext {
+    let request: ApprovalRequest
+    let awsRegistration: AWSRegistrationCandidate?
+    let pid: pid_t
+    let identity: AVProcessIdentity
+    let callerPath: String
+    let scriptApproval: ScriptApproval?
+    let authorizationGate: RetainedAuthorizationGate
+    let processChains: [[RetainedProcessChainNode]]
+    let currentLaunchers: [LauncherIdentity]
+    let retainedGateProvenance: RetainedProcessProvenanceMatch?
+    let peer: xpc_connection_t
+    let message: xpc_object_t
+}
+
 private let awsHelperProtocolVersion = 1
 
 private final class ApprovalServer: @unchecked Sendable {
@@ -2319,17 +2334,6 @@ private final class ApprovalServer: @unchecked Sendable {
             callerPID: pid,
             ancestorFallbackPath: ancestorFallbackPath
         ) ?? launcher
-        let directAccessRules = loadDirectAccessRules()
-        let directAccessLauncher = matchingDirectAccessLauncher(
-            request: request,
-            configuredGate: configuredGate,
-            trustedAVGateClient: isTrustedAvCaller(path: callerPath, signing: signing),
-            launchers: policyLaunchers,
-            rules: directAccessRules
-        )
-        let durablePolicy = configuredGate.flatMap {
-            resolveSecretGatePolicy(gate: $0, launchers: policyLaunchers)
-        }
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
         }
@@ -2344,39 +2348,46 @@ private final class ApprovalServer: @unchecked Sendable {
         } else {
             nil
         }
-        let preferredPolicy = automaticSecretGatePolicy(
-            sessionPolicy: sessionPolicy,
-            durablePolicy: durablePolicy,
-            classification: classification,
-            hasActiveBlessing: activeBlessing != nil
+        let automaticAuthorizationContext = AutomaticAuthorizationContext(
+            request: request,
+            awsRegistration: awsRegistration,
+            pid: pid,
+            identity: identity,
+            callerPath: callerPath,
+            scriptApproval: scriptApproval,
+            authorizationGate: authorizationGate,
+            processChains: processChains,
+            currentLaunchers: launchers,
+            retainedGateProvenance: retainedGateProvenance,
+            peer: peer,
+            message: message
         )
         if let configuredGate,
            let sessionPolicy,
-           preferredPolicy?.origin == .fullAccessSession,
            let sessionLease
         {
             let authorizingLauncher = sessionPolicy.launcher ?? policyLauncher
-            let authorized = fullAccessSession.withActiveLease(sessionLease) {
+            let handled = fullAccessSession.withActiveLease(sessionLease) {
                 automaticallyAuthorize(
-                    request: request,
-                    awsRegistration: awsRegistration,
-                    pid: pid,
-                    identity: identity,
-                    callerPath: callerPath,
+                    context: automaticAuthorizationContext,
                     launcher: authorizingLauncher,
-                    scriptApproval: scriptApproval,
                     gate: configuredGate,
-                    policy: sessionPolicy,
-                    authorizationGate: authorizationGate,
-                    processChains: processChains,
-                    currentLaunchers: launchers,
-                    retainedGateProvenance: retainedGateProvenance,
-                    peer: peer,
-                    message: message
+                    policy: sessionPolicy
                 )
                 return true
             } ?? false
-            if authorized { return }
+            if handled { return }
+        }
+        let directAccessRules = loadDirectAccessRules()
+        let directAccessLauncher = matchingDirectAccessLauncher(
+            request: request,
+            configuredGate: configuredGate,
+            trustedAVGateClient: isTrustedAvCaller(path: callerPath, signing: signing),
+            launchers: policyLaunchers,
+            rules: directAccessRules
+        )
+        let durablePolicy = configuredGate.flatMap {
+            resolveSecretGatePolicy(gate: $0, launchers: policyLaunchers)
         }
         let retainedProcessExplanation: String?
         if !keepsDetachedProcessAccess,
@@ -2490,58 +2501,12 @@ private final class ApprovalServer: @unchecked Sendable {
            )
         {
             let authorizingLauncher = fallbackPolicy.launcher ?? policyLauncher
-            do {
-                let payload = try approvedPayload(
-                    for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-                )
-                let reason = secretGateAuthorizationReason(
-                    gate: configuredGate,
-                    policy: fallbackPolicy
-                )
-                let accessRequestID = UUID()
-                let record = accessRequestRecord(
-                    id: accessRequestID,
-                    request: request,
-                    callerPath: callerPath,
-                    decision: "Approved",
-                    approvalSource: "Auto",
-                    reason: reason,
-                    launcher: authorizingLauncher
-                )
-                guard onAccessRequest(record) else {
-                    reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
-                    return
-                }
-                if let authorizingLauncher {
-                    rememberRetainedProvenance(
-                        at: authorizationGate,
-                        launcher: authorizingLauncher,
-                        chains: processChains,
-                        retainedMatch: launchers.contains(where: {
-                            $0.designatedRequirement == authorizingLauncher.designatedRequirement
-                        }) ? nil : retainedGateProvenance
-                    )
-                    Task { @MainActor in
-                        self.onAutoApproval(autoApprovalRecord(
-                            accessRequestID: accessRequestID,
-                            request: request,
-                            script: scriptApproval,
-                            launcher: authorizingLauncher
-                        ))
-                    }
-                }
-                reply(peer, to: message, ok: true, error: nil, secrets: payload.secrets, value: payload.value)
-            } catch {
-                _ = onAccessRequest(accessRequestRecord(
-                    request: request,
-                    callerPath: callerPath,
-                    decision: "Failed",
-                    approvalSource: "Auto",
-                    reason: error.localizedDescription,
-                    launcher: authorizingLauncher
-                ))
-                reply(peer, to: message, ok: false, error: error.localizedDescription)
-            }
+            automaticallyAuthorize(
+                context: automaticAuthorizationContext,
+                launcher: authorizingLauncher,
+                gate: configuredGate,
+                policy: fallbackPolicy
+            )
             return
         }
         let promptLauncher = policyLauncher
@@ -2774,64 +2739,58 @@ private final class ApprovalServer: @unchecked Sendable {
     }
 
     private func automaticallyAuthorize(
-        request: ApprovalRequest,
-        awsRegistration: AWSRegistrationCandidate?,
-        pid: pid_t,
-        identity: AVProcessIdentity,
-        callerPath: String,
+        context: AutomaticAuthorizationContext,
         launcher: LauncherIdentity?,
-        scriptApproval: ScriptApproval?,
         gate: SecretGate,
-        policy: ResolvedSecretGatePolicy,
-        authorizationGate: RetainedAuthorizationGate,
-        processChains: [[RetainedProcessChainNode]],
-        currentLaunchers: [LauncherIdentity],
-        retainedGateProvenance: RetainedProcessProvenanceMatch?,
-        peer: xpc_connection_t,
-        message: xpc_object_t
+        policy: ResolvedSecretGatePolicy
     ) {
         do {
             let payload = try approvedPayload(
-                for: request,
-                awsRegistration: awsRegistration,
-                pid: pid,
-                identity: identity
+                for: context.request,
+                awsRegistration: context.awsRegistration,
+                pid: context.pid,
+                identity: context.identity
             )
             let accessRequestID = UUID()
             let record = accessRequestRecord(
                 id: accessRequestID,
-                request: request,
-                callerPath: callerPath,
+                request: context.request,
+                callerPath: context.callerPath,
                 decision: "Approved",
                 approvalSource: "Auto",
                 reason: secretGateAuthorizationReason(gate: gate, policy: policy),
                 launcher: launcher
             )
             guard onAccessRequest(record) else {
-                reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                reply(
+                    context.peer,
+                    to: context.message,
+                    ok: false,
+                    error: "approval audit log is unavailable"
+                )
                 return
             }
             if let launcher {
                 rememberRetainedProvenance(
-                    at: authorizationGate,
+                    at: context.authorizationGate,
                     launcher: launcher,
-                    chains: processChains,
-                    retainedMatch: currentLaunchers.contains(where: {
+                    chains: context.processChains,
+                    retainedMatch: context.currentLaunchers.contains(where: {
                         $0.designatedRequirement == launcher.designatedRequirement
-                    }) ? nil : retainedGateProvenance
+                    }) ? nil : context.retainedGateProvenance
                 )
                 Task { @MainActor in
                     self.onAutoApproval(autoApprovalRecord(
                         accessRequestID: accessRequestID,
-                        request: request,
-                        script: scriptApproval,
+                        request: context.request,
+                        script: context.scriptApproval,
                         launcher: launcher
                     ))
                 }
             }
             reply(
-                peer,
-                to: message,
+                context.peer,
+                to: context.message,
                 ok: true,
                 error: nil,
                 secrets: payload.secrets,
@@ -2839,14 +2798,19 @@ private final class ApprovalServer: @unchecked Sendable {
             )
         } catch {
             _ = onAccessRequest(accessRequestRecord(
-                request: request,
-                callerPath: callerPath,
+                request: context.request,
+                callerPath: context.callerPath,
                 decision: "Failed",
                 approvalSource: "Auto",
                 reason: error.localizedDescription,
                 launcher: launcher
             ))
-            reply(peer, to: message, ok: false, error: error.localizedDescription)
+            reply(
+                context.peer,
+                to: context.message,
+                ok: false,
+                error: error.localizedDescription
+            )
         }
     }
 
@@ -3805,18 +3769,16 @@ private func resolveSecretGatePolicy(
     gate: SecretGate,
     launchers: [LauncherIdentity]
 ) -> ResolvedSecretGatePolicy? {
-    for launcher in launchers {
-        if let policy = gate.appPolicies.first(where: { $0.requirement == launcher.designatedRequirement }) {
-            return ResolvedSecretGatePolicy(
-                protection: policy.requiresHardenedRuntime
-                    && !launcher.runtimeProtection.allowsSecretGateAccess
-                    ? .noAccess
-                    : policy.protection,
-                source: shortAppName(launcher.identifier),
-                launcher: launcher,
-                origin: .durable
-            )
-        }
+    if let match = matchingSecretGateAppPolicy(gate: gate, launchers: launchers) {
+        return ResolvedSecretGatePolicy(
+            protection: match.policy.requiresHardenedRuntime
+                && !match.launcher.runtimeProtection.allowsSecretGateAccess
+                ? .noAccess
+                : match.policy.protection,
+            source: shortAppName(match.launcher.identifier),
+            launcher: match.launcher,
+            origin: .durable
+        )
     }
     guard let firstLauncher = launchers.first(where: { !$0.isStandalone }) else { return nil }
     return ResolvedSecretGatePolicy(
@@ -3855,20 +3817,27 @@ private func fullAccessSessionLauncher(
     gate: SecretGate,
     launchers: [LauncherIdentity]
 ) -> LauncherIdentity? {
-    for launcher in launchers {
-        guard let policy = gate.appPolicies.first(where: {
-            $0.requirement == launcher.designatedRequirement
-        }) else {
-            continue
-        }
-        guard !policy.requiresHardenedRuntime
-                || launcher.runtimeProtection.allowsSecretGateAccess
-        else {
-            return nil
-        }
-        return launcher
+    if let match = matchingSecretGateAppPolicy(gate: gate, launchers: launchers) {
+        guard !match.policy.requiresHardenedRuntime
+                || match.launcher.runtimeProtection.allowsSecretGateAccess
+        else { return nil }
+        return match.launcher
     }
     return launchers.first { !$0.isStandalone }
+}
+
+private func matchingSecretGateAppPolicy(
+    gate: SecretGate,
+    launchers: [LauncherIdentity]
+) -> (launcher: LauncherIdentity, policy: SecretGatePolicy)? {
+    for launcher in launchers {
+        if let policy = gate.appPolicies.first(where: {
+            $0.requirement == launcher.designatedRequirement
+        }) {
+            return (launcher, policy)
+        }
+    }
+    return nil
 }
 
 private func secretGateAuthorizationReason(
@@ -7632,7 +7601,9 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
               title: "Waiting for Touch ID…",
               isEnabled: false,
               showsWarning: false
-          )
+          ),
+          fullAccessSessionConfirmationPresentation.message
+            .contains("Unknown and unverifiable requests still require approval or fail closed.")
     else {
         return 1
     }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -66,11 +66,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         action: #selector(installCLI),
         keyEquivalent: ""
     )
+    private lazy var fullAccessSessionItem = NSMenuItem(
+        title: "Start Full Access Session…",
+        action: #selector(toggleFullAccessSession),
+        keyEquivalent: ""
+    )
     private lazy var quitItem = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q")
     private lazy var quitSeparator = NSMenuItem.separator()
     private var autoApprovalItems: [NSMenuItem] = []
     private var autoApprovalSeparator: NSMenuItem?
     private var autoApprovals: [AutoApprovalRecord] = []
+    private let fullAccessSessionController = FullAccessSessionController()
+    private lazy var fullAccessSessionModel: FullAccessSessionModel = {
+        let model = FullAccessSessionModel(controller: fullAccessSessionController)
+        model.onChange = { [weak self] in
+            self?.refreshFullAccessSessionPresentation()
+        }
+        return model
+    }()
+    private var normalStatusImage: NSImage?
     private let autoApprovalTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
@@ -147,6 +161,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func userSessionDidResignActive(_ notification: Notification) {
         isUserSessionActive = false
+        fullAccessSessionModel.end()
         if NSApp.modalWindow is ApprovalPanel {
             NSApp.abortModal()
         }
@@ -159,6 +174,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func screensDidSleep(_ notification: Notification) {
         areScreensAwake = false
+        fullAccessSessionModel.end()
         if NSApp.modalWindow is ApprovalPanel {
             NSApp.abortModal()
         }
@@ -169,11 +185,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installStatusMenu() {
-        statusItem.button?.image = brandImage()
+        normalStatusImage = brandImage()
+        refreshStatusImage()
 
         let menu = NSMenu()
         menu.addItem(scanStatusItem)
         menu.addItem(doctorStatusItem)
+        menu.addItem(.separator())
+        fullAccessSessionItem.target = self
+        menu.addItem(fullAccessSessionItem)
         menu.addItem(.separator())
         checkForUpdatesItem.target = self
         menu.addItem(checkForUpdatesItem)
@@ -193,7 +213,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handOffToLaunchAgent() {
         isStartingUp = true
-        statusItem.button?.image = brandImage()
+        normalStatusImage = brandImage()
+        refreshStatusImage()
         statusItem.button?.alphaValue = 0.5
         setStatusMenuItemTitle("Starting Automic Vault", on: scanStatusItem)
         updateMenuVisibility(
@@ -251,14 +272,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             doctorStatusItem.isHidden = doctorStatusItem.title.isEmpty
             installCLIItem.isHidden = FileManager.default.fileExists(atPath: installedAVCLIPath)
         }
-        statusItem.button?.image = brandImage()
+        normalStatusImage = brandImage()
+        refreshStatusImage()
         statusItem.button?.alphaValue = 1
         _ = migrateBackgroundKeychainItems()
         autoApprovals = loadAccessRequestRecords().compactMap(autoApprovalRecord)
         refreshAutoApprovalMenuItems()
         refreshCLIInstallState()
         do {
-            let approval = try ApprovalServer(serviceName: approvalServiceName) { [weak self] event in
+            let approval = try ApprovalServer(
+                serviceName: approvalServiceName,
+                fullAccessSession: fullAccessSessionController
+            ) { [weak self] event in
                 self?.recordAutoApproval(event)
             } onAccessRequest: { [weak self] record in
                 let recorded = appendAccessRequestRecord(record)
@@ -297,6 +322,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        fullAccessSessionModel.end()
         automaticUpdateCheckTask?.cancel()
         NSWorkspace.shared.notificationCenter.removeObserver(self)
         stopServices()
@@ -340,6 +366,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor @objc private func quit() {
         NSApp.terminate(nil)
+    }
+
+    @MainActor @objc private func toggleFullAccessSession() {
+        fullAccessSessionModel.refresh()
+        if fullAccessSessionModel.isActive {
+            fullAccessSessionModel.end()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Start Full Access Session?"
+        alert.informativeText = "For up to one hour, every recognized operation from every verified app may run automatically, including operations that use or disclose protected secrets. Unknown and unverifiable requests still require approval or fail closed."
+        alert.addButton(withTitle: "Continue to Touch ID")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        fullAccessSessionModel.start()
     }
 
     @MainActor @objc private func checkForUpdates() {
@@ -519,7 +562,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let controller = AutomicVaultMainWindowController { [weak self] in
+        let controller = AutomicVaultMainWindowController(
+            fullAccessSession: fullAccessSessionModel
+        ) { [weak self] in
             self?.checkForUpdates()
         }
         controller.setAvailableUpdateVersion(readyUpdate?.version)
@@ -629,7 +674,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             #if !DEBUG
             lastTelemetryFindingCount = nil
             #endif
-            statusItem.button?.image = brandImage()
+            normalStatusImage = brandImage()
+            refreshStatusImage()
             setScanStatus(
                 "No Vulnerabilities Detected",
                 image: shieldImage(symbolName: "shield.fill", color: .systemGreen)
@@ -643,17 +689,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 lastTelemetryFindingCount = detectorCount
             }
             #endif
-            statusItem.button?.image = switch level {
+            normalStatusImage = switch level {
             case .medium: brandImage()
             case .high: brandImage(color: .systemRed)
             }
+            refreshStatusImage()
             setScanStatus(
                 vulnerabilityStatusTitle(count: count),
                 image: shieldImage(color: level.color)
             )
         case .failed:
-            statusItem.button?.image = brandImage(color: .systemRed)
+            normalStatusImage = brandImage(color: .systemRed)
+            refreshStatusImage()
             setScanStatus("Scan failed", image: shieldImage(color: .systemRed))
+        }
+    }
+
+    private func refreshFullAccessSessionPresentation() {
+        automaticApprovalFlashWorkItem?.cancel()
+        automaticApprovalFlashWorkItem = nil
+        preFlashStatusImage = nil
+        if let snapshot = fullAccessSessionModel.snapshot {
+            fullAccessSessionItem.title = "End Full Access Session (\(fullAccessSessionRemainingLabel(snapshot)))"
+        } else {
+            fullAccessSessionItem.title = fullAccessSessionModel.isAuthenticating
+                ? "Waiting for Touch ID…"
+                : "Start Full Access Session…"
+        }
+        fullAccessSessionItem.isEnabled = !fullAccessSessionModel.isAuthenticating
+        refreshStatusImage()
+    }
+
+    private func refreshStatusImage() {
+        statusItem.button?.image = if fullAccessSessionModel.isActive {
+            shieldImage(
+                symbolName: "exclamationmark.shield.fill",
+                color: .systemOrange,
+                accessibilityDescription: "Full Access Session active"
+            )
+        } else {
+            normalStatusImage ?? brandImage()
         }
     }
 
@@ -885,6 +960,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 extension AppDelegate: NSMenuDelegate {
     func menuWillOpen(_ menu: NSMenu) {
         guard !isStartingUp, !isUpdating else { return }
+        fullAccessSessionModel.refresh()
+        refreshFullAccessSessionPresentation()
         refreshAutoApprovalMenuItems()
         refreshDoctorStatus()
     }
@@ -1716,6 +1793,7 @@ private final class ApprovalServer: @unchecked Sendable {
     private let serviceName: String
     private let teamIdentifier: String
     private let hardeners: [HardenerMetadata]?
+    private let fullAccessSession: FullAccessSessionController
     private let onAutoApproval: @MainActor (AutoApprovalRecord) -> Void
     private let onAccessRequest: @Sendable (AccessRequestRecord) -> Bool
     private let onBlessRequest: @MainActor (
@@ -1735,6 +1813,7 @@ private final class ApprovalServer: @unchecked Sendable {
 
     init(
         serviceName: String,
+        fullAccessSession: FullAccessSessionController = FullAccessSessionController(),
         hardeners: [HardenerMetadata]? = nil,
         onAutoApproval: @escaping @MainActor (AutoApprovalRecord) -> Void = { _ in },
         onAccessRequest: @escaping @Sendable (AccessRequestRecord) -> Bool = { appendAccessRequestRecord($0) },
@@ -1750,6 +1829,7 @@ private final class ApprovalServer: @unchecked Sendable {
         self.serviceName = serviceName
         self.teamIdentifier = teamIdentifier
         self.hardeners = hardeners
+        self.fullAccessSession = fullAccessSession
         self.onAutoApproval = onAutoApproval
         self.onAccessRequest = onAccessRequest
         self.onBlessRequest = onBlessRequest
@@ -2244,12 +2324,23 @@ private final class ApprovalServer: @unchecked Sendable {
             launchers: policyLaunchers,
             rules: directAccessRules
         )
-        let resolvedPolicy = configuredGate.flatMap {
+        let durablePolicy = configuredGate.flatMap {
             resolveSecretGatePolicy(gate: $0, launchers: policyLaunchers)
         }
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
         }
+        let sessionPolicy: ResolvedSecretGatePolicy? = if let configuredGate, let classification {
+            resolveFullAccessSessionPolicy(
+                gate: configuredGate,
+                launchers: policyLaunchers,
+                classification: classification,
+                sessionActive: fullAccessSession.isActive()
+            )
+        } else {
+            nil
+        }
+        let resolvedPolicy = sessionPolicy ?? durablePolicy
         let retainedProcessExplanation: String?
         if !keepsDetachedProcessAccess,
            retainedBlessingMatch != nil,
@@ -2367,7 +2458,10 @@ private final class ApprovalServer: @unchecked Sendable {
                 let payload = try approvedPayload(
                     for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
                 )
-                let reason = "\(configuredGate.protectionTitle(resolvedPolicy.protection)) from \(resolvedPolicy.source)"
+                let reason = secretGateAuthorizationReason(
+                    gate: configuredGate,
+                    policy: resolvedPolicy
+                )
                 let accessRequestID = UUID()
                 let record = accessRequestRecord(
                     id: accessRequestID,
@@ -3610,6 +3704,58 @@ private func resolveSecretGatePolicy(
         source: gate.defaultPolicyLabel,
         launcher: firstLauncher
     )
+}
+
+private func resolveFullAccessSessionPolicy(
+    gate: SecretGate,
+    launchers: [LauncherIdentity],
+    classification: SecretGateRequestClassification,
+    sessionActive: Bool
+) -> ResolvedSecretGatePolicy? {
+    guard let launcher = fullAccessSessionLauncher(gate: gate, launchers: launchers),
+          let protection = fullAccessSessionProtection(
+              for: gate,
+              classification: classification,
+              launcherEligible: true,
+              sessionActive: sessionActive
+          )
+    else {
+        return nil
+    }
+    return ResolvedSecretGatePolicy(
+        protection: protection,
+        source: "Full Access Session",
+        launcher: launcher
+    )
+}
+
+private func fullAccessSessionLauncher(
+    gate: SecretGate,
+    launchers: [LauncherIdentity]
+) -> LauncherIdentity? {
+    for launcher in launchers {
+        guard let policy = gate.appPolicies.first(where: {
+            $0.requirement == launcher.designatedRequirement
+        }) else {
+            continue
+        }
+        guard !policy.requiresHardenedRuntime
+                || launcher.runtimeProtection.allowsSecretGateAccess
+        else {
+            return nil
+        }
+        return launcher
+    }
+    return launchers.first { !$0.isStandalone }
+}
+
+private func secretGateAuthorizationReason(
+    gate: SecretGate,
+    policy: ResolvedSecretGatePolicy
+) -> String {
+    policy.source == "Full Access Session"
+        ? policy.source
+        : "\(gate.protectionTitle(policy.protection)) from \(policy.source)"
 }
 
 private func secretGateProtectionAllows(
@@ -5913,6 +6059,36 @@ private func runApprovalSelfCheck() -> Int32 {
           resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [blockedLauncher])?.protection == .readOnly,
           resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [unhardenedLauncher])?.protection == .noAccess,
           resolveSecretGatePolicy(gate: grandfatheredGate, launchers: [unhardenedLauncher])?.protection == .readOnly,
+          resolveFullAccessSessionPolicy(
+              gate: policyGate,
+              launchers: [],
+              classification: .readOnly,
+              sessionActive: true
+          ) == nil,
+          resolveFullAccessSessionPolicy(
+              gate: policyGate,
+              launchers: [blockedLauncher],
+              classification: .secretDump,
+              sessionActive: true
+          )?.protection == .fullIncludingSecretDumps,
+          resolveFullAccessSessionPolicy(
+              gate: policyGate,
+              launchers: [blockedLauncher],
+              classification: .unknown,
+              sessionActive: true
+          ) == nil,
+          resolveFullAccessSessionPolicy(
+              gate: policyGate,
+              launchers: [blockedLauncher],
+              classification: .readOnly,
+              sessionActive: false
+          ) == nil,
+          resolveFullAccessSessionPolicy(
+              gate: runtimeProtectedGate,
+              launchers: [unhardenedLauncher],
+              classification: .readOnly,
+              sessionActive: true
+          ) == nil,
           matchingSecretGate(request: readOnlyGh, signing: ghSigning, hardeners: [ghMetadata])?.id == "gh",
           matchingSecretGate(request: ghRequest(keys: ["OTHER_TOKEN"]), signing: ghSigning, hardeners: [ghMetadata]) == nil,
           matchingSecretGate(request: ghRequest(keys: []), signing: ghSigning, hardeners: [ghMetadata]) == nil,
@@ -7194,6 +7370,94 @@ private func runUpdatePreflight() async -> Int32 {
     }
 }
 
+@MainActor
+private func runFullAccessSessionSelfCheck() async -> Int32 {
+    let now = Date(timeIntervalSince1970: 1_000)
+    let controller = FullAccessSessionController()
+    guard !controller.isActive(at: now),
+          !controller.start(at: now, duration: 0),
+          controller.start(at: now, duration: fullAccessSessionMaximumDuration * 2),
+          controller.snapshot(at: now)?.expiresAt
+            == now.addingTimeInterval(fullAccessSessionMaximumDuration),
+          !controller.isActive(at: now.addingTimeInterval(fullAccessSessionMaximumDuration))
+    else {
+        return 1
+    }
+
+    let gate = SecretGate(
+        id: "gh",
+        keyPatterns: ["GH_TOKEN_*"],
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: []
+    )
+    let launcher = LauncherIdentity(
+        pid: 42,
+        path: "/Applications/Terminal.app/Contents/MacOS/Terminal",
+        identifier: "com.apple.Terminal",
+        teamIdentifier: "APPLE",
+        designatedRequirement: #"identifier "com.apple.Terminal" and anchor apple"#,
+        runtimeProtection: .hardened
+    )
+    guard resolveFullAccessSessionPolicy(
+        gate: gate,
+        launchers: [launcher],
+        classification: .secretDump,
+        sessionActive: true
+    ).map({ secretGateAuthorizationReason(gate: gate, policy: $0) })
+        == "Full Access Session",
+        resolveFullAccessSessionPolicy(
+            gate: gate,
+            launchers: [launcher],
+            classification: .unknown,
+            sessionActive: true
+        ) == nil,
+        resolveFullAccessSessionPolicy(
+            gate: gate,
+            launchers: [],
+            classification: .readOnly,
+            sessionActive: true
+        ) == nil
+    else {
+        return 1
+    }
+
+    let authenticatedController = FullAccessSessionController()
+    let authenticated = FullAccessSessionModel(
+        controller: authenticatedController,
+        authenticate: { true }
+    )
+    await authenticated.authenticateAndStart()
+    guard authenticated.isActive,
+          authenticated.snapshot.map({ fullAccessSessionRemainingLabel($0) })?
+            .contains("remaining") == true
+    else {
+        return 1
+    }
+    authenticated.end()
+    guard !authenticated.isActive else { return 1 }
+
+    let rejected = FullAccessSessionModel(
+        controller: FullAccessSessionController(),
+        authenticate: { false }
+    )
+    await rejected.authenticateAndStart()
+    guard !rejected.isActive else { return 1 }
+
+    let canceled = FullAccessSessionModel(
+        controller: FullAccessSessionController(),
+        authenticate: {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+            return true
+        }
+    )
+    canceled.start()
+    await Task.yield()
+    canceled.end()
+    try? await Task.sleep(nanoseconds: 30_000_000)
+    return canceled.isActive ? 1 : 0
+}
+
 if CommandLine.arguments.contains("--self-check-approvals") {
     exit(MainActor.assumeIsolated { runApprovalSelfCheck() })
 }
@@ -7240,6 +7504,13 @@ if CommandLine.arguments.contains("--self-check-launch-agent-handoff") {
 
 if CommandLine.arguments.contains("--self-check-menu-status") {
     exit(MainActor.assumeIsolated { runMenuStatusSelfCheck() })
+}
+
+if CommandLine.arguments.contains("--self-check-full-access-session") {
+    Task { @MainActor in
+        exit(await runFullAccessSessionSelfCheck())
+    }
+    dispatchMain()
 }
 
 if CommandLine.arguments.contains("--self-check-scan-scheduling") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -379,9 +379,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.alertStyle = .warning
         alert.messageText = fullAccessSessionConfirmationPresentation.title
         alert.informativeText = fullAccessSessionConfirmationPresentation.message
+        let lifetimePicker = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 180, height: 26))
+        let lifetimes = FullAccessSessionLifetime.allCases
+        lifetimePicker.addItems(withTitles: lifetimes.map(\.title))
+        if let selectedIndex = lifetimes.firstIndex(of: fullAccessSessionModel.selectedLifetime) {
+            lifetimePicker.selectItem(at: selectedIndex)
+        }
+        let lifetimeLabel = NSTextField(labelWithString: "Duration")
+        let lifetimeControls = NSStackView(views: [lifetimeLabel, lifetimePicker])
+        lifetimeControls.orientation = .horizontal
+        lifetimeControls.spacing = 12
+        alert.accessoryView = lifetimeControls
         alert.addButton(withTitle: fullAccessSessionConfirmationPresentation.actionTitle)
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let selectedIndex = lifetimePicker.indexOfSelectedItem
+        guard lifetimes.indices.contains(selectedIndex) else { return }
+        fullAccessSessionModel.selectedLifetime = lifetimes[selectedIndex]
         fullAccessSessionModel.start()
     }
 
@@ -7486,24 +7500,19 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
     let now = Date(timeIntervalSince1970: 1_000)
     let controller = FullAccessSessionController()
     guard !controller.isActive(at: now, uptime: 100),
-          !controller.start(at: now, uptime: 100, duration: 0),
-          controller.start(
-              at: now,
-              uptime: 100,
-              duration: fullAccessSessionMaximumDuration * 2
-          ),
+          controller.start(at: now, uptime: 100, lifetime: .oneHour),
           controller.snapshot(at: now, uptime: 100)?.expiresAt
-            == now.addingTimeInterval(fullAccessSessionMaximumDuration),
+            == now.addingTimeInterval(60 * 60),
           !controller.isActive(
               at: now.addingTimeInterval(-300),
-              uptime: 100 + fullAccessSessionMaximumDuration
+              uptime: 100 + 60 * 60
           )
     else {
         return 1
     }
 
     let leasedController = FullAccessSessionController()
-    guard leasedController.start(at: now, uptime: 200, duration: 60),
+    guard leasedController.start(at: now, uptime: 200, lifetime: .untilEnded),
           let lease = leasedController.lease(at: now, uptime: 200),
           leasedController.withActiveLease(lease, at: now, uptime: 200, {
               "released"
@@ -7584,16 +7593,22 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
     let authenticatedController = FullAccessSessionController()
     let authenticated = FullAccessSessionModel(
         controller: authenticatedController,
-        authenticate: { true }
+        authenticate: { lifetime in lifetime == .untilEnded }
     )
     await authenticated.authenticateAndStart()
     guard authenticated.isActive,
-          authenticated.snapshot.map({ fullAccessSessionRemainingLabel($0) })?
-            .contains("remaining") == true,
+          authenticated.selectedLifetime == .untilEnded,
+          authenticated.snapshot?.lifetime == .untilEnded,
+          authenticated.snapshot.map({ fullAccessSessionRemainingLabel($0) })
+            == "Until turned off",
           fullAccessSessionMenuPresentation(
               snapshot: authenticated.snapshot,
               isAuthenticating: false
-          ).showsWarning,
+          ) == FullAccessSessionMenuPresentation(
+              title: "End Full Access Session (Until turned off)",
+              isEnabled: true,
+              showsWarning: true
+          ),
           fullAccessSessionMenuPresentation(
               snapshot: nil,
               isAuthenticating: true
@@ -7603,7 +7618,7 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
               showsWarning: false
           ),
           fullAccessSessionConfirmationPresentation.message
-            .contains("Unknown and unverifiable requests still require approval or fail closed.")
+            .contains("every valid recognized operation from every verified app may be automically authorized")
     else {
         return 1
     }
@@ -7612,14 +7627,14 @@ private func runFullAccessSessionSelfCheck() async -> Int32 {
 
     let rejected = FullAccessSessionModel(
         controller: FullAccessSessionController(),
-        authenticate: { false }
+        authenticate: { _ in false }
     )
     await rejected.authenticateAndStart()
     guard !rejected.isActive else { return 1 }
 
     let canceled = FullAccessSessionModel(
         controller: FullAccessSessionController(),
-        authenticate: {
+        authenticate: { _ in
             try? await Task.sleep(nanoseconds: 20_000_000)
             return true
         }

--- a/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
@@ -1,12 +1,30 @@
 import Foundation
 
-public let fullAccessSessionMaximumDuration: TimeInterval = 60 * 60
+public enum FullAccessSessionLifetime: String, CaseIterable, Hashable, Sendable {
+    case oneHour
+    case eightHours
+    case untilEnded
+
+    fileprivate var duration: TimeInterval? {
+        switch self {
+        case .oneHour: 60 * 60
+        case .eightHours: 8 * 60 * 60
+        case .untilEnded: nil
+        }
+    }
+}
 
 public struct FullAccessSessionSnapshot: Equatable, Sendable {
-    public let expiresAt: Date
-    private let expiresAtUptime: TimeInterval
+    public let lifetime: FullAccessSessionLifetime
+    public let expiresAt: Date?
+    private let expiresAtUptime: TimeInterval?
 
-    public init(expiresAt: Date, expiresAtUptime: TimeInterval) {
+    fileprivate init(
+        lifetime: FullAccessSessionLifetime,
+        expiresAt: Date?,
+        expiresAtUptime: TimeInterval?
+    ) {
+        self.lifetime = lifetime
         self.expiresAt = expiresAt
         self.expiresAtUptime = expiresAtUptime
     }
@@ -15,14 +33,16 @@ public struct FullAccessSessionSnapshot: Equatable, Sendable {
         at date: Date = Date(),
         uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
     ) -> Bool {
-        expiresAt > date && expiresAtUptime > uptime
+        guard let expiresAt, let expiresAtUptime else { return true }
+        return expiresAt > date && expiresAtUptime > uptime
     }
 
     public func remaining(
         at date: Date = Date(),
         uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
-    ) -> TimeInterval {
-        max(0, min(
+    ) -> TimeInterval? {
+        guard let expiresAt, let expiresAtUptime else { return nil }
+        return max(0, min(
             expiresAt.timeIntervalSince(date),
             expiresAtUptime - uptime
         ))
@@ -49,16 +69,17 @@ public final class FullAccessSessionController: @unchecked Sendable {
     public func start(
         at date: Date = Date(),
         uptime: TimeInterval = ProcessInfo.processInfo.systemUptime,
-        duration: TimeInterval = fullAccessSessionMaximumDuration
+        lifetime: FullAccessSessionLifetime = .untilEnded
     ) -> Bool {
-        guard uptime.isFinite, duration.isFinite, duration > 0 else { return false }
-        let boundedDuration = min(duration, fullAccessSessionMaximumDuration)
-        let expiresAtUptime = uptime + boundedDuration
-        guard expiresAtUptime.isFinite else { return false }
+        guard uptime.isFinite else { return false }
+        let expiresAt = lifetime.duration.map(date.addingTimeInterval)
+        let expiresAtUptime = lifetime.duration.map { uptime + $0 }
+        if let expiresAtUptime, !expiresAtUptime.isFinite { return false }
         let newState = State(
             id: UUID(),
             snapshot: FullAccessSessionSnapshot(
-                expiresAt: date.addingTimeInterval(boundedDuration),
+                lifetime: lifetime,
+                expiresAt: expiresAt,
                 expiresAtUptime: expiresAtUptime
             )
         )

--- a/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
@@ -4,22 +4,39 @@ public let fullAccessSessionMaximumDuration: TimeInterval = 60 * 60
 
 public struct FullAccessSessionSnapshot: Equatable, Sendable {
     public let expiresAt: Date
+    private let expiresAtUptime: TimeInterval
 
-    public init(expiresAt: Date) {
+    public init(expiresAt: Date, expiresAtUptime: TimeInterval) {
         self.expiresAt = expiresAt
+        self.expiresAtUptime = expiresAtUptime
     }
 
-    public func isActive(at date: Date = Date()) -> Bool {
-        expiresAt > date
+    public func isActive(
+        at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Bool {
+        expiresAt > date && expiresAtUptime > uptime
     }
 
-    public func remaining(at date: Date = Date()) -> TimeInterval {
-        max(0, expiresAt.timeIntervalSince(date))
+    public func remaining(
+        at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> TimeInterval {
+        max(0, min(
+            expiresAt.timeIntervalSince(date),
+            expiresAtUptime - uptime
+        ))
     }
+}
+
+public struct FullAccessSessionLease: Equatable, Sendable {
+    fileprivate let id: UUID
+    public let snapshot: FullAccessSessionSnapshot
 }
 
 public final class FullAccessSessionController: @unchecked Sendable {
     private struct State {
+        let id: UUID
         let expiresAt: Date
         let expiresAtUptime: TimeInterval
     }
@@ -40,6 +57,7 @@ public final class FullAccessSessionController: @unchecked Sendable {
         let expiresAtUptime = uptime + boundedDuration
         guard expiresAtUptime.isFinite else { return false }
         let newState = State(
+            id: UUID(),
             expiresAt: date.addingTimeInterval(boundedDuration),
             expiresAtUptime: expiresAtUptime
         )
@@ -55,15 +73,34 @@ public final class FullAccessSessionController: @unchecked Sendable {
         at date: Date = Date(),
         uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
     ) -> FullAccessSessionSnapshot? {
+        lease(at: date, uptime: uptime)?.snapshot
+    }
+
+    public func lease(
+        at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> FullAccessSessionLease? {
         lock.withLock {
-            guard let state,
-                  state.expiresAt > date,
-                  state.expiresAtUptime > uptime
-            else {
-                self.state = nil
-                return nil
-            }
-            return FullAccessSessionSnapshot(expiresAt: state.expiresAt)
+            guard let state = activeState(at: date, uptime: uptime) else { return nil }
+            return FullAccessSessionLease(
+                id: state.id,
+                snapshot: FullAccessSessionSnapshot(
+                    expiresAt: state.expiresAt,
+                    expiresAtUptime: state.expiresAtUptime
+                )
+            )
+        }
+    }
+
+    public func withActiveLease<Result>(
+        _ lease: FullAccessSessionLease,
+        at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime,
+        _ release: () throws -> Result
+    ) rethrows -> Result? {
+        try lock.withLock {
+            guard activeState(at: date, uptime: uptime)?.id == lease.id else { return nil }
+            return try release()
         }
     }
 
@@ -72,6 +109,17 @@ public final class FullAccessSessionController: @unchecked Sendable {
         uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
     ) -> Bool {
         snapshot(at: date, uptime: uptime) != nil
+    }
+
+    private func activeState(at date: Date, uptime: TimeInterval) -> State? {
+        guard let state,
+              state.expiresAt > date,
+              state.expiresAtUptime > uptime
+        else {
+            self.state = nil
+            return nil
+        }
+        return state
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public let fullAccessSessionMaximumDuration: TimeInterval = 60 * 60
+
+public struct FullAccessSessionSnapshot: Equatable, Sendable {
+    public let expiresAt: Date
+
+    public init(expiresAt: Date) {
+        self.expiresAt = expiresAt
+    }
+
+    public func isActive(at date: Date = Date()) -> Bool {
+        expiresAt > date
+    }
+
+    public func remaining(at date: Date = Date()) -> TimeInterval {
+        max(0, expiresAt.timeIntervalSince(date))
+    }
+}
+
+public final class FullAccessSessionController: @unchecked Sendable {
+    private let lock = NSLock()
+    private var expiresAt: Date?
+
+    public init() {}
+
+    @discardableResult
+    public func start(
+        at date: Date = Date(),
+        duration: TimeInterval = fullAccessSessionMaximumDuration
+    ) -> Bool {
+        guard duration.isFinite, duration > 0 else { return false }
+        let expiration = date.addingTimeInterval(min(duration, fullAccessSessionMaximumDuration))
+        lock.lock()
+        expiresAt = expiration
+        lock.unlock()
+        return true
+    }
+
+    public func end() {
+        lock.lock()
+        expiresAt = nil
+        lock.unlock()
+    }
+
+    public func snapshot(at date: Date = Date()) -> FullAccessSessionSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let expiresAt, expiresAt > date else {
+            self.expiresAt = nil
+            return nil
+        }
+        return FullAccessSessionSnapshot(expiresAt: expiresAt)
+    }
+
+    public func isActive(at date: Date = Date()) -> Bool {
+        snapshot(at: date) != nil
+    }
+}
+
+public func fullAccessSessionProtection(
+    for gate: SecretGate,
+    classification: SecretGateRequestClassification,
+    launcherEligible: Bool,
+    sessionActive: Bool
+) -> SecretGateProtection? {
+    guard launcherEligible, sessionActive else { return nil }
+    let protection = gate.normalizedProtection(.fullIncludingSecretDumps)
+    return protection.allows(classification) ? protection : nil
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
@@ -19,42 +19,59 @@ public struct FullAccessSessionSnapshot: Equatable, Sendable {
 }
 
 public final class FullAccessSessionController: @unchecked Sendable {
+    private struct State {
+        let expiresAt: Date
+        let expiresAtUptime: TimeInterval
+    }
+
     private let lock = NSLock()
-    private var expiresAt: Date?
+    private var state: State?
 
     public init() {}
 
     @discardableResult
     public func start(
         at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime,
         duration: TimeInterval = fullAccessSessionMaximumDuration
     ) -> Bool {
-        guard duration.isFinite, duration > 0 else { return false }
-        let expiration = date.addingTimeInterval(min(duration, fullAccessSessionMaximumDuration))
-        lock.lock()
-        expiresAt = expiration
-        lock.unlock()
+        guard uptime.isFinite, duration.isFinite, duration > 0 else { return false }
+        let boundedDuration = min(duration, fullAccessSessionMaximumDuration)
+        let expiresAtUptime = uptime + boundedDuration
+        guard expiresAtUptime.isFinite else { return false }
+        let newState = State(
+            expiresAt: date.addingTimeInterval(boundedDuration),
+            expiresAtUptime: expiresAtUptime
+        )
+        lock.withLock { state = newState }
         return true
     }
 
     public func end() {
-        lock.lock()
-        expiresAt = nil
-        lock.unlock()
+        lock.withLock { state = nil }
     }
 
-    public func snapshot(at date: Date = Date()) -> FullAccessSessionSnapshot? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let expiresAt, expiresAt > date else {
-            self.expiresAt = nil
-            return nil
+    public func snapshot(
+        at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> FullAccessSessionSnapshot? {
+        lock.withLock {
+            guard let state,
+                  state.expiresAt > date,
+                  state.expiresAtUptime > uptime
+            else {
+                self.state = nil
+                return nil
+            }
+            return FullAccessSessionSnapshot(expiresAt: state.expiresAt)
         }
-        return FullAccessSessionSnapshot(expiresAt: expiresAt)
     }
 
-    public func isActive(at date: Date = Date()) -> Bool {
-        snapshot(at: date) != nil
+    public func isActive(
+        at date: Date = Date(),
+        uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Bool {
+        snapshot(at: date, uptime: uptime) != nil
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/FullAccessSession.swift
@@ -37,8 +37,7 @@ public struct FullAccessSessionLease: Equatable, Sendable {
 public final class FullAccessSessionController: @unchecked Sendable {
     private struct State {
         let id: UUID
-        let expiresAt: Date
-        let expiresAtUptime: TimeInterval
+        let snapshot: FullAccessSessionSnapshot
     }
 
     private let lock = NSLock()
@@ -58,8 +57,10 @@ public final class FullAccessSessionController: @unchecked Sendable {
         guard expiresAtUptime.isFinite else { return false }
         let newState = State(
             id: UUID(),
-            expiresAt: date.addingTimeInterval(boundedDuration),
-            expiresAtUptime: expiresAtUptime
+            snapshot: FullAccessSessionSnapshot(
+                expiresAt: date.addingTimeInterval(boundedDuration),
+                expiresAtUptime: expiresAtUptime
+            )
         )
         lock.withLock { state = newState }
         return true
@@ -84,10 +85,7 @@ public final class FullAccessSessionController: @unchecked Sendable {
             guard let state = activeState(at: date, uptime: uptime) else { return nil }
             return FullAccessSessionLease(
                 id: state.id,
-                snapshot: FullAccessSessionSnapshot(
-                    expiresAt: state.expiresAt,
-                    expiresAtUptime: state.expiresAtUptime
-                )
+                snapshot: state.snapshot
             )
         }
     }
@@ -113,8 +111,7 @@ public final class FullAccessSessionController: @unchecked Sendable {
 
     private func activeState(at date: Date, uptime: TimeInterval) -> State? {
         guard let state,
-              state.expiresAt > date,
-              state.expiresAtUptime > uptime
+              state.snapshot.isActive(at: date, uptime: uptime)
         else {
             self.state = nil
             return nil

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
@@ -16,13 +16,17 @@ import Testing
     let now = Date(timeIntervalSince1970: 2_000)
     let session = FullAccessSessionController()
 
-    #expect(!session.start(at: now, duration: 0))
-    #expect(!session.start(at: now, duration: -1))
-    #expect(!session.start(at: now, duration: .infinity))
-    #expect(!session.start(at: now, duration: .nan))
-    #expect(session.start(at: now, duration: fullAccessSessionMaximumDuration * 2))
+    #expect(!session.start(at: now, uptime: 100, duration: 0))
+    #expect(!session.start(at: now, uptime: 100, duration: -1))
+    #expect(!session.start(at: now, uptime: 100, duration: .infinity))
+    #expect(!session.start(at: now, uptime: 100, duration: .nan))
+    #expect(session.start(
+        at: now,
+        uptime: 100,
+        duration: fullAccessSessionMaximumDuration * 2
+    ))
 
-    let snapshot = try #require(session.snapshot(at: now))
+    let snapshot = try #require(session.snapshot(at: now, uptime: 100))
     #expect(snapshot.expiresAt == now.addingTimeInterval(fullAccessSessionMaximumDuration))
     #expect(snapshot.remaining(at: now) == fullAccessSessionMaximumDuration)
 }
@@ -31,14 +35,25 @@ import Testing
     let now = Date(timeIntervalSince1970: 3_000)
     let session = FullAccessSessionController()
 
-    #expect(session.start(at: now, duration: 30))
-    #expect(session.isActive(at: now.addingTimeInterval(29)))
-    #expect(!session.isActive(at: now.addingTimeInterval(30)))
-    #expect(session.snapshot(at: now.addingTimeInterval(30)) == nil)
+    #expect(session.start(at: now, uptime: 200, duration: 30))
+    #expect(session.isActive(at: now.addingTimeInterval(29), uptime: 229))
+    #expect(!session.isActive(at: now.addingTimeInterval(30), uptime: 230))
+    #expect(session.snapshot(at: now.addingTimeInterval(30), uptime: 230) == nil)
 
-    #expect(session.start(at: now, duration: 30))
+    #expect(session.start(at: now, uptime: 300, duration: 30))
     session.end()
-    #expect(!session.isActive(at: now))
+    #expect(!session.isActive(at: now, uptime: 300))
+}
+
+@Test func fullAccessSessionExpiresWhenTheWallClockMovesBackward() {
+    let now = Date(timeIntervalSince1970: 4_000)
+    let session = FullAccessSessionController()
+
+    #expect(session.start(at: now, uptime: 500, duration: 60))
+    #expect(session.snapshot(
+        at: now.addingTimeInterval(-300),
+        uptime: 560
+    ) == nil)
 }
 
 @Test(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+@Test func fullAccessSessionStartsInactiveAndDoesNotPersistAcrossControllers() {
+    let now = Date(timeIntervalSince1970: 1_000)
+    let first = FullAccessSessionController()
+
+    #expect(!first.isActive(at: now))
+    #expect(first.start(at: now, duration: 300))
+    #expect(first.isActive(at: now))
+    #expect(!FullAccessSessionController().isActive(at: now))
+}
+
+@Test func fullAccessSessionDurationIsPositiveAndCappedAtOneHour() throws {
+    let now = Date(timeIntervalSince1970: 2_000)
+    let session = FullAccessSessionController()
+
+    #expect(!session.start(at: now, duration: 0))
+    #expect(!session.start(at: now, duration: -1))
+    #expect(!session.start(at: now, duration: .infinity))
+    #expect(!session.start(at: now, duration: .nan))
+    #expect(session.start(at: now, duration: fullAccessSessionMaximumDuration * 2))
+
+    let snapshot = try #require(session.snapshot(at: now))
+    #expect(snapshot.expiresAt == now.addingTimeInterval(fullAccessSessionMaximumDuration))
+    #expect(snapshot.remaining(at: now) == fullAccessSessionMaximumDuration)
+}
+
+@Test func fullAccessSessionExpiresAndCanAlwaysBeEnded() {
+    let now = Date(timeIntervalSince1970: 3_000)
+    let session = FullAccessSessionController()
+
+    #expect(session.start(at: now, duration: 30))
+    #expect(session.isActive(at: now.addingTimeInterval(29)))
+    #expect(!session.isActive(at: now.addingTimeInterval(30)))
+    #expect(session.snapshot(at: now.addingTimeInterval(30)) == nil)
+
+    #expect(session.start(at: now, duration: 30))
+    session.end()
+    #expect(!session.isActive(at: now))
+}
+
+@Test(
+    arguments: SecretGateRequestClassification.allCases
+)
+func fullAccessSessionAllowsEveryRecognizedClassification(
+    classification: SecretGateRequestClassification
+) {
+    let gate = fullAccessTestGate(id: "aws", keyPatterns: ["AWS_*"])
+    let protection = fullAccessSessionProtection(
+        for: gate,
+        classification: classification,
+        launcherEligible: true,
+        sessionActive: true
+    )
+
+    if classification == .unknown {
+        #expect(protection == nil)
+    } else {
+        #expect(protection == .fullIncludingSecretDumps)
+    }
+}
+
+@Test func fullAccessSessionRequiresAnActiveSessionAndEligibleLauncher() {
+    let gate = fullAccessTestGate(id: "aws", keyPatterns: ["AWS_*"])
+
+    #expect(fullAccessSessionProtection(
+        for: gate,
+        classification: .readOnly,
+        launcherEligible: false,
+        sessionActive: true
+    ) == nil)
+    #expect(fullAccessSessionProtection(
+        for: gate,
+        classification: .readOnly,
+        launcherEligible: true,
+        sessionActive: false
+    ) == nil)
+}
+
+@Test func fullAccessSessionUsesEachGatesNormalizedFullAccessLevel() {
+    let brew = fullAccessTestGate(id: "brew", keyPatterns: [])
+    let secretless = fullAccessTestGate(id: "custom", keyPatterns: [])
+
+    #expect(fullAccessSessionProtection(
+        for: brew,
+        classification: .mutating,
+        launcherEligible: true,
+        sessionActive: true
+    ) == .fullExceptSecretDumps)
+    #expect(fullAccessSessionProtection(
+        for: secretless,
+        classification: .mutating,
+        launcherEligible: true,
+        sessionActive: true
+    ) == .fullExceptSecretDumps)
+    #expect(fullAccessSessionProtection(
+        for: secretless,
+        classification: .secretDump,
+        launcherEligible: true,
+        sessionActive: true
+    ) == nil)
+}
+
+private func fullAccessTestGate(id: String, keyPatterns: [String]) -> SecretGate {
+    SecretGate(
+        id: id,
+        keyPatterns: keyPatterns,
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: []
+    )
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
@@ -28,7 +28,7 @@ import Testing
 
     let snapshot = try #require(session.snapshot(at: now, uptime: 100))
     #expect(snapshot.expiresAt == now.addingTimeInterval(fullAccessSessionMaximumDuration))
-    #expect(snapshot.remaining(at: now) == fullAccessSessionMaximumDuration)
+    #expect(snapshot.remaining(at: now, uptime: 100) == fullAccessSessionMaximumDuration)
 }
 
 @Test func fullAccessSessionExpiresAndCanAlwaysBeEnded() {
@@ -52,8 +52,42 @@ import Testing
     #expect(session.start(at: now, uptime: 500, duration: 60))
     #expect(session.snapshot(
         at: now.addingTimeInterval(-300),
+        uptime: 559
+    )?.remaining(at: now.addingTimeInterval(-300), uptime: 559) == 1)
+    #expect(session.snapshot(
+        at: now.addingTimeInterval(-300),
         uptime: 560
     ) == nil)
+}
+
+@Test func endingWaitsForAnAuthorizedReleaseToFinish() throws {
+    let now = Date(timeIntervalSince1970: 5_000)
+    let session = FullAccessSessionController()
+    #expect(session.start(at: now, uptime: 600, duration: 60))
+    let lease = try #require(session.lease(at: now, uptime: 600))
+    let releaseStarted = DispatchSemaphore(value: 0)
+    let allowReleaseToFinish = DispatchSemaphore(value: 0)
+    let releaseFinished = DispatchSemaphore(value: 0)
+    let endFinished = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+        _ = session.withActiveLease(lease, at: now, uptime: 600) {
+            releaseStarted.signal()
+            allowReleaseToFinish.wait()
+        }
+        releaseFinished.signal()
+    }
+    #expect(releaseStarted.wait(timeout: .now() + 1) == .success)
+    DispatchQueue.global().async {
+        session.end()
+        endFinished.signal()
+    }
+    #expect(endFinished.wait(timeout: .now() + 0.02) == .timedOut)
+
+    allowReleaseToFinish.signal()
+    #expect(releaseFinished.wait(timeout: .now() + 1) == .success)
+    #expect(endFinished.wait(timeout: .now() + 1) == .success)
+    #expect(!session.isActive(at: now, uptime: 600))
 }
 
 @Test(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/FullAccessSessionTests.swift
@@ -7,40 +7,50 @@ import Testing
     let first = FullAccessSessionController()
 
     #expect(!first.isActive(at: now))
-    #expect(first.start(at: now, duration: 300))
+    #expect(first.start(at: now))
     #expect(first.isActive(at: now))
+    #expect(first.snapshot(at: now)?.lifetime == .untilEnded)
     #expect(!FullAccessSessionController().isActive(at: now))
 }
 
-@Test func fullAccessSessionDurationIsPositiveAndCappedAtOneHour() throws {
+@Test(
+    arguments: [
+        (FullAccessSessionLifetime.oneHour, 60.0 * 60),
+        (FullAccessSessionLifetime.eightHours, 8.0 * 60 * 60),
+    ]
+)
+func timedFullAccessSessionLifetimeExpiresAtItsPreset(
+    lifetime: FullAccessSessionLifetime,
+    expectedDuration: TimeInterval
+) throws {
     let now = Date(timeIntervalSince1970: 2_000)
     let session = FullAccessSessionController()
 
-    #expect(!session.start(at: now, uptime: 100, duration: 0))
-    #expect(!session.start(at: now, uptime: 100, duration: -1))
-    #expect(!session.start(at: now, uptime: 100, duration: .infinity))
-    #expect(!session.start(at: now, uptime: 100, duration: .nan))
-    #expect(session.start(
-        at: now,
-        uptime: 100,
-        duration: fullAccessSessionMaximumDuration * 2
-    ))
+    #expect(session.start(at: now, uptime: 100, lifetime: lifetime))
 
     let snapshot = try #require(session.snapshot(at: now, uptime: 100))
-    #expect(snapshot.expiresAt == now.addingTimeInterval(fullAccessSessionMaximumDuration))
-    #expect(snapshot.remaining(at: now, uptime: 100) == fullAccessSessionMaximumDuration)
+    #expect(snapshot.lifetime == lifetime)
+    #expect(snapshot.expiresAt == now.addingTimeInterval(expectedDuration))
+    #expect(snapshot.remaining(at: now, uptime: 100) == expectedDuration)
 }
 
-@Test func fullAccessSessionExpiresAndCanAlwaysBeEnded() {
+@Test func fullAccessSessionExpiresAndCanAlwaysBeEnded() throws {
     let now = Date(timeIntervalSince1970: 3_000)
     let session = FullAccessSessionController()
 
-    #expect(session.start(at: now, uptime: 200, duration: 30))
-    #expect(session.isActive(at: now.addingTimeInterval(29), uptime: 229))
-    #expect(!session.isActive(at: now.addingTimeInterval(30), uptime: 230))
-    #expect(session.snapshot(at: now.addingTimeInterval(30), uptime: 230) == nil)
+    #expect(session.start(at: now, uptime: 200, lifetime: .oneHour))
+    #expect(session.isActive(at: now.addingTimeInterval(3_599), uptime: 3_799))
+    #expect(!session.isActive(at: now.addingTimeInterval(3_600), uptime: 3_800))
+    #expect(session.snapshot(at: now.addingTimeInterval(3_600), uptime: 3_800) == nil)
 
-    #expect(session.start(at: now, uptime: 300, duration: 30))
+    #expect(session.start(at: now, uptime: 300, lifetime: .untilEnded))
+    let snapshot = try #require(session.snapshot(
+        at: now.addingTimeInterval(60 * 60 * 24 * 365),
+        uptime: 60 * 60 * 24 * 365
+    ))
+    #expect(snapshot.lifetime == .untilEnded)
+    #expect(snapshot.expiresAt == nil)
+    #expect(snapshot.remaining(at: now, uptime: 300) == nil)
     session.end()
     #expect(!session.isActive(at: now, uptime: 300))
 }
@@ -49,21 +59,21 @@ import Testing
     let now = Date(timeIntervalSince1970: 4_000)
     let session = FullAccessSessionController()
 
-    #expect(session.start(at: now, uptime: 500, duration: 60))
+    #expect(session.start(at: now, uptime: 500, lifetime: .oneHour))
     #expect(session.snapshot(
         at: now.addingTimeInterval(-300),
-        uptime: 559
-    )?.remaining(at: now.addingTimeInterval(-300), uptime: 559) == 1)
+        uptime: 4_099
+    )?.remaining(at: now.addingTimeInterval(-300), uptime: 4_099) == 1)
     #expect(session.snapshot(
         at: now.addingTimeInterval(-300),
-        uptime: 560
+        uptime: 4_100
     ) == nil)
 }
 
 @Test func endingWaitsForAnAuthorizedReleaseToFinish() throws {
     let now = Date(timeIntervalSince1970: 5_000)
     let session = FullAccessSessionController()
-    #expect(session.start(at: now, uptime: 600, duration: 60))
+    #expect(session.start(at: now, uptime: 600, lifetime: .untilEnded))
     let lease = try #require(session.lease(at: now, uptime: 600))
     let releaseStarted = DispatchSemaphore(value: 0)
     let allowReleaseToFinish = DispatchSemaphore(value: 0)


### PR DESCRIPTION
## Summary

- add a Touch ID-only **Full Access Session** that automically authorizes every valid recognized operation for eligible verified launchers across Authorization Gates
- let the user choose **1 hour**, **8 hours**, or **Until turned off**, with Until turned off selected by default
- keep the session and its selected lifetime in memory only; timed sessions use wall-clock and monotonic deadlines, and every session ends on lock, display sleep, app exit/update, or explicit user action
- add conspicuous menu-bar, banner, remaining-time/Until-turned-off, Settings, and Authorization History presentation
- preserve fail-closed behavior for Unknown operations, unverifiable launchers, untrusted Gate Clients or Targets, malformed requests, missing Secrets, and failed required Authorization Records
- document the security boundary and decision in the canonical domain language, architecture, and ADR 0006

## Security properties

- activation calls LocalAuthentication with `deviceOwnerAuthenticationWithBiometrics`; password fallback is not accepted and biometric reuse duration is zero
- the selected lifetime is part of the local Touch ID activation flow; no CLI, URL, XPC, environment, preference, or persisted activation interface exists
- pending biometric attempts are invalidated on End, lock, or display sleep and rechecked after authentication before the session starts
- automatic release holds a generation-bound session lease across payload loading, required audit persistence, provenance recording, and XPC reply, so End/lock/sleep cannot race with release
- explicit per-launcher Approval Required policies are temporarily overlaid only when the launcher remains eligible; failed hardened-runtime requirements are not bypassed
- an active Full Access Session outranks a narrower active script Blessing; normal durable policy retains the existing Blessing boundary
- Unknown classifications never receive Full Access
- the existing record-before-release path remains mandatory, with `Full Access Session` recorded as the policy reason
- choosing Install and Relaunch revokes active and pending sessions before update UI hides the End control
- **Until turned off** is not persisted and does not survive lock, display sleep, app exit/update, or an explicit End action

## Verification

- `swift build --package-path src/menu-helper --disable-automatic-resolution --product AutomicVaultMenubar`
- `swift build --package-path src/menu-helper --disable-automatic-resolution -c release --product AutomicVaultMenubar`
- `swift test --disable-automatic-resolution` with local Swift Testing framework search/rpath flags (81 tests)
- `AutomicVaultMenubar --self-check-full-access-session`
- `AutomicVaultMenubar --self-check-dashboard-search`
- `AutomicVaultMenubar --self-check-menu-status`
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked` (817 library tests plus binary and integration suites)
- `git diff --check`
