### PR TITLE
Refuse Homebrew hardening with services

### DIFF
--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -6,7 +6,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V16";
+const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V17";
 const TARGET: &str = "/opt/homebrew/bin/brew";
 const PREFIX: &str = "/opt/homebrew";
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
@@ -34,7 +34,7 @@ fn main() {
     }
 
     validate_caller().unwrap_or_else(|err| fail(err));
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd = effective_cwd(std::env::current_dir());
     let mut command = approved_command(
         args,
         std::env::vars_os(),
@@ -78,6 +78,7 @@ where
     let mut command = Command::new(TARGET);
     command
         .args(request.args)
+        .current_dir(cwd)
         .env_clear()
         .envs(stub_env(source_env));
     if cask.is_some() {
@@ -87,6 +88,12 @@ where
         command.pre_exec(drop_to_effective_identity);
     }
     Ok(command)
+}
+
+fn effective_cwd(cwd: io::Result<PathBuf>) -> PathBuf {
+    cwd.ok()
+        .filter(|cwd| fs::read_dir(cwd).is_ok())
+        .unwrap_or_else(|| PathBuf::from("/"))
 }
 
 fn drop_to_effective_identity() -> io::Result<()> {
@@ -581,6 +588,32 @@ mod tests {
         assert_eq!(request.target, TARGET);
         assert_eq!(request.args, ["install", "--cask", "Visual Studio Code"]);
         assert_eq!(request.cwd, "/tmp/a project");
+    }
+
+    #[test]
+    fn unreadable_working_directory_falls_back_to_root() {
+        use std::os::unix::fs::PermissionsExt;
+
+        assert_eq!(
+            effective_cwd(Err(io::Error::from(io::ErrorKind::PermissionDenied))),
+            Path::new("/")
+        );
+        let unreadable = temp_path("unreadable-cwd");
+        fs::create_dir(&unreadable).unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        assert_eq!(effective_cwd(Ok(unreadable.clone())), Path::new("/"));
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::remove_dir(unreadable).unwrap();
+
+        let command = approved_command(
+            vec!["--version".into()],
+            [],
+            Path::new("/"),
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap();
+        assert_eq!(command.get_current_dir(), Some(Path::new("/")));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,7 +39,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 17;
+pub(crate) const INSTALL_REVISION: u32 = 18;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()

--- a/src/isotopes/hardeners/homebrew.md
+++ b/src/isotopes/hardeners/homebrew.md
@@ -4,6 +4,7 @@
 
 - Only `brew` can alter `/opt/homebrew`.
 - Hardened Homebrew manages formulae and a narrow class of CLI-only casks.
+- Homebrew services are incompatible with hardened Homebrew.
 - Approval gates can be configured to stop agents installing things behind your
   back.
 
@@ -69,6 +70,14 @@ is that solution.
 - Do not add `/opt/homebrew/share/zsh/site-functions` to `fpath` or bypass zsh's
   ownership checks. Older user-owned Automic Vault completion mirrors are no
   longer updated and may be removed.
+
+## Caveats
+
+- Hardening refuses to run while any Homebrew service is loaded or registered.
+  Stop each service with `/opt/homebrew/bin/brew services stop <formula>` before
+  hardening.
+- If the protected `automic` account cannot read the current working directory,
+  the hardened launcher runs Homebrew from `/` instead.
 
 ## Casks
 

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -24,8 +24,8 @@ const BREW_USER_UID_FILE: &str = "var/automic/user-uid";
 const LEGACY_CASK_USER_UID_FILE: &str = "var/automic/cask-user-uid";
 const STUB_MARKER_PREFIX: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V";
 #[cfg(test)]
-const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V16";
-const STUB_VERSION: u32 = 16;
+const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V17";
+const STUB_VERSION: u32 = 17;
 const ID_RANGE: std::ops::RangeInclusive<u32> = 550..=599;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -217,6 +217,13 @@ fn preflight() -> Result<(PathBuf, PathBuf, PathBuf, SourceUser), String> {
         ));
     }
     let source_user = source_user()?;
+    let services = homebrew_services(&target, &source_user)?;
+    if !services.is_empty() {
+        return Err(format!(
+            "these Homebrew services are incompatible with hardened Homebrew: {}. Stop each one with `/opt/homebrew/bin/brew services stop <formula>`, then rerun `av harden brew`",
+            services.join(", ")
+        ));
+    }
     let casks = incompatible_installed_casks(&prefix)?;
     if !casks.is_empty() {
         return Err(format!(
@@ -225,6 +232,58 @@ fn preflight() -> Result<(PathBuf, PathBuf, PathBuf, SourceUser), String> {
         ));
     }
     Ok((prefix, stub, source, source_user))
+}
+
+fn homebrew_services(target: &Path, source_user: &SourceUser) -> Result<Vec<String>, String> {
+    let mut command = if super::effective_uid() == 0 {
+        let mut command = Command::new(SUDO_PATH);
+        command
+            .args(["-H", "-u", &source_user.name, "--", "/usr/bin/env"])
+            .args(["HOMEBREW_NO_AUTO_UPDATE=1", "HOMEBREW_NO_ANALYTICS=1"])
+            .arg(target);
+        command
+    } else {
+        Command::new(target)
+    };
+    let output = command
+        .args(["services", "list", "--json"])
+        .env("HOMEBREW_NO_AUTO_UPDATE", "1")
+        .env("HOMEBREW_NO_ANALYTICS", "1")
+        .output()
+        .map_err(|err| format!("failed to inspect Homebrew services: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to inspect Homebrew services: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    parse_homebrew_services(&output.stdout)
+}
+
+fn parse_homebrew_services(json: &[u8]) -> Result<Vec<String>, String> {
+    let services = serde_json::from_slice::<serde_json::Value>(json)
+        .map_err(|err| format!("Homebrew returned malformed services JSON: {err}"))?;
+    let services = services
+        .as_array()
+        .ok_or_else(|| "Homebrew returned malformed services JSON".to_string())?;
+    let mut names = Vec::new();
+    for service in services {
+        let malformed = || "Homebrew returned malformed services JSON".to_string();
+        let service = service.as_object().ok_or_else(malformed)?;
+        let name = service
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(malformed)?;
+        let status = service
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(malformed)?;
+        let user = service.get("user").ok_or_else(malformed)?;
+        if status != "none" || !user.is_null() {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
 }
 
 pub(crate) fn unharden(stdout: &mut dyn Write) -> Result<super::RootOnlyOutcome, String> {
@@ -1378,6 +1437,21 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
+    fn identifies_loaded_and_registered_homebrew_services() {
+        let services = parse_homebrew_services(
+            br#"[
+                {"name":"dnsmasq","status":"none","user":null},
+                {"name":"postgresql@17","status":"started","user":"alice"},
+                {"name":"redis","status":"none","user":"alice"}
+            ]"#,
+        )
+        .unwrap();
+
+        assert_eq!(services, ["postgresql@17", "redis"]);
+        assert!(parse_homebrew_services(br#"[{"name":"redis"}]"#).is_err());
+    }
+
+    #[test]
     fn detects_stub_marker_owner_group_and_mode() {
         let _guard = crate::global_test_env_lock().lock().unwrap();
         let path = temp_path("brew-stub-detect");
@@ -1442,7 +1516,7 @@ mod tests {
         assert!(is_managed_stub_file(&path));
         assert!(!stub_is_current(&path));
 
-        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V17 future").unwrap();
+        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V18 future").unwrap();
         assert!(stub_is_current(&path));
 
         for invalid in [

--- a/tests/brew_stub_build.rs
+++ b/tests/brew_stub_build.rs
@@ -1,7 +1,4 @@
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn av_brew_stub_binary_is_built() {
@@ -13,7 +10,7 @@ fn av_brew_stub_binary_is_built() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "AUTOMIC_VAULT_BREW_STUB_V16"
+        "AUTOMIC_VAULT_BREW_STUB_V17"
     );
 
     let output = Command::new(env!("CARGO_BIN_EXE_av-brew-stub"))
@@ -21,34 +18,4 @@ fn av_brew_stub_binary_is_built() {
         .output()
         .unwrap();
     assert!(!output.status.success());
-}
-
-#[test]
-fn av_brew_stub_does_not_require_a_readable_current_directory() {
-    let root = std::env::temp_dir().join(format!(
-        "av-brew-stub-cwd-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    fs::create_dir_all(root.join("cwd")).unwrap();
-
-    let output = Command::new("/bin/sh")
-        .args([
-            "-c",
-            "cd \"$1/cwd\" && chmod 000 \"$1\" && exec \"$2\" --version",
-            "sh",
-        ])
-        .arg(&root)
-        .arg(env!("CARGO_BIN_EXE_av-brew-stub"))
-        .output()
-        .unwrap();
-
-    fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
-    fs::remove_dir_all(&root).unwrap();
-    assert!(
-        !String::from_utf8_lossy(&output.stderr)
-            .contains("failed to read current directory: Permission denied")
-    );
 }


### PR DESCRIPTION
## Summary

- refuse `av harden brew` while any Homebrew service is loaded or registered
- repeat the fail-closed services check in the privileged phase before ownership changes
- run hardened Homebrew from `/` when the protected account cannot read the invoking working directory
- document both limitations and bump the CLI and Homebrew stub compatibility revisions

## Why

Homebrew stores service data and logs beneath `/opt/homebrew/var`, but the hardener recursively transfers the prefix to the protected `automic` account. Existing user services then lose access to their state. Leaving those paths user-owned would weaken the hardener's ownership invariant, so the safe short-term behavior is to refuse hardening until services are stopped.

The launcher also inherited working directories that `automic` could not traverse, causing Homebrew to fail while reconstructing `PWD`. The fallback makes the effective working directory explicit and binds `/` into the Authorization Request.

## Validation

- `cargo test` (841 library tests plus all binary and integration tests)
- `cargo fmt -- --check`
- `git diff --check`

Refs #152
