### PR TITLE
Allow version-numbered launcher executables

### DIFF
--- a/docs/signed-cli-launchers.md
+++ b/docs/signed-cli-launchers.md
@@ -33,8 +33,8 @@ a version-number filename extension as data. Selection alone grants nothing:
 Automic Vault resolves symlinks and verifies that the selected file is executable
 and has an eligible signature. If the signature is missing, ad-hoc, invalid, or
 not Developer ID for a standalone executable, selection fails. If the identity
-cannot be verified later, automic authorization fails closed and requires
-Approval.
+cannot be verified later, Automic authorization fails closed and requires
+manual approval.
 
 Launcher-specific rules match the exact designated requirement, which binds the
 signing identifier and Team ID together. A rule does not match a sibling product

--- a/docs/signed-cli-launchers.md
+++ b/docs/signed-cli-launchers.md
@@ -23,13 +23,25 @@ Placing such an executable inside an unsigned app does not make it eligible.
 2. In Automic Vault Settings, add a launcher to the relevant tool or blessed
    script policy.
 3. Select the resolved native executable, not a shell or package-manager shim.
+   The picker starts in `/Applications`; press Command-Shift-G to enter another
+   path directly. Version-numbered executables such as `2.1.226` are supported.
 4. Review the identifier, Team ID, path, and designated requirement before
    allowing it.
 
-Automic Vault resolves symlinks and verifies the selected executable itself. If
-the signature is missing, ad-hoc, invalid, or not Developer ID for a standalone
-executable, selection fails. If the identity cannot be verified later, automatic
-approval fails closed and requires manual approval.
+The picker permits generic files because macOS may classify an executable with
+a version-number filename extension as data. Selection alone grants nothing:
+Automic Vault resolves symlinks and verifies that the selected file is executable
+and has an eligible signature. If the signature is missing, ad-hoc, invalid, or
+not Developer ID for a standalone executable, selection fails. If the identity
+cannot be verified later, automic authorization fails closed and requires
+Approval.
+
+Launcher-specific rules match the exact designated requirement, which binds the
+signing identifier and Team ID together. A rule does not match a sibling product
+from the same signing team, and it is not bound to the selected path. The
+`av bless --endorse-launcher` option instead records a Launcher Endorsement while
+blessing the script at the command's path; it does not enroll that path as a
+launcher executable.
 
 Some package formats start a signed native payload through a wrapper. Prefer a
 standalone installer or Homebrew cask when available because the live launcher

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2855,7 +2855,7 @@ private struct LauncherSigning {
     let runtimeProtection: LauncherRuntimeProtection
 }
 
-let launcherPickerAllowedContentTypes: [UTType] = [.applicationBundle, .data]
+private let launcherPickerAllowedContentTypes: [UTType] = [.applicationBundle, .data]
 
 func launcherPickerAllows(filenameExtension: String) -> Bool {
     guard let type = UTType(filenameExtension: filenameExtension) else { return false }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2855,6 +2855,13 @@ private struct LauncherSigning {
     let runtimeProtection: LauncherRuntimeProtection
 }
 
+let launcherPickerAllowedContentTypes: [UTType] = [.applicationBundle, .data]
+
+func launcherPickerAllows(filenameExtension: String) -> Bool {
+    guard let type = UTType(filenameExtension: filenameExtension) else { return false }
+    return launcherPickerAllowedContentTypes.contains { type.conforms(to: $0) }
+}
+
 private func secretGateAdmissionError(
     appName: String,
     protection: LauncherRuntimeProtection
@@ -2906,7 +2913,7 @@ private func pickLauncher(_ completion: @escaping (LauncherSigning?) -> Void) {
     panel.title = "Allow Launcher"
     panel.prompt = "Choose"
     panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
-    panel.allowedContentTypes = [.applicationBundle, .unixExecutable]
+    panel.allowedContentTypes = launcherPickerAllowedContentTypes
     panel.canChooseFiles = true
     panel.canChooseDirectories = false
     panel.allowsMultipleSelection = false

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -6256,7 +6256,8 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         appSigning: { _ in nil },
         allowsStandaloneFallback: false
     ).first
-    guard satisfiesDeveloperIDRequirement({ _ in errSecSuccess }),
+    guard launcherPickerAllows(filenameExtension: "226"),
+          satisfiesDeveloperIDRequirement({ _ in errSecSuccess }),
           let launcher = launcherIdentity(
               pid: 42,
               path: developerID.mainExecutable,


### PR DESCRIPTION
## Summary

- allow the launcher picker to select version-numbered executables such as Claude Code's `2.1.226`
- keep executable, strict code-signature, Developer ID, and Hardened Runtime validation as the admission boundary
- document path navigation, exact designated-requirement matching, and the separate purpose of `av bless --endorse-launcher`

## Root cause

macOS infers a dynamic data type from a version-number filename extension, so `NSOpenPanel` filtered the executable out before Automic Vault could validate its signature.

## Validation

- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `AutomicVaultMenubar --self-check-standalone-launchers`
- `cargo test --all-targets --all-features --locked`
- `cargo fmt --all -- --check`

Refs #141