### PR TITLE
Use AppUpdater 4.1.1

### DIFF
--- a/src/menu-helper/Package.resolved
+++ b/src/menu-helper/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d93079baa7a89315235b673cd99e0dbd0fa144ba078e9adb5eadb4a17a246e63",
+  "originHash" : "2b5021eedc672644a563e0e553844d9c337ced6579c27983314e3d8634e8e611",
   "pins" : [
     {
       "identity" : "appupdater",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/AppUpdater.git",
       "state" : {
-        "revision" : "6a6975b05f4ffcdebe16307dbd2b5419ca6592bf",
-        "version" : "4.1.0"
+        "revision" : "5898041575a7a8ed5d44e7d31251156b3d463677",
+        "version" : "4.1.1"
       }
     },
     {


### PR DESCRIPTION
Resolve AppUpdater 4.1.1 at commit 5898041, which adds host-and-code context to updater network errors without exposing signed download URLs.

Validation: menu-helper package compiled and passed 100 tests; the full signed release build succeeded.