### PR TITLE
Harden Docker registry credentials

### DIFF
--- a/docs/adr/0014-docker-credential-helper.md
+++ b/docs/adr/0014-docker-credential-helper.md
@@ -21,8 +21,10 @@ establish Target integrity.
 
 The Docker Hardener installs an exact root-owned
 `/usr/local/bin/docker-credential-av` launcher for the signed Automic Vault
-CLI and changes Docker's default credential store to `av`. It does not replace
-Docker's vendor CLI.
+CLI and changes Docker's default credential store to `av`. Every containing
+directory through the filesystem root must also be a real, root-owned directory
+protected from group/world writes; installation and detection fail closed if
+that invariant is not met. It does not replace Docker's vendor CLI.
 
 Each registry credential is stored as one opaque Secret. Its Secret Name is a
 fixed prefix plus the SHA-256 digest of the exact registry address. The stored

--- a/docs/adr/0014-docker-credential-helper.md
+++ b/docs/adr/0014-docker-credential-helper.md
@@ -1,0 +1,76 @@
+# ADR 0014: Bind Docker registry credentials to live vendor-signed Targets
+
+Status: accepted
+
+## Context
+
+Docker Desktop configures `credsStore` to invoke a credential helper. The
+helper protects registry credentials at rest, but Docker's protocol returns a
+usable password, personal access token, or identity token as plaintext JSON to
+any process that invokes `get` with the registry address. The helper does not
+authenticate the process or authorize its operation.
+
+Docker Desktop ships its macOS CLI, Compose, and Buildx executables with
+Docker's Developer ID Application identity and Hardened Runtime. Rebuilding
+those Targets as Automic Vault Isotopes would replace a stronger upstream
+distribution identity without removing the protocol's ambient-access flaw.
+The Docker application bundle is user-writable, so its pathname alone cannot
+establish Target integrity.
+
+## Decision
+
+The Docker Hardener installs an exact root-owned
+`/usr/local/bin/docker-credential-av` launcher for the signed Automic Vault
+CLI and changes Docker's default credential store to `av`. It does not replace
+Docker's vendor CLI.
+
+Each registry credential is stored as one opaque Secret. Its Secret Name is a
+fixed prefix plus the SHA-256 digest of the exact registry address. The stored
+value contains the address, username, and secret required by Docker's protocol.
+The address remains visible in the Authorization Request and user-facing
+explanation; the credential bytes do not leave Secret Custody for lookup or
+verification.
+
+For `get`, the helper submits the registry address to the Secret Gate. The menu
+app derives the same Secret Name and obtains the helper's live parent from the
+kernel. It accepts only explicitly supported Docker Desktop Targets at their
+canonical bundle locations with Docker team `9BNSXJN65R`, the expected signing
+identifier, a valid Developer ID signature, and an eligible Hardened Runtime.
+The complete Authorization Request uses that live Target and its live
+arguments. The parent process identity and code identity are revalidated after
+any Approval and immediately before the Secret is loaded. The Authorization
+Record is persisted and verified before the credential is returned.
+
+`store` and `erase` use dedicated XPC operations. They accept only the same
+signed Automic Vault helper beneath a verified Docker Target, validate the
+registry-derived Secret Name, and use the existing approved Secret-mutation
+path. They revalidate the Docker process before changing Secret Custody.
+
+Hardening migrates credentials from the configured legacy helper without
+printing them. It stores every credential with save-if-absent-or-equal
+semantics before deleting any legacy entry. If deletion or the atomic Docker
+configuration update fails, it restores deleted legacy entries and leaves the
+old configuration in effect. Unsupported per-registry helper configurations
+fail closed rather than being partially migrated.
+
+The helper implements Docker's required `store`, `get`, and `erase` operations.
+The optional `list` extension is not exposed because it would add registry and
+username disclosure that Docker authentication does not require.
+
+## Consequences
+
+An arbitrary same-user process can still invoke the helper binary, but it
+cannot retrieve, replace, or delete a Docker credential without a live eligible
+Docker parent and an Authorization Decision for the actual Launcher, Target,
+arguments, registry Secret Name, and process execution.
+
+The authorized Docker Target necessarily receives the usable credential in
+memory because the upstream protocol has no capability or operation-scoped
+token interface. Automic Vault cannot make a compromised authorized Target keep
+that credential confidential.
+
+Docker Desktop updates remain vendor-managed. A changed Target continues only
+if its live signing identity and runtime protections satisfy the allowlist.
+Unsigned binaries, unexpected plugins, unsafe runtime exceptions, unknown
+operations, and incomplete migrations fail closed. A code-signed Isotope
+remains a fallback if Docker stops shipping an eligible required Target.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,15 @@ Target to that installed generation. Doctor verifies the resulting identity,
 ownership, permissions, content manifest, and command resolution. See
 [ADR 0012](adr/0012-verified-upstream-tool-releases.md).
 
+A Hardener may bind a vendor-managed Target already installed outside Automic
+Vault when protected Secrets are available only through an Automic Vault Gate
+Client. Because that Target may remain user-writable and vendor-updated, its
+path is never treated as integrity evidence. The gate verifies the live
+process's vendor identity, signing identifier, runtime protections, arguments,
+and process execution immediately before every Secret Application. Unknown
+Targets and changed runtime posture fail closed. See
+[ADR 0014](adr/0014-docker-credential-helper.md).
+
 ### Secret Custody
 
 Automic Vault stores named opaque Secrets in the macOS Data Protection Keychain. Each Secret has an availability choice independent of authorization policy.

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -1,0 +1,258 @@
+use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use ring::digest::{SHA256, digest};
+use serde_json::{Value, json};
+
+use super::inject;
+
+const HELPER_STUB: &str = "#!/usr/local/bin/av docker-credential\n";
+const HELPER_PATH: &str = "/usr/local/bin/docker-credential-av";
+const MAX_INPUT_BYTES: u64 = 64 * 1024;
+const MAX_SERVER_URL_BYTES: usize = 2048;
+const SECRET_PREFIX: &str = "DOCKER_REGISTRY_CREDENTIAL_";
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct DockerCredential {
+    pub(crate) server_url: String,
+    pub(crate) username: String,
+    pub(crate) secret: String,
+}
+
+pub(crate) fn run(mut args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    let mut stdin = std::io::stdin().lock();
+    match run_with_io(&mut args, &mut stdin, stdout) {
+        Ok(()) => 0,
+        Err(error) => {
+            let _ = writeln!(stderr, "docker-credential-av: {error}");
+            1
+        }
+    }
+}
+
+fn run_with_io(
+    args: &mut Vec<OsString>,
+    input: &mut dyn Read,
+    output: &mut dyn Write,
+) -> Result<(), String> {
+    if !args.first().is_some_and(is_helper_stub_arg) {
+        return Err(
+            "refusing invocation without the installed Automic Vault helper launcher".into(),
+        );
+    }
+    args.remove(0);
+    let [action] = args.as_slice() else {
+        return Err("usage: docker-credential-av <store|get|erase>".into());
+    };
+    let action = action
+        .to_str()
+        .ok_or_else(|| "credential-helper action must be valid UTF-8".to_string())?;
+    match action {
+        "store" => {
+            let credential = parse_credential(&read_limited(input)?)?;
+            crate::secrets::store_docker_credential(
+                &secret_name(&credential.server_url),
+                &credential.storage_json(),
+            )
+        }
+        "get" => {
+            let server_url = parse_server_url(&read_limited(input)?)?;
+            let stored = inject::docker_credential(secret_name(&server_url), server_url.clone())?;
+            let credential = parse_credential(&stored)?;
+            if credential.server_url != server_url {
+                return Err(
+                    "stored Docker credential does not match the requested registry".into(),
+                );
+            }
+            writeln!(
+                output,
+                "{}",
+                json!({"Username": credential.username, "Secret": credential.secret})
+            )
+            .map_err(|error| format!("failed to return Docker credential: {error}"))
+        }
+        "erase" => {
+            let server_url = parse_server_url(&read_limited(input)?)?;
+            crate::secrets::delete_docker_credential(&secret_name(&server_url), &server_url)
+        }
+        "list" => Err(
+            "list is intentionally unsupported because it discloses registry account metadata"
+                .into(),
+        ),
+        _ => Err(format!("unknown credential-helper action: {action}")),
+    }
+}
+
+pub(crate) fn secret_name(server_url: &str) -> String {
+    let hash = digest(&SHA256, server_url.as_bytes());
+    let hex = hash
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<String>();
+    format!("{SECRET_PREFIX}{hex}")
+}
+
+pub(crate) fn parse_credential(input: &str) -> Result<DockerCredential, String> {
+    let value: Value = serde_json::from_str(input)
+        .map_err(|error| format!("invalid Docker credential JSON: {error}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Docker credential must be a JSON object".to_string())?;
+    if object
+        .keys()
+        .any(|key| !["ServerURL", "Username", "Secret"].contains(&key.as_str()))
+    {
+        return Err("Docker credential contains an unknown field".into());
+    }
+    let string = |name: &str| {
+        object
+            .get(name)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| format!("Docker credential has no {name}"))
+    };
+    let credential = DockerCredential {
+        server_url: string("ServerURL")?,
+        username: string("Username")?,
+        secret: string("Secret")?,
+    };
+    validate_server_url(&credential.server_url)?;
+    if credential.username.as_bytes().contains(&0) || credential.secret.as_bytes().contains(&0) {
+        return Err("Docker credential contains NUL".into());
+    }
+    Ok(credential)
+}
+
+impl DockerCredential {
+    pub(crate) fn storage_json(&self) -> String {
+        json!({
+            "ServerURL": self.server_url,
+            "Username": self.username,
+            "Secret": self.secret,
+        })
+        .to_string()
+    }
+}
+
+fn parse_server_url(input: &str) -> Result<String, String> {
+    let server_url = input.trim_end_matches(['\r', '\n']);
+    validate_server_url(server_url)?;
+    Ok(server_url.to_string())
+}
+
+fn validate_server_url(server_url: &str) -> Result<(), String> {
+    if server_url.is_empty()
+        || server_url.len() > MAX_SERVER_URL_BYTES
+        || server_url
+            .bytes()
+            .any(|byte| byte == 0 || byte == b'\r' || byte == b'\n')
+    {
+        return Err("invalid Docker registry address".into());
+    }
+    Ok(())
+}
+
+fn read_limited(input: &mut dyn Read) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    input
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("failed to read credential-helper input: {error}"))?;
+    if bytes.len() as u64 > MAX_INPUT_BYTES {
+        return Err(format!(
+            "credential-helper input exceeds {MAX_INPUT_BYTES} bytes"
+        ));
+    }
+    String::from_utf8(bytes).map_err(|_| "credential-helper input must be valid UTF-8".into())
+}
+
+fn is_helper_stub_arg(arg: &OsString) -> bool {
+    let path = PathBuf::from(arg);
+    path == helper_path()
+        && std::fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_file())
+        && std::fs::read_to_string(path).is_ok_and(|contents| contents == HELPER_STUB)
+}
+
+pub(crate) fn helper_path() -> PathBuf {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(HELPER_PATH))
+}
+
+pub(crate) fn helper_stub_valid(path: &Path) -> bool {
+    std::fs::read_to_string(path).is_ok_and(|contents| contents == HELPER_STUB)
+        && std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+}
+
+pub(crate) const fn helper_stub() -> &'static str {
+    HELPER_STUB
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn credential_round_trip_uses_registry_bound_secret_name() {
+        let credential = parse_credential(
+            r#"{"ServerURL":"https://ghcr.io","Username":"octocat","Secret":"token"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            parse_credential(&credential.storage_json()).unwrap(),
+            credential
+        );
+        assert_eq!(
+            secret_name("https://ghcr.io").len(),
+            SECRET_PREFIX.len() + 64
+        );
+        assert_ne!(secret_name("ghcr.io"), secret_name("https://ghcr.io"));
+    }
+
+    #[test]
+    fn helper_store_get_and_erase_use_test_secret_custody() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-docker-helper-{}", std::process::id()));
+        let helper = root.join("docker-credential-av");
+        let keychain = root.join("keychain");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&helper, HELPER_STUB).unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH", &helper);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        }
+        let mut args = vec![helper.clone().into_os_string(), "store".into()];
+        run_with_io(
+            &mut args,
+            &mut r#"{"ServerURL":"registry.example","Username":"user","Secret":"secret"}"#
+                .as_bytes(),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        let mut args = vec![helper.clone().into_os_string(), "get".into()];
+        let mut output = Vec::new();
+        run_with_io(&mut args, &mut "registry.example\n".as_bytes(), &mut output).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output).unwrap(),
+            json!({"Username":"user", "Secret":"secret"})
+        );
+        let mut args = vec![helper.clone().into_os_string(), "erase".into()];
+        run_with_io(
+            &mut args,
+            &mut "registry.example\n".as_bytes(),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert!(!keychain.join(secret_name("registry.example")).exists());
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -12,6 +12,7 @@ const HELPER_PATH: &str = "/usr/local/bin/docker-credential-av";
 const MAX_INPUT_BYTES: u64 = 64 * 1024;
 const MAX_SERVER_URL_BYTES: usize = 2048;
 const SECRET_PREFIX: &str = "DOCKER_REGISTRY_CREDENTIAL_";
+const CREDENTIALS_NOT_FOUND: &str = "credentials not found in native keychain";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DockerCredential {
@@ -25,9 +26,17 @@ pub(crate) fn run(mut args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut 
     match run_with_io(&mut args, &mut stdin, stdout) {
         Ok(()) => 0,
         Err(error) => {
-            let _ = writeln!(stderr, "docker-credential-av: {error}");
+            write_error(&error, stdout, stderr);
             1
         }
+    }
+}
+
+fn write_error(error: &str, stdout: &mut dyn Write, stderr: &mut dyn Write) {
+    if error == CREDENTIALS_NOT_FOUND {
+        let _ = writeln!(stdout, "{error}");
+    } else {
+        let _ = writeln!(stderr, "docker-credential-av: {error}");
     }
 }
 
@@ -61,7 +70,15 @@ fn run_with_io(
         }
         "get" => {
             let server_url = parse_server_url(&read_limited(input)?)?;
-            let stored = inject::docker_credential(secret_name(&server_url), server_url.clone())?;
+            let key = secret_name(&server_url);
+            let stored =
+                inject::docker_credential(key.clone(), server_url.clone()).map_err(|error| {
+                    if error == format!("failed to load secret {key}: -25300") {
+                        CREDENTIALS_NOT_FOUND.into()
+                    } else {
+                        error
+                    }
+                })?;
             let credential = parse_credential(&stored)?;
             if credential.server_url != server_url {
                 return Err(
@@ -252,6 +269,22 @@ mod tests {
         )
         .unwrap();
         assert!(!keychain.join(secret_name("registry.example")).exists());
+        let mut args = vec![helper.clone().into_os_string(), "get".into()];
+        let error = run_with_io(
+            &mut args,
+            &mut "registry.example\n".as_bytes(),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert_eq!(error, CREDENTIALS_NOT_FOUND);
+        let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+        write_error(&error, &mut stdout, &mut stderr);
+        assert_eq!(stdout, b"credentials not found in native keychain\n");
+        assert!(stderr.is_empty());
+        stdout.clear();
+        write_error("approval denied", &mut stdout, &mut stderr);
+        assert!(stdout.is_empty());
+        assert_eq!(stderr, b"docker-credential-av: approval denied\n");
         unsafe {
             std::env::remove_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH");
             std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -48,6 +48,9 @@ fn run_with_io(
     let action = action
         .to_str()
         .ok_or_else(|| "credential-helper action must be valid UTF-8".to_string())?;
+    if matches!(action, "store" | "get" | "erase") {
+        crate::secrets::ensure_docker_helper_ready()?;
+    }
     match action {
         "store" => {
             let credential = parse_credential(&read_limited(input)?)?;

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -30,6 +30,7 @@ struct Options {
 
 #[derive(Debug, PartialEq, Eq)]
 struct ApprovalRequest {
+    op: &'static str,
     keys: Vec<String>,
     target: String,
     args: Vec<String>,
@@ -40,6 +41,8 @@ struct ApprovalRequest {
     shebang_script: Option<String>,
     script_data: Option<Vec<u8>>,
     snapshot_incompatible_interpreter: Option<&'static str>,
+    tool: Option<&'static str>,
+    docker_server_url: Option<String>,
 }
 
 unsafe extern "C" {
@@ -314,6 +317,7 @@ fn approval_request(
         .cloned()
         .collect();
     Ok(ApprovalRequest {
+        op: "inject",
         keys: options.keys.clone(),
         target: target.display().to_string(),
         args: options.args.iter().map(os_display).collect(),
@@ -327,7 +331,38 @@ fn approval_request(
         shebang_script: options.shebang_script.as_ref().map(os_display),
         script_data: script_data.map(<[u8]>::to_vec),
         snapshot_incompatible_interpreter,
+        tool: None,
+        docker_server_url: None,
     })
+}
+
+pub(super) fn docker_credential(key: String, server_url: String) -> Result<String, String> {
+    validate_key_name(&key)?;
+    let request = ApprovalRequest {
+        op: "docker-get",
+        keys: vec![key.clone()],
+        target: String::new(),
+        args: Vec::new(),
+        cwd: std::env::current_dir()
+            .map_err(|err| format!("failed to read current directory: {err}"))?
+            .display()
+            .to_string(),
+        replace_existing_env: false,
+        allow_missing_keys: false,
+        env_conflicts: Vec::new(),
+        shebang_script: None,
+        script_data: None,
+        snapshot_incompatible_interpreter: None,
+        tool: Some("docker"),
+        docker_server_url: Some(server_url),
+    };
+    if crate::test_keychain_dir().is_some() {
+        return load_test_secret_if_present(&key)?
+            .ok_or_else(|| format!("failed to load secret {key}: -25300"));
+    }
+    xpc_approve_injection(&request)?
+        .remove(&key)
+        .ok_or_else(|| format!("Automic Vault returned no Docker credential for {key}"))
 }
 
 struct VerifiedScript {
@@ -591,7 +626,7 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
     }
 
     unsafe {
-        set_string(message, b"op\0", "inject")?;
+        set_string(message, b"op\0", request.op)?;
         set_string(message, b"target\0", &request.target)?;
         set_string(message, b"cwd\0", &request.cwd)?;
         if let Some(script) = &request.shebang_script {
@@ -607,6 +642,12 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
         }
         if let Some(interpreter) = request.snapshot_incompatible_interpreter {
             set_string(message, b"snapshot_incompatible_interpreter\0", interpreter)?;
+        }
+        if let Some(tool) = request.tool {
+            set_string(message, b"tool\0", tool)?;
+        }
+        if let Some(server_url) = &request.docker_server_url {
+            set_string(message, b"docker_server_url\0", server_url)?;
         }
         xpc_dictionary_set_bool(
             message,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 mod aws;
 mod bless;
+pub(crate) mod docker_credential;
 pub(crate) mod doctor;
 mod inject;
 mod list;
@@ -39,7 +40,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 21;
+pub(crate) const INSTALL_REVISION: u32 = 22;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -198,6 +199,15 @@ where
                 }
             }
         }
+        Some("__install-docker-helper") if rest.is_empty() => {
+            match hardeners::docker::install_privileged() {
+                Ok(()) => 0,
+                Err(err) => {
+                    let _ = writeln!(stderr, "av: {err}");
+                    1
+                }
+            }
+        }
         Some("__install-env-wrapper") if rest.len() >= 2 => {
             let Some(target) = rest[0].to_str() else {
                 let _ = writeln!(stderr, "av: invalid env-wrapper hardener name");
@@ -286,6 +296,10 @@ where
                 let result = hardeners::aws_cli::run_aws(stdout, yes);
                 return finish_hardening(result, "aws", stdout, stderr);
             }
+            if target == "docker" {
+                let result = hardeners::docker::run(stdout, yes);
+                return finish_hardening(result, "docker", stdout, stderr);
+            }
             if target == "gh" || target == "gh-cli" {
                 let result = hardeners::gh_cli::run(stdout, yes);
                 return finish_hardening(result, "gh", stdout, stderr);
@@ -334,6 +348,7 @@ where
         Some("aws-credentials") if rest == [OsString::from("official-v2")] => {
             aws::credentials(Some("official-v2"), stdout, stderr)
         }
+        Some("docker-credential") => docker_credential::run(rest, stdout, stderr),
         Some("list" | "ls") => list::run(rest, stdout, stderr),
         Some("bless") => bless::run(rest, stderr),
         Some("open") => {

--- a/src/isotopes/detectors/docker/credential_helpers.md
+++ b/src/isotopes/detectors/docker/credential_helpers.md
@@ -10,11 +10,14 @@
 - `$DOCKER_CONFIG/config.json`
 - `~/.docker/config.json`
 
-## Why This is not Yet Hardened
+## Mitigation
 
-Docker credential helpers are ambient: any process running as the user can ask
-the configured helper for registry credentials. A hardener needs an
-approval-aware helper that preserves Docker's credential-helper protocol and
-registry routing. Rewriting the existing helper configuration is not enough.
+Run:
 
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+```sh
+av harden docker
+```
+
+This keeps Docker Desktop's vendor-signed CLI, migrates credentials from its
+default helper into Automic Vault, and installs an approval-aware helper.
+Non-Automic per-registry helpers fail closed rather than being partly migrated.

--- a/src/isotopes/detectors/docker/mod.rs
+++ b/src/isotopes/detectors/docker/mod.rs
@@ -230,6 +230,13 @@ mod tests {
                 .iter()
                 .any(|reason| reason.contains("credential helper `desktop`"))
         );
+        assert!(
+            docker_config_hazards(
+                r#"{"credsStore":"av","credHelpers":{"registry.example":"av"}}"#,
+                Path::new("/tmp/config.json"),
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/src/isotopes/detectors/docker/mod.rs
+++ b/src/isotopes/detectors/docker/mod.rs
@@ -67,6 +67,9 @@ fn docker_config_hazards(contents: &str, path: &Path) -> Vec<String> {
     }
 
     for helper in string_values_for_key(contents, "credsStore") {
+        if helper == "av" {
+            continue;
+        }
         reasons.push(format!(
             "Docker config uses ambient credential store `{helper}`: {}",
             path.display()
@@ -74,6 +77,9 @@ fn docker_config_hazards(contents: &str, path: &Path) -> Vec<String> {
     }
 
     for helper in credential_helper_values(contents) {
+        if helper == "av" {
+            continue;
+        }
         reasons.push(format!(
             "Docker config uses ambient per-registry credential helper `{helper}`: {}",
             path.display()

--- a/src/isotopes/detectors/docker_credential_helper/detector.md
+++ b/src/isotopes/detectors/docker_credential_helper/detector.md
@@ -9,10 +9,13 @@
 - `$DOCKER_CONFIG/config.json`
 - `~/.docker/config.json`
 
-## Why This is not Yet Hardened
+## Mitigation
 
-Docker credential helpers are a credential-store boundary, not a normal CLI
-secret file. This detector reports Docker config that uses the packaged helpers
-without changing Docker's helper settings.
+Run:
 
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+```sh
+av harden docker
+```
+
+Automic Vault replaces the ambient default helper with its Secret Gate while
+retaining Docker Desktop's vendor-signed CLI.

--- a/src/isotopes/hardeners/docker.md
+++ b/src/isotopes/hardeners/docker.md
@@ -3,7 +3,9 @@
 `av harden docker` keeps Docker Desktop's vendor-signed, Hardened Runtime CLI
 and replaces its ambient credential helper with Automic Vault's Secret Gate.
 It migrates credentials without printing them, installs a root-owned helper at
-`/usr/local/bin/docker-credential-av`, and updates Docker's `credsStore`.
+`/usr/local/bin/docker-credential-av` only when every containing directory is
+root-owned and protected from group/world writes, and updates Docker's
+`credsStore`.
 
 The Docker helper protocol necessarily returns a usable registry token to an
 authorized Docker process. Automic Vault verifies the live Docker Desktop code

--- a/src/isotopes/hardeners/docker.md
+++ b/src/isotopes/hardeners/docker.md
@@ -1,0 +1,11 @@
+# Docker
+
+`av harden docker` keeps Docker Desktop's vendor-signed, Hardened Runtime CLI
+and replaces its ambient credential helper with Automic Vault's Secret Gate.
+It migrates credentials without printing them, installs a root-owned helper at
+`/usr/local/bin/docker-credential-av`, and updates Docker's `credsStore`.
+
+The Docker helper protocol necessarily returns a usable registry token to an
+authorized Docker process. Automic Vault verifies the live Docker Desktop code
+signature, Hardened Runtime, process ancestry, arguments, and registry before
+release. Non-Automic per-registry helpers and inline credentials fail closed.

--- a/src/isotopes/hardeners/docker.rs
+++ b/src/isotopes/hardeners/docker.rs
@@ -44,6 +44,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     if !testing {
         crate::secrets::ensure_docker_helper_ready()?;
         verify_vendor_install()?;
+        validate_helper_install_path(&helper_path())?;
     }
     let path = config_path()?;
     let mut config = read_config(&path)?;
@@ -126,7 +127,9 @@ pub(crate) fn install_privileged() -> Result<(), String> {
     if super::effective_uid() != 0 {
         return Err("Docker helper installation requires root".into());
     }
-    install_stub(&helper_path())
+    let helper = helper_path();
+    validate_helper_install_path(&helper)?;
+    install_stub(&helper)
 }
 
 pub(crate) fn detect() -> HardenerDetection {
@@ -519,12 +522,36 @@ fn helper_path() -> PathBuf {
     crate::cli::docker_credential::helper_path()
 }
 
+fn validate_helper_install_path(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Docker helper has no parent: {}", path.display()))?;
+    for ancestor in parent.ancestors() {
+        let metadata = fs::symlink_metadata(ancestor)
+            .map_err(|error| format!("failed to inspect {}: {error}", ancestor.display()))?;
+        if !secure_install_directory(&metadata, 0) {
+            return Err(format!(
+                "refusing Docker helper path through unsafe directory {}: every containing directory must be root-owned and protected from group/world writes",
+                ancestor.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn secure_install_directory(metadata: &fs::Metadata, owner_uid: u32) -> bool {
+    metadata.file_type().is_dir()
+        && metadata.uid() == owner_uid
+        && metadata.permissions().mode() & 0o022 == 0
+}
+
 fn helper_valid(path: &Path) -> bool {
     let metadata = fs::symlink_metadata(path).ok();
     crate::cli::docker_credential::helper_stub_valid(path)
         && metadata.as_ref().is_some_and(|metadata| {
             metadata.permissions().mode() & 0o777 == 0o755
-                && (test_config_path().is_some() || metadata.uid() == 0)
+                && (test_config_path().is_some()
+                    || (metadata.uid() == 0 && validate_helper_install_path(path).is_ok()))
         })
 }
 
@@ -684,6 +711,29 @@ mod tests {
         );
         assert!(validate_config(&json!({"credHelpers":{"ghcr.io":"desktop"}})).is_err());
         assert!(validate_config(&json!({"auths":{"ghcr.io":{"auth":"plaintext-ish"}}})).is_err());
+    }
+
+    #[test]
+    fn helper_install_directories_reject_writes_and_symlinks() {
+        let root =
+            std::env::temp_dir().join(format!("av-docker-helper-path-{}", std::process::id()));
+        let directory = root.join("bin");
+        let link = root.join("link");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&directory).unwrap();
+        fs::set_permissions(&directory, fs::Permissions::from_mode(0o755)).unwrap();
+        let metadata = fs::symlink_metadata(&directory).unwrap();
+        assert!(secure_install_directory(&metadata, metadata.uid()));
+        assert!(!secure_install_directory(&metadata, metadata.uid() + 1));
+
+        fs::set_permissions(&directory, fs::Permissions::from_mode(0o775)).unwrap();
+        let metadata = fs::symlink_metadata(&directory).unwrap();
+        assert!(!secure_install_directory(&metadata, metadata.uid()));
+
+        std::os::unix::fs::symlink(&directory, &link).unwrap();
+        let metadata = fs::symlink_metadata(&link).unwrap();
+        assert!(!secure_install_directory(&metadata, metadata.uid()));
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/isotopes/hardeners/docker.rs
+++ b/src/isotopes/hardeners/docker.rs
@@ -1,0 +1,741 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, IsTerminal, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Map, Value, json};
+
+use super::{
+    HardenerCommand, HardenerDetection, HardenerDiagnostic, RequiredExecutable, RequiredIdentity,
+    SecretGateDescriptor, SecretGateRoute, StubRequirements,
+};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const SUDO_PATH: &str = "/usr/bin/sudo";
+const DOCKER_APP: &str = "/Applications/Docker.app";
+const DOCKER_TEAM: &str = "9BNSXJN65R";
+const MAX_CONFIG: u64 = 1024 * 1024;
+const MAX_HELPER_OUTPUT: u64 = 1024 * 1024;
+const PRIVILEGE_MODE: super::PrivilegeMode = super::PrivilegeMode::Mixed;
+
+const TARGETS: [(&str, &str, &str); 3] = [
+    (
+        "docker",
+        "/Applications/Docker.app/Contents/Resources/bin/docker",
+        "docker",
+    ),
+    (
+        "docker-compose",
+        "/Applications/Docker.app/Contents/Resources/cli-plugins/docker-compose",
+        "docker-compose",
+    ),
+    (
+        "docker-buildx",
+        "/Applications/Docker.app/Contents/Resources/cli-plugins/docker-buildx",
+        "docker-buildx",
+    ),
+];
+
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
+    let testing = test_config_path().is_some();
+    PRIVILEGE_MODE.require_user("docker", testing)?;
+    if !testing {
+        crate::secrets::ensure_docker_helper_ready()?;
+        verify_vendor_install()?;
+    }
+    let path = config_path()?;
+    let mut config = read_config(&path)?;
+    let old_store = validate_config(&config)?;
+    let credentials = match old_store.as_deref() {
+        Some("av") | None => Vec::new(),
+        Some(store) => read_legacy_credentials(store)?,
+    };
+
+    writeln!(stdout, "╭─ harden docker").ok();
+    writeln!(stdout, "│").ok();
+    writeln!(stdout, "├─ keep Docker Desktop's vendor-signed CLI").ok();
+    writeln!(stdout, "├─ install {}", helper_path().display()).ok();
+    if let Some(store) = old_store.as_deref().filter(|store| *store != "av") {
+        writeln!(
+            stdout,
+            "├─ migrate {} credential{} from `{store}` without printing them",
+            credentials.len(),
+            if credentials.len() == 1 { "" } else { "s" }
+        )
+        .ok();
+    }
+    writeln!(stdout, "├─ set Docker's credential store to `av`").ok();
+    writeln!(stdout, "│").ok();
+    if !confirm(stdout, yes)? {
+        writeln!(stdout, "╰─ cancelled").ok();
+        return Ok(());
+    }
+
+    for credential in &credentials {
+        crate::secrets::store_secret_if_absent_or_equal(
+            &crate::cli::docker_credential::secret_name(&credential.server_url),
+            &credential.storage_json(),
+        )?;
+    }
+    install_helper()?;
+    let source = old_store
+        .as_deref()
+        .filter(|store| *store != "av")
+        .map(source_helper)
+        .transpose()?;
+    let mut erased = Vec::new();
+    if let Some(source) = source.as_deref() {
+        for credential in &credentials {
+            erased.push(credential);
+            if let Err(error) = helper_action(source, "erase", &credential.server_url) {
+                return Err(with_rollback(
+                    "legacy Docker credential deletion failed",
+                    error,
+                    restore_legacy(source, &erased),
+                ));
+            }
+        }
+    }
+    config
+        .as_object_mut()
+        .expect("validated config")
+        .insert("credsStore".into(), Value::String("av".into()));
+    if let Err(error) = write_config(&path, &config) {
+        if let Some(source) = source.as_deref() {
+            return Err(with_rollback(
+                "Docker configuration update failed",
+                error,
+                restore_legacy(source, &erased),
+            ));
+        }
+        return Err(format!("Docker configuration update failed: {error}"));
+    }
+    writeln!(stdout, "╰─ hardened docker").ok();
+    super::write_secret_gate_notice(stdout, "docker");
+    Ok(())
+}
+
+pub(crate) fn install_privileged() -> Result<(), String> {
+    if test_config_path().is_some()
+        || crate::test_env_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH").is_some()
+    {
+        return Err("test path overrides are forbidden during privileged installation".into());
+    }
+    if super::effective_uid() != 0 {
+        return Err("Docker helper installation requires root".into());
+    }
+    install_stub(&helper_path())
+}
+
+pub(crate) fn detect() -> HardenerDetection {
+    let helper = helper_path();
+    let config = config_path().ok();
+    let config_valid = config
+        .as_deref()
+        .and_then(|path| read_config(path).ok())
+        .is_some_and(|value| validate_config(&value).ok().flatten().as_deref() == Some("av"));
+    let stub_valid = helper_valid(&helper);
+    let vendor = test_config_path().is_some() || verify_vendor_install().is_ok();
+    let hardened = config_valid && stub_valid && vendor;
+    let commands = TARGETS
+        .iter()
+        .map(|(name, target, _)| HardenerCommand {
+            name: (*name).into(),
+            hardened,
+            stub_valid,
+            stub_path: Some(helper.display().to_string()),
+            target_path: (*target).into(),
+            required_paths: if test_config_path().is_some() {
+                Vec::new()
+            } else {
+                vec![RequiredExecutable {
+                    name: "Automic Vault CLI",
+                    path: AV_PATH.into(),
+                }]
+            },
+            stub_requirements: Some(stub_requirements(&helper)),
+            injected_keys: Vec::new(),
+            assignment_keys: Vec::new(),
+            isotope: None,
+        })
+        .collect();
+    let mut detection = HardenerDetection::commands(hardened, commands);
+    detection.applicable =
+        config.as_deref().is_some_and(Path::exists) || Path::new(TARGETS[0].1).exists();
+    if !vendor && test_config_path().is_none() {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "docker_vendor_cli_invalid",
+            message: verify_vendor_install().unwrap_err(),
+            remediation: "Reinstall or update Docker Desktop, then rerun `av harden docker`."
+                .into(),
+            path: Some(DOCKER_APP.into()),
+        });
+    }
+    detection
+}
+
+pub(crate) fn secret_gate() -> SecretGateDescriptor {
+    SecretGateDescriptor {
+        id: "docker",
+        key_patterns: vec!["DOCKER_REGISTRY_CREDENTIAL_*".into()],
+        routes: TARGETS
+            .iter()
+            .map(|(_, target, _)| SecretGateRoute {
+                operation: "docker-get",
+                script_path: None,
+                target_path: (*target).into(),
+                caller_identifiers: vec!["com.automicvault.av"],
+                key_patterns: vec!["DOCKER_REGISTRY_CREDENTIAL_*".into()],
+                replace_existing_env: false,
+                allow_missing_keys: false,
+            })
+            .collect(),
+    }
+}
+
+fn validate_config(config: &Value) -> Result<Option<String>, String> {
+    let object = config
+        .as_object()
+        .ok_or_else(|| "Docker config must be a JSON object".to_string())?;
+    if let Some(helpers) = object.get("credHelpers") {
+        let helpers = helpers
+            .as_object()
+            .ok_or_else(|| "Docker `credHelpers` must be an object".to_string())?;
+        if helpers.values().any(|helper| helper.as_str() != Some("av")) {
+            return Err(
+                "non-Automic per-registry Docker credential helpers are not supported yet".into(),
+            );
+        }
+    }
+    if object.get("auths").is_some_and(|value| !value.is_object()) {
+        return Err("Docker `auths` must be an object".into());
+    }
+    if object
+        .get("auths")
+        .and_then(Value::as_object)
+        .is_some_and(|auths| {
+            auths.values().any(|entry| {
+                entry.as_object().is_some_and(|entry| {
+                    ["auth", "identitytoken", "identityToken"]
+                        .iter()
+                        .any(|key| {
+                            entry
+                                .get(*key)
+                                .and_then(Value::as_str)
+                                .is_some_and(|value| !value.trim().is_empty())
+                        })
+                })
+            })
+        })
+    {
+        return Err("inline Docker credentials must be removed before hardening".into());
+    }
+    match object.get("credsStore") {
+        None => Ok(None),
+        Some(Value::String(store)) if !store.is_empty() => Ok(Some(store.clone())),
+        Some(_) => Err("Docker `credsStore` must be a non-empty string".into()),
+    }
+}
+
+fn read_legacy_credentials(
+    store: &str,
+) -> Result<Vec<crate::cli::docker_credential::DockerCredential>, String> {
+    let helper = source_helper(store)?;
+    let output = helper_output(&helper, "list", "")?;
+    let list: Map<String, Value> = serde_json::from_str(&output)
+        .map_err(|error| format!("legacy Docker helper returned invalid list JSON: {error}"))?;
+    let mut servers = list
+        .into_iter()
+        .map(|(server, username)| {
+            username.as_str().ok_or_else(|| {
+                "legacy Docker helper list contains a non-string username".to_string()
+            })?;
+            Ok(server)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    servers.sort();
+    servers.dedup();
+    servers
+        .into_iter()
+        .map(|server| {
+            let output = helper_output(&helper, "get", &server)?;
+            let credential = crate::cli::docker_credential::parse_credential(&output)?;
+            (credential.server_url == server)
+                .then_some(credential)
+                .ok_or_else(|| {
+                    "legacy Docker helper returned a credential for another registry".into()
+                })
+        })
+        .collect()
+}
+
+fn source_helper(store: &str) -> Result<PathBuf, String> {
+    if let Some(path) = crate::test_env_var("AUTOMIC_VAULT_TEST_DOCKER_SOURCE_HELPER") {
+        return Ok(path.into());
+    }
+    let name = match store {
+        "desktop" => "docker-credential-desktop",
+        "osxkeychain" => "docker-credential-osxkeychain",
+        _ => return Err(format!("unsupported Docker credential store `{store}`")),
+    };
+    let path = PathBuf::from(DOCKER_APP)
+        .join("Contents/Resources/bin")
+        .join(name);
+    verify_signed_executable(&path, name)?;
+    Ok(path)
+}
+
+fn helper_output(path: &Path, action: &str, input: &str) -> Result<String, String> {
+    let mut child = helper_command(path, action)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("failed to start {}: {error}", path.display()))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(input.as_bytes())
+            .map_err(|error| format!("failed to write to {}: {error}", path.display()))?;
+    }
+    let mut bytes = Vec::new();
+    child
+        .stdout
+        .take()
+        .expect("piped stdout")
+        .take(MAX_HELPER_OUTPUT + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("failed to read from {}: {error}", path.display()))?;
+    if bytes.len() as u64 > MAX_HELPER_OUTPUT {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err("legacy Docker helper output exceeded 1 MiB".into());
+    }
+    let status = child
+        .wait()
+        .map_err(|error| format!("failed to wait for {}: {error}", path.display()))?;
+    if !status.success() {
+        return Err(format!(
+            "legacy Docker helper `{action}` failed ({status}); open Docker Desktop and retry"
+        ));
+    }
+    String::from_utf8(bytes).map_err(|_| "legacy Docker helper returned non-UTF-8 output".into())
+}
+
+fn helper_action(path: &Path, action: &str, input: &str) -> Result<(), String> {
+    let mut child = helper_command(path, action)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("failed to start {}: {error}", path.display()))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(input.as_bytes())
+            .map_err(|error| format!("failed to write to {}: {error}", path.display()))?;
+    }
+    let status = child
+        .wait()
+        .map_err(|error| format!("failed to wait for {}: {error}", path.display()))?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| format!("legacy Docker helper `{action}` failed ({status})"))
+}
+
+fn helper_command(path: &Path, action: &str) -> Command {
+    let mut command = Command::new(path);
+    command
+        .arg(action)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .env("HOME", std::env::var_os("HOME").unwrap_or_default());
+    command
+}
+
+fn restore_legacy(
+    path: &Path,
+    credentials: &[&crate::cli::docker_credential::DockerCredential],
+) -> Result<(), String> {
+    for credential in credentials {
+        helper_action(path, "store", &credential.storage_json())?;
+    }
+    Ok(())
+}
+
+fn with_rollback(context: &str, error: String, rollback: Result<(), String>) -> String {
+    match rollback {
+        Ok(()) => format!("{context}: {error}; restored legacy credentials"),
+        Err(rollback) => format!(
+            "{context}: {error}; legacy credential restoration also failed: {rollback}; Automic Vault retains the migrated copies"
+        ),
+    }
+}
+
+fn config_path() -> Result<PathBuf, String> {
+    if let Some(path) = test_config_path() {
+        return Ok(path);
+    }
+    if let Some(directory) = std::env::var_os("DOCKER_CONFIG").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(directory).join("config.json"));
+    }
+    let home = std::env::var_os("HOME").ok_or_else(|| "HOME is not set".to_string())?;
+    Ok(PathBuf::from(home).join(".docker/config.json"))
+}
+
+fn test_config_path() -> Option<PathBuf> {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_DOCKER_CONFIG").map(PathBuf::from)
+}
+
+fn read_config(path: &Path) -> Result<Value, String> {
+    let file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(json!({})),
+        Err(error) => return Err(format!("failed to open {}: {error}", path.display())),
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    if !metadata.is_file() || metadata.len() > MAX_CONFIG {
+        return Err(format!("refusing unsafe Docker config: {}", path.display()));
+    }
+    let mut contents = String::new();
+    file.take(MAX_CONFIG + 1)
+        .read_to_string(&mut contents)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if contents.len() as u64 > MAX_CONFIG {
+        return Err("Docker config exceeds 1 MiB".into());
+    }
+    serde_json::from_str(&contents)
+        .map_err(|error| format!("invalid Docker config {}: {error}", path.display()))
+}
+
+fn write_config(path: &Path, value: &Value) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Docker config has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let staging = parent.join(format!(
+        ".config.json.av.{}.{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&staging)
+            .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+        serde_json::to_writer_pretty(&mut file, value)
+            .map_err(|error| format!("failed to encode Docker config: {error}"))?;
+        file.write_all(b"\n")
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        fs::rename(&staging, path)
+            .map_err(|error| format!("failed to replace {}: {error}", path.display()))?;
+        OpenOptions::new()
+            .read(true)
+            .open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("failed to sync {}: {error}", parent.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(staging);
+    }
+    result
+}
+
+fn install_helper() -> Result<(), String> {
+    if test_config_path().is_some() {
+        return install_stub(&helper_path());
+    }
+    super::env_wrapper::validate_privileged_av(Path::new(AV_PATH))?;
+    let revision = Command::new(AV_PATH)
+        .arg("__version")
+        .output()
+        .map_err(|error| format!("failed to check {AV_PATH}: {error}"))?;
+    if !revision.status.success()
+        || std::str::from_utf8(&revision.stdout)
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            != Some(crate::cli::INSTALL_REVISION)
+    {
+        return Err("update the av CLI from the Automic Vault app before hardening Docker".into());
+    }
+    let status = Command::new(SUDO_PATH)
+        .args([AV_PATH, "__install-docker-helper"])
+        .status()
+        .map_err(|error| format!("failed to run sudo: {error}"))?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| format!("Docker helper installation failed: {status}"))
+}
+
+fn install_stub(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Docker helper has no parent: {}", path.display()))?;
+    let staging = parent.join(format!(
+        ".docker-credential-av.{}.{}.tmp",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&staging)
+            .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+        file.write_all(crate::cli::docker_credential::helper_stub().as_bytes())
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        file.set_permissions(fs::Permissions::from_mode(0o755))
+            .map_err(|error| format!("failed to chmod {}: {error}", staging.display()))?;
+        fs::rename(&staging, path)
+            .map_err(|error| format!("failed to replace {}: {error}", path.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(staging);
+    }
+    result
+}
+
+fn helper_path() -> PathBuf {
+    crate::cli::docker_credential::helper_path()
+}
+
+fn helper_valid(path: &Path) -> bool {
+    let metadata = fs::symlink_metadata(path).ok();
+    crate::cli::docker_credential::helper_stub_valid(path)
+        && metadata.as_ref().is_some_and(|metadata| {
+            metadata.permissions().mode() & 0o777 == 0o755
+                && (test_config_path().is_some() || metadata.uid() == 0)
+        })
+}
+
+fn stub_requirements(path: &Path) -> StubRequirements {
+    let test_ids = test_config_path().and_then(|_| {
+        path.parent()
+            .and_then(|parent| parent.metadata().ok())
+            .map(|metadata| (metadata.uid(), metadata.gid()))
+    });
+    StubRequirements {
+        mode: 0o755,
+        owner: RequiredIdentity {
+            name: if test_ids.is_some() {
+                "test user"
+            } else {
+                "root"
+            },
+            id: Some(test_ids.map_or(0, |ids| ids.0)),
+        },
+        group: RequiredIdentity {
+            name: if test_ids.is_some() {
+                "test group"
+            } else {
+                "wheel"
+            },
+            id: Some(test_ids.map_or(0, |ids| ids.1)),
+        },
+    }
+}
+
+fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String> {
+    if yes {
+        writeln!(stdout, "◇ Continue? yes (--yes)").ok();
+        return Ok(true);
+    }
+    write!(stdout, "◇ Continue? [y/N] ").ok();
+    stdout
+        .flush()
+        .map_err(|error| format!("failed to flush prompt: {error}"))?;
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .map_err(|error| format!("failed to read confirmation: {error}"))?;
+    if !io::stdin().is_terminal() {
+        writeln!(stdout).ok();
+    }
+    Ok(matches!(
+        input.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn verify_vendor_install() -> Result<(), String> {
+    if !Path::new(DOCKER_APP).is_dir() {
+        return Err("Docker Desktop is not installed in /Applications".into());
+    }
+    let status = Command::new("/usr/sbin/spctl")
+        .args(["--assess", "--type", "execute"])
+        .arg(DOCKER_APP)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to assess Docker Desktop notarization: {error}"))?;
+    if !status.success() {
+        return Err("Docker Desktop failed Apple's execution policy assessment".into());
+    }
+    for (_, path, identifier) in TARGETS {
+        if Path::new(path).exists() || identifier == "docker" {
+            verify_signed_executable(Path::new(path), identifier)?;
+        }
+    }
+    Ok(())
+}
+
+fn verify_signed_executable(path: &Path, identifier: &str) -> Result<(), String> {
+    let requirement = format!(
+        "=identifier \"{identifier}\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{DOCKER_TEAM}\""
+    );
+    let status = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--strict", "-R", &requirement])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to verify {}: {error}", path.display()))?;
+    if !status.success() {
+        return Err(format!("Docker signature is invalid: {}", path.display()));
+    }
+    let details = codesign_output(&["-d", "-vvv"], path)?;
+    for required in [
+        "flags=0x10000(runtime)",
+        "Authority=Developer ID Application: Docker Inc (9BNSXJN65R)",
+        "TeamIdentifier=9BNSXJN65R",
+        "Timestamp=",
+    ] {
+        if !details.contains(required) {
+            return Err(format!(
+                "Docker signature for {} did not confirm {required:?}",
+                path.display()
+            ));
+        }
+    }
+    let entitlements = codesign_output(&["-d", "--entitlements", ":-"], path)?;
+    for blocked in [
+        "com.apple.security.get-task-allow",
+        "com.apple.security.cs.allow-dyld-environment-variables",
+        "com.apple.security.cs.disable-library-validation",
+        "com.apple.security.cs.disable-executable-page-protection",
+        "com.apple.security.cs.debugger",
+    ] {
+        if entitlements.contains(blocked) {
+            return Err(format!(
+                "Docker executable enables unsafe entitlement {blocked}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn codesign_output(args: &[&str], path: &Path) -> Result<String, String> {
+    let output = Command::new("/usr/bin/codesign")
+        .args(args)
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .env("LANG", "C")
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if output.status.success() {
+        Ok(text)
+    } else {
+        Err(format!(
+            "failed to inspect Docker signature: {}",
+            text.trim()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_validation_fails_closed_and_accepts_av() {
+        assert_eq!(
+            validate_config(&json!({"credsStore":"av"})).unwrap(),
+            Some("av".into())
+        );
+        assert!(validate_config(&json!({"credHelpers":{"ghcr.io":"desktop"}})).is_err());
+        assert!(validate_config(&json!({"auths":{"ghcr.io":{"auth":"plaintext-ish"}}})).is_err());
+    }
+
+    #[test]
+    fn hardening_migrates_before_switching_helpers() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-docker-hardener-{}", std::process::id()));
+        let config = root.join("config.json");
+        let installed = root.join("docker-credential-av");
+        let source = root.join("docker-credential-desktop");
+        let legacy = root.join("legacy.json");
+        let keychain = root.join("keychain");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&config, r#"{"auths":{},"credsStore":"desktop"}"#).unwrap();
+        fs::write(
+            &legacy,
+            r#"{"ServerURL":"registry.example","Username":"user","Secret":"token"}"#,
+        )
+        .unwrap();
+        fs::write(&source, format!("#!/bin/sh\ncase \"$1\" in\nlist) [ -f '{0}' ] && printf '%s' '{{\"registry.example\":\"user\"}}' || printf '%s' '{{}}' ;;\nget) cat '{0}' ;;\nerase) cat >/dev/null; rm -f '{0}' ;;\nstore) cat >'{0}' ;;\n*) exit 2 ;;\nesac\n", legacy.display())).unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o700)).unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_DOCKER_CONFIG", &config);
+            std::env::set_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH", &installed);
+            std::env::set_var("AUTOMIC_VAULT_TEST_DOCKER_SOURCE_HELPER", &source);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        }
+        run(&mut Vec::new(), true).unwrap();
+        let updated: Value = serde_json::from_slice(&fs::read(&config).unwrap()).unwrap();
+        assert_eq!(updated["credsStore"], "av");
+        assert!(!legacy.exists());
+        let saved = fs::read_to_string(keychain.join(crate::cli::docker_credential::secret_name(
+            "registry.example",
+        )))
+        .unwrap();
+        assert_eq!(
+            crate::cli::docker_credential::parse_credential(&saved)
+                .unwrap()
+                .secret,
+            "token"
+        );
+        assert!(helper_valid(&installed));
+        unsafe {
+            for name in [
+                "AUTOMIC_VAULT_TEST_DOCKER_CONFIG",
+                "AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH",
+                "AUTOMIC_VAULT_TEST_DOCKER_SOURCE_HELPER",
+                "AUTOMIC_VAULT_TEST_KEYCHAIN_DIR",
+            ] {
+                std::env::remove_var(name);
+            }
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod aws_cli;
 pub(crate) mod aws_release;
 pub(crate) mod codex;
+pub(crate) mod docker;
 pub(crate) mod env_wrapper;
 pub(crate) mod gh_cli;
 pub(crate) mod homebrew;
@@ -234,6 +235,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
     let mut metadata = vec![
         gated_hardener!(aws_cli, "aws"),
         ungated_hardener!(codex, "codex"),
+        gated_hardener!(docker, "docker"),
         gated_hardener!(homebrew, "brew"),
         gated_hardener!(gh_cli, "gh"),
         gated_hardener!(stripe_cli, "stripe"),

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1430,6 +1430,8 @@ private struct ApprovalRequest {
     let tool: String?
     let title: String?
     let detail: String?
+    let dockerServerURL: String?
+    let dockerParent: DockerCredentialParent?
 
     init(
         op: String,
@@ -1445,7 +1447,9 @@ private struct ApprovalRequest {
         snapshotIncompatibleInterpreter: String? = nil,
         tool: String?,
         title: String?,
-        detail: String?
+        detail: String?,
+        dockerServerURL: String? = nil,
+        dockerParent: DockerCredentialParent? = nil
     ) {
         self.op = op
         self.keys = keys
@@ -1461,6 +1465,8 @@ private struct ApprovalRequest {
         self.tool = tool
         self.title = title
         self.detail = detail
+        self.dockerServerURL = dockerServerURL
+        self.dockerParent = dockerParent
     }
 }
 
@@ -1468,6 +1474,8 @@ enum SecretMutation {
     case save(account: String, value: String, accessibility: StoredSecretAccessibility)
     case saveIfAbsentOrEqual(account: String, value: String)
     case delete(account: String)
+    case dockerSave(account: String, value: String, serverURL: String, username: String)
+    case dockerDelete(account: String, serverURL: String)
     case rename(account: String, newAccount: String)
     case setAccessibility(account: String, accessibility: StoredSecretAccessibility)
 
@@ -1489,6 +1497,18 @@ enum SecretMutation {
                 "delete", [account], ["delete", account], "Delete \(account)?",
                 "This will remove the secret from Automic Vault."
             )
+        case .dockerSave(let account, _, let serverURL, let username):
+            properties = (
+                "docker-save", [account], ["credential", "store", serverURL],
+                "Store Docker credential for \(serverURL)?",
+                "Docker will use the \(username) credential for this registry through its Automic Vault Secret Gate."
+            )
+        case .dockerDelete(let account, let serverURL):
+            properties = (
+                "docker-delete", [account], ["credential", "erase", serverURL],
+                "Delete Docker credential for \(serverURL)?",
+                "Docker will no longer be able to authenticate to this registry with the stored credential."
+            )
         case .rename(let account, let newAccount):
             properties = (
                 "rename", [account, newAccount], ["rename", account, newAccount],
@@ -1504,6 +1524,10 @@ enum SecretMutation {
                     : "This will restrict the secret to use while your Mac is unlocked."
             )
         }
+        let tool = switch self {
+        case .dockerSave, .dockerDelete: "docker"
+        default: URL(fileURLWithPath: callerPath).lastPathComponent
+        }
         return ApprovalRequest(
             op: properties.op,
             keys: properties.keys,
@@ -1515,7 +1539,7 @@ enum SecretMutation {
             envConflicts: [],
             shebangScript: nil,
             scriptData: nil,
-            tool: URL(fileURLWithPath: callerPath).lastPathComponent,
+            tool: tool,
             title: properties.title,
             detail: properties.detail
         )
@@ -1528,6 +1552,10 @@ enum SecretMutation {
         case .saveIfAbsentOrEqual(let account, let value):
             saveStoredSecretIfAbsentOrEqual(account: account, value: value)
         case .delete(let account):
+            deleteStoredSecretRevokingDirectAccess(account: account)
+        case .dockerSave(let account, let value, _, _):
+            saveStoredSecret(account: account, value: value, accessibility: .whenUnlocked)
+        case .dockerDelete(let account, _):
             deleteStoredSecretRevokingDirectAccess(account: account)
         case .rename(let account, let newAccount):
             renameStoredSecretRevokingDirectAccess(account: account, to: newAccount)
@@ -1589,9 +1617,11 @@ private func performApprovedSecretMutation(
     onAccessRequest: (AccessRequestRecord) -> Bool,
     cancellation: ApprovalCancellation? = nil,
     decision: ((ApprovalRequest) -> ApprovalDecision)? = nil,
-    perform: ((SecretMutation) -> OSStatus)? = nil
+    perform: ((SecretMutation) -> OSStatus)? = nil,
+    preflight: (() -> String?)? = nil,
+    requestOverride: ApprovalRequest? = nil
 ) -> (status: OSStatus?, error: String?) {
-    let request = mutation.approvalRequest(callerPath: callerPath)
+    let request = requestOverride ?? mutation.approvalRequest(callerPath: callerPath)
     if cancellation?.isCanceled == true {
         _ = onAccessRequest(canceledAccessRequestRecord(
             request: request, callerPath: callerPath, launcher: launcher
@@ -1632,6 +1662,17 @@ private func performApprovedSecretMutation(
             launcher: launcher
         ))
         return (nil, canceled ? "secret mutation canceled" : "secret mutation denied")
+    }
+    if let error = preflight?() {
+        _ = onAccessRequest(accessRequestRecord(
+            request: request,
+            callerPath: callerPath,
+            decision: "Failed",
+            approvalSource: "Manual",
+            reason: error,
+            launcher: launcher
+        ))
+        return (nil, error)
     }
     guard onAccessRequest(accessRequestRecord(
         request: request,
@@ -1948,6 +1989,26 @@ private struct AWSRegistration {
     var credentials: AWSCredentials?
 }
 
+private struct DockerCredentialParent: Sendable {
+    let pid: pid_t
+    let startUsec: UInt64
+    let euid: uid_t
+    let target: String
+    let arguments: [String]
+}
+
+private struct DockerCredentialCandidate: Sendable {
+    let parent: DockerCredentialParent
+    let serverURL: String
+    let secretName: String
+}
+
+private struct StoredDockerCredential {
+    let serverURL: String
+    let username: String
+    let secret: String
+}
+
 private struct ApprovedPayload {
     let secrets: [String: String]
     let value: String?
@@ -2122,7 +2183,14 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: String(negotiated))
-        case .inject, .keys, .authorize:
+        case .dockerHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
+            let requested = xpc_dictionary_get_uint64(message, "requested_version")
+            guard requested == 1 else {
+                reply(peer, to: message, ok: false, error: "Docker helper protocol upgrade is required")
+                return
+            }
+            reply(peer, to: message, ok: true, error: nil, value: "1")
+        case .inject, .keys, .authorize, .dockerGet:
             handleInject(
                 message,
                 on: peer,
@@ -2134,6 +2202,10 @@ private final class ApprovalServer: @unchecked Sendable {
             )
         case .awsCredentials where isTrustedAvCaller(path: callerPath, signing: signing):
             handleAWSCredentials(message, on: peer, pid: pid, identity: identity)
+        case .dockerSave where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleDockerSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
+        case .dockerDelete where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleDockerDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
         case .list where isTrustedAvCaller(path: callerPath, signing: signing):
             handleList(
                 message,
@@ -2346,7 +2418,20 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
         }
-        let request = approvalRequestWithCredentialContext(parsedRequest)
+        let dockerRequest: ApprovalRequest
+        do {
+            dockerRequest = try dockerCredentialRequest(
+                from: message,
+                request: parsedRequest,
+                helperIdentity: identity,
+                helperPath: callerPath,
+                helperSigning: signing
+            )
+        } catch {
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
+            return
+        }
+        let request = approvalRequestWithCredentialContext(dockerRequest)
         let awsRegistration: AWSRegistrationCandidate?
         do {
             awsRegistration = try awsRegistrationCandidate(from: message, request: request)
@@ -3225,6 +3310,74 @@ private final class ApprovalServer: @unchecked Sendable {
         handleDelete(message, on: peer, cancellation: cancellation, caller: caller)
     }
 
+    private func handleDockerSave(
+        _ message: xpc_object_t,
+        on peer: xpc_connection_t,
+        cancellation: ApprovalCancellation,
+        caller: MutationCaller
+    ) {
+        guard let keyPointer = xpc_dictionary_get_string(message, "key"),
+              let valuePointer = xpc_dictionary_get_string(message, "value")
+        else {
+            reply(peer, to: message, ok: false, error: "invalid Docker credential store request")
+            return
+        }
+        let key = String(cString: keyPointer)
+        let value = String(cString: valuePointer)
+        guard let credential = parseDockerCredential(value),
+              key == dockerCredentialSecretName(credential.serverURL)
+        else {
+            reply(peer, to: message, ok: false, error: "invalid Docker credential")
+            return
+        }
+        do {
+            let parent = try dockerCredentialParent(for: caller.identity)
+            handleMutation(
+                .dockerSave(account: key, value: value, serverURL: credential.serverURL, username: credential.username),
+                on: peer,
+                message: message,
+                cancellation: cancellation,
+                caller: caller,
+                requiredDockerParent: parent
+            )
+        } catch {
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
+        }
+    }
+
+    private func handleDockerDelete(
+        _ message: xpc_object_t,
+        on peer: xpc_connection_t,
+        cancellation: ApprovalCancellation,
+        caller: MutationCaller
+    ) {
+        guard let keyPointer = xpc_dictionary_get_string(message, "key"),
+              let serverPointer = xpc_dictionary_get_string(message, "docker_server_url")
+        else {
+            reply(peer, to: message, ok: false, error: "invalid Docker credential erase request")
+            return
+        }
+        let key = String(cString: keyPointer)
+        let serverURL = String(cString: serverPointer)
+        guard validDockerServerURL(serverURL), key == dockerCredentialSecretName(serverURL) else {
+            reply(peer, to: message, ok: false, error: "invalid Docker credential")
+            return
+        }
+        do {
+            let parent = try dockerCredentialParent(for: caller.identity)
+            handleMutation(
+                .dockerDelete(account: key, serverURL: serverURL),
+                on: peer,
+                message: message,
+                cancellation: cancellation,
+                caller: caller,
+                requiredDockerParent: parent
+            )
+        } catch {
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
+        }
+    }
+
     private func handleDelete(
         _ message: xpc_object_t,
         on peer: xpc_connection_t,
@@ -3254,10 +3407,34 @@ private final class ApprovalServer: @unchecked Sendable {
         on peer: xpc_connection_t,
         message: xpc_object_t,
         cancellation: ApprovalCancellation,
-        caller: MutationCaller
+        caller: MutationCaller,
+        requiredDockerParent: DockerCredentialParent? = nil
     ) {
-        let launcher = launcherIdentities(for: caller.identity).first
+        let launcher = requiredDockerParent.flatMap { parent in
+            var identity = AVProcessIdentity()
+            guard av_process_identity(parent.pid, &identity) else { return nil }
+            return launcherIdentity(pid: parent.pid, identity: identity)
+        } ?? launcherIdentities(for: caller.identity).first
         let launcherFallbackPath = launcherFallbackPath(for: caller.identity) ?? caller.path
+        let requestOverride = requiredDockerParent.map { parent in
+            let request = mutation.approvalRequest(callerPath: caller.path)
+            return ApprovalRequest(
+                op: request.op,
+                keys: request.keys,
+                target: parent.target,
+                args: Array(parent.arguments.dropFirst()),
+                cwd: request.cwd,
+                replaceExistingEnv: request.replaceExistingEnv,
+                allowMissingKeys: request.allowMissingKeys,
+                envConflicts: request.envConflicts,
+                shebangScript: request.shebangScript,
+                scriptData: request.scriptData,
+                snapshotIncompatibleInterpreter: request.snapshotIncompatibleInterpreter,
+                tool: request.tool,
+                title: request.title,
+                detail: request.detail
+            )
+        }
         DispatchQueue.main.async {
             let result = performApprovedSecretMutation(
                 mutation,
@@ -3268,14 +3445,24 @@ private final class ApprovalServer: @unchecked Sendable {
                 launcherFallbackPath: launcherFallbackPath,
                 canRequestHumanApproval: self.canRequestHumanApproval,
                 onAccessRequest: self.onAccessRequest,
-                cancellation: cancellation
+                cancellation: cancellation,
+                preflight: requiredDockerParent.map { parent in
+                    {
+                        self.dockerCredentialParentValid(parent)
+                            ? nil
+                            : "Docker Target changed before the approved credential mutation"
+                    }
+                },
+                requestOverride: requestOverride
             )
             guard let status = result.status else {
                 self.reply(peer, to: message, ok: false, error: result.error)
                 return
             }
             switch mutation {
-            case .save(let account, _, _), .saveIfAbsentOrEqual(let account, _):
+            case .save(let account, _, _),
+                 .saveIfAbsentOrEqual(let account, _),
+                 .dockerSave(let account, _, _, _):
                 if status == errSecSuccess {
                     self.reply(peer, to: message, ok: true, error: nil)
                 } else {
@@ -3286,7 +3473,7 @@ private final class ApprovalServer: @unchecked Sendable {
                         error: "failed to store secret \(account): \(status)"
                     )
                 }
-            case .delete(let account):
+            case .delete(let account), .dockerDelete(let account, _):
                 if status == errSecSuccess || status == errSecItemNotFound {
                     self.reply(peer, to: message, ok: true, error: nil)
                 } else {
@@ -3370,13 +3557,135 @@ private final class ApprovalServer: @unchecked Sendable {
         )
     }
 
+    private func dockerCredentialRequest(
+        from message: xpc_object_t,
+        request: ApprovalRequest,
+        helperIdentity: AVProcessIdentity,
+        helperPath: String,
+        helperSigning: SigningInfo
+    ) throws -> ApprovalRequest {
+        guard request.op == "docker-get" else {
+            guard request.tool != "docker" else {
+                throw AppError("Docker credentials require the Docker helper protocol")
+            }
+            return request
+        }
+        guard request.tool == "docker",
+              isTrustedAvCaller(path: helperPath, signing: helperSigning),
+              request.target.isEmpty,
+              request.args.isEmpty,
+              request.keys.count == 1,
+              !request.replaceExistingEnv,
+              !request.allowMissingKeys,
+              request.envConflicts.isEmpty,
+              request.shebangScript == nil,
+              request.scriptData == nil,
+              let serverPointer = xpc_dictionary_get_string(message, "docker_server_url")
+        else { throw AppError("invalid Docker credential request") }
+        let serverURL = String(cString: serverPointer)
+        let secretName = dockerCredentialSecretName(serverURL)
+        guard validDockerServerURL(serverURL), request.keys == [secretName] else {
+            throw AppError("Docker registry Secret Name does not match its address")
+        }
+        let parent = try dockerCredentialParent(for: helperIdentity)
+        return ApprovalRequest(
+            op: request.op,
+            keys: [secretName],
+            target: parent.target,
+            args: Array(parent.arguments.dropFirst()),
+            cwd: request.cwd,
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "docker",
+            title: "Use Docker credential for \(serverURL)?",
+            detail: "The verified Docker Target will receive the usable registry credential in plaintext, as required by Docker's credential-helper protocol.",
+            dockerServerURL: serverURL,
+            dockerParent: parent
+        )
+    }
+
+    private func dockerCredentialParent(
+        for helperIdentity: AVProcessIdentity
+    ) throws -> DockerCredentialParent {
+        let parentPID = helperIdentity.ppid
+        var parentIdentity = AVProcessIdentity()
+        guard parentPID > 1,
+              av_process_identity(parentPID, &parentIdentity),
+              parentIdentity.euid == helperIdentity.euid,
+              let arguments = processArguments(parentPID),
+              !arguments.isEmpty
+        else { throw AppError("Docker credential helper has no live parent") }
+        let target = pathString(parentIdentity)
+        guard dockerTargetIdentityValid(pid: parentPID, path: target) else {
+            throw AppError("Docker credential helper parent is not an eligible Docker Target")
+        }
+        return DockerCredentialParent(
+            pid: parentPID,
+            startUsec: parentIdentity.start_usec,
+            euid: parentIdentity.euid,
+            target: target,
+            arguments: arguments
+        )
+    }
+
+    private func dockerCredentialParentValid(_ parent: DockerCredentialParent) -> Bool {
+        var identity = AVProcessIdentity()
+        return av_process_identity(parent.pid, &identity)
+            && identity.start_usec == parent.startUsec
+            && identity.euid == parent.euid
+            && pathString(identity) == parent.target
+            && processArguments(parent.pid) == parent.arguments
+            && dockerTargetIdentityValid(pid: parent.pid, path: parent.target)
+    }
+
+    private func dockerTargetIdentityValid(pid: pid_t, path: String) -> Bool {
+        let identifiers = [
+            "/Applications/Docker.app/Contents/Resources/bin/docker": "docker",
+            "/Applications/Docker.app/Contents/Resources/cli-plugins/docker-compose": "docker-compose",
+            "/Applications/Docker.app/Contents/Resources/cli-plugins/docker-buildx": "docker-buildx",
+        ]
+        guard let identifier = identifiers[path],
+              let signing = liveSigningInfo(pid: pid),
+              signing.mainExecutable == path
+        else { return false }
+        return signing.identifier == identifier
+            && signing.teamIdentifier == "9BNSXJN65R"
+            && signing.isDeveloperID
+            && signing.runtimeProtection.allowsSecretGateAccess
+    }
+
     private func approvedPayload(
         for request: ApprovalRequest,
         awsRegistration: AWSRegistrationCandidate?,
         pid: pid_t,
         identity: AVProcessIdentity
     ) throws -> ApprovedPayload {
+        let dockerParent: DockerCredentialParent?
+        if request.op == "docker-get" {
+            guard let serverURL = request.dockerServerURL,
+                  request.keys == [dockerCredentialSecretName(serverURL)],
+                  let parent = request.dockerParent,
+                  dockerCredentialParentValid(parent),
+                  parent.target == request.target,
+                  Array(parent.arguments.dropFirst()) == request.args
+            else { throw AppError("invalid Docker credential request") }
+            dockerParent = parent
+        } else {
+            dockerParent = nil
+        }
         let secrets = try approvedSecrets(for: request)
+        if let dockerParent,
+           let serverURL = request.dockerServerURL
+        {
+            guard dockerCredentialParentValid(dockerParent),
+                  let value = secrets[dockerCredentialSecretName(serverURL)],
+                  let credential = parseDockerCredential(value),
+                  credential.serverURL == serverURL
+            else { throw AppError("Docker credential changed before Secret Application") }
+        }
         guard let awsRegistration else { return ApprovedPayload(secrets: secrets, value: nil) }
         let key = BlessedExecutionKey(pid: pid, startUsec: identity.start_usec)
         awsRegistrationsLock.lock()
@@ -3620,7 +3929,7 @@ private final class ApprovalServer: @unchecked Sendable {
             return nil
         }
         let op = String(cString: opPointer)
-        guard op == "inject" || op == "keys" || op == "authorize" else { return nil }
+        guard op == "inject" || op == "keys" || op == "authorize" || op == "docker-get" else { return nil }
         let scriptData: Data?
         if xpc_dictionary_get_value(message, "script_data") != nil {
             guard let data = xpcData(message, key: "script_data") else { return nil }
@@ -3973,6 +4282,8 @@ private func classifySecretGateRequest(
     switch gateID {
     case "gh":
         return ghRequestClassification(request.args)
+    case "docker":
+        return dockerRequestClassification(request.args)
     case "aws":
         if awsRequestMayUseLongLivedCredentials(request) { return .secretDump }
         return awsRequestIsReadOnly(awsCommandWords(request)) ? .readOnly : .mutating
@@ -3984,6 +4295,51 @@ private func classifySecretGateRequest(
             arguments: secretGateCommandWords(request)
         )
     }
+}
+
+private func dockerRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
+    let words = dockerCommandWords(args).map { $0.lowercased() }
+    guard let command = words.first else { return .unknown }
+    if words.contains("--push") { return .mutating }
+    switch command {
+    case "search": return .readOnly
+    case "manifest" where words.dropFirst().first == "inspect": return .readOnly
+    case "pull", "run", "create", "build": return .localWrite
+    case "image" where words.dropFirst().first == "pull": return .localWrite
+    case "push": return .mutating
+    case "image" where words.dropFirst().first == "push": return .mutating
+    case "buildx":
+        guard words.count >= 2 else { return .unknown }
+        if words[1] == "imagetools", words.dropFirst(2).first == "inspect" { return .readOnly }
+        return words[1] == "build" ? .localWrite : .unknown
+    case "compose":
+        guard words.count >= 2 else { return .unknown }
+        if words[1] == "push" { return .mutating }
+        return ["build", "create", "pull", "run", "up"].contains(words[1]) ? .localWrite : .unknown
+    default: return .unknown
+    }
+}
+
+private func dockerCommandWords(_ args: [String]) -> [String] {
+    let optionsWithValue = Set(["--config", "-c", "--context", "-H", "--host", "-l", "--log-level"])
+    let flags = Set(["--debug", "-D", "--tls", "--tlsverify"])
+    var index = 0
+    while index < args.count {
+        let argument = args[index]
+        if argument == "--" { return [] }
+        if optionsWithValue.contains(argument) {
+            guard index + 1 < args.count else { return [] }
+            index += 2
+            continue
+        }
+        if optionsWithValue.contains(where: { argument.hasPrefix("\($0)=") }) || flags.contains(argument) {
+            index += 1
+            continue
+        }
+        if argument.hasPrefix("-") { return [] }
+        return Array(args[index...])
+    }
+    return []
 }
 
 private func secretGateCommandWords(_ request: ApprovalRequest) -> [String] {
@@ -4394,6 +4750,34 @@ private func validSecretKeyName(_ key: String) -> Bool {
     return key.unicodeScalars.dropFirst().allSatisfy {
         $0 == "_" || $0.isASCIIAlpha || $0.isASCIIDigit
     }
+}
+
+private func validDockerServerURL(_ serverURL: String) -> Bool {
+    !serverURL.isEmpty
+        && serverURL.utf8.count <= 2048
+        && !serverURL.unicodeScalars.contains(where: { $0.value == 0 || $0.value == 10 || $0.value == 13 })
+}
+
+private func dockerCredentialSecretName(_ serverURL: String) -> String {
+    let hash = SHA256.hash(data: Data(serverURL.utf8)).map { String(format: "%02X", $0) }.joined()
+    return "DOCKER_REGISTRY_CREDENTIAL_\(hash)"
+}
+
+private func parseDockerCredential(_ value: String) -> StoredDockerCredential? {
+    guard value.utf8.count <= 64 * 1024,
+          let data = value.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          Set(object.keys) == Set(["ServerURL", "Username", "Secret"]),
+          let serverURL = object["ServerURL"] as? String,
+          let username = object["Username"] as? String,
+          let secret = object["Secret"] as? String,
+          validDockerServerURL(serverURL),
+          !username.isEmpty,
+          !secret.isEmpty,
+          !username.unicodeScalars.contains(where: { $0.value == 0 }),
+          !secret.unicodeScalars.contains(where: { $0.value == 0 })
+    else { return nil }
+    return StoredDockerCredential(serverURL: serverURL, username: username, secret: secret)
 }
 
 private func isGhTokenKey(_ key: String) -> Bool {
@@ -7057,6 +7441,27 @@ private func runGhReadOnlySelfCheck() -> Int32 {
     return 0
 }
 
+private func runDockerCredentialSelfCheck() -> Int32 {
+    guard dockerRequestClassification(["search", "alpine"]) == .readOnly,
+          dockerRequestClassification(["pull", "alpine"]) == .localWrite,
+          dockerRequestClassification(["push", "example/image"]) == .mutating,
+          dockerRequestClassification(["future-command"]) == .unknown,
+          dockerRequestClassification(["buildx", "build", "--push", "."]) == .mutating,
+          dockerCredentialSecretName("https://ghcr.io")
+              == "DOCKER_REGISTRY_CREDENTIAL_82445E613488865FCEA004BCAB798DA99E6D3695EEC0072488AFB0A3B0A3D323",
+          let credential = parseDockerCredential(
+              #"{"ServerURL":"https://ghcr.io","Username":"octocat","Secret":"token"}"#
+          ),
+          credential.serverURL == "https://ghcr.io",
+          credential.username == "octocat",
+          credential.secret == "token",
+          parseDockerCredential(
+              #"{"ServerURL":"https://ghcr.io","Username":"octocat","Secret":"token","Extra":true}"#
+          ) == nil
+    else { return 1 }
+    return 0
+}
+
 private func runAwsReadOnlySelfCheck() -> Int32 {
     let allowed = [
         ["--version"],
@@ -7823,6 +8228,10 @@ if CommandLine.arguments.contains("--self-check-secret-mutations") {
 
 if CommandLine.arguments.contains("--self-check-gh-read-only") {
     exit(runGhReadOnlySelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-docker-credentials") {
+    exit(runDockerCredentialSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-aws-read-only") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -6309,7 +6309,52 @@ private func runSecretMutationSelfCheck() -> Int32 {
             return errSecSuccess
         }
     )
-    return unaudited.status == nil && !performedWithoutAudit ? 0 : 1
+    guard unaudited.status == nil, !performedWithoutAudit else { return 1 }
+
+    let dockerRequest = ApprovalRequest(
+        op: "docker-save",
+        keys: ["DOCKER_REGISTRY_CREDENTIAL_TEST"],
+        target: "/Applications/Docker.app/Contents/Resources/bin/docker",
+        args: ["login", "registry.example"],
+        cwd: "",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        envConflicts: [],
+        shebangScript: nil,
+        scriptData: nil,
+        tool: "docker",
+        title: nil,
+        detail: nil
+    )
+    var approvedRequest: ApprovalRequest?
+    var performedAfterFailedPreflight = false
+    let changedDocker = performApprovedSecretMutation(
+        .dockerDelete(account: "DOCKER_REGISTRY_CREDENTIAL_TEST", serverURL: "registry.example"),
+        callerPath: "/usr/local/bin/av",
+        pid: 42,
+        signing: SigningInfo(identifier: "com.automicvault.av", teamIdentifier: "TEAM"),
+        launcher: nil,
+        launcherFallbackPath: "/Applications/Terminal.app",
+        canRequestHumanApproval: { true },
+        onAccessRequest: { _ in true },
+        decision: {
+            approvedRequest = $0
+            return .approved
+        },
+        perform: { _ in
+            performedAfterFailedPreflight = true
+            return errSecSuccess
+        },
+        preflight: { "Docker Target changed before mutation" },
+        requestOverride: dockerRequest
+    )
+    guard approvedRequest?.target == dockerRequest.target,
+          approvedRequest?.args == dockerRequest.args,
+          changedDocker.status == nil,
+          changedDocker.error == "Docker Target changed before mutation",
+          !performedAfterFailedPreflight
+    else { return 1 }
+    return 0
 }
 
 @MainActor

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -1,9 +1,13 @@
 public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case awsHelperVersion = "aws-helper-version"
+    case dockerHelperVersion = "docker-helper-version"
     case inject
     case keys
     case authorize
     case awsCredentials = "aws-credentials"
+    case dockerGet = "docker-get"
+    case dockerSave = "docker-save"
+    case dockerDelete = "docker-delete"
     case list
     case save
     case saveIfAbsentOrEqual = "save-if-absent"

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -585,7 +585,7 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
         if keyPatterns.isEmpty {
             return [.noAccess, .readOnly, .fullExceptSecretDumps]
         }
-        if id == "gh" {
+        if id == "gh" || id == "docker" {
             return [
                 .noAccess,
                 .readOnly,
@@ -606,7 +606,7 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
         if keyPatterns.isEmpty, protection == .fullIncludingSecretDumps {
             protection = .fullExceptSecretDumps
         }
-        if id != "gh", protection == .readOnlyAndLocalWrites {
+        if id != "gh" && id != "docker", protection == .readOnlyAndLocalWrites {
             protection = .readOnly
         }
         if !keyPatterns.isEmpty, protection == .readOnlyAndUpdates {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
+const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 1;
 
 struct XpcReply {
     value: Option<String>,
@@ -19,6 +20,7 @@ pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
         "save",
         Some((b"key\0", account)),
         Some((b"value\0", value)),
+        None,
         None,
     )
     .map(|_| ())
@@ -54,6 +56,7 @@ pub(crate) fn store_secret_if_absent_or_equal(account: &str, value: &str) -> Res
             Some((b"key\0", account)),
             Some((b"value\0", value)),
             None,
+            None,
         )
         .map(|_| ())
     }
@@ -66,6 +69,7 @@ pub(crate) fn bless_script(path: &str, endorse_launcher: bool) -> Result<bool, S
         None,
         // Compatibility wire key. The domain term is Launcher Endorsement.
         endorse_launcher.then_some(&b"endorse_caller\0"[..]),
+        None,
     )
     .map(|reply| reply.value.as_deref() == Some("already blessed"))
 }
@@ -89,7 +93,63 @@ pub(crate) fn list_secret_names() -> Result<Vec<String>, String> {
         .map_err(|err| format!("failed to read current directory: {err}"))?
         .to_string_lossy()
         .into_owned();
-    Ok(xpc_request("list", Some((b"cwd\0", &cwd)), None, None)?.names)
+    Ok(xpc_request("list", Some((b"cwd\0", &cwd)), None, None, None)?.names)
+}
+
+pub(crate) fn ensure_docker_helper_ready() -> Result<(), String> {
+    if crate::test_keychain_dir().is_some() {
+        return Ok(());
+    }
+    let reply = xpc_request(
+        "docker-helper-version",
+        None,
+        None,
+        None,
+        Some((b"requested_version\0", DOCKER_HELPER_PROTOCOL_VERSION)),
+    )?;
+    match reply.value.as_deref() {
+        Some("1") => Ok(()),
+        Some(version) => Err(format!(
+            "the running Automic Vault app reported unsupported Docker helper version {version}"
+        )),
+        None => Err("the running Automic Vault app returned no Docker helper version".into()),
+    }
+}
+
+pub(crate) fn store_docker_credential(account: &str, value: &str) -> Result<(), String> {
+    if let Some(dir) = crate::test_keychain_dir() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|err| format!("failed to create test keychain dir: {err}"))?;
+        let path = PathBuf::from(dir).join(account);
+        return std::fs::write(&path, value)
+            .map_err(|err| format!("failed to write {}: {err}", path.display()));
+    }
+    xpc_request(
+        "docker-save",
+        Some((b"key\0", account)),
+        Some((b"value\0", value)),
+        None,
+        None,
+    )
+    .map(|_| ())
+}
+
+pub(crate) fn delete_docker_credential(account: &str, server_url: &str) -> Result<(), String> {
+    if let Some(dir) = crate::test_keychain_dir() {
+        return match std::fs::remove_file(PathBuf::from(dir).join(account)) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(format!("failed to delete test Docker credential: {err}")),
+        };
+    }
+    xpc_request(
+        "docker-delete",
+        Some((b"key\0", account)),
+        Some((b"docker_server_url\0", server_url)),
+        None,
+        None,
+    )
+    .map(|_| ())
 }
 
 #[cfg(target_os = "macos")]
@@ -98,6 +158,7 @@ fn xpc_request(
     field: Option<(&'static [u8], &str)>,
     extra: Option<(&'static [u8], &str)>,
     bool_field: Option<&'static [u8]>,
+    uint_field: Option<(&'static [u8], u64)>,
 ) -> Result<XpcReply, String> {
     use std::ffi::CString;
     use std::os::raw::{c_char, c_int, c_void};
@@ -122,6 +183,7 @@ fn xpc_request(
         ) -> XpcObject;
         fn xpc_dictionary_create_empty() -> XpcObject;
         fn xpc_dictionary_set_bool(xdict: XpcObject, key: *const c_char, value: bool);
+        fn xpc_dictionary_set_uint64(xdict: XpcObject, key: *const c_char, value: u64);
         fn xpc_dictionary_get_bool(xdict: XpcObject, key: *const c_char) -> bool;
         fn xpc_dictionary_set_string(xdict: XpcObject, key: *const c_char, value: *const c_char);
         fn xpc_dictionary_get_string(xdict: XpcObject, key: *const c_char) -> *const c_char;
@@ -182,6 +244,9 @@ fn xpc_request(
         }
         if let Some(bool_field) = bool_field {
             xpc_dictionary_set_bool(message, bool_field.as_ptr().cast(), true);
+        }
+        if let Some((uint_field, value)) = uint_field {
+            xpc_dictionary_set_uint64(message, uint_field.as_ptr().cast(), value);
         }
         xpc_dictionary_set_bool(message, b"interactive\0".as_ptr().cast(), true);
     }
@@ -280,6 +345,7 @@ fn xpc_request(
     _field: Option<(&'static [u8], &str)>,
     _extra: Option<(&'static [u8], &str)>,
     _bool_field: Option<&'static [u8]>,
+    _uint_field: Option<(&'static [u8], u64)>,
 ) -> Result<XpcReply, String> {
     Err("the Automic Vault menu bar approval service is only available on macOS".to_string())
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -104,7 +104,12 @@ pub(crate) fn ensure_docker_helper_ready() -> Result<(), String> {
         None,
         None,
         Some((b"requested_version\0", DOCKER_HELPER_PROTOCOL_VERSION)),
-    )?;
+    )
+    .map_err(|error| {
+        format!(
+            "Docker credential-helper protocol negotiation failed; update and open the Automic Vault app: {error}"
+        )
+    })?;
     match reply.value.as_deref() {
         Some("1") => Ok(()),
         Some(version) => Err(format!(

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 1;
 
@@ -12,7 +10,7 @@ pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
     if let Some(dir) = crate::test_keychain_dir() {
         std::fs::create_dir_all(&dir)
             .map_err(|err| format!("failed to create test keychain dir: {err}"))?;
-        let path = PathBuf::from(dir).join(account);
+        let path = dir.join(account);
         return std::fs::write(&path, value)
             .map_err(|err| format!("failed to write {}: {err}", path.display()));
     }
@@ -30,7 +28,7 @@ pub(crate) fn store_secret_if_absent_or_equal(account: &str, value: &str) -> Res
     if let Some(dir) = crate::test_keychain_dir() {
         std::fs::create_dir_all(&dir)
             .map_err(|err| format!("failed to create test keychain dir: {err}"))?;
-        let path = PathBuf::from(dir).join(account);
+        let path = dir.join(account);
         match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -120,7 +118,7 @@ pub(crate) fn store_docker_credential(account: &str, value: &str) -> Result<(), 
     if let Some(dir) = crate::test_keychain_dir() {
         std::fs::create_dir_all(&dir)
             .map_err(|err| format!("failed to create test keychain dir: {err}"))?;
-        let path = PathBuf::from(dir).join(account);
+        let path = dir.join(account);
         return std::fs::write(&path, value)
             .map_err(|err| format!("failed to write {}: {err}", path.display()));
     }
@@ -136,7 +134,7 @@ pub(crate) fn store_docker_credential(account: &str, value: &str) -> Result<(), 
 
 pub(crate) fn delete_docker_credential(account: &str, server_url: &str) -> Result<(), String> {
     if let Some(dir) = crate::test_keychain_dir() {
-        return match std::fs::remove_file(PathBuf::from(dir).join(account)) {
+        return match std::fs::remove_file(dir.join(account)) {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(err) => Err(format!("failed to delete test Docker credential: {err}")),


### PR DESCRIPTION
Closes #161.

## What changed

- add `av harden docker` and a root-owned `docker-credential-av` launcher
- migrate credentials from Docker Desktop's `desktop` or `osxkeychain` helper into Automic Vault with save-before-delete semantics and rollback
- keep Docker Desktop's vendor-signed Docker, Compose, and Buildx CLIs instead of producing isotopes
- verify Docker's notarization, Developer ID team, signing identifiers, Hardened Runtime, timestamp, and unsafe-entitlement absence
- authorize helper reads, stores, and erases through XPC using the live Docker parent, exact PID start time, UID, executable, arguments, code identity, registry, and derived Secret Name
- reject inline credentials, non-Automic per-registry helpers, malformed protocol input, and helper `list` metadata disclosure
- document the resulting security boundary in ADR 0014

## Why

Docker's credential-helper protocol protects secrets at rest but returns a usable registry credential as plaintext JSON to any caller of `get`. The hardener moves custody and authorization into Automic Vault while retaining Docker's stronger vendor distribution identity. The plaintext handoff remains only at the unavoidable protocol boundary, after the actual Docker Target has been authorized and revalidated.

## Validation

- `cargo test --all-targets` — passed
- `cargo test docker --lib` — passed
- `swift test` — 100 tests passed
- `AutomicVaultMenubar --self-check-docker-credentials` — passed
- `AutomicVaultMenubar --self-check-secret-mutations` — passed
- hardener metadata successfully verified the installed Docker Desktop signatures and runtime posture

`cargo clippy --all-targets -- -D warnings` remains blocked by the repository's existing Rust 1.96 lint backlog outside this change.
