### PR TITLE
Reject lossy working directories

### DIFF
--- a/src/cli/aws.rs
+++ b/src/cli/aws.rs
@@ -146,15 +146,14 @@ fn launch(generation: AwsGeneration, args: Vec<OsString>) -> Result<i32, String>
     {
         crate::isotopes::hardeners::aws_release::current_release_valid()?;
     }
-    let cwd = std::env::current_dir()
-        .map_err(|error| format!("failed to read current directory: {error}"))?;
+    let cwd = crate::path_security::current_working_directory_utf8()?;
     let words = args
         .iter()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect::<Vec<_>>();
     let generated_config = xpc_request("inject", |message| unsafe {
         xpc_set_string(message, "target", &target.to_string_lossy())?;
-        xpc_set_string(message, "cwd", &cwd.to_string_lossy())?;
+        xpc_set_string(message, "cwd", &cwd)?;
         xpc_set_string(message, "tool", "aws")?;
         xpc_set_string(message, "aws_profile", &profile)?;
         xpc_set_string(message, "aws_generation", generation.name())?;

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -317,10 +317,7 @@ fn approval_request(
         keys: options.keys.clone(),
         target: target.display().to_string(),
         args: options.args.iter().map(os_display).collect(),
-        cwd: std::env::current_dir()
-            .map_err(|err| format!("failed to read current directory: {err}"))?
-            .display()
-            .to_string(),
+        cwd: crate::path_security::current_working_directory_utf8()?,
         replace_existing_env: options.replace_existing_env,
         allow_missing_keys: options.allow_missing_keys,
         env_conflicts,

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2311,7 +2311,7 @@ private struct AccessRequestRow: View {
                     AccessMetaLine("Secret names", record.keys.isEmpty ? "(none)" : record.keys.joined(separator: ", "))
                     AccessMetaLine("Gate client", record.callerPath)
                     AccessMetaLine("Target", record.target)
-                    AccessMetaLine("Working directory", record.cwd)
+                    AccessMetaLine("Working directory", escapedSecurityPath(record.cwd))
                     if let detail = record.detail, !detail.isEmpty {
                         AccessMetaLine("Detail", detail)
                     }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -5201,7 +5201,7 @@ private func showApprovalAlert(
         title: request.title,
         detail: request.detail,
         automaticApprovalExplanation: automaticApprovalExplanation,
-        cwd: request.cwd,
+        cwd: escapedSecurityPath(request.cwd),
         keys: request.keys.joined(separator: ", "),
         blessing: blessing,
         sections: approvalPromptSections(

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -743,6 +743,27 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
     }
 }
 
+public func escapedSecurityPath(_ path: String) -> String {
+    var escaped = ""
+    escaped.reserveCapacity(path.utf8.count)
+    for scalar in path.unicodeScalars {
+        switch scalar.value {
+        case 0x5C: escaped += #"\\"#
+        case 0x09: escaped += #"\t"#
+        case 0x0A: escaped += #"\n"#
+        case 0x0D: escaped += #"\r"#
+        default:
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator:
+                escaped += #"\u{"# + String(scalar.value, radix: 16, uppercase: true) + "}"
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+    }
+    return escaped
+}
+
 struct ScanReport: Codable {
     let findings: [DetectorFinding]
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -4,6 +4,14 @@ import Security
 import Testing
 @testable import MenubarHelperCore
 
+@Test func securityPathsEscapeDisplayControls() {
+    #expect(
+        escapedSecurityPath("/tmp/line\nname\t\\\u{202E}txt")
+            == #"/tmp/line\nname\t\\\u{202E}txt"#
+    )
+    #expect(escapedSecurityPath("/tmp/ordinary path") == "/tmp/ordinary path")
+}
+
 @Test func markdownRenderingDropsInitialHeadingMarker() {
     #expect(markdownDroppingInitialHeadingMarker("# gh-cli Detector\n\n## Trigger Conditions") == "\n## Trigger Conditions")
     #expect(markdownDroppingInitialHeadingMarker("# gh-cli Detector") == "")

--- a/src/path_security.rs
+++ b/src/path_security.rs
@@ -3,6 +3,18 @@ use std::ffi::{CString, OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
+pub(crate) fn current_working_directory_utf8() -> Result<String, String> {
+    let path = std::env::current_dir()
+        .map_err(|error| format!("failed to read current directory: {error}"))?;
+    path_to_utf8(path)
+}
+
+fn path_to_utf8(path: PathBuf) -> Result<String, String> {
+    path.into_os_string()
+        .into_string()
+        .map_err(|_| "working directory is not valid UTF-8".to_string())
+}
+
 /// The wording consumers match on to recognise a user-writable PATH reason.
 /// Producers build reasons with [`user_writable_path_reason`] rather than
 /// composing this by hand.
@@ -71,6 +83,7 @@ pub(crate) fn is_user_writable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::ffi::OsStringExt;
     use std::os::unix::fs::PermissionsExt;
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -134,5 +147,15 @@ mod tests {
         );
         std::fs::set_permissions(&protected, std::fs::Permissions::from_mode(0o755)).unwrap();
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_non_utf8_working_directory_paths() {
+        let path = PathBuf::from(OsString::from_vec(vec![b'/', b't', b'm', b'p', b'/', 0xff]));
+
+        assert_eq!(
+            path_to_utf8(path),
+            Err("working directory is not valid UTF-8".to_string())
+        );
     }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -85,10 +85,7 @@ pub(crate) fn list_secret_names() -> Result<Vec<String>, String> {
         names.sort();
         return Ok(names);
     }
-    let cwd = std::env::current_dir()
-        .map_err(|err| format!("failed to read current directory: {err}"))?
-        .to_string_lossy()
-        .into_owned();
+    let cwd = crate::path_security::current_working_directory_utf8()?;
     Ok(xpc_request("list", Some((b"cwd\0", &cwd)), None, None)?.names)
 }
 


### PR DESCRIPTION
## Summary
- reject non-UTF-8 working directories before CLI-to-XPC requests
- share the check across inject, list, and AWS
- escape control and bidi characters only at Approval and History display boundaries

## Tests
- cargo test
- swift test --package-path src/menu-helper