### PR TITLE
Fix Brew shellenv and PATH probe recursion

### DIFF
--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -6,9 +6,10 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V17";
+const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V18";
 const TARGET: &str = "/opt/homebrew/bin/brew";
 const PREFIX: &str = "/opt/homebrew";
+const SHELLENV_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const BREW_USER_UID: &str = "/opt/homebrew/var/automic/user-uid";
 const FORBIDDEN_CASK_ARTIFACTS: &str = "app appimage artifact audiounitplugin bashcompletion colorpicker commandwrapper dictionary fishcompletion font generatedscript inputmethod installer internetplugin keyboardlayout manpage mdimporter pkg postflight postflightblock postflightsteps preflight preflightblock preflightsteps prefpane qlplugin screensaver service stageonly suite uninstall uninstallpostflightsteps uninstallpreflightsteps vst3plugin vstplugin zshcompletion";
@@ -69,6 +70,8 @@ where
     F: FnOnce(&AuthorizationRequest) -> Result<(), String>,
 {
     let mut request = authorization_request(&args, cwd)?;
+    let shellenv =
+        command_index(&request.args).is_some_and(|index| request.args[index] == "shellenv");
     let (args, cask) = governed_args(&request.args)?;
     request.args = args;
     if let Some(cask) = &cask {
@@ -81,6 +84,9 @@ where
         .current_dir(cwd)
         .env_clear()
         .envs(stub_env(source_env));
+    if shellenv {
+        command.env("PATH", SHELLENV_PATH);
+    }
     if cask.is_some() {
         command.env("HOMEBREW_NO_AUTO_UPDATE", "1");
     }
@@ -106,10 +112,7 @@ fn drop_to_effective_identity() -> io::Result<()> {
 }
 
 fn governed_args(args: &[String]) -> Result<(Vec<String>, Option<CaskMutation>), String> {
-    let Some(command_index) = args
-        .iter()
-        .position(|arg| arg == "--" || !arg.starts_with('-'))
-    else {
+    let Some(command_index) = command_index(args) else {
         return Ok((args.to_vec(), None));
     };
     let command = args[command_index].as_str();
@@ -161,6 +164,11 @@ fn governed_args(args: &[String]) -> Result<(Vec<String>, Option<CaskMutation>),
         args.insert(command_index + 1, "--formula".into());
     }
     Ok((args, None))
+}
+
+fn command_index(args: &[String]) -> Option<usize> {
+    args.iter()
+        .position(|arg| arg == "--" || !arg.starts_with('-'))
 }
 
 fn cask_operands(args: &[String], command_index: usize) -> Result<Vec<String>, String> {
@@ -680,6 +688,25 @@ mod tests {
         assert!(env.contains(&("HOME".into(), "/opt/homebrew/var/automic".into())));
         assert!(env.contains(&("TERM".into(), "xterm-256color".into())));
         assert!(!env.iter().any(|(key, _)| key == "SECRET"));
+    }
+
+    #[test]
+    fn shellenv_child_path_does_not_look_already_configured() {
+        let command = approved_command(
+            vec!["shellenv".into()],
+            [],
+            Path::new("/tmp"),
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap();
+        let path = command
+            .get_envs()
+            .find(|(key, _)| *key == "PATH")
+            .and_then(|(_, value)| value)
+            .unwrap();
+
+        assert_eq!(path, SHELLENV_PATH);
     }
 
     #[test]

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -6,7 +6,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V18";
+const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V19";
 const TARGET: &str = "/opt/homebrew/bin/brew";
 const PREFIX: &str = "/opt/homebrew";
 const SHELLENV_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
@@ -112,6 +112,9 @@ fn drop_to_effective_identity() -> io::Result<()> {
 }
 
 fn governed_args(args: &[String]) -> Result<(Vec<String>, Option<CaskMutation>), String> {
+    if args.iter().any(|arg| arg == "--") {
+        return Err("`--` is unavailable in hardened Homebrew commands".into());
+    }
     let Some(command_index) = command_index(args) else {
         return Ok((args.to_vec(), None));
     };
@@ -167,8 +170,7 @@ fn governed_args(args: &[String]) -> Result<(Vec<String>, Option<CaskMutation>),
 }
 
 fn command_index(args: &[String]) -> Option<usize> {
-    args.iter()
-        .position(|arg| arg == "--" || !arg.starts_with('-'))
+    args.iter().position(|arg| !arg.starts_with('-'))
 }
 
 fn cask_operands(args: &[String], command_index: usize) -> Result<Vec<String>, String> {
@@ -775,8 +777,14 @@ mod tests {
             (vec!["info".into(), "install".into()], None)
         );
         assert_eq!(
-            governed_args(&["--".into(), "install".into()]).unwrap(),
-            (vec!["--".into(), "install".into()], None)
+            governed_args(&[
+                "--".into(),
+                "install".into(),
+                "--cask".into(),
+                "codex".into(),
+            ])
+            .unwrap_err(),
+            "`--` is unavailable in hardened Homebrew commands"
         );
     }
 

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -24,8 +24,8 @@ const BREW_USER_UID_FILE: &str = "var/automic/user-uid";
 const LEGACY_CASK_USER_UID_FILE: &str = "var/automic/cask-user-uid";
 const STUB_MARKER_PREFIX: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V";
 #[cfg(test)]
-const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V18";
-const STUB_VERSION: u32 = 18;
+const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V19";
+const STUB_VERSION: u32 = 19;
 const ID_RANGE: std::ops::RangeInclusive<u32> = 550..=599;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1513,7 +1513,7 @@ mod tests {
         assert!(is_managed_stub_file(&path));
         assert!(!stub_is_current(&path));
 
-        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V19 future").unwrap();
+        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V20 future").unwrap();
         assert!(stub_is_current(&path));
 
         for invalid in [

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -24,8 +24,8 @@ const BREW_USER_UID_FILE: &str = "var/automic/user-uid";
 const LEGACY_CASK_USER_UID_FILE: &str = "var/automic/cask-user-uid";
 const STUB_MARKER_PREFIX: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V";
 #[cfg(test)]
-const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V17";
-const STUB_VERSION: u32 = 17;
+const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V18";
+const STUB_VERSION: u32 = 18;
 const ID_RANGE: std::ops::RangeInclusive<u32> = 550..=599;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -48,11 +48,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
 
     writeln!(stdout, "╭─ harden brew").ok();
     writeln!(stdout, "│").ok();
-    writeln!(
-        stdout,
-        "◆ casks are (mostly) UNSUPPORTED"
-    )
-    .ok();
+    writeln!(stdout, "◆ casks are (mostly) UNSUPPORTED").ok();
     writeln!(
         stdout,
         "│  Casks can modify applications, system libraries, services, and user data."
@@ -63,11 +59,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
         "│  Only CLI-only casks that link protected executables into /opt/homebrew/bin are allowed."
     )
     .ok();
-    writeln!(
-        stdout,
-        "◆ `brew services` is UNSUPPORTED"
-    )
-    .ok();
+    writeln!(stdout, "◆ `brew services` is UNSUPPORTED").ok();
     writeln!(stdout, "│").ok();
     writeln!(
         stdout,
@@ -1521,7 +1513,7 @@ mod tests {
         assert!(is_managed_stub_file(&path));
         assert!(!stub_is_current(&path));
 
-        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V18 future").unwrap();
+        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V19 future").unwrap();
         assert!(stub_is_current(&path));
 
         for invalid in [

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -777,13 +777,14 @@ public func doctorIssues(from doctorJSON: Data, loginShellPATHAvailable: Bool = 
         }
     }
     guard !loginShellPATHAvailable else { return issues }
-    issues.removeAll { $0.kind == "stub_not_first_on_path" }
-    issues.append(DoctorIssue(
-        hardener: "PATH",
-        kind: "login_shell_path_unavailable",
-        message: "PATH inspection is unavailable in the menu bar app",
-        remediation: "Run `av doctor` from a login shell to inspect PATH."
-    ))
+    issues.removeAll {
+        [
+            "agent_cli_signature_invalid",
+            "agent_cli_unavailable",
+            "isotope_not_first_on_path",
+            "stub_not_first_on_path",
+        ].contains($0.kind)
+    }
     return issues
 }
 
@@ -1803,12 +1804,7 @@ public func loadDoctorIssues(avExecutableURL: URL) -> [DoctorIssue] {
     )
     return data.flatMap {
         try? doctorIssues(from: $0, loginShellPATHAvailable: false)
-    } ?? [DoctorIssue(
-        hardener: "PATH",
-        kind: "login_shell_path_unavailable",
-        message: "PATH inspection is unavailable in the menu bar app",
-        remediation: "Run `av doctor` from a login shell to inspect PATH."
-    )]
+    } ?? []
 }
 
 func loadJSON(

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1804,7 +1804,12 @@ public func loadDoctorIssues(avExecutableURL: URL) -> [DoctorIssue] {
     )
     return data.flatMap {
         try? doctorIssues(from: $0, loginShellPATHAvailable: false)
-    } ?? []
+    } ?? [DoctorIssue(
+        hardener: "Doctor",
+        kind: "doctor_unavailable",
+        message: "Doctor results are unavailable",
+        remediation: "Run `av doctor` in Terminal to inspect the failure."
+    )]
 }
 
 func loadJSON(

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1,5 +1,4 @@
 import CryptoKit
-import Darwin
 import Foundation
 import Security
 
@@ -782,8 +781,8 @@ public func doctorIssues(from doctorJSON: Data, loginShellPATHAvailable: Bool = 
     issues.append(DoctorIssue(
         hardener: "PATH",
         kind: "login_shell_path_unavailable",
-        message: "Unable to inspect the login-shell PATH",
-        remediation: "Ensure the configured login shell starts successfully, then refresh Doctor."
+        message: "PATH inspection is unavailable in the menu bar app",
+        remediation: "Run `av doctor` from a login shell to inspect PATH."
     ))
     return issues
 }
@@ -1797,40 +1796,29 @@ public func loadHardenerMetadata(avExecutableURL: URL) -> [HardenerMetadata] {
 }
 
 public func loadDoctorIssues(avExecutableURL: URL) -> [DoctorIssue] {
-    let shellPATH = loginShellPATH()
-    var environment = ProcessInfo.processInfo.environment
-    if let shellPATH {
-        environment["PATH"] = shellPATH
-    }
     let data = loadJSON(
         avExecutableURL: avExecutableURL,
         arguments: ["doctor", "--json"],
-        acceptedTerminationStatuses: [0, 1],
-        environment: environment
+        acceptedTerminationStatuses: [0, 1]
     )
     return data.flatMap {
-        try? doctorIssues(from: $0, loginShellPATHAvailable: shellPATH != nil)
-    } ?? (shellPATH == nil ? [DoctorIssue(
+        try? doctorIssues(from: $0, loginShellPATHAvailable: false)
+    } ?? [DoctorIssue(
         hardener: "PATH",
         kind: "login_shell_path_unavailable",
-        message: "Unable to inspect the login-shell PATH",
-        remediation: "Ensure the configured login shell starts successfully, then refresh Doctor."
-    )] : [])
+        message: "PATH inspection is unavailable in the menu bar app",
+        remediation: "Run `av doctor` from a login shell to inspect PATH."
+    )]
 }
 
 func loadJSON(
     avExecutableURL: URL,
     arguments: [String],
-    acceptedTerminationStatuses: Set<Int32> = [0],
-    environment: [String: String]? = nil
+    acceptedTerminationStatuses: Set<Int32> = [0]
 ) -> Data? {
     let process = Process()
     process.executableURL = avExecutableURL
     process.arguments = arguments
-    if let environment {
-        process.environment = environment
-    }
-
     let output = Pipe()
     process.standardOutput = output
     process.standardError = Pipe()
@@ -1845,46 +1833,6 @@ func loadJSON(
     process.waitUntilExit()
     guard acceptedTerminationStatuses.contains(process.terminationStatus) else { return nil }
     return data
-}
-
-func loginShellPATH() -> String? {
-    guard let record = getpwuid(getuid()),
-          let shellPointer = record.pointee.pw_shell,
-          let shell = String(validatingCString: shellPointer),
-          !shell.isEmpty
-    else { return nil }
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: shell)
-    process.arguments = ["-lic", "/usr/bin/printenv PATH"]
-    let output = Pipe()
-    process.standardOutput = output
-    process.standardError = Pipe()
-    do {
-        try process.run()
-    } catch {
-        return nil
-    }
-    let data = output.fileHandleForReading.readDataToEndOfFile()
-    process.waitUntilExit()
-    guard process.terminationStatus == 0 else { return nil }
-    return loginShellPATH(from: data)
-}
-
-func loginShellPATH(from data: Data) -> String? {
-    guard let output = String(data: data, encoding: .utf8) else { return nil }
-    var path: Substring?
-    for outputLine in output.split(whereSeparator: \.isNewline) {
-        var line = outputLine
-        while line.hasPrefix("\u{1B}]") {
-            guard let terminator = line.firstIndex(of: "\u{07}") else { return nil }
-            line = line[line.index(after: terminator)...]
-        }
-        if line.hasPrefix("/") {
-            path = line
-        }
-    }
-    return path.map(String.init)
 }
 
 public func defaultAVExecutableURL() -> URL {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -186,6 +186,15 @@ import Testing
     #expect(try doctorIssues(from: data).isEmpty)
 }
 
+@Test func doctorLoadFailureIsReportedDirectly() {
+    let issues = loadDoctorIssues(
+        avExecutableURL: URL(fileURLWithPath: "/no/such/automic-vault-av")
+    )
+
+    #expect(issues.map(\.kind) == ["doctor_unavailable"])
+    #expect(issues.first?.message == "Doctor results are unavailable")
+}
+
 @Test func detectorDocumentationReferencesHardenerCommand() {
     #expect(hardenerNameReferencedByDocumentation("```sh\nav harden gh\n```") == "gh")
     #expect(hardenerNameReferencedByDocumentation("Run `sudo av harden aws` after import.") == "aws")

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -165,13 +165,8 @@ import Testing
     let issues = try doctorIssues(from: data, loginShellPATHAvailable: false)
 
     #expect(issues.map(\.kind) == ["hardening_not_applied", "login_shell_path_unavailable"])
-}
-
-@Test func loginShellPATHUsesLastAbsoluteLine() {
-    #expect(loginShellPATH(from: Data("startup noise\n/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
-    #expect(loginShellPATH(from: Data("\u{1B}]0;zsh\u{07}/usr/bin:/bin\n".utf8)) == "/usr/bin:/bin")
-    #expect(loginShellPATH(from: Data("\u{1B}]0;zsh/usr/bin:/bin\n".utf8)) == nil)
-    #expect(loginShellPATH(from: Data("\u{1B}]0;zsh\n/usr/bin:/bin\n".utf8)) == nil)
+    #expect(issues.last?.message == "PATH inspection is unavailable in the menu bar app")
+    #expect(issues.last?.remediation == "Run `av doctor` from a login shell to inspect PATH.")
 }
 
 @Test func JSONLoaderCanAcceptDoctorIssueExitStatus() throws {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -154,19 +154,26 @@ import Testing
     #expect(Set(issues.map(\.id)).count == 2)
 }
 
-@Test func unavailableLoginShellPATHSuppressesMisleadingPATHIssues() throws {
+@Test func unavailableLoginShellPATHSuppressesAllUnverifiablePATHIssues() throws {
     let data = Data(#"""
-    {"results":[{"name":"aws","commands":["aws"],"issues":[
-      {"kind":"stub_not_first_on_path","command":"aws","message":"shadowed","remediation":"Fix PATH.","stub_path":"/usr/local/bin/aws","target_path":"/opt/homebrew/bin/aws","resolved_path":"/opt/homebrew/bin/aws"},
-      {"kind":"hardening_not_applied","command":"aws","message":"not hardened","remediation":"Harden it.","stub_path":"/usr/local/bin/aws","target_path":"/opt/homebrew/bin/aws","resolved_path":null}
-    ]}]}
+    {"results":[
+      {"name":"aws","commands":["aws"],"issues":[
+        {"kind":"stub_not_first_on_path","command":"aws","message":"shadowed","remediation":"Fix PATH.","stub_path":"/usr/local/bin/aws","target_path":"/opt/homebrew/bin/aws","resolved_path":"/opt/homebrew/bin/aws"},
+        {"kind":"hardening_not_applied","command":"aws","message":"not hardened","remediation":"Harden it.","stub_path":"/usr/local/bin/aws","target_path":"/opt/homebrew/bin/aws","resolved_path":null}
+      ]},
+      {"name":"gh","commands":["gh"],"issues":[
+        {"kind":"isotope_not_first_on_path","command":"gh","message":"gh is not available through PATH","remediation":"Fix PATH.","stub_path":"/opt/homebrew/opt/gh-cli/bin/gh","target_path":"/opt/homebrew/opt/gh-cli/bin/gh","resolved_path":null}
+      ]},
+      {"name":"codex","commands":["codex"],"issues":[
+        {"kind":"agent_cli_unavailable","command":"codex","message":"codex is not available through PATH","remediation":"Fix PATH.","stub_path":"/usr/local/bin/codex","target_path":null,"resolved_path":null},
+        {"kind":"agent_cli_signature_invalid","command":"codex","message":"codex has an invalid signature","remediation":"Fix PATH.","stub_path":"/usr/local/bin/codex","target_path":null,"resolved_path":"/usr/bin/codex"}
+      ]}
+    ]}
     """#.utf8)
 
     let issues = try doctorIssues(from: data, loginShellPATHAvailable: false)
 
-    #expect(issues.map(\.kind) == ["hardening_not_applied", "login_shell_path_unavailable"])
-    #expect(issues.last?.message == "PATH inspection is unavailable in the menu bar app")
-    #expect(issues.last?.remediation == "Run `av doctor` from a login shell to inspect PATH.")
+    #expect(issues.map(\.kind) == ["hardening_not_applied"])
 }
 
 @Test func JSONLoaderCanAcceptDoctorIssueExitStatus() throws {

--- a/tests/brew_stub_build.rs
+++ b/tests/brew_stub_build.rs
@@ -10,7 +10,7 @@ fn av_brew_stub_binary_is_built() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "AUTOMIC_VAULT_BREW_STUB_V17"
+        "AUTOMIC_VAULT_BREW_STUB_V18"
     );
 
     let output = Command::new(env!("CARGO_BIN_EXE_av-brew-stub"))

--- a/tests/brew_stub_build.rs
+++ b/tests/brew_stub_build.rs
@@ -10,7 +10,7 @@ fn av_brew_stub_binary_is_built() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "AUTOMIC_VAULT_BREW_STUB_V18"
+        "AUTOMIC_VAULT_BREW_STUB_V19"
     );
 
     let output = Command::new(env!("CARGO_BIN_EXE_av-brew-stub"))


### PR DESCRIPTION
Fixes #152.

## What changed

- Give the authorized `brew shellenv` child a sanitized system-only PATH that does not already contain the Homebrew prefix, so Homebrew emits its shell exports.
- Keep `shellenv` behind the existing Homebrew Execution Gate; this does not add an authorization bypass.
- Reject `--` before authorization so command classification cannot be bypassed.
- Bump the hardened Brew stub marker to V19 so Doctor detects older stubs as stale.
- Stop the menu bar app from executing the user's login-shell startup files to discover PATH.
- Suppress PATH-order and PATH-resolution findings in menu-bar Doctor because the app cannot verify the user's shell PATH safely. Non-PATH findings remain visible; `av doctor` continues to perform full PATH validation when run from a login shell.
- Report Doctor execution or decoding failures explicitly instead of mislabeling them as PATH failures.

## Upgrade note

Installing the updated app does not replace an existing root-owned setuid Brew launcher. Existing hardened installations must run `av harden brew` once to install the bundled V19 launcher.

## Root cause

The stub always launched Homebrew with `/opt/homebrew/bin:/opt/homebrew/sbin` first in PATH. Homebrew's `shellenv` treats that as already configured and returns successfully without output.

Separately, the menu bar app ran `$SHELL -lic` to inspect PATH. A normal `.zprofile` can call the hardened Brew stub, which synchronously asks the same app for authorization while the app is waiting for the login shell.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- Regression tests verify the system-only `shellenv` PATH, reject `--` before command classification, suppress PATH-derived menu-bar Doctor issues, and report Doctor load failures directly.
