### PR TITLE
Support Claude Code's Hardened Runtime profile

### DIFF
--- a/docs/adr/0009-support-library-validation-launchers.md
+++ b/docs/adr/0009-support-library-validation-launchers.md
@@ -1,0 +1,74 @@
+# ADR 0009: Support Launchers That Disable Library Validation
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+ADR-backed enforcement introduced by pull request #102 requires Hardened
+Runtime for new Secret Gate Launcher rules. It permits JIT executable-memory
+exceptions but rejects disabled library validation. Claude Code's official
+Developer ID-signed executable enables Hardened Runtime together with JIT,
+unsigned executable memory, and disabled library validation. As a result,
+making its version-numbered executable selectable for issue #141 would still
+leave an important agent Launcher ineligible for ordinary gate policy.
+
+Apple describes disabled library validation as allowing a process to load
+third-party code that is not signed by Apple or the same Team. This weakens the
+Launcher's in-process trust boundary, but it is distinct from the entitlement
+that permits DYLD environment variables to inject code or change library search
+paths. Treating both capabilities as the same hard failure prevents legitimate
+plug-in hosts without preserving that distinction.
+
+A global eligibility expansion must not silently broaden existing rules. A
+strictly hardened Launcher could otherwise add disabled library validation in a
+later release and retain authority that the user granted under a stronger
+posture.
+
+## Decision
+
+A Launcher remains eligible when it enables Hardened Runtime and its only
+additional supported runtime exception is disabled library validation. The UI
+warns that third-party libraries and plug-ins can run inside the Launcher and
+inherit its Secret Gate authority.
+
+Automic Vault continues to reject a Launcher that lacks Hardened Runtime or
+enables DYLD environment variables, disables executable-page protection, or
+allows debugger attachment. JIT and unsigned executable memory remain supported
+as before.
+
+New Launcher-specific Secret Gate rules and Direct Access Rules store a
+Launcher Runtime Requirement derived from the live signing posture at
+enrollment. Runtime authorization accepts the same posture or a stronger one:
+
+- a strict Hardened Runtime rule accepts only a strictly hardened Launcher;
+- a rule created with library validation disabled accepts that exception or its
+  later removal; and
+- neither rule accepts a missing Hardened Runtime flag or a blocked exception.
+
+Existing strict records from #102 decode as strict. Older explicit policies
+that were deliberately grandfathered continue to decode as legacy unchecked
+records. Existing Direct Access Rules decode as strict because their enrollment
+path has always required the then-current runtime eligibility check.
+
+Default Authorization Policy applies only to a live Launcher that satisfies the
+current eligibility classifier. Defaults do not persist a per-Launcher posture;
+their authority follows the user's chosen default and the current definition of
+a Verified Launcher.
+
+Launcher identity remains exact designated-requirement equality. No exception
+is specific to Anthropic, a path, a display name, or a Team ID alone.
+
+## Consequences
+
+- Claude Code can participate in ordinary Secret Gate policy once its signed
+  executable is selectable.
+- Third-party code loaded inside an eligible Launcher can exercise that
+  Launcher's authority, so enrollment and Direct Access confirmation show a
+  warning.
+- Existing strict durable rules do not gain authority when a Launcher later
+  disables library validation.
+- A Launcher that adds an injection, executable-page, debugger, or unknown
+  blocked exception loses automic authorization and requires Approval.
+- The stored policy formats gain an additive runtime-requirement field; existing
+  records decode without migration.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,19 @@ Authorization Record.
 
 The policy identity is the Launcher's designated requirement, checked against the live process and its launch chain. Paths, process identifiers, names, and icons help the user recognize software but do not establish identity. Hardened Runtime requirements and rejected entitlements form part of launcher eligibility.
 
+Eligible Launchers must enable Hardened Runtime. JIT executable-memory
+exceptions and disabled library validation are supported compatibility
+exceptions. Disabled library validation is presented as a warning because
+third-party code loaded into the Launcher inherits its authority. DYLD
+environment-variable injection, disabled executable-page protection, and
+debugger attachment remain ineligible.
+
+New durable Launcher rules store the accepted Launcher Runtime Requirement.
+Every request rechecks the live signature and permits an equal or stronger
+posture, so removing an exception is safe while adding an unacknowledged
+exception fails closed. Existing strict rules remain strict. Compatibility
+records that predate runtime requirements retain their established behavior.
+
 Retained Launcher Provenance identifies an intermediary by its macOS process
 execution identity, including PID version and process start time, and by its live
 code identity. PID alone, PID plus start time, a pathname, or a basename is not
@@ -160,6 +173,9 @@ The Direct Secret Gate starts at Approval Required and has no broad default.
 Adding each Direct Access Rule requires an explicit warning and acknowledgement.
 Runtime signature or Hardened Runtime verification failure disables automic
 authorization and falls back to Approval when human approval is available.
+An eligible Launcher that disables library validation remains subject to its
+exact designated requirement and live runtime check, and the UI warns that
+loaded third-party code can inherit its authority.
 
 Detached-process access is off by default. While it is off, Retained Launcher
 Provenance may be observed in memory only to explain an Approval that the setting

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -60,6 +60,22 @@ The app or executable at the root of the operation's verified launch chain, such
 
 A live Launcher whose code signature, designated requirement, and runtime protections meet the gate's eligibility rules. Code signing establishes identity and integrity, not intent. Failed verification prevents automic authorization.
 
+Eligible Launchers enable Hardened Runtime. A gate may accept narrowly defined
+compatibility exceptions while continuing to block runtime capabilities that
+permit environment-driven code injection, disable executable-page protection,
+or allow debugger attachment. A Launcher that disables library validation may
+be eligible, but the UI must warn that third-party libraries and plug-ins can
+run inside its process and inherit its authority.
+
+### Launcher Runtime Requirement
+
+The maximum Hardened Runtime exception profile accepted when a durable
+Launcher rule is created. It is stored with the rule and checked against the
+live Launcher on every request. Removing an accepted exception remains valid;
+adding an exception beyond the stored requirement disables automic
+authorization. Legacy rules that predate runtime requirements retain their
+existing compatibility behavior.
+
 ### Launcher Identity
 
 The designated requirement stored when the user establishes trust and revalidated for each request. A path, display name, process identifier, or icon is metadata, not identity.

--- a/docs/signed-cli-launchers.md
+++ b/docs/signed-cli-launchers.md
@@ -12,6 +12,19 @@ For a standalone executable to be eligible, it must:
 - pass strict macOS code-signature validation; and
 - enable Hardened Runtime before it can receive secret-gate access.
 
+JIT launchers may enable `allow-jit` and
+`allow-unsigned-executable-memory`. Launchers such as Claude Code may also
+disable library validation so they can load third-party libraries or plug-ins.
+Automic Vault supports that exception, warns that loaded code can inherit the
+Launcher's authority, and records the accepted runtime requirement with each
+new rule.
+
+Automic Vault continues to reject launchers that allow DYLD environment
+variables, disable executable-page protection, enable debugger attachment, or
+do not enable Hardened Runtime. Every request rechecks the live posture. A rule
+created for a strictly hardened Launcher does not silently expand if the
+Launcher later disables library validation.
+
 Unsigned and ad-hoc signed executables are rejected. Ad-hoc signing can protect
 one build from modification, but it does not establish a vendor or Team identity.
 Placing such an executable inside an unsigned app does not make it eligible.
@@ -28,8 +41,8 @@ Placing such an executable inside an unsigned app does not make it eligible.
 
 Automic Vault resolves symlinks and verifies the selected executable itself. If
 the signature is missing, ad-hoc, invalid, or not Developer ID for a standalone
-executable, selection fails. If the identity cannot be verified later, automatic
-approval fails closed and requires manual approval.
+executable, selection fails. If the identity cannot be verified later, automic
+authorization fails closed and requires Approval.
 
 Some package formats start a signed native payload through a wrapper. Prefer a
 standalone installer or Homebrew cask when available because the live launcher

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -570,27 +570,34 @@ final class DashboardModel: ObservableObject {
         return false
     }
 
-    func chooseDirectAccessLauncher(_ completion: @escaping (BlessedScriptLauncher?) -> Void) {
+    func chooseDirectAccessLauncher(_ completion: @escaping (DirectAccessLauncherSelection?) -> Void) {
         pickLauncher { signing in
             guard let signing else { return }
-            guard signing.runtimeProtection.allowsSecretGateAccess else {
+            guard let runtimeRequirement = signing.runtimeProtection.secretGateAdmissionRequirement else {
                 showLauncherCannotBeAllowed(secretGateAdmissionError(
                     appName: signing.identifier,
                     protection: signing.runtimeProtection
                 ))
                 return
             }
-            completion(BlessedScriptLauncher(
-                bundleIdentifier: signing.identifier,
-                requirement: signing.requirement
+            completion(DirectAccessLauncherSelection(
+                launcher: BlessedScriptLauncher(
+                    bundleIdentifier: signing.identifier,
+                    requirement: signing.requirement
+                ),
+                runtimeRequirement: runtimeRequirement
             ))
         }
     }
 
-    func addDirectAccessLauncher(_ launcher: BlessedScriptLauncher, to secret: StoredSecret) {
+    func addDirectAccessLauncher(_ selection: DirectAccessLauncherSelection, to secret: StoredSecret) {
         finishPolicyUpdate(
-            allowDirectAccess(to: secret.account, for: launcher),
-            error: "Could not allow \(launcher.bundleIdentifier) to use \(secret.account)"
+            allowDirectAccess(
+                to: secret.account,
+                for: selection.launcher,
+                runtimeRequirement: selection.runtimeRequirement
+            ),
+            error: "Could not allow \(selection.launcher.bundleIdentifier) to use \(secret.account)"
         )
     }
 
@@ -648,7 +655,7 @@ final class DashboardModel: ObservableObject {
     func addApp(to gate: SecretGate) {
         chooseLauncher { [weak self] signing in
             guard let self, let signing else { return }
-            guard signing.runtimeProtection.allowsSecretGateAccess else {
+            guard let runtimeRequirement = signing.runtimeProtection.secretGateAdmissionRequirement else {
                 showLauncherCannotBeAllowed(secretGateAdmissionError(
                     appName: signing.identifier,
                     protection: signing.runtimeProtection
@@ -659,7 +666,7 @@ final class DashboardModel: ObservableObject {
                 requirement: signing.requirement,
                 protection: .readOnly,
                 for: gate,
-                requiresHardenedRuntime: true
+                runtimeRequirement: runtimeRequirement
             )
             if status == errSecSuccess {
                 self.errorMessage = nil
@@ -683,7 +690,7 @@ final class DashboardModel: ObservableObject {
                 requirement: app.requirement,
                 protection: protection,
                 for: gate,
-                requiresHardenedRuntime: app.requiresHardenedRuntime
+                runtimeRequirement: app.runtimeRequirement
             ),
             error: "Could not update \(app.bundleIdentifier)"
         )
@@ -1682,7 +1689,7 @@ private struct StoredSecretDetailView: View {
     @State private var isAvailableWhileLocked: Bool
     @State private var isConfirmingDelete = false
     @State private var isConfirmingDirectAccess = false
-    @State private var pendingDirectAccessLauncher: BlessedScriptLauncher?
+    @State private var pendingDirectAccessLauncher: DirectAccessLauncherSelection?
 
     init(model: DashboardModel, secret: StoredSecret) {
         self.model = model
@@ -1785,13 +1792,14 @@ private struct StoredSecretDetailView: View {
         .sheet(isPresented: $isConfirmingDirectAccess, onDismiss: {
             pendingDirectAccessLauncher = nil
         }) {
-            if let launcher = pendingDirectAccessLauncher {
+            if let selection = pendingDirectAccessLauncher {
                 DirectAccessConfirmationView(
                     secretName: secret.account,
-                    launcherName: launcher.bundleIdentifier
+                    launcherName: selection.launcher.bundleIdentifier,
+                    runtimeWarning: launcherRuntimeWarning(selection.runtimeRequirement)
                 ) {
                     isConfirmingDirectAccess = false
-                    model.addDirectAccessLauncher(launcher, to: secret)
+                    model.addDirectAccessLauncher(selection, to: secret)
                 }
             }
         }
@@ -1816,6 +1824,7 @@ private struct StoredSecretDetailView: View {
 private struct DirectAccessConfirmationView: View {
     let secretName: String
     let launcherName: String
+    let runtimeWarning: String?
     let confirm: () -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -1827,12 +1836,15 @@ private struct DirectAccessConfirmationView: View {
                     .foregroundStyle(.orange)
                 Text("The verified Launcher “\(launcherName)” will be able to apply \(secretName) to any Target and arguments it chooses through direct av inject requests.")
                     .fixedSize(horizontal: false, vertical: true)
+                if let runtimeWarning {
+                    InfoBlock(title: "Warning", text: runtimeWarning)
+                }
                 Link("Read the safer alternatives", destination: directAccessDocumentationURL)
                     .font(.callout)
                 Spacer(minLength: 0)
             }
             .padding(22)
-            .frame(width: 470, height: 180, alignment: .topLeading)
+            .frame(width: 470, height: runtimeWarning == nil ? 180 : 260, alignment: .topLeading)
             .navigationTitle("Allow Direct Secret Access?")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -2855,12 +2867,38 @@ private struct LauncherSigning {
     let runtimeProtection: LauncherRuntimeProtection
 }
 
+struct DirectAccessLauncherSelection {
+    let launcher: BlessedScriptLauncher
+    let runtimeRequirement: LauncherRuntimeRequirement
+}
+
+private let libraryValidationWarning = "This Launcher permits third-party libraries and plug-ins to run inside its process. That code can inherit the Launcher’s Secret Gate authority."
+
+private func launcherRuntimeWarning(_ requirement: LauncherRuntimeRequirement) -> String? {
+    requirement == .hardenedAllowingLibraryValidationDisabled
+        ? libraryValidationWarning
+        : nil
+}
+
+private func launcherRuntimeWarning(_ protection: LauncherRuntimeProtection) -> String? {
+    switch protection {
+    case .hardened:
+        nil
+    case .hardenedWithLibraryValidationDisabled:
+        libraryValidationWarning
+    case .hardenedRuntimeMissing:
+        "This Launcher does not enable Hardened Runtime. It can be endorsed for an exact Blessed Script, but it cannot receive Secret Gate access."
+    case .unsafeEntitlements(let entitlements):
+        "This Launcher enables blocked Hardened Runtime exceptions: \(entitlements.joined(separator: ", ")). It can be endorsed for an exact Blessed Script, but it cannot receive Secret Gate access."
+    }
+}
+
 private func secretGateAdmissionError(
     appName: String,
     protection: LauncherRuntimeProtection
 ) -> String {
     switch protection {
-    case .hardened:
+    case .hardened, .hardenedWithLibraryValidationDisabled:
         return ""
     case .hardenedRuntimeMissing:
         return "\(appName) does not enable Hardened Runtime and cannot receive secret-gate access."
@@ -2894,6 +2932,10 @@ private func chooseLauncher(_ completion: @escaping (LauncherSigning?) -> Void) 
         Designated requirement:
         \(signing.requirement)
         """
+        if let warning = launcherRuntimeWarning(signing.runtimeProtection) {
+            alert.alertStyle = .warning
+            alert.informativeText += "\n\nWarning:\n\(warning)"
+        }
         alert.addButton(withTitle: "Allow")
         alert.addButton(withTitle: "Cancel")
         completion(alert.runModal() == .alertFirstButtonReturn ? signing : nil)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3595,8 +3595,7 @@ private func resolveSecretGatePolicy(
     for launcher in launchers {
         if let policy = gate.appPolicies.first(where: { $0.requirement == launcher.designatedRequirement }) {
             return ResolvedSecretGatePolicy(
-                protection: policy.requiresHardenedRuntime
-                    && !launcher.runtimeProtection.allowsSecretGateAccess
+                protection: !policy.runtimeRequirement.allows(launcher.runtimeProtection)
                     ? .noAccess
                     : policy.protection,
                 source: shortAppName(launcher.identifier),
@@ -6300,6 +6299,27 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         runtimeProtection: .hardenedRuntimeMissing,
         isStandalone: true
     )
+    let libraryValidationLauncher = LauncherIdentity(
+        pid: launcher.pid,
+        path: launcher.path,
+        identifier: launcher.identifier,
+        teamIdentifier: launcher.teamIdentifier,
+        designatedRequirement: launcher.designatedRequirement,
+        runtimeProtection: .hardenedWithLibraryValidationDisabled,
+        isStandalone: true
+    )
+    let injectableLauncher = LauncherIdentity(
+        pid: launcher.pid,
+        path: launcher.path,
+        identifier: launcher.identifier,
+        teamIdentifier: launcher.teamIdentifier,
+        designatedRequirement: launcher.designatedRequirement,
+        runtimeProtection: .unsafeEntitlements([
+            "com.apple.security.cs.allow-dyld-environment-variables",
+            "com.apple.security.cs.disable-library-validation",
+        ]),
+        isStandalone: true
+    )
 
     let unconfiguredGate = SecretGate(
         id: "test",
@@ -6320,9 +6340,25 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
             requiresHardenedRuntime: true
         )]
     )
+    let libraryLoadingGate = SecretGate(
+        id: "test",
+        keyPatterns: [],
+        routes: [],
+        defaultProtection: .noAccess,
+        appPolicies: [SecretGatePolicy(
+            bundleIdentifier: developerID.identifier,
+            requirement: requirement,
+            protection: .readOnly,
+            runtimeRequirement: .hardenedAllowingLibraryValidationDisabled
+        )]
+    )
     guard resolveSecretGatePolicy(gate: unconfiguredGate, launchers: [launcher]) == nil,
           resolveSecretGatePolicy(gate: configuredGate, launchers: [launcher])?.protection == .readOnly,
-          resolveSecretGatePolicy(gate: configuredGate, launchers: [unhardenedLauncher])?.protection == .noAccess
+          resolveSecretGatePolicy(gate: configuredGate, launchers: [unhardenedLauncher])?.protection == .noAccess,
+          resolveSecretGatePolicy(gate: configuredGate, launchers: [libraryValidationLauncher])?.protection == .noAccess,
+          resolveSecretGatePolicy(gate: libraryLoadingGate, launchers: [launcher])?.protection == .readOnly,
+          resolveSecretGatePolicy(gate: libraryLoadingGate, launchers: [libraryValidationLauncher])?.protection == .readOnly,
+          resolveSecretGatePolicy(gate: libraryLoadingGate, launchers: [injectableLauncher])?.protection == .noAccess
     else { return 1 }
     return 0
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -408,7 +408,9 @@ public struct SecretGatePolicy: Equatable, Sendable {
     public let bundleIdentifier: String
     public let requirement: String
     public let protection: SecretGateProtection
-    public let requiresHardenedRuntime: Bool
+    public let runtimeRequirement: LauncherRuntimeRequirement
+
+    public var requiresHardenedRuntime: Bool { runtimeRequirement != .legacyUnchecked }
 
     public init(
         bundleIdentifier: String,
@@ -416,25 +418,69 @@ public struct SecretGatePolicy: Equatable, Sendable {
         protection: SecretGateProtection,
         requiresHardenedRuntime: Bool = false
     ) {
+        self.init(
+            bundleIdentifier: bundleIdentifier,
+            requirement: requirement,
+            protection: protection,
+            runtimeRequirement: requiresHardenedRuntime ? .hardened : .legacyUnchecked
+        )
+    }
+
+    public init(
+        bundleIdentifier: String,
+        requirement: String,
+        protection: SecretGateProtection,
+        runtimeRequirement: LauncherRuntimeRequirement
+    ) {
         self.bundleIdentifier = bundleIdentifier
         self.requirement = requirement
         self.protection = protection
-        self.requiresHardenedRuntime = requiresHardenedRuntime
+        self.runtimeRequirement = runtimeRequirement
     }
 }
 
 public enum LauncherRuntimeProtection: Equatable, Sendable {
     case hardened
+    case hardenedWithLibraryValidationDisabled
     case hardenedRuntimeMissing
     case unsafeEntitlements([String])
 
-    public var allowsSecretGateAccess: Bool { self == .hardened }
+    public var secretGateAdmissionRequirement: LauncherRuntimeRequirement? {
+        switch self {
+        case .hardened:
+            .hardened
+        case .hardenedWithLibraryValidationDisabled:
+            .hardenedAllowingLibraryValidationDisabled
+        case .hardenedRuntimeMissing, .unsafeEntitlements:
+            nil
+        }
+    }
+
+    public var allowsSecretGateAccess: Bool { secretGateAdmissionRequirement != nil }
 }
 
-private let unsafeLauncherRuntimeEntitlements: Set<String> = [
+public enum LauncherRuntimeRequirement: String, Codable, Equatable, Sendable {
+    case legacyUnchecked
+    case hardened
+    case hardenedAllowingLibraryValidationDisabled
+
+    public func allows(_ protection: LauncherRuntimeProtection) -> Bool {
+        switch self {
+        case .legacyUnchecked:
+            true
+        case .hardened:
+            protection == .hardened
+        case .hardenedAllowingLibraryValidationDisabled:
+            protection == .hardened || protection == .hardenedWithLibraryValidationDisabled
+        }
+    }
+}
+
+private let libraryValidationEntitlement = "com.apple.security.cs.disable-library-validation"
+
+private let blockedLauncherRuntimeEntitlements: Set<String> = [
     "com.apple.security.cs.allow-dyld-environment-variables",
     "com.apple.security.cs.disable-executable-page-protection",
-    "com.apple.security.cs.disable-library-validation",
     "com.apple.security.get-task-allow",
 ]
 
@@ -445,8 +491,18 @@ public func launcherRuntimeProtection(
     guard signatureFlags & SecCodeSignatureFlags.runtime.rawValue != 0 else {
         return .hardenedRuntimeMissing
     }
-    let unsafe = enabledEntitlements.intersection(unsafeLauncherRuntimeEntitlements).sorted()
-    return unsafe.isEmpty ? .hardened : .unsafeEntitlements(unsafe)
+    let blocked = enabledEntitlements.intersection(blockedLauncherRuntimeEntitlements)
+    if !blocked.isEmpty {
+        let relevant = blocked.union(
+            enabledEntitlements.contains(libraryValidationEntitlement)
+                ? [libraryValidationEntitlement]
+                : []
+        )
+        return .unsafeEntitlements(relevant.sorted())
+    }
+    return enabledEntitlements.contains(libraryValidationEntitlement)
+        ? .hardenedWithLibraryValidationDisabled
+        : .hardened
 }
 
 public func launcherRuntimeProtection(
@@ -793,7 +849,7 @@ public func loadSecretGates(
                         bundleIdentifier: appIdentifier(from: $0) ?? "unknown",
                         requirement: $0,
                         protection: prototype.normalizedProtection(record.protection),
-                        requiresHardenedRuntime: record.requiresHardenedRuntime == true
+                        runtimeRequirement: record.resolvedRuntimeRequirement
                     )
                 }
             }.uniqueSorted()
@@ -864,13 +920,31 @@ public func setSecretGateAppProtection(
     service: String = secretGatePoliciesKeychainService,
     account: String = secretGatePoliciesKeychainAccount
 ) -> OSStatus {
+    setSecretGateAppProtection(
+        requirement: requirement,
+        protection: protection,
+        for: gate,
+        runtimeRequirement: requiresHardenedRuntime ? .hardened : .legacyUnchecked,
+        service: service,
+        account: account
+    )
+}
+
+public func setSecretGateAppProtection(
+    requirement: String,
+    protection: SecretGateProtection,
+    for gate: SecretGate,
+    runtimeRequirement: LauncherRuntimeRequirement,
+    service: String = secretGatePoliciesKeychainService,
+    account: String = secretGatePoliciesKeychainAccount
+) -> OSStatus {
     let protection = gate.normalizedProtection(protection)
     return setSecretGatePolicyRecord(
         SecretGatePolicyRecord(
             gateID: gate.id,
             requirement: requirement,
             protection: protection,
-            requiresHardenedRuntime: requiresHardenedRuntime
+            runtimeRequirement: runtimeRequirement
         ),
         service: service,
         account: account
@@ -909,17 +983,23 @@ private struct SecretGatePolicyRecord: Codable, Equatable {
     let requirement: String?
     let protection: SecretGateProtection
     let requiresHardenedRuntime: Bool?
+    let runtimeRequirement: LauncherRuntimeRequirement?
+
+    var resolvedRuntimeRequirement: LauncherRuntimeRequirement {
+        runtimeRequirement ?? (requiresHardenedRuntime == true ? .hardened : .legacyUnchecked)
+    }
 
     init(
         gateID: String,
         requirement: String?,
         protection: SecretGateProtection,
-        requiresHardenedRuntime: Bool? = nil
+        runtimeRequirement: LauncherRuntimeRequirement? = nil
     ) {
         self.gateID = gateID
         self.requirement = requirement
         self.protection = protection
-        self.requiresHardenedRuntime = requiresHardenedRuntime
+        self.requiresHardenedRuntime = runtimeRequirement.map { $0 != .legacyUnchecked }
+        self.runtimeRequirement = runtimeRequirement
     }
 }
 
@@ -1396,10 +1476,32 @@ public func migrateBackgroundKeychainItems(
 public struct DirectAccessRule: Codable, Equatable, Sendable {
     public let secretName: String
     public let launcher: BlessedScriptLauncher
+    public let runtimeRequirement: LauncherRuntimeRequirement
 
-    public init(secretName: String, launcher: BlessedScriptLauncher) {
+    public init(
+        secretName: String,
+        launcher: BlessedScriptLauncher,
+        runtimeRequirement: LauncherRuntimeRequirement = .hardened
+    ) {
         self.secretName = secretName
         self.launcher = launcher
+        self.runtimeRequirement = runtimeRequirement
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case secretName
+        case launcher
+        case runtimeRequirement
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        secretName = try container.decode(String.self, forKey: .secretName)
+        launcher = try container.decode(BlessedScriptLauncher.self, forKey: .launcher)
+        runtimeRequirement = try container.decodeIfPresent(
+            LauncherRuntimeRequirement.self,
+            forKey: .runtimeRequirement
+        ) ?? .hardened
     }
 }
 
@@ -1415,6 +1517,7 @@ public func loadDirectAccessRules(
 public func allowDirectAccess(
     to secretName: String,
     for launcher: BlessedScriptLauncher,
+    runtimeRequirement: LauncherRuntimeRequirement = .hardened,
     service: String = directAccessKeychainService,
     account: String = directAccessKeychainAccount
 ) -> OSStatus {
@@ -1427,7 +1530,11 @@ public func allowDirectAccess(
     rules.removeAll {
         $0.secretName == secretName && $0.launcher.requirement == launcher.requirement
     }
-    rules.append(DirectAccessRule(secretName: secretName, launcher: launcher))
+    rules.append(DirectAccessRule(
+        secretName: secretName,
+        launcher: launcher,
+        runtimeRequirement: runtimeRequirement
+    ))
     return saveDirectAccessRules(rules, service: service, account: account)
 }
 
@@ -1460,13 +1567,12 @@ public func directAccessAllows(
     runtimeProtection: LauncherRuntimeProtection,
     rules: [DirectAccessRule]
 ) -> Bool {
-    guard !secretNames.isEmpty,
-          !launcherRequirement.isEmpty,
-          runtimeProtection.allowsSecretGateAccess
-    else { return false }
+    guard !secretNames.isEmpty, !launcherRequirement.isEmpty else { return false }
     return Set(secretNames).allSatisfy { secretName in
         rules.contains {
-            $0.secretName == secretName && $0.launcher.requirement == launcherRequirement
+            $0.secretName == secretName
+                && $0.launcher.requirement == launcherRequirement
+                && $0.runtimeRequirement.allows(runtimeProtection)
         }
     }
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -417,8 +417,27 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(!directAccessAllows(
         secretNames: ["ALPHA_TOKEN"],
         launcherRequirement: launcher.requirement,
-        runtimeProtection: .hardenedRuntimeMissing,
+        runtimeProtection: .hardenedWithLibraryValidationDisabled,
         rules: rules
+    ))
+    let libraryLoadingRules = rules.map {
+        DirectAccessRule(
+            secretName: $0.secretName,
+            launcher: $0.launcher,
+            runtimeRequirement: .hardenedAllowingLibraryValidationDisabled
+        )
+    }
+    #expect(directAccessAllows(
+        secretNames: ["ALPHA_TOKEN", "BETA_TOKEN"],
+        launcherRequirement: launcher.requirement,
+        runtimeProtection: .hardenedWithLibraryValidationDisabled,
+        rules: libraryLoadingRules
+    ))
+    #expect(!directAccessAllows(
+        secretNames: ["ALPHA_TOKEN"],
+        launcherRequirement: launcher.requirement,
+        runtimeProtection: .hardenedRuntimeMissing,
+        rules: libraryLoadingRules
     ))
     #expect(!directAccessAllows(
         secretNames: [],
@@ -440,12 +459,18 @@ private func secretlessGateMetadata() -> HardenerMetadata {
 
     #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: secretService) == errSecSuccess)
     #expect(allowDirectAccess(
-        to: "API_TOKEN", for: zeta, service: policyService, account: policyAccount
+        to: "API_TOKEN",
+        for: zeta,
+        runtimeRequirement: .hardenedAllowingLibraryValidationDisabled,
+        service: policyService,
+        account: policyAccount
     ) == errSecSuccess)
     #expect(allowDirectAccess(
         to: "API_TOKEN", for: alpha, service: policyService, account: policyAccount
     ) == errSecSuccess)
-    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).map(\.launcher) == [alpha, zeta])
+    let rules = loadDirectAccessRules(service: policyService, account: policyAccount)
+    #expect(rules.map(\.launcher) == [alpha, zeta])
+    #expect(rules.last?.runtimeRequirement == .hardenedAllowingLibraryValidationDisabled)
     #expect(loadStoredSecrets(
         service: secretService,
         directAccessRules: loadDirectAccessRules(service: policyService, account: policyAccount)
@@ -460,6 +485,24 @@ private func secretlessGateMetadata() -> HardenerMetadata {
         to: "API_TOKEN", service: policyService, account: policyAccount
     ) == errSecSuccess)
     #expect(loadDirectAccessRules(service: policyService, account: policyAccount).isEmpty)
+}
+
+@Test func legacyDirectAccessRulesRemainStrictlyHardened() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.direct.\(UUID().uuidString)"
+    let account = "rules"
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+    let legacy = #"[{"secretName":"API_TOKEN","launcher":{"bundleIdentifier":"com.example.app","requirement":"requirement"}}]"#
+    #expect(saveStoredSecret(account: account, value: legacy, service: service) == errSecSuccess)
+
+    let rule = try #require(loadDirectAccessRules(service: service, account: account).first)
+    #expect(rule.runtimeRequirement == .hardened)
+    #expect(!directAccessAllows(
+        secretNames: ["API_TOKEN"],
+        launcherRequirement: "requirement",
+        runtimeProtection: .hardenedWithLibraryValidationDisabled,
+        rules: [rule]
+    ))
 }
 
 @Test func malformedDirectAccessPolicyFailsClosedAndIsNotReplaced() throws {
@@ -538,6 +581,7 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(gate.defaultProtection == .fullExceptSecretDumps)
     #expect(gate.appPolicies.first?.protection == .fullExceptSecretDumps)
     #expect(gate.appPolicies.first?.requiresHardenedRuntime == false)
+    #expect(gate.appPolicies.first?.runtimeRequirement == .legacyUnchecked)
 
     #expect(setSecretGateDefaultProtection(
         .readOnly,
@@ -551,6 +595,22 @@ private func secretlessGateMetadata() -> HardenerMetadata {
         account: account
     ).first)
     #expect(gate.defaultProtection == .readOnlyAndUpdates)
+}
+
+@Test func existingHardenedRuntimePoliciesRemainStrict() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.\(UUID().uuidString)"
+    let account = "policies.\(UUID().uuidString)"
+    defer { _ = deleteStoredSecret(account: account, service: service) }
+    let legacy = #"[{"gateID":"test","requirement":"identifier \"com.example.app\"","protection":"readOnly","requiresHardenedRuntime":true}]"#
+    #expect(saveStoredSecret(account: account, value: legacy, service: service) == errSecSuccess)
+
+    let gate = try #require(loadSecretGates(
+        hardeners: [testGateMetadata()],
+        service: service,
+        account: account
+    ).first)
+    #expect(gate.appPolicies.first?.runtimeRequirement == .hardened)
 }
 
 @Test func unhealthyInstalledWrapperKeepsItsSecretGate() throws {
@@ -618,7 +678,7 @@ func protectionPolicyMatrix(
         requirement: requirement,
         protection: .noAccess,
         for: gate,
-        requiresHardenedRuntime: true,
+        runtimeRequirement: .hardenedAllowingLibraryValidationDisabled,
         service: service,
         account: account
     ) == errSecSuccess)
@@ -626,6 +686,7 @@ func protectionPolicyMatrix(
     let appPolicy = try #require(gate.appPolicies.first)
     #expect(appPolicy.protection == .noAccess)
     #expect(appPolicy.requiresHardenedRuntime)
+    #expect(appPolicy.runtimeRequirement == .hardenedAllowingLibraryValidationDisabled)
     #expect(gate.defaultPolicyLabel == "All Other Apps")
     #expect(secretGateProtection(for: requirement, in: gate).protection == .noAccess)
     #expect(secretGateProtection(for: #"identifier "com.other.app""#, in: gate).protection == .fullExceptSecretDumps)
@@ -634,12 +695,12 @@ func protectionPolicyMatrix(
         requirement: appPolicy.requirement,
         protection: .readOnly,
         for: gate,
-        requiresHardenedRuntime: appPolicy.requiresHardenedRuntime,
+        runtimeRequirement: appPolicy.runtimeRequirement,
         service: service,
         account: account
     ) == errSecSuccess)
     gate = try #require(loadSecretGates(hardeners: [metadata], service: service, account: account).first)
-    #expect(gate.appPolicies.first?.requiresHardenedRuntime == true)
+    #expect(gate.appPolicies.first?.runtimeRequirement == .hardenedAllowingLibraryValidationDisabled)
 
     #expect(removeSecretGateAppPolicy(appPolicy, from: gate, service: service, account: account) == errSecSuccess)
     gate = try #require(loadSecretGates(hardeners: [metadata], service: service, account: account).first)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
@@ -18,9 +18,13 @@ import Testing
             "com.apple.security.cs.allow-unsigned-executable-memory",
         ]
     ) == .hardened)
+    #expect(launcherRuntimeProtection(
+        signatureFlags: SecCodeSignatureFlags.runtime.rawValue,
+        enabledEntitlements: ["com.apple.security.cs.disable-library-validation"]
+    ) == .hardenedWithLibraryValidationDisabled)
 }
 
-@Test func hardenedRuntimeExceptionsPreventSecretGateAdmission() {
+@Test func injectionAndDebuggingExceptionsPreventSecretGateAdmission() {
     let unsafe: Set<String> = [
         "com.apple.security.cs.allow-dyld-environment-variables",
         "com.apple.security.cs.disable-executable-page-protection",
@@ -40,5 +44,20 @@ import Testing
             "com.apple.security.cs.allow-dyld-environment-variables": false,
             "com.apple.security.cs.disable-library-validation": true,
         ],
-    ]) == .unsafeEntitlements(["com.apple.security.cs.disable-library-validation"]))
+    ]) == .hardenedWithLibraryValidationDisabled)
+}
+
+@Test func runtimeRequirementsRejectPostEnrollmentExpansion() {
+    #expect(LauncherRuntimeRequirement.hardened.allows(.hardened))
+    #expect(!LauncherRuntimeRequirement.hardened.allows(.hardenedWithLibraryValidationDisabled))
+
+    let libraryLoading = LauncherRuntimeRequirement.hardenedAllowingLibraryValidationDisabled
+    #expect(libraryLoading.allows(.hardened))
+    #expect(libraryLoading.allows(.hardenedWithLibraryValidationDisabled))
+    #expect(!libraryLoading.allows(.hardenedRuntimeMissing))
+    #expect(!libraryLoading.allows(.unsafeEntitlements([
+        "com.apple.security.cs.allow-dyld-environment-variables",
+    ])))
+
+    #expect(LauncherRuntimeRequirement.legacyUnchecked.allows(.hardenedRuntimeMissing))
 }


### PR DESCRIPTION
## Summary

- support the Hardened Runtime profile used by Claude Code without adding an Anthropic-specific identity exception
- treat disabled library validation as an eligible, warned compatibility exception while continuing to block injection, executable-page, debugger, and missing-runtime failures
- persist the accepted runtime profile on new Secret Gate and Direct Access rules and revalidate the live Launcher on every request
- preserve strict existing rules, grandfathered pre-runtime policies, exact designated-requirement matching, and fail-closed behavior

## Why

PR #143 makes Claude Code version-numbered executables selectable, but #102 still rejects the official binary because it carries `com.apple.security.cs.disable-library-validation`. Selection alone therefore does not resolve the Claude Code use case in #141.

Apple distinguishes disabled library validation, which permits a host to load third-party code, from DYLD environment-variable injection. This PR preserves that distinction while warning that loaded libraries and plug-ins inherit the Launcher authority.

## Security model

New durable rules record one of two checked postures:

- strict Hardened Runtime
- Hardened Runtime allowing disabled library validation

A rule accepts the recorded posture or a stronger one. Removing the library-validation exception remains valid; adding it to a strict Launcher invalidates automic authorization until the user creates a new rule. Missing Hardened Runtime and these exceptions remain blocked:

- `com.apple.security.cs.allow-dyld-environment-variables`
- `com.apple.security.cs.disable-executable-page-protection`
- `com.apple.security.get-task-allow`

Existing #102 records decode as strict. Older deliberately grandfathered policies remain grandfathered. Existing Direct Access Rules decode as strict. The additive stored field is rollback-safe: older builds ignore it, retain the compatibility Boolean, and continue to reject disabled library validation.

The picker and Direct Access confirmation show a warning when third-party libraries may inherit Secret Gate authority. Launcher identity remains exact designated-requirement equality; no path, display name, or Team ID alone gains authority.

ADR 0009 records the authority-boundary change.

## Validation

- `swift test --package-path src/menu-helper --disable-automatic-resolution` (76 tests)
- `swift build --package-path src/menu-helper --disable-automatic-resolution -c release`
- release `AutomicVaultMenubar --self-check-standalone-launchers`
- `cargo test --all-targets --all-features --locked` (824 unit tests plus integration targets)
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #141
Follow-up to #102
Companion to #143
