### PR TITLE
refactor(scan): define the user-writable PATH reason once

### DIFF
--- a/src/cli/shell_secrets.rs
+++ b/src/cli/shell_secrets.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::path_security::USER_WRITABLE_PATH_REASON;
+
 pub(crate) fn bash_reasons() -> Result<Vec<String>, String> {
     let home = home_dir()?;
     let mut paths = vec![
@@ -39,12 +41,7 @@ fn path_reasons(shell: &str) -> Vec<String> {
     let path = std::env::var_os("PATH").unwrap_or_default();
     crate::path_security::user_writable_entries_before_system_paths(&path)
         .into_iter()
-        .map(|entry| {
-            format!(
-                "{shell} PATH has a user-writable directory before protected system directories: {}",
-                entry.display()
-            )
-        })
+        .map(|entry| format!("{shell} {USER_WRITABLE_PATH_REASON}: {}", entry.display()))
         .collect()
 }
 

--- a/src/cli/shell_secrets.rs
+++ b/src/cli/shell_secrets.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::path_security::USER_WRITABLE_PATH_REASON;
+use crate::path_security::{user_writable_entries_before_system_paths, user_writable_path_reason};
 
 pub(crate) fn bash_reasons() -> Result<Vec<String>, String> {
     let home = home_dir()?;
@@ -39,9 +39,9 @@ pub(crate) fn zsh_reasons() -> Result<Vec<String>, String> {
 
 fn path_reasons(shell: &str) -> Vec<String> {
     let path = std::env::var_os("PATH").unwrap_or_default();
-    crate::path_security::user_writable_entries_before_system_paths(&path)
+    user_writable_entries_before_system_paths(&path)
         .into_iter()
-        .map(|entry| format!("{shell} {USER_WRITABLE_PATH_REASON}: {}", entry.display()))
+        .map(|entry| user_writable_path_reason(shell, &entry))
         .collect()
 }
 

--- a/src/isotopes/detectors/macos/mod.rs
+++ b/src/isotopes/detectors/macos/mod.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::path::Path;
 
+use crate::path_security::USER_WRITABLE_PATH_REASON;
 use crate::{AffectedFile, Finding};
 
 const DOCS_URL: &str = "https://github.com/automic-vault/automic-vault/blob/main/src/isotopes/detectors/macos/detector.md";
@@ -23,10 +24,7 @@ fn findings_for_gui_path(path: &std::ffi::OsStr) -> Vec<Finding> {
             source: "macOS",
             homepage: DOCS_URL,
             severity: "high",
-            explanation: format!(
-                "macOS GUI PATH has a user-writable directory before protected system directories: {}",
-                entry.display()
-            ),
+            explanation: format!("macOS GUI {USER_WRITABLE_PATH_REASON}: {}", entry.display()),
             solution: "Move protected system directories before user-writable directories in the launchd PATH, then log out and back in.".to_string(),
             affected: vec![AffectedFile {
                 path: entry.display().to_string(),

--- a/src/isotopes/detectors/macos/mod.rs
+++ b/src/isotopes/detectors/macos/mod.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::path::Path;
 
-use crate::path_security::USER_WRITABLE_PATH_REASON;
+use crate::path_security::{user_writable_entries_before_system_paths, user_writable_path_reason};
 use crate::{AffectedFile, Finding};
 
 const DOCS_URL: &str = "https://github.com/automic-vault/automic-vault/blob/main/src/isotopes/detectors/macos/detector.md";
@@ -18,13 +18,13 @@ fn findings_for_gui_path(path: &std::ffi::OsStr) -> Vec<Finding> {
         return Vec::new();
     }
 
-    crate::path_security::user_writable_entries_before_system_paths(path)
+    user_writable_entries_before_system_paths(path)
         .into_iter()
         .map(|entry| Finding {
             source: "macOS",
             homepage: DOCS_URL,
             severity: "high",
-            explanation: format!("macOS GUI {USER_WRITABLE_PATH_REASON}: {}", entry.display()),
+            explanation: user_writable_path_reason("macOS GUI", &entry),
             solution: "Move protected system directories before user-writable directories in the launchd PATH, then log out and back in.".to_string(),
             affected: vec![AffectedFile {
                 path: entry.display().to_string(),

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::Finding;
+use crate::path_security::USER_WRITABLE_PATH_REASON;
 
 mod acli;
 mod akamai;
@@ -383,8 +384,6 @@ pub(crate) fn findings(home: &Path) -> Vec<Finding> {
 }
 
 const SHELL_PATH_FINDING_SOURCES: &[&str] = &["bash", "zsh"];
-const SHELL_PATH_FINDING_MARKER: &str =
-    "PATH has a user-writable directory before protected system directories";
 const MERGED_SHELL_PATH_SOURCE: &str = "bash+zsh";
 const MERGED_SHELL_PATH_SOLUTION: &str = "Shell startup files contain arbitrary user programs and shared environment configuration. Automic Vault cannot rewrite them without changing shell behavior or guessing which commands need each secret. Move the reported value with `av save KEY`, then inject it only into the command that needs it. For an unsafe `PATH`, move every protected system directory before the reported user-writable directories and remove empty or relative entries.";
 
@@ -418,7 +417,7 @@ fn shell_path_entry(finding: &Finding) -> Option<&str> {
     }
     finding
         .explanation
-        .split_once(SHELL_PATH_FINDING_MARKER)?
+        .split_once(USER_WRITABLE_PATH_REASON)?
         .1
         .strip_prefix(": ")
 }

--- a/src/path_security.rs
+++ b/src/path_security.rs
@@ -3,13 +3,18 @@ use std::ffi::{CString, OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
-/// The shared half of every reason reporting an entry from
-/// [`user_writable_entries_before_system_paths`]. Producers prefix the source
-/// (`Bash`, `Zsh`, `macOS GUI`) and append `": {entry}"`. Consumers recognise
-/// those reasons by matching this text, so it needs one definition rather than
-/// a copy per call site.
+/// The wording consumers match on to recognise a user-writable PATH reason.
+/// Producers build reasons with [`user_writable_path_reason`] rather than
+/// composing this by hand.
 pub(crate) const USER_WRITABLE_PATH_REASON: &str =
     "PATH has a user-writable directory before protected system directories";
+
+/// The reason reporting one entry from
+/// [`user_writable_entries_before_system_paths`], prefixed by the source that
+/// found it (`Bash`, `Zsh`, `macOS GUI`).
+pub(crate) fn user_writable_path_reason(source: &str, entry: &Path) -> String {
+    format!("{source} {USER_WRITABLE_PATH_REASON}: {}", entry.display())
+}
 
 pub(crate) fn user_writable_entries_before_system_paths(path: &OsStr) -> Vec<PathBuf> {
     let entries = std::env::split_paths(path)

--- a/src/path_security.rs
+++ b/src/path_security.rs
@@ -3,6 +3,14 @@ use std::ffi::{CString, OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
+/// The shared half of every reason reporting an entry from
+/// [`user_writable_entries_before_system_paths`]. Producers prefix the source
+/// (`Bash`, `Zsh`, `macOS GUI`) and append `": {entry}"`. Consumers recognise
+/// those reasons by matching this text, so it needs one definition rather than
+/// a copy per call site.
+pub(crate) const USER_WRITABLE_PATH_REASON: &str =
+    "PATH has a user-writable directory before protected system directories";
+
 pub(crate) fn user_writable_entries_before_system_paths(path: &OsStr) -> Vec<PathBuf> {
     let entries = std::env::split_paths(path)
         .map(|entry| {


### PR DESCRIPTION
Fixes #146.

The user-writable PATH reason was duplicated between the Bash/Zsh producer and the macOS GUI-PATH producer. PR #145 added a consumer that matched another copy of the same text. Rewording one copy could silently stop shell finding deduplication.

This branch puts the singular reason builder and its shared recognition text in `path_security`. Both producers call the builder, and the detector merge introduced by #145 matches `USER_WRITABLE_PATH_REASON`. The merged display sentence remains explicit because its plural grammar is intentionally different: “Bash and zsh PATH have…”.

Output is unchanged.

Validation:

- `cargo test --lib`: 832 passed
- `cargo fmt --check`: clean
- `git diff --check`: clean
