### PR TITLE
Remove ungated secret retrieval from Gate Clients

### DIFF
--- a/docs/adr/0010-no-ungated-secret-retrieval.md
+++ b/docs/adr/0010-no-ungated-secret-retrieval.md
@@ -1,0 +1,49 @@
+# ADR 0010: Prohibit Ungated Secret Retrieval by Gate Clients
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Context
+
+The menu bar app owns Automic Vault's private Data Protection Keychain access
+group. The standalone `av` Gate Client has no Keychain entitlement and uses XPC
+for Secret operations.
+
+An internal XPC `load` operation nevertheless allowed a correctly signed `av`
+process to request any existing Secret Name and receive its raw value. The
+operation was used for migration preflight and verification, but it did not
+construct a complete Authorization Request, evaluate policy, obtain Approval,
+or persist an Authorization Record. Code signing established the Gate Client's
+identity; it did not establish authority for Secret Disclosure.
+
+## Decision
+
+The approval service will not expose a generic operation that returns an
+existing Secret to a Gate Client.
+
+Existing Secret bytes may leave custody only as an authorized Secret
+Application or Secret Disclosure. The helper must evaluate the complete
+request and persist and verify its Authorization Record before replying with
+Secret bytes.
+
+Secret mutation and migration checks that need to compare an incoming value
+with an existing value run inside the menu bar app. They return success or a
+non-secret error, never the stored value. Such mutations retain their explicit
+human Approval and Authorization Record requirements.
+
+Compatibility code does not justify a weaker path. The automatic migration of
+the legacy `ARGOCD_CONFIG_YAML` Secret is retired instead of preserving an API
+that releases the stored document to `av`.
+
+## Consequences
+
+- A signed copy of `av` cannot retrieve a Secret merely by naming it.
+- Migration conflict checks are narrow, approved status operations rather than
+  unrecorded Secret Disclosures.
+- Old clients that send the removed `load` operation fail closed with an
+  invalid-operation response.
+- Users with the recent legacy Argo CD whole-config Secret must recover it
+  through an explicitly approved Secret Use before running the current
+  hardener.
+- Release builds verify that `av` remains unentitled for Keychain access and
+  that the menu bar app alone carries the exact private access group.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,14 @@ The Homebrew migration intentionally broadens persisted `readOnly` rules to allo
 
 Secret bytes stay in the app's private Keychain access group. Gate policy and Authorization History use separate services. Availability controls whether Keychain may return a Secret while the device is locked. Authorization controls whether the operation may receive it. Both checks must pass.
 
+A Gate Client's code signature authenticates the component but grants no
+authority to retrieve an existing Secret. The approval service exposes no
+generic Secret-load operation. Existing Secret bytes may leave custody only as
+the payload of a complete Secret Application or Secret Disclosure after its
+Authorization Decision and verified Authorization Record. Checks used while
+storing or migrating Secrets compare and verify values inside the menu bar app
+and return status only.
+
 Direct Access Rules are authorization policy, not Secret Availability. They are
 stored separately from Secret bytes. Renaming or deleting a Secret revokes its
 rules so recreating an old Secret Name cannot silently restore authority.
@@ -156,6 +164,11 @@ Human Approval requires an active user session and awake displays. Requests that
 ## Recording before release
 
 An allowed Secret Use must produce a persisted, verified Authorization Record before the secret bytes leave custody. A failure to write or read back the record denies release. Denial and internal-failure records are best effort because recording failure must not replace the original denial with authority.
+
+No trusted-client shortcut may bypass this ordering. A signed Gate Client may
+submit an Authorization Request or an approved Secret mutation; it may not ask
+the menu bar app to return an arbitrary existing Secret for client-side
+inspection or migration.
 
 Authorization History is bounded local operational history. Same-user compromise or storage failure can damage it. Product copy must not promise an append-only audit trail or complete forensic evidence.
 

--- a/docs/secret-gate-security-audit.md
+++ b/docs/secret-gate-security-audit.md
@@ -53,6 +53,18 @@ Automic Vault commits:
 - `4c3e734` Protect approval audit records in Keychain
 - `e779532` Require launcher identity for auto approval
 
+### Ungated trusted-client load
+
+The follow-up review found that the approval service accepted a generic `load`
+operation from the signed `av` Gate Client and returned an arbitrary existing
+Secret without an Authorization Decision or Authorization Record. GitHub and
+Argo CD migration code used the operation for comparison and compatibility.
+
+The operation is removed. Equality and read-back verification now happen
+inside the menu bar app and return only status. GitHub migration uses that
+approved mutation path, and the legacy `ARGOCD_CONFIG_YAML` automatic migration
+is retired. See [ADR 0010](adr/0010-no-ungated-secret-retrieval.md).
+
 Isotope commits:
 
 - GH CLI `d80395cbb` Pin approval service to signing team

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -222,11 +222,13 @@ fi
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$ROOT/target/release/av"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$ROOT/target/release/av-brew-stub"
 assert_no_embedded_entitlements "$ROOT/target/release/av"
+assert_no_embedded_entitlements "$ROOT/target/release/av-brew-stub"
 cp "$ROOT/target/release/av" "$MACOS/av"
 cp "$ROOT/target/release/av-brew-stub" "$MACOS/av-brew-stub"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$MACOS/av"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$MACOS/av-brew-stub"
 assert_no_embedded_entitlements "$MACOS/av"
+assert_no_embedded_entitlements "$MACOS/av-brew-stub"
 app_codesign_args=("${codesign_args[@]}")
 if [[ -f "$MENU_HELPER_PROFILE" && "$identity" != "-" ]]; then
   cp "$MENU_HELPER_PROFILE" "$CONTENTS/embedded.provisionprofile"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -94,6 +94,8 @@ DMG_MOUNT="$SWIFT_TARGET/dmg-mount"
 ICON_BUILD="$SWIFT_TARGET/icon"
 MENU_HELPER_PROFILE="$HOME/Library/MobileDevice/Provisioning Profiles/Automic_Vault_Developer_ID.provisionprofile"
 MENU_HELPER_ENTITLEMENTS="$SWIFT_TARGET/menu-helper.entitlements.plist"
+SIGNED_MENU_HELPER_ENTITLEMENTS="$SWIFT_TARGET/signed-menu-helper.entitlements.plist"
+PRIVATE_KEYCHAIN_ACCESS_GROUP="ZU76A67LGU.com.automicvault"
 INSTALLED_APP="/Applications/Automic Vault.app"
 CONTENTS="$APP/Contents"
 MACOS="$CONTENTS/MacOS"
@@ -102,6 +104,47 @@ LAUNCH_AGENTS="$CONTENTS/Library/LaunchAgents"
 LAUNCH_AGENT_NAME="com.automicvault.menubar-helper"
 LAUNCH_AGENT_PLIST="$LAUNCH_AGENTS/$LAUNCH_AGENT_NAME.plist"
 INSTALLED_LAUNCH_AGENT="$HOME/Library/LaunchAgents/$LAUNCH_AGENT_NAME.plist"
+
+assert_no_embedded_entitlements() {
+  local executable="$1"
+  local entitlements
+  if ! entitlements="$(codesign -d --entitlements :- "$executable" 2>/dev/null)"; then
+    echo "error: failed to inspect signed entitlements for $executable" >&2
+    exit 1
+  fi
+  if [[ -n "$entitlements" ]]; then
+    echo "error: Gate Client must not have embedded entitlements: $executable" >&2
+    exit 1
+  fi
+}
+
+assert_private_keychain_entitlement() {
+  local application="$1"
+  if ! codesign -d --entitlements :- "$application" \
+    2>/dev/null >"$SIGNED_MENU_HELPER_ENTITLEMENTS"; then
+    echo "error: failed to inspect signed entitlements for $application" >&2
+    exit 1
+  fi
+  if ! plutil -lint "$SIGNED_MENU_HELPER_ENTITLEMENTS" >/dev/null; then
+    echo "error: menu bar app has no valid signed entitlements" >&2
+    exit 1
+  fi
+  local groups
+  if ! groups="$(
+    plutil -extract keychain-access-groups json -o - "$SIGNED_MENU_HELPER_ENTITLEMENTS"
+  )"; then
+    echo "error: menu bar app has no Keychain access group" >&2
+    exit 1
+  fi
+  if [[ "$groups" == *"*"* ]]; then
+    echo "error: menu bar app must not have a wildcard Keychain access group" >&2
+    exit 1
+  fi
+  if [[ "$groups" != "[\"$PRIVATE_KEYCHAIN_ACCESS_GROUP\"]" ]]; then
+    echo "error: menu bar app must have exactly $PRIVATE_KEYCHAIN_ACCESS_GROUP; found $groups" >&2
+    exit 1
+  fi
+}
 
 cargo build --release --locked --manifest-path "$ROOT/Cargo.toml"
 AV_CLI_REVISION="$("$ROOT/target/release/av" __version)"
@@ -178,22 +221,27 @@ fi
 
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$ROOT/target/release/av"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$ROOT/target/release/av-brew-stub"
+assert_no_embedded_entitlements "$ROOT/target/release/av"
 cp "$ROOT/target/release/av" "$MACOS/av"
 cp "$ROOT/target/release/av-brew-stub" "$MACOS/av-brew-stub"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$MACOS/av"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$MACOS/av-brew-stub"
+assert_no_embedded_entitlements "$MACOS/av"
 app_codesign_args=("${codesign_args[@]}")
 if [[ -f "$MENU_HELPER_PROFILE" && "$identity" != "-" ]]; then
   cp "$MENU_HELPER_PROFILE" "$CONTENTS/embedded.provisionprofile"
   security cms -D -i "$MENU_HELPER_PROFILE" |
     plutil -extract Entitlements xml1 -o "$MENU_HELPER_ENTITLEMENTS" -
   plutil -replace keychain-access-groups -json \
-    "[\"${APPLE_TEAM_ID}.com.automicvault\"]" \
+    "[\"$PRIVATE_KEYCHAIN_ACCESS_GROUP\"]" \
     "$MENU_HELPER_ENTITLEMENTS"
   app_codesign_args+=(--entitlements "$MENU_HELPER_ENTITLEMENTS")
 fi
 codesign "${app_codesign_args[@]}" "$APP"
 codesign --verify --deep --strict "$APP"
+if [[ -f "$MENU_HELPER_PROFILE" && "$identity" != "-" ]]; then
+  assert_private_keychain_entitlement "$APP"
+fi
 if [[ "$dmg" -eq 1 ]]; then
   rm -rf "$DMG" "$DMG_STAGE"
   mkdir -p "$DMG_STAGE"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,7 +39,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 16;
+pub(crate) const INSTALL_REVISION: u32 = 17;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()

--- a/src/isotopes/detectors/argocd/detector.md
+++ b/src/isotopes/detectors/argocd/detector.md
@@ -10,6 +10,20 @@
 av harden argocd
 ```
 
+Older Automic Vault builds could store the entire config as the legacy Secret
+Name `ARGOCD_CONFIG_YAML`. Current builds intentionally do not retrieve that
+Secret during hardening. To recover it, explicitly approve one Secret
+Application that restores the config, then immediately harden it:
+
+```sh
+av inject --replace-existing-env +ARGOCD_CONFIG_YAML -- /bin/sh -c \
+  'umask 077; mkdir -p "$HOME/.argocd"; printf %s "$ARGOCD_CONFIG_YAML" > "$HOME/.argocd/config"'
+av harden argocd
+```
+
+The first command temporarily restores the plaintext token. Do not leave the
+recovered config unhardened.
+
 ## Sensitive Files
 
 - `$ARGOCD_CONFIG_DIR/config`

--- a/src/isotopes/hardeners/gh_cli.rs
+++ b/src/isotopes/hardeners/gh_cli.rs
@@ -43,7 +43,6 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     }
 
     let destinations = migration_destinations(&credentials, &configured_hosts)?;
-    preflight_destinations(&destinations)?;
 
     if credentials.is_empty() {
         writeln!(stdout, "├─ no legacy gh credentials found").ok();
@@ -76,13 +75,14 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
         return Ok(());
     }
 
-    install.apply(isotope::GH)?;
     if credentials.is_empty() {
+        install.apply(isotope::GH)?;
         writeln!(stdout, "╰─ installed gh isotope").ok();
         super::write_secret_gate_notice(stdout, "gh");
         return Ok(());
     }
-    store_and_verify_destinations(&destinations)?;
+    store_destinations(&destinations)?;
+    install.apply(isotope::GH)?;
     for path in &hosts_paths {
         remove_plaintext_tokens(path)?;
     }
@@ -496,28 +496,9 @@ fn insert_destination(
     Ok(())
 }
 
-fn preflight_destinations(destinations: &BTreeMap<String, String>) -> Result<(), String> {
-    let existing = crate::secrets::list_secret_names()?
-        .into_iter()
-        .collect::<BTreeSet<_>>();
-    for (key, expected) in destinations {
-        if existing.contains(key) && crate::secrets::load_secret(key)? != *expected {
-            return Err(format!(
-                "refusing to replace differing existing GitHub credential {key}"
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn store_and_verify_destinations(destinations: &BTreeMap<String, String>) -> Result<(), String> {
+fn store_destinations(destinations: &BTreeMap<String, String>) -> Result<(), String> {
     for (key, token) in destinations {
         crate::secrets::store_secret_if_absent_or_equal(key, token)?;
-    }
-    for (key, expected) in destinations {
-        if crate::secrets::load_secret(key)? != *expected {
-            return Err(format!("failed to verify GitHub credential {key}"));
-        }
     }
     Ok(())
 }
@@ -856,6 +837,53 @@ mod tests {
                 .unwrap()
                 .contains("oauth_token: incoming")
         );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn harden_preserves_sources_and_skips_install_after_partial_store_failure() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_path("gh-partial-store-failure");
+        let config = dir.join("config");
+        let keychain = dir.join("keychain");
+        let gh = dir.join("gh");
+        fs::create_dir_all(&config).unwrap();
+        fs::create_dir_all(&keychain).unwrap();
+        fs::write(&gh, "original").unwrap();
+        fs::write(
+            config.join("hosts.yml"),
+            "github.com:\n    user: monalisa\n    oauth_token: incoming\n",
+        )
+        .unwrap();
+        fs::write(keychain.join("GH_TOKEN_GITHUB_COM_MONALISA"), "existing").unwrap();
+        unsafe {
+            std::env::set_var("GH_CONFIG_DIR", &config);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+            std::env::set_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH", &gh);
+        }
+
+        let error = run(&mut Vec::new(), true).unwrap_err();
+
+        unsafe {
+            std::env::remove_var("GH_CONFIG_DIR");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_GH_CLI_PATH");
+        }
+        assert!(error.contains("refusing to replace"));
+        assert_eq!(
+            fs::read_to_string(keychain.join("GH_TOKEN_GITHUB_COM")).unwrap(),
+            "incoming"
+        );
+        assert_eq!(
+            fs::read_to_string(keychain.join("GH_TOKEN_GITHUB_COM_MONALISA")).unwrap(),
+            "existing"
+        );
+        assert!(
+            fs::read_to_string(config.join("hosts.yml"))
+                .unwrap()
+                .contains("oauth_token: incoming")
+        );
+        assert_eq!(fs::read_to_string(&gh).unwrap(), "original");
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/isotopes/hardeners/migrations/argocd.rs
+++ b/src/isotopes/hardeners/migrations/argocd.rs
@@ -5,14 +5,9 @@ use std::path::{Path, PathBuf};
 
 const KEYCHAIN_SERVICE: &str = "com.automicvault.isotope";
 const ARGOCD_AUTH_TOKEN_ENV_KEY: &str = "ARGOCD_AUTH_TOKEN";
-const ARGOCD_CONFIG_ENV_KEY: &str = "ARGOCD_CONFIG_YAML";
 
 pub trait CredentialStore {
     fn store_secret(&self, key: &str, value: &str) -> Result<(), String>;
-
-    fn load_secret(&self, _key: &str) -> Result<String, String> {
-        Err("secret not found".to_string())
-    }
 }
 
 pub struct KeychainCredentialStore;
@@ -27,9 +22,6 @@ pub fn migrate_credentials() -> Result<(), String> {
         if migrate_credentials_file(path, &KeychainCredentialStore)? {
             return Ok(());
         }
-    }
-    if let Some(path) = paths.first() {
-        migrate_legacy_keychain_config(path, &KeychainCredentialStore)?;
     }
     Ok(())
 }
@@ -47,28 +39,6 @@ pub fn migrate_credentials_file(path: &Path, store: &dyn CredentialStore) -> Res
     store.store_secret(ARGOCD_AUTH_TOKEN_ENV_KEY, &token)?;
     fs::write(path, sanitized_argocd_config(&contents))
         .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
-    Ok(true)
-}
-
-fn migrate_legacy_keychain_config(
-    restore_path: &Path,
-    store: &dyn CredentialStore,
-) -> Result<bool, String> {
-    let contents = match store.load_secret(ARGOCD_CONFIG_ENV_KEY) {
-        Ok(contents) => contents,
-        Err(_) => return Ok(false),
-    };
-    let Some(token) = migratable_auth_token(&contents)? else {
-        return Ok(false);
-    };
-
-    store.store_secret(ARGOCD_AUTH_TOKEN_ENV_KEY, &token)?;
-    if let Some(parent) = restore_path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
-    }
-    fs::write(restore_path, sanitized_argocd_config(&contents))
-        .map_err(|err| format!("failed to write {}: {err}", restore_path.display()))?;
     Ok(true)
 }
 
@@ -190,44 +160,6 @@ impl CredentialStore for KeychainCredentialStore {
     fn store_secret(&self, key: &str, value: &str) -> Result<(), String> {
         keychain_store_secret(KEYCHAIN_SERVICE, key, value)
     }
-
-    fn load_secret(&self, key: &str) -> Result<String, String> {
-        keychain_load_secret(KEYCHAIN_SERVICE, key)
-    }
-}
-
-#[cfg(all(target_os = "macos", not(coverage)))]
-fn keychain_load_secret(service: &str, account: &str) -> Result<String, String> {
-    unsafe extern "C" {
-        fn isotope_copy_generic_password_json(
-            service_cstr: *const c_char,
-            account_cstr: *const c_char,
-            error_cstr: *mut *mut c_char,
-        ) -> *mut c_char;
-    }
-
-    let service_cstr =
-        CString::new(service).map_err(|_| "invalid keychain service name".to_string())?;
-    let account_cstr =
-        CString::new(account).map_err(|_| "invalid keychain account name".to_string())?;
-    let mut error = std::ptr::null_mut();
-    let value = unsafe {
-        isotope_copy_generic_password_json(service_cstr.as_ptr(), account_cstr.as_ptr(), &mut error)
-    };
-    if value.is_null() {
-        let message = unsafe { take_bridge_string(error) }
-            .unwrap_or_else(|| "keychain lookup failed".to_string());
-        return Err(format!("failed to load secret {account}: {message}"));
-    }
-
-    let secret = unsafe { take_bridge_string(value) }
-        .ok_or_else(|| format!("failed to load secret {account}: invalid keychain data"))?;
-    Ok(secret)
-}
-
-#[cfg(any(not(target_os = "macos"), coverage))]
-fn keychain_load_secret(_service: &str, _account: &str) -> Result<String, String> {
-    Err("Automic Vault secret storage is only available on macOS".to_string())
 }
 
 #[cfg(all(target_os = "macos", not(coverage)))]
@@ -295,7 +227,6 @@ mod tests {
     #[derive(Default)]
     struct TestCredentialStore {
         values: RefCell<Vec<(String, String)>>,
-        legacy_config: RefCell<Option<String>>,
     }
 
     impl CredentialStore for TestCredentialStore {
@@ -304,16 +235,6 @@ mod tests {
                 .borrow_mut()
                 .push((key.to_string(), value.to_string()));
             Ok(())
-        }
-
-        fn load_secret(&self, key: &str) -> Result<String, String> {
-            if key != ARGOCD_CONFIG_ENV_KEY {
-                return Err("missing test key".to_string());
-            }
-            self.legacy_config
-                .borrow()
-                .clone()
-                .ok_or_else(|| "missing test key".to_string())
         }
     }
 
@@ -353,31 +274,6 @@ mod tests {
         let err = migratable_auth_token(contents).unwrap_err();
 
         assert!(err.contains("multiple auth tokens"));
-    }
-
-    #[test]
-    fn migrates_legacy_keychain_config() {
-        let temp = std::env::temp_dir().join(format!(
-            "{}-legacy-keychain-{}",
-            module_path!().replace(':', "_"),
-            std::process::id()
-        ));
-        let path = temp.join(".argocd/config");
-        let contents = "contexts:\n- name: prod\n  server: https://argocd.example.com\n  user: prod\nusers:\n- name: prod\n  auth-token: token\n";
-        let store = TestCredentialStore::default();
-        *store.legacy_config.borrow_mut() = Some(contents.to_string());
-
-        assert!(migrate_legacy_keychain_config(&path, &store).unwrap());
-
-        assert_eq!(
-            store.values.borrow().as_slice(),
-            &[(ARGOCD_AUTH_TOKEN_ENV_KEY.to_string(), "token".to_string())]
-        );
-        assert_eq!(
-            fs::read_to_string(&path).unwrap(),
-            "contexts:\n- name: prod\n  server: https://argocd.example.com\n  user: prod\nusers:\n- name: prod\n  auth-token: \"\"\n"
-        );
-        fs::remove_dir_all(temp).unwrap();
     }
 
     #[test]

--- a/src/isotopes/hardeners/migrations/mod.rs
+++ b/src/isotopes/hardeners/migrations/mod.rs
@@ -140,47 +140,6 @@ unsafe extern "C" fn isotope_store_generic_password_json(
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn isotope_copy_generic_password_json(
-    service: *const std::ffi::c_char,
-    account: *const std::ffi::c_char,
-    error: *mut *mut std::ffi::c_char,
-) -> *mut std::ffi::c_char {
-    let result = (|| {
-        if service.is_null() || account.is_null() {
-            return Err("invalid secret storage arguments".to_string());
-        }
-        let service = unsafe { std::ffi::CStr::from_ptr(service) }
-            .to_str()
-            .map_err(|_| "invalid secret storage service".to_string())?;
-        if service != "com.automicvault.isotope" {
-            return Err(format!("invalid secret storage service: {service}"));
-        }
-        let account = unsafe { std::ffi::CStr::from_ptr(account) }
-            .to_str()
-            .map_err(|_| "invalid secret name".to_string())?;
-        crate::secrets::load_secret(account)
-    })();
-
-    match result.and_then(|value| {
-        std::ffi::CString::new(value).map_err(|_| "invalid secret value".to_string())
-    }) {
-        Ok(value) => value.into_raw(),
-        Err(message) => {
-            set_bridge_error(error, message);
-            std::ptr::null_mut()
-        }
-    }
-}
-
-fn set_bridge_error(error: *mut *mut std::ffi::c_char, message: String) {
-    if !error.is_null() {
-        let message = std::ffi::CString::new(message)
-            .unwrap_or_else(|_| std::ffi::CString::new("secret storage request failed").unwrap());
-        unsafe { *error = message.into_raw() };
-    }
-}
-
-#[unsafe(no_mangle)]
 unsafe extern "C" fn isotope_free_c_string(value: *mut std::ffi::c_char) {
     if !value.is_null() {
         drop(unsafe { std::ffi::CString::from_raw(value) });

--- a/src/menu-helper/Package.resolved
+++ b/src/menu-helper/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "2b5021eedc672644a563e0e553844d9c337ced6579c27983314e3d8634e8e611",
+  "originHash" : "d93079baa7a89315235b673cd99e0dbd0fa144ba078e9adb5eadb4a17a246e63",
   "pins" : [
     {
       "identity" : "appupdater",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/AppUpdater.git",
       "state" : {
-        "revision" : "135698443e7a3a721659a651c79010316f256b1e",
+        "revision" : "6a6975b05f4ffcdebe16307dbd2b5419ca6592bf",
         "version" : "4.1.0"
       }
     },

--- a/src/menu-helper/Package.resolved
+++ b/src/menu-helper/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "d93079baa7a89315235b673cd99e0dbd0fa144ba078e9adb5eadb4a17a246e63",
+  "originHash" : "2b5021eedc672644a563e0e553844d9c337ced6579c27983314e3d8634e8e611",
   "pins" : [
     {
       "identity" : "appupdater",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/AppUpdater.git",
       "state" : {
-        "revision" : "6a6975b05f4ffcdebe16307dbd2b5419ca6592bf",
+        "revision" : "135698443e7a3a721659a651c79010316f256b1e",
         "version" : "4.1.0"
       }
     },

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1918,7 +1918,7 @@ private final class ApprovalServer: @unchecked Sendable {
             )
         case .save where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case .saveIfAbsent where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .saveIfAbsentOrEqual where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(
                 message,
                 on: peer,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1875,7 +1875,10 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid XPC request")
             return
         }
-        let op = String(cString: opPointer)
+        guard let op = ApprovalServiceOperation(rawValue: String(cString: opPointer)) else {
+            reply(peer, to: message, ok: false, error: "invalid XPC operation")
+            return
+        }
 
         guard isAllowedCaller(path: callerPath, signing: signing) else {
             reply(peer, to: message, ok: false, error: "Gate Client is not trusted")
@@ -1889,9 +1892,9 @@ private final class ApprovalServer: @unchecked Sendable {
         )
 
         switch op {
-        case "aws-helper-version" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .awsHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
             reply(peer, to: message, ok: true, error: nil, value: String(awsHelperProtocolVersion))
-        case "inject", "keys", "authorize":
+        case .inject, .keys, .authorize:
             handleInject(
                 message,
                 on: peer,
@@ -1901,9 +1904,9 @@ private final class ApprovalServer: @unchecked Sendable {
                 callerPath: callerPath,
                 signing: signing
             )
-        case "aws-credentials" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .awsCredentials where isTrustedAvCaller(path: callerPath, signing: signing):
             handleAWSCredentials(message, on: peer, pid: pid, identity: identity)
-        case "list" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .list where isTrustedAvCaller(path: callerPath, signing: signing):
             handleList(
                 message,
                 on: peer,
@@ -1913,9 +1916,9 @@ private final class ApprovalServer: @unchecked Sendable {
                 callerPath: callerPath,
                 signing: signing
             )
-        case "save" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .save where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "save-if-absent" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .saveIfAbsent where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(
                 message,
                 on: peer,
@@ -1923,23 +1926,21 @@ private final class ApprovalServer: @unchecked Sendable {
                 caller: mutationCaller,
                 ifAbsentOrEqual: true
             )
-        case "load" where isTrustedAvCaller(path: callerPath, signing: signing):
-            handleLoad(message, on: peer)
-        case "bless" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .bless where isTrustedAvCaller(path: callerPath, signing: signing):
             handleBless(message, on: peer, identity: identity)
-        case "delete" where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .delete where isTrustedAvCaller(path: callerPath, signing: signing):
             handleDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "save" where isTrustedGhCaller(path: callerPath, signing: signing):
+        case .save where isTrustedGhCaller(path: callerPath, signing: signing):
             handleGhSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "gh-save" where isTrustedGhCaller(path: callerPath, signing: signing):
+        case .ghSave where isTrustedGhCaller(path: callerPath, signing: signing):
             handleGhSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "delete" where isTrustedGhCaller(path: callerPath, signing: signing):
+        case .delete where isTrustedGhCaller(path: callerPath, signing: signing):
             handleGhDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "gh-delete" where isTrustedGhCaller(path: callerPath, signing: signing):
+        case .ghDelete where isTrustedGhCaller(path: callerPath, signing: signing):
             handleGhDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "stripe-save" where isTrustedStripeCaller(path: callerPath, signing: signing):
+        case .stripeSave where isTrustedStripeCaller(path: callerPath, signing: signing):
             handleStripeSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
-        case "stripe-delete" where isTrustedStripeCaller(path: callerPath, signing: signing):
+        case .stripeDelete where isTrustedStripeCaller(path: callerPath, signing: signing):
             handleStripeDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
         default:
             reply(peer, to: message, ok: false, error: "invalid XPC operation")
@@ -2848,23 +2849,6 @@ private final class ApprovalServer: @unchecked Sendable {
             cancellation: cancellation,
             caller: caller
         )
-    }
-
-    private func handleLoad(_ message: xpc_object_t, on peer: xpc_connection_t) {
-        guard let keyPointer = xpc_dictionary_get_string(message, "key") else {
-            reply(peer, to: message, ok: false, error: "invalid load request")
-            return
-        }
-        let key = String(cString: keyPointer)
-        guard validSecretKeyName(key) else {
-            reply(peer, to: message, ok: false, error: "invalid secret name: \(key)")
-            return
-        }
-        guard let value = loadStoredSecret(account: key) else {
-            reply(peer, to: message, ok: false, error: "failed to load secret \(key): \(errSecItemNotFound)")
-            return
-        }
-        reply(peer, to: message, ok: true, error: nil, value: value)
     }
 
     private func handleBless(
@@ -5545,6 +5529,7 @@ private func showAutomaticAccessToast(
 private func runSecretMutationSelfCheck() -> Int32 {
     for mutation in [
         SecretMutation.save(account: "TEST_SECRET", value: "secret", accessibility: .whenUnlocked),
+        SecretMutation.saveIfAbsentOrEqual(account: "TEST_SECRET", value: "secret"),
         SecretMutation.delete(account: "TEST_SECRET"),
     ] {
         var performed = false
@@ -5565,6 +5550,27 @@ private func runSecretMutationSelfCheck() -> Int32 {
         )
         guard result.status == nil, !performed else { return 1 }
     }
+
+    var performedWhileInactive = false
+    let inactive = performApprovedSecretMutation(
+        .saveIfAbsentOrEqual(account: "TEST_SECRET", value: "secret"),
+        callerPath: "/usr/local/bin/av",
+        pid: 42,
+        signing: SigningInfo(identifier: "com.automicvault.av", teamIdentifier: "TEAM"),
+        launcher: nil,
+        launcherFallbackPath: "/Applications/Terminal.app",
+        canRequestHumanApproval: { false },
+        onAccessRequest: { _ in true },
+        decision: { _ in .approved },
+        perform: { _ in
+            performedWhileInactive = true
+            return errSecSuccess
+        }
+    )
+    guard inactive.status == nil,
+          inactive.error == "secret mutation denied while user session is inactive",
+          !performedWhileInactive
+    else { return 1 }
 
     var cancellationRecord: AccessRequestRecord?
     var performedAfterCancellation = false

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -1,0 +1,16 @@
+public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
+    case awsHelperVersion = "aws-helper-version"
+    case inject
+    case keys
+    case authorize
+    case awsCredentials = "aws-credentials"
+    case list
+    case save
+    case saveIfAbsent = "save-if-absent"
+    case bless
+    case delete
+    case ghSave = "gh-save"
+    case ghDelete = "gh-delete"
+    case stripeSave = "stripe-save"
+    case stripeDelete = "stripe-delete"
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -6,7 +6,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case awsCredentials = "aws-credentials"
     case list
     case save
-    case saveIfAbsent = "save-if-absent"
+    case saveIfAbsentOrEqual = "save-if-absent"
     case bless
     case delete
     case ghSave = "gh-save"

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1709,7 +1709,7 @@ func saveKeychainDataIfAbsentOrEqual(
     addCanonicalAccessGroup(to: &query)
     let status = SecItemAdd(query as CFDictionary, nil)
     guard status == errSecSuccess || status == errSecDuplicateItem else { return status }
-    // A successful add is not sufficient: mutation success means the final stored bytes were verified.
+    guard status == errSecDuplicateItem else { return status }
     switch loadKeychainDataResult(service: service, account: account) {
     case .success(let existing):
         return existing == data ? errSecSuccess : errSecDuplicateItem

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1707,12 +1707,24 @@ func saveKeychainDataIfAbsentOrEqual(
         kSecAttrAccessible as String: StoredSecretAccessibility.whenUnlocked.keychainValue,
     ]
     addCanonicalAccessGroup(to: &query)
-    let status = SecItemAdd(query as CFDictionary, nil)
+    return verifyKeychainDataAfterConditionalAdd(
+        status: SecItemAdd(query as CFDictionary, nil),
+        expected: data
+    ) {
+        loadKeychainDataResult(service: service, account: account)
+    }
+}
+
+func verifyKeychainDataAfterConditionalAdd(
+    status: OSStatus,
+    expected: Data,
+    load: () -> KeychainDataLoad
+) -> OSStatus {
     guard status == errSecSuccess || status == errSecDuplicateItem else { return status }
     // A successful add is not sufficient: mutation success means the final stored bytes were verified.
-    switch loadKeychainDataResult(service: service, account: account) {
+    switch load() {
     case .success(let existing):
-        return existing == data ? errSecSuccess : errSecDuplicateItem
+        return existing == expected ? errSecSuccess : errSecDuplicateItem
     case .notFound:
         return errSecItemNotFound
     case .failure(let status):

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1709,7 +1709,7 @@ func saveKeychainDataIfAbsentOrEqual(
     addCanonicalAccessGroup(to: &query)
     let status = SecItemAdd(query as CFDictionary, nil)
     guard status == errSecSuccess || status == errSecDuplicateItem else { return status }
-    guard status == errSecDuplicateItem else { return status }
+    // A successful add is not sufficient: mutation success means the final stored bytes were verified.
     switch loadKeychainDataResult(service: service, account: account) {
     case .success(let existing):
         return existing == data ? errSecSuccess : errSecDuplicateItem

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1708,13 +1708,15 @@ func saveKeychainDataIfAbsentOrEqual(
     ]
     addCanonicalAccessGroup(to: &query)
     let status = SecItemAdd(query as CFDictionary, nil)
-    guard status == errSecDuplicateItem else { return status }
-    guard case .success(let existing) = loadKeychainDataResult(service: service, account: account),
-          existing == data
-    else {
-        return errSecDuplicateItem
+    guard status == errSecSuccess || status == errSecDuplicateItem else { return status }
+    switch loadKeychainDataResult(service: service, account: account) {
+    case .success(let existing):
+        return existing == data ? errSecSuccess : errSecDuplicateItem
+    case .notFound:
+        return errSecItemNotFound
+    case .failure(let status):
+        return status
     }
-    return errSecSuccess
 }
 
 private func addCanonicalAccessGroup(to query: inout [String: Any]) {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1709,6 +1709,7 @@ func saveKeychainDataIfAbsentOrEqual(
     addCanonicalAccessGroup(to: &query)
     let status = SecItemAdd(query as CFDictionary, nil)
     guard status == errSecSuccess || status == errSecDuplicateItem else { return status }
+    // A successful add is not sufficient: mutation success means the final stored bytes were verified.
     switch loadKeychainDataResult(service: service, account: account) {
     case .success(let existing):
         return existing == data ? errSecSuccess : errSecDuplicateItem

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -5,6 +5,10 @@ import Testing
     #expect(ApprovalServiceOperation(rawValue: "load") == nil)
 }
 
+@Test func conditionalSaveKeepsItsCompatibleWireValue() {
+    #expect(ApprovalServiceOperation.saveIfAbsentOrEqual.rawValue == "save-if-absent")
+}
+
 @Test func approvalServiceOperationValuesAreUnique() {
     let values = ApprovalServiceOperation.allCases.map(\.rawValue)
     #expect(Set(values).count == values.count)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import MenubarHelperCore
+
+@Test func approvalServiceRejectsGenericSecretLoad() {
+    #expect(ApprovalServiceOperation(rawValue: "load") == nil)
+}
+
+@Test func approvalServiceOperationValuesAreUnique() {
+    let values = ApprovalServiceOperation.allCases.map(\.rawValue)
+    #expect(Set(values).count == values.count)
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -777,6 +777,29 @@ func protectionPolicyMatrix(
     #expect(loadStoredSecret(account: account, service: service) == "first")
 }
 
+@Test func conditionalSecretSaveVerifiesNewValueBeforeSuccess() {
+    let expected = Data("secret".utf8)
+    var performedReadback = false
+
+    let status = verifyKeychainDataAfterConditionalAdd(status: errSecSuccess, expected: expected) {
+        performedReadback = true
+        return .success(expected)
+    }
+
+    #expect(performedReadback)
+    #expect(status == errSecSuccess)
+}
+
+@Test func conditionalSecretSavePropagatesNewValueReadbackFailure() {
+    let expected = Data("secret".utf8)
+
+    let status = verifyKeychainDataAfterConditionalAdd(status: errSecSuccess, expected: expected) {
+        .failure(errSecInteractionNotAllowed)
+    }
+
+    #expect(status == errSecInteractionNotAllowed)
+}
+
 @Test func conditionalSecretSavePreservesExistingAccessibility() {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.conditional-save.\(UUID().uuidString)"

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -59,17 +59,6 @@ pub(crate) fn store_secret_if_absent_or_equal(account: &str, value: &str) -> Res
     }
 }
 
-pub(crate) fn load_secret(account: &str) -> Result<String, String> {
-    if let Some(dir) = crate::test_keychain_dir() {
-        let path = PathBuf::from(dir).join(account);
-        return std::fs::read_to_string(&path)
-            .map_err(|err| format!("failed to read {}: {err}", path.display()));
-    }
-    xpc_request("load", Some((b"key\0", account)), None, None)?
-        .value
-        .ok_or_else(|| format!("failed to load secret {account}"))
-}
-
 pub(crate) fn bless_script(path: &str, endorse_launcher: bool) -> Result<bool, String> {
     xpc_request(
         "bless",

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -118,6 +118,20 @@ fn release_builds_are_actions_only_and_fail_closed() {
 }
 
 #[test]
+fn release_build_asserts_secret_custody_entitlements() {
+    assert!(BUILD_SCRIPT.contains("PRIVATE_KEYCHAIN_ACCESS_GROUP=\"ZU76A67LGU.com.automicvault\""));
+    assert!(BUILD_SCRIPT.contains(
+        "assert_no_embedded_entitlements \"$ROOT/target/release/av\""
+    ));
+    assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$MACOS/av\""));
+    assert!(BUILD_SCRIPT.contains("assert_private_keychain_entitlement \"$APP\""));
+    assert!(BUILD_SCRIPT.contains("menu bar app must not have a wildcard Keychain access group"));
+    assert!(BUILD_SCRIPT.contains(
+        "menu bar app must have exactly $PRIVATE_KEYCHAIN_ACCESS_GROUP"
+    ));
+}
+
+#[test]
 fn release_actions_delegate_website_publication_to_the_local_script() {
     assert!(!RELEASE_WORKFLOW.contains("aws-actions/"));
     assert!(!RELEASE_WORKFLOW.contains("aws "));

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -120,15 +120,11 @@ fn release_builds_are_actions_only_and_fail_closed() {
 #[test]
 fn release_build_asserts_secret_custody_entitlements() {
     assert!(BUILD_SCRIPT.contains("PRIVATE_KEYCHAIN_ACCESS_GROUP=\"ZU76A67LGU.com.automicvault\""));
-    assert!(BUILD_SCRIPT.contains(
-        "assert_no_embedded_entitlements \"$ROOT/target/release/av\""
-    ));
+    assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/av\""));
     assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$MACOS/av\""));
     assert!(BUILD_SCRIPT.contains("assert_private_keychain_entitlement \"$APP\""));
     assert!(BUILD_SCRIPT.contains("menu bar app must not have a wildcard Keychain access group"));
-    assert!(BUILD_SCRIPT.contains(
-        "menu bar app must have exactly $PRIVATE_KEYCHAIN_ACCESS_GROUP"
-    ));
+    assert!(BUILD_SCRIPT.contains("menu bar app must have exactly $PRIVATE_KEYCHAIN_ACCESS_GROUP"));
 }
 
 #[test]

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -121,7 +121,12 @@ fn release_builds_are_actions_only_and_fail_closed() {
 fn release_build_asserts_secret_custody_entitlements() {
     assert!(BUILD_SCRIPT.contains("PRIVATE_KEYCHAIN_ACCESS_GROUP=\"ZU76A67LGU.com.automicvault\""));
     assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/av\""));
+    assert!(
+        BUILD_SCRIPT
+            .contains("assert_no_embedded_entitlements \"$ROOT/target/release/av-brew-stub\"")
+    );
     assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$MACOS/av\""));
+    assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$MACOS/av-brew-stub\""));
     assert!(BUILD_SCRIPT.contains("assert_private_keychain_entitlement \"$APP\""));
     assert!(BUILD_SCRIPT.contains("menu bar app must not have a wildcard Keychain access group"));
     assert!(BUILD_SCRIPT.contains("menu bar app must have exactly $PRIVATE_KEYCHAIN_ACCESS_GROUP"));

--- a/tests/secret_custody_boundary.rs
+++ b/tests/secret_custody_boundary.rs
@@ -1,0 +1,21 @@
+const RUST_SECRET_CLIENT: &str = include_str!("../src/secrets.rs");
+const APPROVAL_SERVICE: &str = include_str!("../src/menu-helper/Sources/MenubarHelper/main.swift");
+const APPROVAL_OPERATIONS: &str =
+    include_str!("../src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift");
+const ARGOCD_MIGRATION: &str = include_str!("../src/isotopes/hardeners/migrations/argocd.rs");
+
+#[test]
+fn gate_client_has_no_generic_secret_load_protocol() {
+    assert!(!RUST_SECRET_CLIENT.contains("xpc_request(\"load\""));
+    assert!(!RUST_SECRET_CLIENT.contains("fn load_secret"));
+    assert!(!APPROVAL_SERVICE.contains("handleLoad"));
+    assert!(!APPROVAL_SERVICE.contains("case \"load\""));
+    assert!(!APPROVAL_OPERATIONS.contains("case load"));
+}
+
+#[test]
+fn argocd_migration_does_not_retrieve_legacy_vault_secrets() {
+    assert!(!ARGOCD_MIGRATION.contains("ARGOCD_CONFIG_YAML"));
+    assert!(!ARGOCD_MIGRATION.contains("load_secret"));
+    assert!(!ARGOCD_MIGRATION.contains("isotope_copy_generic_password_json"));
+}


### PR DESCRIPTION
## Summary

- Remove the generic XPC `load` operation that returned existing Secret values without authorization.
- Enforce authorization and Authorization Record requirements for Secret Disclosure.
- Retire automatic `ARGOCD_CONFIG_YAML` migration and document explicit recovery.
- Add release-build entitlement checks and preserve GitHub hardening safety on partial failure.

## Testing

- Added coverage for GitHub hardening after partial store failure.
- Not run (not requested).