### PR TITLE
Occlude credential-looking values in authorization history

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2299,7 +2299,7 @@ private struct AccessRequestRow: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
-                Text(record.command.isEmpty ? record.target : record.command)
+                Text(record.commandForDisplay)
                     .font(.system(size: 12, design: .monospaced))
                     .foregroundStyle(.primary)
                     .textSelection(.enabled)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -863,7 +863,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ]
         )
         title.append(NSAttributedString(
-            string: record.command.replacingOccurrences(of: " \\\n  ", with: " "),
+            string: record.displayCommand.replacingOccurrences(of: " \\\n  ", with: " "),
             attributes: [.font: NSFont.menuFont(ofSize: 0)]
         ))
         item.attributedTitle = title
@@ -951,7 +951,7 @@ private struct AutoApprovalRecord {
     let launcher: String
     let launcherIconPath: String
     let tool: String
-    let command: String
+    let displayCommand: String
     let keys: [String]
     let wasCanceled: Bool
     let wasDenied: Bool
@@ -1024,7 +1024,7 @@ private func autoApprovalRecord(
         launcher: requester.name,
         launcherIconPath: requester.iconPath,
         tool: autoApprovalToolName(request, scriptPath: script?.path),
-        command: autoApprovalCommand(request, scriptPath: script?.path),
+        displayCommand: authorizationHistoryCommand(request, scriptPath: script?.path),
         keys: request.keys,
         wasCanceled: false,
         wasDenied: false
@@ -1041,7 +1041,7 @@ private func autoApprovalRecord(_ record: AccessRequestRecord) -> AutoApprovalRe
         launcher: record.launcher ?? "Unknown app",
         launcherIconPath: "",
         tool: record.tool,
-        command: record.command,
+        displayCommand: record.commandForDisplay,
         keys: record.keys,
         wasCanceled: wasCanceled,
         wasDenied: wasDenied
@@ -1071,7 +1071,8 @@ private func accessRequestRecord(
         id: id,
         date: Date(),
         tool: autoApprovalToolName(request),
-        command: autoApprovalCommand(request),
+        command: exactAuthorizationCommand(request),
+        displayCommand: authorizationHistoryCommand(request),
         decision: decision,
         approvalSource: approvalSource,
         reason: reason,
@@ -1102,7 +1103,15 @@ private func autoApprovalToolName(_ request: ApprovalRequest, scriptPath: String
     return URL(fileURLWithPath: request.target).lastPathComponent
 }
 
-private func autoApprovalCommand(_ request: ApprovalRequest, scriptPath: String? = nil) -> String {
+private struct AuthorizationCommandParts {
+    let tool: String
+    let arguments: [String]
+}
+
+private func authorizationCommandParts(
+    _ request: ApprovalRequest,
+    scriptPath: String? = nil
+) -> AuthorizationCommandParts {
     let scriptPath = scriptPath ?? resolvedShebangScriptPath(request)
     var args = request.args
     if let scriptPath,
@@ -1110,7 +1119,23 @@ private func autoApprovalCommand(_ request: ApprovalRequest, scriptPath: String?
     {
         args.removeFirst(scriptIndex + 1)
     }
-    return prettyShellCommand(target: autoApprovalToolName(request, scriptPath: scriptPath), args: args)
+    return AuthorizationCommandParts(
+        tool: autoApprovalToolName(request, scriptPath: scriptPath),
+        arguments: args
+    )
+}
+
+private func exactAuthorizationCommand(_ request: ApprovalRequest, scriptPath: String? = nil) -> String {
+    let parts = authorizationCommandParts(request, scriptPath: scriptPath)
+    return prettyShellCommand(target: parts.tool, args: parts.arguments)
+}
+
+private func authorizationHistoryCommand(_ request: ApprovalRequest, scriptPath: String? = nil) -> String {
+    let parts = authorizationCommandParts(request, scriptPath: scriptPath)
+    return prettyShellCommand(
+        target: parts.tool,
+        args: redactedAuthorizationArguments(tool: parts.tool, arguments: parts.arguments)
+    )
 }
 
 private func approvalCommandPath(_ request: ApprovalRequest) -> String {
@@ -4877,7 +4902,7 @@ private func showApprovalAlert(
         requesterName: requester.name,
         requesterIconPath: requester.iconPath,
         credentialConsumer: autoApprovalToolName(request),
-        command: autoApprovalCommand(request),
+        command: exactAuthorizationCommand(request),
         commandPath: approvalCommandPath(request),
         title: request.title,
         detail: request.detail,
@@ -5390,6 +5415,10 @@ private func automaticAccessDecisionSymbol(wasDenied: Bool) -> String {
     wasDenied ? "xmark.shield.fill" : "checkmark.shield.fill"
 }
 
+private func automaticAccessToastAccessibilityLabel(_ record: AutoApprovalRecord) -> String {
+    "Dismiss \(record.wasDenied ? "rejection" : "approval") notification for \(record.displayCommand)"
+}
+
 private struct AutomaticAccessToastView: View {
     let record: AutoApprovalRecord
     let dismiss: () -> Void
@@ -5399,7 +5428,7 @@ private struct AutomaticAccessToastView: View {
             content
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Dismiss \(record.wasDenied ? "rejection" : "approval") notification for \(record.command)")
+        .accessibilityLabel(automaticAccessToastAccessibilityLabel(record))
     }
 
     private var content: some View {
@@ -5428,7 +5457,7 @@ private struct AutomaticAccessToastView: View {
             }
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(record.command)
+                Text(record.displayCommand)
                     .font(.system(.callout, design: .monospaced).weight(.medium))
                     .foregroundStyle(.white)
                     .fixedSize(horizontal: false, vertical: true)
@@ -7088,7 +7117,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
     func menuRecord(
         _ time: TimeInterval,
         launcher: String = "ChatGPT",
-        command: String = """
+        displayCommand: String = """
         gh \\
           repo \\
           view
@@ -7100,7 +7129,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
             launcher: launcher,
             launcherIconPath: "",
             tool: "gh",
-            command: command,
+            displayCommand: displayCommand,
             keys: ["GH_TOKEN"],
             wasCanceled: false,
             wasDenied: false
@@ -7108,7 +7137,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
     }
     let groupedMenuRecords = groupedAutoApprovals([
         menuRecord(19_800),
-        menuRecord(18_900, command: "gh issue list"),
+        menuRecord(18_900, displayCommand: "gh issue list"),
         menuRecord(18_000, launcher: "Codex"),
         menuRecord(17_100),
     ])
@@ -7116,7 +7145,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
     guard let groupedSubmenuTitle = groupedMenuItem.submenu?.items.first?.attributedTitle else {
         return 1
     }
-    let groupedCommand = groupedMenuRecords[0].record.command.replacingOccurrences(of: " \\\n  ", with: " ")
+    let groupedCommand = groupedMenuRecords[0].record.displayCommand.replacingOccurrences(of: " \\\n  ", with: " ")
     let groupedCommandStart = groupedSubmenuTitle.length - (groupedCommand as NSString).length
     let request = ApprovalRequest(
         op: "inject",
@@ -7148,6 +7177,37 @@ private func runMenuStatusSelfCheck() -> Int32 {
         title: nil,
         detail: nil
     )
+    let rawCredential = ["ghp", String(repeating: "a", count: 24)].joined(separator: "_")
+    let sensitiveRequest = ApprovalRequest(
+        op: "inject",
+        keys: ["GH_TOKEN"],
+        target: "/opt/homebrew/bin/gh",
+        args: ["api", "-H", "Authorization: Bearer \(rawCredential)"],
+        cwd: "/tmp",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        envConflicts: [],
+        shebangScript: nil,
+        scriptData: nil,
+        tool: "gh",
+        title: nil,
+        detail: nil
+    )
+    let sensitiveRecord = accessRequestRecord(
+        request: sensitiveRequest,
+        callerPath: "/usr/local/bin/av",
+        decision: "Approved",
+        approvalSource: "Auto",
+        reason: "Read Only from app policy",
+        launcher: nil
+    )
+    guard let sensitiveRetrospectiveRecord = autoApprovalRecord(sensitiveRecord) else { return 1 }
+    let sensitiveMenuItem = AppDelegate().autoApprovalMenuItem(
+        groupedAutoApprovals([sensitiveRetrospectiveRecord, sensitiveRetrospectiveRecord])[0]
+    )
+    guard let sensitiveMenuTitle = sensitiveMenuItem.submenu?.items.first?.attributedTitle?.string else {
+        return 1
+    }
     let recordedApproval = AccessRequestRecord(
         date: Date(timeIntervalSince1970: 18_900),
         tool: "aws",
@@ -7179,11 +7239,21 @@ private func runMenuStatusSelfCheck() -> Int32 {
           autoApprovalToolName(request) == "aws",
           approvalCommandPath(request) == "/usr/local/bin/aws",
           approvalCommandPath(envWrapperRequest) == "/usr/local/bin/pulumi",
-          autoApprovalCommand(envWrapperRequest) == """
+          exactAuthorizationCommand(envWrapperRequest) == """
           pulumi \\
             stack \\
             ls
           """,
+          exactAuthorizationCommand(sensitiveRequest).contains(rawCredential),
+          sensitiveRecord.command.contains(rawCredential),
+          !sensitiveRecord.commandForDisplay.contains(rawCredential),
+          sensitiveRecord.commandForDisplay.contains("<redacted>"),
+          !sensitiveRetrospectiveRecord.displayCommand.contains(rawCredential),
+          sensitiveRetrospectiveRecord.displayCommand.contains("<redacted>"),
+          !sensitiveMenuTitle.contains(rawCredential),
+          sensitiveMenuTitle.contains("<redacted>"),
+          !automaticAccessToastAccessibilityLabel(sensitiveRetrospectiveRecord).contains(rawCredential),
+          automaticAccessToastAccessibilityLabel(sensitiveRetrospectiveRecord).contains("<redacted>"),
           scanAlertLevel([["severity": "medium"]]) == .medium,
           scanAlertLevel([["severity": "medium"], ["severity": "high"]]) == .high,
           doctorStatusTitle(count: 0) == nil,
@@ -7192,7 +7262,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
           vulnerabilityStatusTitle(count: 1) == "One Vulnerability Detected",
           vulnerabilityStatusTitle(count: 2) == "Two Vulnerabilities Detected",
           groupedMenuRecords.map(\.count) == [2, 1, 1],
-          groupedMenuRecords[0].records[1].command == "gh issue list",
+          groupedMenuRecords[0].records[1].displayCommand == "gh issue list",
           groupedMenuItem.representedObject == nil,
           groupedMenuItem.submenu?.items.compactMap({ $0.representedObject as? String })
               == groupedMenuRecords[0].records.map({ $0.accessRequestID.uuidString }),
@@ -7217,7 +7287,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
                   launcher: "Codex",
                   launcherIconPath: "/Applications/Codex.app",
                   tool: "aws",
-                  command: "aws s3 ls",
+                  displayCommand: "aws s3 ls",
                   keys: ["AWS_SECRET_ACCESS_KEY"],
                   wasCanceled: false,
                   wasDenied: false
@@ -7228,7 +7298,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
           restoredApproval.accessRequestID == recordedApproval.id,
           restoredApproval.launcher == "Codex",
           restoredApproval.tool == "aws",
-          restoredApproval.command == "aws s3 ls",
+          restoredApproval.displayCommand == "aws <arguments hidden>",
           restoredApproval.keys == ["AWS_SECRET_ACCESS_KEY"],
           let restoredDenial = autoApprovalRecord(AccessRequestRecord(
               id: recordedApproval.id,
@@ -7297,7 +7367,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
           automaticAccessDecisionLabel(wasDenied: restoredApproval.wasDenied) == "AUTO APPROVED",
           automaticAccessDecisionSymbol(wasDenied: restoredApproval.wasDenied) == "checkmark.shield.fill",
           autoApprovalTitle(restoredDenial, formatter: formatter) == "5:15 AM – Codex was denied use of gh",
-          autoApprovalCommand(request) == """
+          exactAuthorizationCommand(request) == """
           aws \\
             s3 \\
             ls

--- a/src/menu-helper/Sources/MenubarHelperCore/AuthorizationCommandRedactor.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AuthorizationCommandRedactor.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+private let authorizationRedaction = "<redacted>"
+
+public func redactedAuthorizationArguments(tool: String, arguments: [String]) -> [String] {
+    let tool = URL(fileURLWithPath: tool).lastPathComponent.lowercased()
+    var result: [String] = []
+    var index = 0
+
+    while index < arguments.count {
+        let argument = arguments[index]
+
+        if isSensitiveValueFlag(argument) {
+            result.append(argument)
+            if index + 1 < arguments.count {
+                result.append(authorizationRedaction)
+                index += 2
+            } else {
+                index += 1
+            }
+            continue
+        }
+
+        if let redacted = redactingInlineSensitiveFlag(argument) {
+            result.append(redacted)
+            index += 1
+            continue
+        }
+
+        if tool == "curl", ["-u", "--user"].contains(argument.lowercased()) {
+            result.append(argument)
+            if index + 1 < arguments.count {
+                result.append(redactingUserPassword(arguments[index + 1]))
+                index += 2
+            } else {
+                index += 1
+            }
+            continue
+        }
+
+        if tool == "curl", argument == "-H" || argument.lowercased() == "--header" {
+            result.append(argument)
+            if index + 1 < arguments.count {
+                result.append(redactingHeader(arguments[index + 1]))
+                index += 2
+            } else {
+                index += 1
+            }
+            continue
+        }
+
+        if tool == "curl", let redacted = redactingInlineCurlArgument(argument) {
+            result.append(redacted)
+            index += 1
+            continue
+        }
+
+        if tool == "sshpass", argument.lowercased() == "-p" {
+            result.append(argument)
+            if index + 1 < arguments.count {
+                result.append(authorizationRedaction)
+                index += 2
+            } else {
+                index += 1
+            }
+            continue
+        }
+
+        if tool == "sshpass", argument.lowercased().hasPrefix("-p"), argument.count > 2 {
+            result.append("\(argument.prefix(2))\(authorizationRedaction)")
+            index += 1
+            continue
+        }
+
+        result.append(redactingStandaloneValue(argument))
+        index += 1
+    }
+
+    return result
+}
+
+private let sensitiveValueFlags: Set<String> = [
+    "--access-token",
+    "--api-key",
+    "--api-token",
+    "--apikey",
+    "--auth-token",
+    "--authorization",
+    "--bearer-token",
+    "--client-secret",
+    "--cookie",
+    "--credentials",
+    "--password",
+    "--passwd",
+    "--passphrase",
+    "--private-key",
+    "--refresh-token",
+    "--secret-access-key",
+    "--secret-key",
+    "--session-token",
+    "--token",
+    "--webhook-secret",
+]
+
+private func isSensitiveValueFlag(_ argument: String) -> Bool {
+    sensitiveValueFlags.contains(argument.lowercased())
+}
+
+private func redactingInlineSensitiveFlag(_ argument: String) -> String? {
+    guard let equals = argument.firstIndex(of: "=") else { return nil }
+    let flag = String(argument[..<equals])
+    guard isSensitiveValueFlag(flag) else { return nil }
+    return "\(flag)=\(authorizationRedaction)"
+}
+
+private func redactingInlineCurlArgument(_ argument: String) -> String? {
+    let lowercased = argument.lowercased()
+    if lowercased.hasPrefix("--user=") {
+        let value = String(argument.dropFirst("--user=".count))
+        return "\(argument.prefix("--user=".count))\(redactingUserPassword(value))"
+    }
+    if lowercased.hasPrefix("-u"), argument.count > 2 {
+        return "\(argument.prefix(2))\(redactingUserPassword(String(argument.dropFirst(2))))"
+    }
+    if lowercased.hasPrefix("--header=") {
+        let value = String(argument.dropFirst("--header=".count))
+        return "\(argument.prefix("--header=".count))\(redactingHeader(value))"
+    }
+    if argument.hasPrefix("-H"), argument.count > 2 {
+        return "\(argument.prefix(2))\(redactingHeader(String(argument.dropFirst(2))))"
+    }
+    return nil
+}
+
+private func redactingStandaloneValue(_ value: String) -> String {
+    if let assignment = redactingEnvironmentAssignment(value) {
+        return assignment
+    }
+    let header = redactingHeader(value)
+    if header != value {
+        return header
+    }
+    let url = redactingURL(value)
+    if url != value {
+        return url
+    }
+    if isRecognizableCredential(value) {
+        return authorizationRedaction
+    }
+    return value
+}
+
+private func redactingEnvironmentAssignment(_ argument: String) -> String? {
+    guard let equals = argument.firstIndex(of: "=") else { return nil }
+    let name = String(argument[..<equals])
+    guard isEnvironmentName(name), isSensitiveName(name) else { return nil }
+    return "\(name)=\(authorizationRedaction)"
+}
+
+private func isEnvironmentName(_ value: String) -> Bool {
+    guard let first = value.unicodeScalars.first,
+          CharacterSet.letters.union(CharacterSet(charactersIn: "_")).contains(first)
+    else { return false }
+    return value.unicodeScalars.allSatisfy {
+        CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_")).contains($0)
+    }
+}
+
+private let sensitiveNames: Set<String> = [
+    "access_key",
+    "access_token",
+    "api_key",
+    "apikey",
+    "api_token",
+    "auth",
+    "auth_token",
+    "authorization",
+    "bearer_token",
+    "client_secret",
+    "cookie",
+    "credentials",
+    "pass",
+    "passwd",
+    "passphrase",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "secret_access_key",
+    "secret_key",
+    "session_token",
+    "signature",
+    "token",
+    "webhook_secret",
+]
+
+private let visibleMetadataNames: Set<String> = [
+    "key_id",
+    "key_name",
+    "profile",
+    "secret_id",
+    "secret_name",
+    "token_id",
+    "token_name",
+]
+
+private func isSensitiveName(_ name: String) -> Bool {
+    let normalized = name
+        .lowercased()
+        .replacingOccurrences(of: "-", with: "_")
+    guard !visibleMetadataNames.contains(normalized) else { return false }
+    if sensitiveNames.contains(normalized) { return true }
+    return sensitiveNames.contains { normalized.hasSuffix("_\($0)") }
+}
+
+private let sensitiveHeaderNames: Set<String> = [
+    "api-key",
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-access-token",
+    "x-api-key",
+    "x-auth-token",
+]
+
+private func redactingHeader(_ argument: String) -> String {
+    guard let colon = argument.firstIndex(of: ":") else { return argument }
+    let name = argument[..<colon].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard sensitiveHeaderNames.contains(name) else { return argument }
+    return "\(argument[..<colon]): \(authorizationRedaction)"
+}
+
+private func redactingUserPassword(_ value: String) -> String {
+    guard let colon = value.firstIndex(of: ":") else { return authorizationRedaction }
+    return "\(value[..<colon]):\(authorizationRedaction)"
+}
+
+private func redactingURL(_ argument: String) -> String {
+    guard let scheme = argument.range(of: "://") else { return argument }
+    var result = argument
+    let authorityStart = scheme.upperBound
+    let authorityEnd = result[authorityStart...].firstIndex(where: { "/?#".contains($0) }) ?? result.endIndex
+    let authority = result[authorityStart..<authorityEnd]
+
+    if let at = authority.lastIndex(of: "@"),
+       let colon = authority[..<at].firstIndex(of: ":")
+    {
+        result.replaceSubrange(result.index(after: colon)..<at, with: authorizationRedaction)
+    }
+
+    guard let question = result.firstIndex(of: "?") else { return result }
+    let queryStart = result.index(after: question)
+    let queryEnd = result[queryStart...].firstIndex(of: "#") ?? result.endIndex
+    let query = result[queryStart..<queryEnd]
+    let redactedQuery = query.split(separator: "&", omittingEmptySubsequences: false).map { item -> String in
+        guard let equals = item.firstIndex(of: "=") else { return String(item) }
+        let encodedName = String(item[..<equals])
+        let name = encodedName.removingPercentEncoding ?? encodedName
+        guard isSensitiveName(name) else { return String(item) }
+        return "\(item[..<equals])=\(authorizationRedaction)"
+    }.joined(separator: "&")
+    result.replaceSubrange(queryStart..<queryEnd, with: redactedQuery)
+    return result
+}
+
+private func isRecognizableCredential(_ value: String) -> Bool {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.contains("-----BEGIN"), trimmed.contains("PRIVATE KEY-----") {
+        return true
+    }
+
+    let token = trimmed.lowercased().hasPrefix("bearer ")
+        ? String(trimmed.dropFirst("bearer ".count))
+        : trimmed
+    let prefixLengths: [(String, Int)] = [
+        ("github_pat_", 12),
+        ("ghp_", 16), ("gho_", 16), ("ghu_", 16), ("ghs_", 16), ("ghr_", 16),
+        ("sk_live_", 12), ("sk_test_", 12), ("rk_live_", 12), ("rk_test_", 12),
+        ("xoxa-", 10), ("xoxb-", 10), ("xoxp-", 10), ("xoxr-", 10), ("xoxs-", 10),
+    ]
+    if prefixLengths.contains(where: { token.hasPrefix($0.0) && token.count >= $0.0.count + $0.1 }) {
+        return true
+    }
+
+    let segments = token.split(separator: ".", omittingEmptySubsequences: false)
+    return token.count >= 32
+        && segments.count == 3
+        && segments[0].hasPrefix("eyJ")
+        && segments.allSatisfy { segment in
+            !segment.isEmpty && segment.unicodeScalars.allSatisfy {
+                CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_")).contains($0)
+            }
+        }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -644,6 +644,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
     public let date: Date
     public let tool: String
     public let command: String
+    public let displayCommand: String?
     public let decision: String
     public let approvalSource: String?
     public let reason: String
@@ -659,6 +660,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         date: Date,
         tool: String,
         command: String,
+        displayCommand: String? = nil,
         decision: String,
         approvalSource: String? = nil,
         reason: String,
@@ -673,6 +675,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         self.date = date
         self.tool = tool
         self.command = command
+        self.displayCommand = displayCommand
         self.decision = decision
         self.approvalSource = approvalSource
         self.reason = reason
@@ -682,6 +685,10 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         self.cwd = cwd
         self.keys = keys
         self.detail = detail
+    }
+
+    public var commandForDisplay: String {
+        displayCommand ?? "\(tool.isEmpty ? "tool" : tool) <arguments hidden>"
     }
 
     public var approvalSourceLabel: String {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationCommandRedactorTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationCommandRedactorTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+@Test func redactsSensitiveFlagValues() {
+    #expect(redactedAuthorizationArguments(
+        tool: "tool",
+        arguments: ["--api-key", "api-secret", "--password=hunter2", "--profile", "production"]
+    ) == ["--api-key", "<redacted>", "--password=<redacted>", "--profile", "production"])
+}
+
+@Test func redactsSensitiveEnvironmentAssignments() {
+    #expect(redactedAuthorizationArguments(
+        tool: "env",
+        arguments: ["API_TOKEN=token-value", "DATABASE_PASSWORD=hunter2", "REGION=us-east-1"]
+    ) == ["API_TOKEN=<redacted>", "DATABASE_PASSWORD=<redacted>", "REGION=us-east-1"])
+}
+
+@Test func redactsSensitiveHeaders() {
+    #expect(redactedAuthorizationArguments(
+        tool: "client",
+        arguments: [
+            "Authorization: Bearer token-value",
+            "X-API-Key: api-secret",
+            "Cookie: session=secret",
+            "Accept: application/json",
+        ]
+    ) == [
+        "Authorization: <redacted>",
+        "X-API-Key: <redacted>",
+        "Cookie: <redacted>",
+        "Accept: application/json",
+    ])
+}
+
+@Test func redactsURLPasswordsAndSensitiveQueryValues() {
+    #expect(redactedAuthorizationArguments(
+        tool: "curl",
+        arguments: ["https://alice:hunter2@example.com/repos?id=42&access_token=token-value#readme"]
+    ) == ["https://alice:<redacted>@example.com/repos?id=42&access_token=<redacted>#readme"])
+}
+
+@Test func redactsToolSpecificCredentialArguments() {
+    #expect(redactedAuthorizationArguments(
+        tool: "/usr/bin/curl",
+        arguments: ["-u", "alice:hunter2", "-HAuthorization: Bearer token-value", "--header", "Cookie: a=b"]
+    ) == ["-u", "alice:<redacted>", "-HAuthorization: <redacted>", "--header", "Cookie: <redacted>"])
+    #expect(redactedAuthorizationArguments(
+        tool: "sshpass",
+        arguments: ["-p", "hunter2", "ssh", "host"]
+    ) == ["-p", "<redacted>", "ssh", "host"])
+}
+
+@Test func redactsRecognizableCredentialFormats() {
+    let stripeToken = ["sk", "live", "1234567890abcdefghijklmnop"].joined(separator: "_")
+    let slackToken = ["xoxb", "1234567890", "abcdefghijklmnop"].joined(separator: "-")
+    let githubToken = ["ghp", String(repeating: "a", count: 24)].joined(separator: "_")
+    let values = [
+        githubToken,
+        stripeToken,
+        slackToken,
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature",
+        "-----BEGIN PRIVATE KEY-----\nsecret material\n-----END PRIVATE KEY-----",
+    ]
+    #expect(redactedAuthorizationArguments(tool: "tool", arguments: values) == Array(repeating: "<redacted>", count: values.count))
+}
+
+@Test func preservesIdentifiersNamesAndOrdinaryArguments() {
+    let values = [
+        "0123456789abcdef0123456789abcdef01234567",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "arn:aws:iam::123456789012:role/example-production-role",
+        "--profile", "production",
+        "--secret-name", "payments-production",
+        "--secret-id", "secret-123",
+        "https://example.com/repos?id=42&profile=production",
+        "-h", "help-topic",
+        "ordinary-positional-value",
+    ]
+    #expect(redactedAuthorizationArguments(tool: "aws", arguments: values) == values)
+}
+
+@Test func accessRequestRecordPersistsExactAndDisplayCommands() throws {
+    let record = AccessRequestRecord(
+        date: Date(timeIntervalSince1970: 1),
+        tool: "curl",
+        command: "curl --api-key api-secret",
+        displayCommand: "curl --api-key <redacted>",
+        decision: "Approved",
+        reason: "Approved in prompt",
+        launcher: "Terminal",
+        callerPath: "/usr/local/bin/av",
+        target: "/usr/bin/curl",
+        cwd: "/tmp",
+        keys: [],
+        detail: nil
+    )
+
+    let decoded = try JSONDecoder().decode(AccessRequestRecord.self, from: JSONEncoder().encode(record))
+    #expect(decoded.command == "curl --api-key api-secret")
+    #expect(decoded.commandForDisplay == "curl --api-key <redacted>")
+    #expect(!decoded.commandForDisplay.contains("api-secret"))
+}
+
+@Test func legacyAccessRequestHidesAllArguments() throws {
+    let data = Data("""
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "date": 0,
+      "tool": "gh",
+      "command": "gh api --header Authorization:secret-value",
+      "decision": "Approved",
+      "reason": "Approved in prompt",
+      "launcher": "Terminal",
+      "callerPath": "/usr/local/bin/av",
+      "target": "/usr/bin/gh",
+      "cwd": "/tmp",
+      "keys": [],
+      "detail": null
+    }
+    """.utf8)
+
+    let record = try JSONDecoder().decode(AccessRequestRecord.self, from: data)
+    #expect(record.command == "gh api --header Authorization:secret-value")
+    #expect(record.commandForDisplay == "gh <arguments hidden>")
+    #expect(!record.commandForDisplay.contains("secret-value"))
+}


### PR DESCRIPTION
## Summary

- preserve exact authorization commands in the existing Data Protection Keychain history
- persist a separately redacted display command for retrospective UI
- hide all arguments for legacy records without a display command
- use replacement text in history rows, menus, toasts, selectable text, and accessibility labels
- keep the live Approval prompt exact

## Why

Authorization history currently renders complete command arguments. Credentials passed as arguments can therefore be exposed visually, through VoiceOver, or through copy operations even though the history itself is protected at rest.

The redactor intentionally uses only high-confidence syntax and recognizable credential formats. It does not use entropy scoring, and preserves hashes, UUIDs, resource identifiers, profiles, Secret Names, and ordinary positional arguments.

Closes #148.

## Validation

- `swift test --package-path src/menu-helper --disable-automatic-resolution` — 86 tests passed
- `AutomicVaultMenubar --self-check-menu-status` — passed
- focused recognizable-credential fixture test — passed after changing realistic test literals to runtime assembly for GitHub push protection

The broader `--self-check-approvals` command still exits nonzero at a pre-existing contradictory AWS gate assertion that expects the same request shape to both match and not match. The exact-command assertion used by the live Approval path passes in the menu self-check.

Manual VoiceOver validation remains to be performed in the running app.
