### PR TITLE
Add project-scoped secret values

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ and update behavior.
 $ av save TOKEN_NAME
 # Confirmation window appears
 
+$ av save --project-directory=. TOKEN_NAME
+# Store a Project Value for the current physical directory
+
 $ av list
 # Approval window appears unless the calling app is allowed in Settings
 
@@ -255,6 +258,12 @@ Automic Vault differs from conventional secrets managers in two ways:
 `av inject` as the shebang for scripts creates a script that always shows an
 approval window when run. The script receives the secrets if you approve its
 runtime request.
+
+Each Secret Name may have a Global Value and Project Values. For each requested
+name, `av inject` selects the nearest Project Value at or above its working
+directory, then falls back to the Global Value. Project directories select a
+value; they do not grant authority. Existing name-based policy covers every
+Value of that Secret.
 
 > [!TIP]
 > #### Portable Scripts
@@ -360,7 +369,7 @@ its decryption key in Automic Vault instead of leaving `.env.keys` in your
 project:
 
 ```sh
-$ av save DOTENV_PRIVATE_KEY
+$ av save --project-directory=. DOTENV_PRIVATE_KEY
 # Paste DOTENV_PRIVATE_KEY from .env.keys
 ```
 

--- a/docs/adr/0013-project-secret-values.md
+++ b/docs/adr/0013-project-secret-values.md
@@ -1,0 +1,56 @@
+# ADR 0013: Select Secret Values by Project Directory
+
+- Status: Accepted
+- Date: 2026-08-14
+
+## Context
+
+Credentials such as `OPENAI_API_KEY` and `DOTENV_PRIVATE_KEY` commonly differ
+between projects, while Tools require their established environment variable
+names. Storing those credentials under invented Secret Names is incompatible
+with transparent injection and obscures the capability the user is granting.
+
+A working directory is controlled by the Launcher. It cannot safely distinguish
+authorized from unauthorized code running as the same user. Treating it as an
+authority boundary would weaken the product's name-based policy model.
+
+## Decision
+
+A Secret is one name-based capability with one optional Global Value and zero
+or more Project Values. Authorization policy, Direct Access Rules, Blessings,
+availability, and Secret mutation operate on the Secret Name and cover all its
+Values.
+
+For each requested Secret Name, the menu bar app selects the nearest Project
+Value at or above the request's physical canonical working directory. Traversal
+stops before crossing a filesystem boundary. If no Project Value matches, the
+Global Value is selected. If neither exists, the Secret is missing. A failure to
+read the selected Value denies the request without fallback.
+
+Selection models only Git's fundamental physical parent traversal. It does not
+invoke Git or inspect `.git`, Git environment variables, configuration, worktree
+metadata, ownership, or the user's home directory.
+
+Project Directories are canonical absolute path strings, not filesystem
+identities. They must exist and be directories when a Value is created, and a
+filesystem or mount root cannot be used. Moving a directory does not move its
+Value; recreating the same path makes the Value selectable again.
+
+The app resolves selected Values once before authorization, includes their
+sources in the immutable Authorization Request and Authorization Record, and
+loads those exact Keychain items after authorization succeeds. The working
+directory and Project Directory are displayed as context, never as proof of
+authority.
+
+## Consequences
+
+- Existing name-based grants intentionally cover later Project Values of the
+  same Secret.
+- A Launcher authorized for a Secret Name may select among its Values by
+  choosing a working directory.
+- Nested Project Values inherit other Secret Names independently from ancestors
+  or their Global Values.
+- Directory deletion makes a Project Value inactive without deleting it, and
+  path reuse reactivates it.
+- No Git dependency, repository registry, or filesystem-identity persistence is
+  introduced.

--- a/docs/adr/0013-project-secret-values.md
+++ b/docs/adr/0013-project-secret-values.md
@@ -42,6 +42,13 @@ loads those exact Keychain items after authorization succeeds. The working
 directory and Project Directory are displayed as context, never as proof of
 authority.
 
+Availability and rename are Secret-level mutations that update all Values.
+Multi-item rename, availability, and whole-Secret deletion use a persisted
+forward-repair journal. Interrupted operations resume in the forward direction,
+and affected names deny Secret Use until repair completes. Deleting one Value
+retains Direct Access Rules while another Value remains; deleting the last
+Value revokes them.
+
 ## Consequences
 
 - Existing name-based grants intentionally cover later Project Values of the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,6 +229,13 @@ Access Rules and Blessings, applies to all Values of that exact Secret Name. A
 Launcher with authority for a Secret may choose a working directory and thereby
 choose among its Values.
 
+Availability and renaming apply to every Value of a Secret. Multi-item
+mutations persist a forward-repair journal before changing Value items. The app
+resumes an interrupted operation, and affected Secret Names remain unavailable
+until repair completes. Removing one Value retains name-based policy while
+another Value remains; removing the last Value deletes the Secret and revokes
+its Direct Access Rules.
+
 A Gate Client's code signature authenticates the component but grants no
 authority to retrieve an existing Secret. The approval service exposes no
 generic Secret-load operation. Existing Secret bytes may leave custody only as

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,10 @@ Targets and changed runtime posture fail closed. See
 
 ### Secret Custody
 
-Automic Vault stores named opaque Secrets in the macOS Data Protection Keychain. Each Secret has an availability choice independent of authorization policy.
+Automic Vault stores named opaque Secrets in the macOS Data Protection
+Keychain. A Secret may contain a Global Value and Project Values. Each Secret
+has one availability choice, shared by all its Values and independent of
+authorization policy.
 
 ### Runtime Authorization
 
@@ -207,6 +210,25 @@ The Homebrew migration intentionally broadens persisted `readOnly` rules to allo
 
 Secret bytes stay in the app's private Keychain access group. Gate policy and Authorization History use separate services. Availability controls whether Keychain may return a Secret while the device is locked. Authorization controls whether the operation may receive it. Both checks must pass.
 
+For each requested Secret Name, the menu bar app selects a Value from the
+Authorization Request's working directory. It examines that physical canonical
+directory and each physical parent on the same filesystem. The nearest Project
+Value wins; otherwise the Global Value is used. If neither exists, the Secret is
+missing. Selection does not inspect `.git`, Git configuration, environment
+variables, or repository metadata, and it does not cross a filesystem boundary.
+
+The app resolves every selected Value before authorization, binds the exact
+sources into the immutable Authorization Request and Authorization Record, and
+loads those exact Keychain items only after authorization succeeds. Failure to
+read a selected Value denies the request; it never falls back to an ancestor or
+Global Value.
+
+A Project Directory path is selection context supplied by the Gate Client, not
+an authority boundary or software identity. Name-based policy, including Direct
+Access Rules and Blessings, applies to all Values of that exact Secret Name. A
+Launcher with authority for a Secret may choose a working directory and thereby
+choose among its Values.
+
 A Gate Client's code signature authenticates the component but grants no
 authority to retrieve an existing Secret. The approval service exposes no
 generic Secret-load operation. Existing Secret bytes may leave custody only as
@@ -216,8 +238,10 @@ storing or migrating Secrets compare and verify values inside the menu bar app
 and return status only.
 
 Direct Access Rules are authorization policy, not Secret Availability. They are
-stored separately from Secret bytes. Renaming or deleting a Secret revokes its
-rules so recreating an old Secret Name cannot silently restore authority.
+stored separately from Secret bytes. Removing one Value does not revoke rules
+while the Secret retains another Value. Renaming a Secret or deleting its last
+Value revokes its rules so recreating an old Secret Name cannot silently restore
+authority.
 
 Human Approval requires an active user session and awake displays. Requests that still need a human decision are denied if the session becomes inactive or the displays sleep. Policy-authorized requests may proceed while locked only when every requested Secret has Available While Locked enabled.
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -141,11 +141,39 @@ Use Launcher, Gate Client, and Target in security-sensitive prose. Avoid the amb
 
 ### Secret
 
-A named, opaque, sensitive value under Automic Vault's control.
+A protected capability identified by one Secret Name. A Secret contains one or
+more opaque, sensitive Values under Automic Vault's control.
 
 ### Secret Name
 
 The identifier used to request a Secret. Use *Secret Name* instead of the overloaded word *key* in product language.
+
+Authorization policy names the Secret, not an individual Value. A rule that
+authorizes a Secret Name therefore covers every current and future Value of that
+Secret Name.
+
+### Secret Value
+
+The opaque bytes selected when a Secret is used. A Secret may have one Global
+Value and any number of Project Values.
+
+### Global Value
+
+The Secret Value used when no Project Value matches the Authorization Request's
+working directory.
+
+### Project Value
+
+A Secret Value associated with one Project Directory. Project Values are
+selection context, not an authorization boundary. The nearest matching Project
+Directory is selected independently for each requested Secret Name.
+
+### Project Directory
+
+An existing directory represented by its canonical absolute path. The path is a
+selector for a Project Value, not an identity or proof of authority. Moving the
+directory does not move the Project Value; recreating a directory at the same
+path makes that Project Value selectable again.
 
 ### Credential
 
@@ -165,7 +193,7 @@ The intentional return of a raw Secret value to the Launcher, standard output, c
 
 ### Secret Availability
 
-The Keychain availability chosen for a Secret:
+The Keychain availability chosen for a Secret and shared by all its Values:
 
 - **When Unlocked:** available while the user's device is unlocked.
 - **Available While Locked:** available after the first unlock following a restart.
@@ -176,7 +204,9 @@ Availability can prevent an authorized operation. It cannot authorize one. Human
 
 ### Authorization Request
 
-The complete, immutable description of one operation. It binds the Launcher, Gate Client, Target, command, arguments, working directory, requested Secret Names, relevant options, and process identity.
+The complete, immutable description of one operation. It binds the Launcher,
+Gate Client, Target, command, arguments, working directory, requested Secret
+Names, selected Secret Value sources, relevant options, and process identity.
 
 ### Authorization Policy
 
@@ -201,7 +231,7 @@ The final allow or deny result and its source. An allowed request is either **au
 
 ### Fail Closed
 
-Uncertainty about policy or operation risk disables automic authorization and requires Approval. Uncertainty about identity, integrity, request completeness, Secret matching, or required Authorization Record persistence denies the request. An error must not fall back to broader access.
+Uncertainty about policy or operation risk disables automic authorization and requires Approval. Uncertainty about identity, integrity, request completeness, Secret matching, selected Secret Value, or required Authorization Record persistence denies the request. An error must not fall back to another Secret Value or broader access.
 
 ## Operation Characteristics
 

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -3,7 +3,7 @@ use std::ffi::{CString, OsString};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -464,6 +464,37 @@ fn build_env(
 
 fn load_test_secret_if_present(key: &str) -> Result<Option<String>, String> {
     if let Some(dir) = crate::test_keychain_dir() {
+        let mut current = std::env::current_dir()
+            .map_err(|err| format!("failed to determine working directory: {err}"))?;
+        let device = current
+            .metadata()
+            .map_err(|err| format!("failed to inspect working directory: {err}"))?
+            .dev();
+        loop {
+            let project = current
+                .to_str()
+                .ok_or("working directory must be valid UTF-8")?;
+            let path = crate::secrets::test_project_secret_path(&dir, project, key);
+            match std::fs::read_to_string(&path) {
+                Ok(value) => return Ok(Some(value)),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(format!("failed to read {}: {err}", path.display())),
+            }
+            let Some(parent) = current.parent() else {
+                break;
+            };
+            let parent = parent.to_path_buf();
+            if parent == current
+                || parent
+                    .metadata()
+                    .map_err(|err| format!("failed to inspect working directory parent: {err}"))?
+                    .dev()
+                    != device
+            {
+                break;
+            }
+            current = parent;
+        }
         let path = std::path::PathBuf::from(dir).join(key);
         return match std::fs::read_to_string(&path) {
             Ok(value) => Ok(Some(value)),

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -464,36 +464,10 @@ fn build_env(
 
 fn load_test_secret_if_present(key: &str) -> Result<Option<String>, String> {
     if let Some(dir) = crate::test_keychain_dir() {
-        let mut current = std::env::current_dir()
+        let current = std::env::current_dir()
             .map_err(|err| format!("failed to determine working directory: {err}"))?;
-        let device = current
-            .metadata()
-            .map_err(|err| format!("failed to inspect working directory: {err}"))?
-            .dev();
-        loop {
-            let project = current
-                .to_str()
-                .ok_or("working directory must be valid UTF-8")?;
-            let path = crate::secrets::test_project_secret_path(&dir, project, key);
-            match std::fs::read_to_string(&path) {
-                Ok(value) => return Ok(Some(value)),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => return Err(format!("failed to read {}: {err}", path.display())),
-            }
-            let Some(parent) = current.parent() else {
-                break;
-            };
-            let parent = parent.to_path_buf();
-            if parent == current
-                || parent
-                    .metadata()
-                    .map_err(|err| format!("failed to inspect working directory parent: {err}"))?
-                    .dev()
-                    != device
-            {
-                break;
-            }
-            current = parent;
+        if let Some(value) = load_test_project_secret(&dir, &current, key)? {
+            return Ok(Some(value));
         }
         let path = std::path::PathBuf::from(dir).join(key);
         return match std::fs::read_to_string(&path) {
@@ -504,6 +478,49 @@ fn load_test_secret_if_present(key: &str) -> Result<Option<String>, String> {
     }
     if let Some(value) = crate::test_env_string(&format!("AUTOMIC_VAULT_TEST_{key}")) {
         return Ok(Some(value));
+    }
+    Ok(None)
+}
+
+fn load_test_project_secret(
+    keychain_directory: &Path,
+    working_directory: &Path,
+    key: &str,
+) -> Result<Option<String>, String> {
+    let mut current = std::fs::canonicalize(working_directory).map_err(|err| {
+        format!(
+            "failed to resolve working directory {}: {err}",
+            working_directory.display()
+        )
+    })?;
+    let device = current
+        .metadata()
+        .map_err(|err| format!("failed to inspect working directory: {err}"))?
+        .dev();
+    loop {
+        let project = current
+            .to_str()
+            .ok_or("working directory must be valid UTF-8")?;
+        let path = crate::secrets::test_project_secret_path(keychain_directory, project, key);
+        match std::fs::read_to_string(&path) {
+            Ok(value) => return Ok(Some(value)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(format!("failed to read {}: {err}", path.display())),
+        }
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        let parent = parent.to_path_buf();
+        if parent == current
+            || parent
+                .metadata()
+                .map_err(|err| format!("failed to inspect working directory parent: {err}"))?
+                .dev()
+                != device
+        {
+            break;
+        }
+        current = parent;
     }
     Ok(None)
 }
@@ -973,6 +990,41 @@ mod tests {
             env.get(std::ffi::OsStr::new("APPROVED_SECRET")),
             Some(&OsString::from("expected"))
         );
+    }
+
+    #[test]
+    fn test_project_secret_lookup_resolves_symlinked_working_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = PathBuf::from("/tmp").join(format!(
+            "av-project-value-symlink-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let keychain = root.join("keychain");
+        let project = root.join("physical/project");
+        let nested = project.join("nested");
+        let alias = root.join("alias");
+        std::fs::create_dir_all(&nested).unwrap();
+        symlink(&project, &alias).unwrap();
+
+        let project = project.canonicalize().unwrap();
+        let stored = crate::secrets::test_project_secret_path(
+            &keychain,
+            project.to_str().unwrap(),
+            "PROJECT_SECRET",
+        );
+        std::fs::create_dir_all(stored.parent().unwrap()).unwrap();
+        std::fs::write(stored, "expected").unwrap();
+
+        assert_eq!(
+            load_test_project_secret(&keychain, &alias.join("nested"), "PROJECT_SECRET").unwrap(),
+            Some("expected".into())
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,7 +29,7 @@ commands:
   $ av inject +KEY... [--] <command>      # inject secrets into a command
   $ av inject -- <command>                # run an approved script
   $ av list                               # list saved secret names
-  $ av save <key>                         # store a secret
+  $ av save [--project-directory=DIR] KEY # store a global or Project Value
   $ av harden <tool> [-y|--yes]           # harden a tool; migrate credentials
   $ av unharden brew [-y|--yes]           # temporarily restore Homebrew for cask migration
   $ av open [--secret-gate <id>]          # open the Automic Vault app

--- a/src/cli/save.rs
+++ b/src/cli/save.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::os::fd::AsRawFd;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
 
 use super::inject;
 
@@ -16,22 +18,89 @@ pub(crate) fn run(args: Vec<OsString>, stderr: &mut dyn Write) -> i32 {
 }
 
 fn run_inner(args: Vec<OsString>) -> Result<(), String> {
-    let [key] = args.as_slice() else {
-        return Err("usage: av save KEY".into());
-    };
+    let (key, project_directory) = parse_args(args)?;
     let key = key
         .to_str()
         .ok_or_else(|| "save key must be valid UTF-8".to_string())?;
     inject::validate_key_name(key)?;
     let value = read_secret_from_tty(key)?;
-    save_value(key, &value)
+    save_value(key, &value, project_directory.as_deref())
 }
 
-fn save_value(key: &str, value: &str) -> Result<(), String> {
+fn parse_args(args: Vec<OsString>) -> Result<(OsString, Option<String>), String> {
+    let mut key = None;
+    let mut project_directory = None;
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        if arg == "--project-directory" {
+            let path = args.next().ok_or_else(usage)?;
+            if project_directory.is_some() {
+                return Err("--project-directory may be specified only once".into());
+            }
+            project_directory = Some(canonical_project_directory(Path::new(&path))?);
+        } else if let Some(path) = arg
+            .to_str()
+            .and_then(|arg| arg.strip_prefix("--project-directory="))
+        {
+            if path.is_empty() || project_directory.is_some() {
+                return Err(usage());
+            }
+            project_directory = Some(canonical_project_directory(Path::new(path))?);
+        } else if key.replace(arg).is_some() {
+            return Err(usage());
+        }
+    }
+    Ok((key.ok_or_else(usage)?, project_directory))
+}
+
+fn usage() -> String {
+    "usage: av save [--project-directory=DIR] KEY".into()
+}
+
+fn canonical_project_directory(path: &Path) -> Result<String, String> {
+    let path = std::fs::canonicalize(path).map_err(|err| {
+        format!(
+            "failed to resolve project directory {}: {err}",
+            path.display()
+        )
+    })?;
+    let metadata = path.metadata().map_err(|err| {
+        format!(
+            "failed to inspect project directory {}: {err}",
+            path.display()
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(format!(
+            "project directory is not a directory: {}",
+            path.display()
+        ));
+    }
+    let parent = path
+        .parent()
+        .ok_or("project directory cannot be a filesystem root")?;
+    let parent_metadata = parent.metadata().map_err(|err| {
+        format!(
+            "failed to inspect project directory parent {}: {err}",
+            parent.display()
+        )
+    })?;
+    if parent == path || parent_metadata.dev() != metadata.dev() {
+        return Err("project directory cannot be a filesystem root".into());
+    }
+    path.into_os_string()
+        .into_string()
+        .map_err(|_| "project directory must be valid UTF-8".into())
+}
+
+fn save_value(key: &str, value: &str, project_directory: Option<&str>) -> Result<(), String> {
     if value.is_empty() {
         return Err("empty key value".into());
     }
-    crate::secrets::store_secret(key, value)
+    match project_directory {
+        Some(path) => crate::secrets::store_project_secret(key, value, path),
+        None => crate::secrets::store_secret(key, value),
+    }
 }
 
 fn read_secret_from_tty(key: &str) -> Result<String, String> {
@@ -99,7 +168,7 @@ mod tests {
             std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &dir);
         }
 
-        save_value("SAVED_KEY", "secret").unwrap();
+        save_value("SAVED_KEY", "secret", None).unwrap();
 
         unsafe {
             std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
@@ -113,6 +182,60 @@ mod tests {
 
     #[test]
     fn rejects_empty_value() {
-        assert_eq!(save_value("SAVED_KEY", "").unwrap_err(), "empty key value");
+        assert_eq!(
+            save_value("SAVED_KEY", "", None).unwrap_err(),
+            "empty key value"
+        );
+    }
+
+    #[test]
+    fn parses_and_canonicalizes_project_directory() {
+        let directory = std::env::temp_dir();
+        let (key, project) = parse_args(vec![
+            OsString::from(format!("--project-directory={}", directory.display())),
+            OsString::from("SAVED_KEY"),
+        ])
+        .unwrap();
+        assert_eq!(key, "SAVED_KEY");
+        assert_eq!(
+            project,
+            Some(
+                std::fs::canonicalize(directory)
+                    .unwrap()
+                    .display()
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn saves_project_value_separately_from_global_value() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-project-save-{}", std::process::id()));
+        let keychain = root.join("keychain");
+        let project = root.join("project");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&project).unwrap();
+        let project = std::fs::canonicalize(project).unwrap();
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain) };
+
+        save_value("SAVED_KEY", "global", None).unwrap();
+        save_value("SAVED_KEY", "project", project.to_str()).unwrap();
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR") };
+        assert_eq!(
+            std::fs::read_to_string(keychain.join("SAVED_KEY")).unwrap(),
+            "global"
+        );
+        assert_eq!(
+            std::fs::read_to_string(crate::secrets::test_project_secret_path(
+                &keychain,
+                project.to_str().unwrap(),
+                "SAVED_KEY"
+            ))
+            .unwrap(),
+            "project"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -750,6 +750,47 @@ final class DashboardModel: ObservableObject {
         }
     }
 
+    func replaceSecretValue(_ storedValue: StoredSecretValue, in secret: StoredSecret, with value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        let mutation: SecretMutation = switch storedValue.source {
+        case .global:
+            .save(account: secret.account, value: value, accessibility: secret.accessibility)
+        case .projectDirectory(let directory):
+            .saveProject(
+                account: secret.account,
+                value: value,
+                directory: directory,
+                accessibility: secret.accessibility,
+                warning: ""
+            )
+        }
+        let result = performInAppSecretMutation(mutation)
+        guard result.status == errSecSuccess else {
+            errorMessage = result.error ?? "Could not replace \(secret.account): \(result.status ?? errSecInternalError)"
+            return false
+        }
+        errorMessage = nil
+        reload()
+        return true
+    }
+
+    func deleteSecretValue(_ value: StoredSecretValue, from secret: StoredSecret) {
+        let result = performInAppSecretMutation(
+            .deleteValue(account: secret.account, source: value.source)
+        )
+        guard let status = result.status else {
+            errorMessage = result.error
+            return
+        }
+        if status == errSecSuccess || status == errSecItemNotFound {
+            if secret.values.count == 1 { selectedItemID = nil }
+            errorMessage = nil
+            reload()
+        } else {
+            errorMessage = "Could not delete \(secret.account) Value: \(status)"
+        }
+    }
+
     func renameSelectedSecret(to newAccount: String) -> Bool {
         guard selectedSection == .allSecrets, let account = selectedItem?.id else { return false }
         let newAccount = newAccount.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2076,6 +2117,9 @@ private struct StoredSecretDetailView: View {
     @State private var isConfirmingDelete = false
     @State private var isConfirmingDirectAccess = false
     @State private var pendingDirectAccessLauncher: DirectAccessLauncherSelection?
+    @State private var replacingValue: StoredSecretValue?
+    @State private var deletingValue: StoredSecretValue?
+    @State private var pendingAccessibility: StoredSecretAccessibility?
 
     init(model: DashboardModel, secret: StoredSecret) {
         self.model = model
@@ -2094,8 +2138,48 @@ private struct StoredSecretDetailView: View {
                 .foregroundStyle(.secondary)
             InfoBlock(
                 title: "All Secrets",
-                text: "Secret value is hidden.\n\(secret.subtitle)"
+                text: "Secret Values are hidden.\n\(secret.subtitle)"
             )
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Values")
+                    .font(.headline)
+                ForEach(secret.values) { value in
+                    HStack(alignment: .center, spacing: 10) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(value.source == .global ? "Global Value" : value.source.displayName)
+                                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                .textSelection(.enabled)
+                            if case .projectDirectory(let path) = value.source,
+                               !projectDirectoryExists(path)
+                            {
+                                Text("Directory Missing")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                            }
+                        }
+                        Spacer()
+                        Button("Replace") { replacingValue = value }
+                            .accessibilityLabel("Replace \(value.source.displayName) for \(secret.account)")
+                        Button(role: .destructive) { deletingValue = value } label: {
+                            Image(systemName: "trash")
+                        }
+                        .accessibilityLabel("Delete \(value.source.displayName) for \(secret.account)")
+                    }
+                    .padding(10)
+                    .background(Color(nsColor: .windowBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+                }
+                Text("Create another Project Value with `av save --project-directory=DIR \(secret.account)`." )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            }
 
             VStack(alignment: .leading, spacing: 8) {
                 Toggle("Available While Locked", isOn: availabilityBinding)
@@ -2175,6 +2259,37 @@ private struct StoredSecretDetailView: View {
         } message: {
             Text("This secret will be permanently deleted.")
         }
+        .alert("Change availability for all Values?", isPresented: Binding(
+            get: { pendingAccessibility != nil },
+            set: { if !$0 { pendingAccessibility = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { pendingAccessibility = nil }
+            Button("Change") {
+                guard let accessibility = pendingAccessibility else { return }
+                pendingAccessibility = nil
+                if model.setAccessibility(accessibility, for: secret) {
+                    isAvailableWhileLocked = accessibility.isAvailableWhileLocked
+                }
+            }
+        } message: {
+            Text("This Secret has \(secret.values.count) Values. The availability setting applies to every Value.")
+        }
+        .alert("Delete Secret Value?", isPresented: Binding(
+            get: { deletingValue != nil },
+            set: { if !$0 { deletingValue = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { deletingValue = nil }
+            Button("Delete", role: .destructive) {
+                guard let value = deletingValue else { return }
+                deletingValue = nil
+                model.deleteSecretValue(value, from: secret)
+            }
+        } message: {
+            Text(deletingValue.map(deleteValueMessage) ?? "")
+        }
+        .sheet(item: $replacingValue) { value in
+            ReplaceSecretValueView(model: model, secret: secret, storedValue: value)
+        }
         .sheet(isPresented: $isConfirmingDirectAccess, onDismiss: {
             pendingDirectAccessLauncher = nil
         }) {
@@ -2195,15 +2310,83 @@ private struct StoredSecretDetailView: View {
         Binding {
             isAvailableWhileLocked
         } set: { isAvailable in
-            let previous = isAvailableWhileLocked
-            isAvailableWhileLocked = isAvailable
             let accessibility: StoredSecretAccessibility = isAvailable
                 ? .afterFirstUnlock
                 : .whenUnlocked
+            if secret.values.count > 1 {
+                pendingAccessibility = accessibility
+                return
+            }
+            let previous = isAvailableWhileLocked
+            isAvailableWhileLocked = isAvailable
             if !model.setAccessibility(accessibility, for: secret) {
                 isAvailableWhileLocked = previous
             }
         }
+    }
+
+    private func deleteValueMessage(_ value: StoredSecretValue) -> String {
+        guard case .projectDirectory(let path) = value.source else {
+            return secret.values.count == 1
+                ? "This is the last Value. Deleting it also deletes the Secret and revokes its Direct Access Rules."
+                : "Project Values remain, but requests outside their directories will have no Global Value."
+        }
+        let alternatives = secret.values.filter { $0.id != value.id }
+        let pathComponents = URL(fileURLWithPath: path).pathComponents
+        let inherited = alternatives.compactMap { candidate -> (Int, StoredSecretValue)? in
+            guard case .projectDirectory(let candidatePath) = candidate.source else { return nil }
+            let candidateComponents = URL(fileURLWithPath: candidatePath).pathComponents
+            guard candidateComponents.count < pathComponents.count,
+                  pathComponents.starts(with: candidateComponents)
+            else { return nil }
+            return (candidateComponents.count, candidate)
+        }.max { $0.0 < $1.0 }?.1 ?? alternatives.first { $0.source == .global }
+        if let inherited {
+            return "Requests under \(escapedSecurityPath(path)) will fall back to \(escapedSecurityPath(inherited.source.displayName))."
+        }
+        return "Requests under \(escapedSecurityPath(path)) will have no Value for this Secret."
+    }
+}
+
+private func projectDirectoryExists(_ path: String) -> Bool {
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        && isDirectory.boolValue
+}
+
+private struct ReplaceSecretValueView: View {
+    @ObservedObject var model: DashboardModel
+    let secret: StoredSecret
+    let storedValue: StoredSecretValue
+    @State private var value = ""
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Replace Secret Value")
+                .font(.system(size: 18, weight: .semibold))
+            Text(storedValue.source.displayName)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+            SecureField("New Value", text: $value)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("New Value for \(secret.account)")
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Replace") {
+                    if model.replaceSecretValue(storedValue, in: secret, with: value) {
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(value.isEmpty)
+            }
+        }
+        .padding(22)
+        .frame(width: 420)
+        .background(.ultraThinMaterial)
     }
 }
 
@@ -2682,6 +2865,14 @@ private struct AccessRequestRow: View {
                     AccessMetaLine("Launcher", record.launcher ?? "unknown")
                     AccessMetaLine("Decision source", record.approvalSourceLabel)
                     AccessMetaLine("Secret names", record.keys.isEmpty ? "(none)" : record.keys.joined(separator: ", "))
+                    if let sources = record.secretValueSources, !sources.isEmpty {
+                        AccessMetaLine(
+                            "Secret values",
+                            sources.sorted { $0.key < $1.key }.map {
+                                "\($0.key): \(escapedSecurityPath($0.value))"
+                            }.joined(separator: "\n")
+                        )
+                    }
                     AccessMetaLine("Gate client", record.callerPath)
                     AccessMetaLine("Target", record.target)
                     AccessMetaLine("Working directory", escapedSecurityPath(record.cwd))

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -340,6 +340,10 @@ final class DashboardModel: ObservableObject {
         return launcherBundles.first
     }
 
+    func storedSecret(named account: String) -> StoredSecret? {
+        snapshot.secrets.first { $0.account == account }
+    }
+
     var selectedAccessRequest: AccessRequestRecord? {
         if let selectedItemID,
            let record = snapshot.accessRequests.first(where: { $0.id.uuidString == selectedItemID }) {
@@ -1722,8 +1726,8 @@ private struct DashboardDetailView: View {
         .ignoresSafeArea(.container, edges: .top)
         .background(.ultraThinMaterial)
         .sheet(isPresented: $model.isRenamingSecret) {
-            if let account = model.selectedItem?.id {
-                RenameSecretView(model: model, account: account)
+            if let secret = model.selectedStoredSecret {
+                RenameSecretView(model: model, account: secret.account, valueCount: secret.values.count)
             }
         }
     }
@@ -2082,12 +2086,29 @@ private struct AddSecretView: View {
                 .textFieldStyle(.roundedBorder)
             SecureField("Value", text: $value)
                 .textFieldStyle(.roundedBorder)
-            Toggle("Available While Locked", isOn: $isAvailableWhileLocked)
-                .toggleStyle(.switch)
-            Text("Allows already-approved apps to use this secret while your Mac is locked, after the first unlock following a restart.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            if let existing = model.storedSecret(
+                named: account.trimmingCharacters(in: .whitespacesAndNewlines)
+            ), !existing.directAccessLaunchers.isEmpty {
+                InfoBlock(
+                    title: "Direct Access",
+                    text: "Already-authorized Launchers can use this new Value immediately: "
+                        + existing.directAccessLaunchers.map(\.bundleIdentifier).joined(separator: ", ")
+                )
+            }
+            if let existing = model.storedSecret(
+                named: account.trimmingCharacters(in: .whitespacesAndNewlines)
+            ) {
+                Text("Availability remains \(existing.accessibility.isAvailableWhileLocked ? "Available While Locked" : "When Unlocked") for all Values.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Toggle("Available While Locked", isOn: $isAvailableWhileLocked)
+                    .toggleStyle(.switch)
+                Text("Allows already-approved apps to use this Secret while your Mac is locked, after the first unlock following a restart.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
@@ -2147,7 +2168,7 @@ private struct StoredSecretDetailView: View {
                 ForEach(secret.values) { value in
                     HStack(alignment: .center, spacing: 10) {
                         VStack(alignment: .leading, spacing: 3) {
-                            Text(value.source == .global ? "Global Value" : value.source.displayName)
+                            Text(value.source == .global ? "Global Value" : escapedSecurityPath(value.source.displayName))
                                 .font(.system(size: 12, weight: .medium, design: .monospaced))
                                 .textSelection(.enabled)
                             if case .projectDirectory(let path) = value.source,
@@ -2160,11 +2181,12 @@ private struct StoredSecretDetailView: View {
                         }
                         Spacer()
                         Button("Replace") { replacingValue = value }
-                            .accessibilityLabel("Replace \(value.source.displayName) for \(secret.account)")
+                            .accessibilityLabel("Replace \(escapedSecurityPath(value.source.displayName)) for \(secret.account)")
+                            .disabled(!storedSecretValueDirectoryExists(value))
                         Button(role: .destructive) { deletingValue = value } label: {
                             Image(systemName: "trash")
                         }
-                        .accessibilityLabel("Delete \(value.source.displayName) for \(secret.account)")
+                        .accessibilityLabel("Delete \(escapedSecurityPath(value.source.displayName)) for \(secret.account)")
                     }
                     .padding(10)
                     .background(Color(nsColor: .windowBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
@@ -2354,6 +2376,11 @@ private func projectDirectoryExists(_ path: String) -> Bool {
         && isDirectory.boolValue
 }
 
+private func storedSecretValueDirectoryExists(_ value: StoredSecretValue) -> Bool {
+    guard case .projectDirectory(let path) = value.source else { return true }
+    return projectDirectoryExists(path)
+}
+
 private struct ReplaceSecretValueView: View {
     @ObservedObject var model: DashboardModel
     let secret: StoredSecret
@@ -2365,13 +2392,20 @@ private struct ReplaceSecretValueView: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Replace Secret Value")
                 .font(.system(size: 18, weight: .semibold))
-            Text(storedValue.source.displayName)
+            Text(escapedSecurityPath(storedValue.source.displayName))
                 .font(.system(.caption, design: .monospaced))
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)
             SecureField("New Value", text: $value)
                 .textFieldStyle(.roundedBorder)
                 .accessibilityLabel("New Value for \(secret.account)")
+            if !secret.directAccessLaunchers.isEmpty {
+                InfoBlock(
+                    title: "Direct Access",
+                    text: "Already-authorized Launchers can use this replacement immediately: "
+                        + secret.directAccessLaunchers.map(\.bundleIdentifier).joined(separator: ", ")
+                )
+            }
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
@@ -2430,11 +2464,13 @@ private struct DirectAccessConfirmationView: View {
 private struct RenameSecretView: View {
     @ObservedObject var model: DashboardModel
     @State private var account: String
+    let valueCount: Int
     @Environment(\.dismiss) private var dismiss
 
-    init(model: DashboardModel, account: String) {
+    init(model: DashboardModel, account: String, valueCount: Int) {
         self.model = model
         _account = State(initialValue: account)
+        self.valueCount = valueCount
     }
 
     var body: some View {
@@ -2444,6 +2480,11 @@ private struct RenameSecretView: View {
                 .foregroundStyle(.primary)
             TextField("Name", text: $account)
                 .textFieldStyle(.roundedBorder)
+            if valueCount > 1 {
+                Text("All \(valueCount) Values will be renamed together.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1256,7 +1256,8 @@ private func accessRequestRecord(
         target: request.target,
         cwd: request.cwd,
         keys: request.keys.sorted(),
-        detail: request.detail
+        detail: request.detail,
+        secretValueSources: request.selectedValues.mapValues { $0.source.displayName }
     )
 }
 
@@ -1432,6 +1433,7 @@ private struct ApprovalRequest {
     let detail: String?
     let dockerServerURL: String?
     let dockerParent: DockerCredentialParent?
+    let selectedValues: [String: StoredSecretValue]
 
     init(
         op: String,
@@ -1449,7 +1451,8 @@ private struct ApprovalRequest {
         title: String?,
         detail: String?,
         dockerServerURL: String? = nil,
-        dockerParent: DockerCredentialParent? = nil
+        dockerParent: DockerCredentialParent? = nil,
+        selectedValues: [String: StoredSecretValue] = [:]
     ) {
         self.op = op
         self.keys = keys
@@ -1467,15 +1470,46 @@ private struct ApprovalRequest {
         self.detail = detail
         self.dockerServerURL = dockerServerURL
         self.dockerParent = dockerParent
+        self.selectedValues = selectedValues
+    }
+
+    func selecting(_ values: [String: StoredSecretValue]) -> ApprovalRequest {
+        ApprovalRequest(
+            op: op,
+            keys: keys,
+            target: target,
+            args: args,
+            cwd: cwd,
+            replaceExistingEnv: replaceExistingEnv,
+            allowMissingKeys: allowMissingKeys,
+            envConflicts: envConflicts,
+            shebangScript: shebangScript,
+            scriptData: scriptData,
+            snapshotIncompatibleInterpreter: snapshotIncompatibleInterpreter,
+            tool: tool,
+            title: title,
+            detail: detail,
+            dockerServerURL: dockerServerURL,
+            dockerParent: dockerParent,
+            selectedValues: values
+        )
     }
 }
 
 enum SecretMutation {
     case save(account: String, value: String, accessibility: StoredSecretAccessibility)
+    case saveProject(
+        account: String,
+        value: String,
+        directory: String,
+        accessibility: StoredSecretAccessibility,
+        warning: String
+    )
     case saveIfAbsentOrEqual(account: String, value: String)
     case delete(account: String)
     case dockerSave(account: String, value: String, serverURL: String, username: String)
     case dockerDelete(account: String, serverURL: String)
+    case deleteValue(account: String, source: StoredSecretValueSource)
     case rename(account: String, newAccount: String)
     case setAccessibility(account: String, accessibility: StoredSecretAccessibility)
 
@@ -1486,6 +1520,11 @@ enum SecretMutation {
             properties = (
                 "save", [account], ["save", account], "Store \(account)?",
                 "This will create or replace a secret in Automic Vault."
+            )
+        case .saveProject(let account, _, let directory, _, let warning):
+            properties = (
+                "save", [account], ["save", "--project-directory=\(directory)", account],
+                "Store \(account) Project Value?", warning
             )
         case .saveIfAbsentOrEqual(let account, _):
             properties = (
@@ -1509,6 +1548,11 @@ enum SecretMutation {
                 "Delete Docker credential for \(serverURL)?",
                 "Docker will no longer be able to authenticate to this registry with the stored credential."
             )
+        case .deleteValue(let account, let source):
+            properties = (
+                "delete", [account], ["delete", account, source.displayName],
+                "Delete \(account) Value?", "This will remove the selected Secret Value."
+            )
         case .rename(let account, let newAccount):
             properties = (
                 "rename", [account, newAccount], ["rename", account, newAccount],
@@ -1528,12 +1572,30 @@ enum SecretMutation {
         case .dockerSave, .dockerDelete: "docker"
         default: URL(fileURLWithPath: callerPath).lastPathComponent
         }
+        let cwd: String
+        let selectedValues: [String: StoredSecretValue]
+        switch self {
+        case .saveProject(let account, _, let directory, let accessibility, _):
+            cwd = directory
+            selectedValues = [account: StoredSecretValue(
+                source: .projectDirectory(directory),
+                keychainAccount: storedSecretKeychainAccount(
+                    secretName: account,
+                    source: .projectDirectory(directory)
+                ),
+                accessibility: accessibility,
+                keychainProperties: []
+            )]
+        default:
+            cwd = ""
+            selectedValues = [:]
+        }
         return ApprovalRequest(
             op: properties.op,
             keys: properties.keys,
             target: callerPath,
             args: properties.args,
-            cwd: "",
+            cwd: cwd,
             replaceExistingEnv: false,
             allowMissingKeys: false,
             envConflicts: [],
@@ -1541,26 +1603,47 @@ enum SecretMutation {
             scriptData: nil,
             tool: tool,
             title: properties.title,
-            detail: properties.detail
+            detail: properties.detail,
+            selectedValues: selectedValues
         )
     }
 
     fileprivate func perform() -> OSStatus {
+        let repairStatus = resumePendingSecretMutation()
+        guard repairStatus == errSecSuccess else { return repairStatus }
         switch self {
         case .save(let account, let value, let accessibility):
-            saveStoredSecret(account: account, value: value, accessibility: accessibility)
+            let existing = loadStoredSecrets().first { $0.account == account }
+            guard existing?.hasConsistentAccessibility != false else { return errSecDecode }
+            return saveStoredSecret(
+                account: account,
+                value: value,
+                accessibility: existing?.accessibility ?? accessibility
+            )
+        case .saveProject(let account, let value, let directory, let accessibility, _):
+            return saveStoredSecret(
+                account: account,
+                value: value,
+                accessibility: accessibility,
+                source: .projectDirectory(directory)
+            )
         case .saveIfAbsentOrEqual(let account, let value):
-            saveStoredSecretIfAbsentOrEqual(account: account, value: value)
+            return saveStoredSecretIfAbsentOrEqual(account: account, value: value)
         case .delete(let account):
-            deleteStoredSecretRevokingDirectAccess(account: account)
+            return deleteStoredSecretRevokingDirectAccess(account: account)
         case .dockerSave(let account, let value, _, _):
-            saveStoredSecret(account: account, value: value, accessibility: .whenUnlocked)
+            return saveStoredSecret(account: account, value: value, accessibility: .whenUnlocked)
         case .dockerDelete(let account, _):
-            deleteStoredSecretRevokingDirectAccess(account: account)
+            return deleteStoredSecretRevokingDirectAccess(account: account)
+        case .deleteValue(let account, let source):
+            return deleteStoredSecretValueRevokingDirectAccessIfLast(
+                secretName: account,
+                source: source
+            )
         case .rename(let account, let newAccount):
-            renameStoredSecretRevokingDirectAccess(account: account, to: newAccount)
+            return renameStoredSecretRevokingDirectAccess(account: account, to: newAccount)
         case .setAccessibility(let account, let accessibility):
-            setStoredSecretAccessibility(account: account, accessibility: accessibility)
+            return setStoredSecretAccessibility(account: account, accessibility: accessibility)
         }
     }
 }
@@ -1581,6 +1664,7 @@ private struct TransientApprovalKey: Hashable {
     let envConflicts: [String]
     let shebangScript: String?
     let tool: String?
+    let selectedValueSources: [String]
 }
 
 private enum ApprovalDecision: Equatable {
@@ -1756,12 +1840,13 @@ private func isApprovalCancellationEvent(_ event: xpc_object_t) -> Bool {
 
 private func missingRequiredSecret(
     for request: ApprovalRequest,
-    exists: (String) -> Bool = { storedSecretExists(account: $0) }
+    exists: ((String) -> Bool)? = nil
 ) -> String? {
     guard !request.allowMissingKeys else { return nil }
     let conflicts = Set(request.envConflicts)
     return request.keys.first {
-        (request.replaceExistingEnv || !conflicts.contains($0)) && !exists($0)
+        (request.replaceExistingEnv || !conflicts.contains($0))
+            && !(exists?($0) ?? (request.selectedValues[$0] != nil))
     }
 }
 
@@ -1986,6 +2071,7 @@ private struct AWSRegistration {
     let target: String
     let interpreter: String
     let useLongLivedCredentials: Bool
+    let secretValues: [String: StoredSecretValue]
     var credentials: AWSCredentials?
 }
 
@@ -2424,20 +2510,38 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
         }
-        let dockerRequest: ApprovalRequest
+        let request: ApprovalRequest
         do {
-            dockerRequest = try dockerCredentialRequest(
+            let dockerRequest = try dockerCredentialRequest(
                 from: message,
                 request: parsedRequest,
                 helperIdentity: identity,
                 helperPath: callerPath,
                 helperSigning: signing
             )
+            let repairStatus = resumePendingSecretMutation()
+            if repairStatus != errSecSuccess {
+                let names = pendingSecretMutationNames()
+                if names == nil || !Set(dockerRequest.keys).isDisjoint(with: names!) {
+                    reply(
+                        peer,
+                        to: message,
+                        ok: false,
+                        error: "secret repair must complete before this request: \(repairStatus)"
+                    )
+                    return
+                }
+            }
+            let selected = try resolveStoredSecretValues(
+                names: dockerRequest.keys,
+                cwd: dockerRequest.cwd,
+                secrets: loadStoredSecrets()
+            )
+            request = approvalRequestWithCredentialContext(dockerRequest.selecting(selected))
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
             return
         }
-        let request = approvalRequestWithCredentialContext(dockerRequest)
         let awsRegistration: AWSRegistrationCandidate?
         do {
             awsRegistration = try awsRegistrationCandidate(from: message, request: request)
@@ -2783,7 +2887,10 @@ private final class ApprovalServer: @unchecked Sendable {
             allowMissingKeys: request.allowMissingKeys,
             envConflicts: request.envConflicts.sorted(),
             shebangScript: request.shebangScript,
-            tool: request.tool
+            tool: request.tool,
+            selectedValueSources: request.selectedValues
+                .map { "\($0.key)=\($0.value.source.displayName)" }
+                .sorted()
         )
         let promptBlessing: BlessedScriptPromptContext?
         if let activeBlessing {
@@ -3161,9 +3268,53 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         let value = String(cString: valuePointer)
-        let mutation: SecretMutation = ifAbsentOrEqual
-            ? .saveIfAbsentOrEqual(account: key, value: value)
-            : .save(account: key, value: value, accessibility: .whenUnlocked)
+        let projectDirectory = xpc_dictionary_get_string(message, "project_directory")
+            .map(String.init(cString:))
+        if ifAbsentOrEqual, projectDirectory != nil {
+            reply(peer, to: message, ok: false, error: "conditional save does not support Project Values")
+            return
+        }
+        let storedSecret = loadStoredSecrets(
+            directAccessRules: loadDirectAccessRules()
+        ).first { $0.account == key }
+        if let storedSecret, !storedSecret.hasConsistentAccessibility {
+            reply(peer, to: message, ok: false, error: "secret \(key) must be repaired before it can be changed")
+            return
+        }
+        let accessibility = storedSecret?.accessibility ?? .whenUnlocked
+        let mutation: SecretMutation
+        if ifAbsentOrEqual {
+            mutation = .saveIfAbsentOrEqual(account: key, value: value)
+        } else if let projectDirectory {
+            do {
+                _ = try validateCanonicalProjectDirectory(projectDirectory)
+            } catch {
+                reply(peer, to: message, ok: false, error: error.localizedDescription)
+                return
+            }
+            var warning = "This will create or replace a Project Value for \(escapedSecurityPath(projectDirectory))."
+            if let launchers = storedSecret?.directAccessLaunchers, !launchers.isEmpty {
+                warning += " Direct Access Launchers already authorized for \(key) can use this value immediately: "
+                    + launchers.map(\.bundleIdentifier).joined(separator: ", ") + "."
+            }
+            let source: StoredSecretValueSource = .projectDirectory(projectDirectory)
+            if storedSecret?.values.contains(where: { $0.source == source }) != true,
+               let inherited = try? resolveStoredSecretValues(
+                   names: [key], cwd: projectDirectory, secrets: storedSecret.map { [$0] } ?? []
+               )[key]
+            {
+                warning += " It will mask the inherited \(escapedSecurityPath(inherited.source.displayName))."
+            }
+            mutation = .saveProject(
+                account: key,
+                value: value,
+                directory: projectDirectory,
+                accessibility: accessibility,
+                warning: warning
+            )
+        } else {
+            mutation = .save(account: key, value: value, accessibility: accessibility)
+        }
         handleMutation(
             mutation,
             on: peer,
@@ -3438,7 +3589,10 @@ private final class ApprovalServer: @unchecked Sendable {
                 snapshotIncompatibleInterpreter: request.snapshotIncompatibleInterpreter,
                 tool: request.tool,
                 title: request.title,
-                detail: request.detail
+                detail: request.detail,
+                dockerServerURL: request.dockerServerURL,
+                dockerParent: request.dockerParent,
+                selectedValues: request.selectedValues
             )
         }
         DispatchQueue.main.async {
@@ -3467,6 +3621,7 @@ private final class ApprovalServer: @unchecked Sendable {
             }
             switch mutation {
             case .save(let account, _, _),
+                 .saveProject(let account, _, _, _, _),
                  .saveIfAbsentOrEqual(let account, _),
                  .dockerSave(let account, _, _, _):
                 if status == errSecSuccess {
@@ -3490,7 +3645,7 @@ private final class ApprovalServer: @unchecked Sendable {
                         error: "failed to delete secret \(account): \(status)"
                     )
                 }
-            case .rename, .setAccessibility:
+            case .deleteValue, .rename, .setAccessibility:
                 self.reply(peer, to: message, ok: false, error: "invalid XPC mutation")
             }
         }
@@ -3500,11 +3655,20 @@ private final class ApprovalServer: @unchecked Sendable {
         let conflicts = Set(request.envConflicts)
         var secrets: [String: String] = [:]
         for key in request.keys where request.replaceExistingEnv || !conflicts.contains(key) {
-            guard let value = loadStoredSecret(account: key) else {
+            guard let selected = request.selectedValues[key] else {
                 if request.allowMissingKeys { continue }
                 throw AppError("failed to load secret \(key): \(errSecItemNotFound)")
             }
-            secrets[key] = value
+            switch loadStoredSecretValue(selected) {
+            case .success(let value):
+                secrets[key] = value
+            case .notFound:
+                throw AppError("selected value for \(key) no longer exists")
+            case .failure(let status):
+                throw AppError("failed to load selected value for \(key): \(status)")
+            case .invalidUTF8:
+                throw AppError("selected value for \(key) is not valid UTF-8")
+            }
         }
         return secrets
     }
@@ -3706,6 +3870,7 @@ private final class ApprovalServer: @unchecked Sendable {
             target: awsRegistration.target,
             interpreter: awsRegistration.interpreter,
             useLongLivedCredentials: awsRegistration.useLongLivedCredentials,
+            secretValues: request.selectedValues,
             credentials: nil
         )
         awsRegistrationsLock.unlock()
@@ -3806,9 +3971,11 @@ private final class ApprovalServer: @unchecked Sendable {
         _ registration: AWSRegistration,
         parentPID: pid_t
     ) async throws -> AWSCredentials {
-        guard let accessKey = loadStoredSecret(account: "AWS_ACCESS_KEY_ID"),
-              let secretKey = loadStoredSecret(account: "AWS_SECRET_ACCESS_KEY")
-        else { throw AppError("AWS access keys are missing from Automic Vault") }
+        guard let accessKeyValue = registration.secretValues["AWS_ACCESS_KEY_ID"],
+              let secretKeyValue = registration.secretValues["AWS_SECRET_ACCESS_KEY"],
+              case .success(let accessKey) = loadStoredSecretValue(accessKeyValue),
+              case .success(let secretKey) = loadStoredSecretValue(secretKeyValue)
+        else { throw AppError("selected AWS access keys are unavailable") }
         var credentials = AWSCredentials(accessKeyID: accessKey, secretAccessKey: secretKey)
         if registration.useLongLivedCredentials { return credentials }
 
@@ -4381,7 +4548,8 @@ private func approvalRequestWithCredentialContext(_ request: ApprovalRequest) ->
         snapshotIncompatibleInterpreter: request.snapshotIncompatibleInterpreter,
         tool: request.tool,
         title: "Use long-lived AWS credentials?",
-        detail: "AWS does not allow non-MFA GetSessionToken credentials to call this operation. Unless the selected profile uses MFA or assumes a role, Automic Vault will provide your original AWS access keys directly to AWS CLI; they retain every IAM permission assigned to those keys."
+        detail: "AWS does not allow non-MFA GetSessionToken credentials to call this operation. Unless the selected profile uses MFA or assumes a role, Automic Vault will provide your original AWS access keys directly to AWS CLI; they retain every IAM permission assigned to those keys.",
+        selectedValues: request.selectedValues
     )
 }
 
@@ -5804,6 +5972,22 @@ private func approvalPromptSections(
             ApprovalPromptRow("Signed", "\(signing.identifier) / \(signing.teamIdentifier)"),
         ]),
     ]
+
+    if !request.keys.isEmpty {
+        sections.insert(ApprovalPromptSection(
+            "Secret Values",
+            "key.horizontal",
+            request.keys.sorted().map { key in
+                let source = request.selectedValues[key]?.source
+                let display = switch source {
+                case .global: "Global Value"
+                case .projectDirectory(let path): escapedSecurityPath(path)
+                case nil: "(missing)"
+                }
+                return ApprovalPromptRow(key, display)
+            }
+        ), at: 1)
+    }
 
     let chain = approvalProcessChain(pid: pid)
     let chainRows = chain.map { [ApprovalPromptRow("Process chain", $0)] } ?? []
@@ -7750,7 +7934,8 @@ private func runTransientApprovalSelfCheck() -> Int32 {
             allowMissingKeys: false,
             envConflicts: [],
             shebangScript: nil,
-            tool: "gh"
+            tool: "gh",
+            selectedValueSources: []
         )
     }
     let approval = key()

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1497,7 +1497,12 @@ private struct ApprovalRequest {
 }
 
 enum SecretMutation {
-    case save(account: String, value: String, accessibility: StoredSecretAccessibility)
+    case save(
+        account: String,
+        value: String,
+        accessibility: StoredSecretAccessibility,
+        warning: String = ""
+    )
     case saveProject(
         account: String,
         value: String,
@@ -1505,7 +1510,7 @@ enum SecretMutation {
         accessibility: StoredSecretAccessibility,
         warning: String
     )
-    case saveIfAbsentOrEqual(account: String, value: String)
+    case saveIfAbsentOrEqual(account: String, value: String, warning: String = "")
     case delete(account: String)
     case dockerSave(account: String, value: String, serverURL: String, username: String)
     case dockerDelete(account: String, serverURL: String)
@@ -1516,20 +1521,22 @@ enum SecretMutation {
     fileprivate func approvalRequest(callerPath: String) -> ApprovalRequest {
         let properties: (op: String, keys: [String], args: [String], title: String, detail: String)
         switch self {
-        case .save(let account, _, _):
+        case .save(let account, _, _, let warning):
             properties = (
                 "save", [account], ["save", account], "Store \(account)?",
-                "This will create or replace a secret in Automic Vault."
+                "This will create or replace a Global Value in Automic Vault."
+                    + (warning.isEmpty ? "" : " \(warning)")
             )
         case .saveProject(let account, _, let directory, _, let warning):
             properties = (
-                "save", [account], ["save", "--project-directory=\(directory)", account],
+                "save", [account], ["save", "--project-directory=\(escapedSecurityPath(directory))", account],
                 "Store \(account) Project Value?", warning
             )
-        case .saveIfAbsentOrEqual(let account, _):
+        case .saveIfAbsentOrEqual(let account, _, let warning):
             properties = (
                 "save-if-absent", [account], ["save-if-absent", account], "Store \(account)?",
-                "This will create the secret only if no differing value already exists."
+                "This will create the Global Value only if no differing value already exists."
+                    + (warning.isEmpty ? "" : " \(warning)")
             )
         case .delete(let account):
             properties = (
@@ -1550,7 +1557,7 @@ enum SecretMutation {
             )
         case .deleteValue(let account, let source):
             properties = (
-                "delete", [account], ["delete", account, source.displayName],
+                "delete", [account], ["delete", account, escapedSecurityPath(source.displayName)],
                 "Delete \(account) Value?", "This will remove the selected Secret Value."
             )
         case .rename(let account, let newAccount):
@@ -1609,11 +1616,19 @@ enum SecretMutation {
     }
 
     fileprivate func perform() -> OSStatus {
-        let repairStatus = resumePendingSecretMutation()
-        guard repairStatus == errSecSuccess else { return repairStatus }
+        guard let pendingNames = pendingSecretMutationNames() else { return errSecDecode }
+        if !pendingNames.isEmpty {
+            let repairStatus = resumePendingSecretMutation()
+            return repairStatus == errSecSuccess ? errSecNotAvailable : repairStatus
+        }
         switch self {
-        case .save(let account, let value, let accessibility):
-            let existing = loadStoredSecrets().first { $0.account == account }
+        case .save(let account, let value, let accessibility, _):
+            let secrets: [StoredSecret]
+            switch loadStoredSecretsResult() {
+            case .success(let loaded): secrets = loaded
+            case .failure(let status): return status
+            }
+            let existing = secrets.first { $0.account == account }
             guard existing?.hasConsistentAccessibility != false else { return errSecDecode }
             return saveStoredSecret(
                 account: account,
@@ -1621,13 +1636,21 @@ enum SecretMutation {
                 accessibility: existing?.accessibility ?? accessibility
             )
         case .saveProject(let account, let value, let directory, let accessibility, _):
+            guard (try? validateCanonicalProjectDirectory(directory)) != nil else { return errSecParam }
+            let secrets: [StoredSecret]
+            switch loadStoredSecretsResult() {
+            case .success(let loaded): secrets = loaded
+            case .failure(let status): return status
+            }
+            let existing = secrets.first { $0.account == account }
+            guard existing?.hasConsistentAccessibility != false else { return errSecDecode }
             return saveStoredSecret(
                 account: account,
                 value: value,
-                accessibility: accessibility,
+                accessibility: existing?.accessibility ?? accessibility,
                 source: .projectDirectory(directory)
             )
-        case .saveIfAbsentOrEqual(let account, let value):
+        case .saveIfAbsentOrEqual(let account, let value, _):
             return saveStoredSecretIfAbsentOrEqual(account: account, value: value)
         case .delete(let account):
             return deleteStoredSecretRevokingDirectAccess(account: account)
@@ -2482,7 +2505,21 @@ private final class ApprovalServer: @unchecked Sendable {
         peer: xpc_connection_t,
         message: xpc_object_t
     ) {
-        let names = loadStoredSecrets().map(\.account)
+        let names: [String]
+        switch loadStoredSecretsResult() {
+        case .success(let secrets): names = secrets.map(\.account)
+        case .failure(let status):
+            _ = onAccessRequest(accessRequestRecord(
+                request: request,
+                callerPath: callerPath,
+                decision: "Failed",
+                approvalSource: approvalSource,
+                reason: "Stored Secret names are unavailable: \(status)",
+                launcher: launcher
+            ))
+            reply(peer, to: message, ok: false, error: "stored Secret names are unavailable: \(status)")
+            return
+        }
         guard onAccessRequest(accessRequestRecord(
             request: request,
             callerPath: callerPath,
@@ -2519,24 +2556,41 @@ private final class ApprovalServer: @unchecked Sendable {
                 helperPath: callerPath,
                 helperSigning: signing
             )
-            let repairStatus = resumePendingSecretMutation()
-            if repairStatus != errSecSuccess {
-                let names = pendingSecretMutationNames()
-                if names == nil || !Set(dockerRequest.keys).isDisjoint(with: names!) {
-                    reply(
-                        peer,
-                        to: message,
-                        ok: false,
-                        error: "secret repair must complete before this request: \(repairStatus)"
-                    )
-                    return
+            let conflicts = Set(dockerRequest.envConflicts)
+            let selectionNames = dockerRequest.keys.filter {
+                dockerRequest.replaceExistingEnv || !conflicts.contains($0)
+            }
+            if !selectionNames.isEmpty {
+                let repairStatus = resumePendingSecretMutation()
+                if repairStatus != errSecSuccess {
+                    let names = pendingSecretMutationNames()
+                    if names.map({ !Set(selectionNames).isDisjoint(with: $0) }) ?? true {
+                        reply(
+                            peer,
+                            to: message,
+                            ok: false,
+                            error: "secret repair must complete before this request: \(repairStatus)"
+                        )
+                        return
+                    }
                 }
             }
-            let selected = try resolveStoredSecretValues(
-                names: dockerRequest.keys,
-                cwd: dockerRequest.cwd,
-                secrets: loadStoredSecrets()
-            )
+            let selected: [String: StoredSecretValue]
+            if selectionNames.isEmpty {
+                selected = [:]
+            } else {
+                let storedSecrets: [StoredSecret]
+                switch loadStoredSecretsResult() {
+                case .success(let loaded): storedSecrets = loaded
+                case .failure(let status):
+                    throw AppError("failed to inspect stored Secrets: \(status)")
+                }
+                selected = try resolveStoredSecretValues(
+                    names: selectionNames,
+                    cwd: dockerRequest.cwd,
+                    secrets: storedSecrets
+                )
+            }
             request = approvalRequestWithCredentialContext(dockerRequest.selecting(selected))
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
@@ -3256,6 +3310,22 @@ private final class ApprovalServer: @unchecked Sendable {
         caller: MutationCaller,
         ifAbsentOrEqual: Bool = false
     ) {
+        guard let pendingNames = pendingSecretMutationNames() else {
+            reply(peer, to: message, ok: false, error: "pending Secret mutation state is unavailable")
+            return
+        }
+        if !pendingNames.isEmpty {
+            let status = resumePendingSecretMutation()
+            reply(
+                peer,
+                to: message,
+                ok: false,
+                error: status == errSecSuccess
+                    ? "a previous Secret mutation was repaired; retry this save"
+                    : "a previous Secret mutation still requires repair: \(status)"
+            )
+            return
+        }
         guard let keyPointer = xpc_dictionary_get_string(message, "key"),
               let valuePointer = xpc_dictionary_get_string(message, "value")
         else {
@@ -3274,17 +3344,40 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "conditional save does not support Project Values")
             return
         }
-        let storedSecret = loadStoredSecrets(
-            directAccessRules: loadDirectAccessRules()
-        ).first { $0.account == key }
+        let directAccessRules: [DirectAccessRule]
+        switch loadDirectAccessRulesResult() {
+        case .success(let loaded): directAccessRules = loaded
+        case .failure(let status):
+            reply(peer, to: message, ok: false, error: "Direct Access policy is unavailable: \(status)")
+            return
+        }
+        let storedSecrets: [StoredSecret]
+        switch loadStoredSecretsResult(directAccessRules: directAccessRules) {
+        case .success(let loaded): storedSecrets = loaded
+        case .failure(let status):
+            reply(peer, to: message, ok: false, error: "stored Secrets are unavailable: \(status)")
+            return
+        }
+        let storedSecret = storedSecrets.first { $0.account == key }
         if let storedSecret, !storedSecret.hasConsistentAccessibility {
             reply(peer, to: message, ok: false, error: "secret \(key) must be repaired before it can be changed")
             return
         }
         let accessibility = storedSecret?.accessibility ?? .whenUnlocked
+        let directAccessWarning: String
+        if let launchers = storedSecret?.directAccessLaunchers, !launchers.isEmpty {
+            directAccessWarning = "Direct Access Launchers already authorized for \(key) can use this value immediately: "
+                + launchers.map(\.bundleIdentifier).joined(separator: ", ") + "."
+        } else {
+            directAccessWarning = ""
+        }
         let mutation: SecretMutation
         if ifAbsentOrEqual {
-            mutation = .saveIfAbsentOrEqual(account: key, value: value)
+            mutation = .saveIfAbsentOrEqual(
+                account: key,
+                value: value,
+                warning: directAccessWarning
+            )
         } else if let projectDirectory {
             do {
                 _ = try validateCanonicalProjectDirectory(projectDirectory)
@@ -3293,10 +3386,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             var warning = "This will create or replace a Project Value for \(escapedSecurityPath(projectDirectory))."
-            if let launchers = storedSecret?.directAccessLaunchers, !launchers.isEmpty {
-                warning += " Direct Access Launchers already authorized for \(key) can use this value immediately: "
-                    + launchers.map(\.bundleIdentifier).joined(separator: ", ") + "."
-            }
+            if !directAccessWarning.isEmpty { warning += " \(directAccessWarning)" }
             let source: StoredSecretValueSource = .projectDirectory(projectDirectory)
             if storedSecret?.values.contains(where: { $0.source == source }) != true,
                let inherited = try? resolveStoredSecretValues(
@@ -3313,7 +3403,12 @@ private final class ApprovalServer: @unchecked Sendable {
                 warning: warning
             )
         } else {
-            mutation = .save(account: key, value: value, accessibility: accessibility)
+            mutation = .save(
+                account: key,
+                value: value,
+                accessibility: accessibility,
+                warning: directAccessWarning
+            )
         }
         handleMutation(
             mutation,
@@ -3620,9 +3715,9 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             switch mutation {
-            case .save(let account, _, _),
+            case .save(let account, _, _, _),
                  .saveProject(let account, _, _, _, _),
-                 .saveIfAbsentOrEqual(let account, _),
+                 .saveIfAbsentOrEqual(let account, _, _),
                  .dockerSave(let account, _, _, _):
                 if status == errSecSuccess {
                     self.reply(peer, to: message, ok: true, error: nil)

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 import Security
 
@@ -11,6 +12,8 @@ public let directAccessKeychainService = "com.automicvault.direct-secret-access"
 public let directAccessKeychainAccount = "DirectAccessRulesV1"
 public let accessRequestLogDefaultsKey = "AccessRequestLog"
 public let accessRequestLogKeychainService = "com.automicvault.access-log"
+private let secretMutationKeychainService = "com.automicvault.secret-mutations"
+private let secretMutationKeychainAccount = "PendingSecretMutationV1"
 private let accessRequestLogLock = NSLock()
 private let canonicalKeychainAccessGroup = "ZU76A67LGU.com.automicvault"
 
@@ -77,6 +80,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         ghCLIURL: URL? = URL(fileURLWithPath: "/opt/homebrew/opt/gh-cli/bin/gh"),
         policyService: String = secretGatePoliciesKeychainService
     ) -> DashboardSnapshot {
+        _ = resumePendingSecretMutation()
         let hardenerMetadata = loadHardenerMetadata(avExecutableURL: avExecutableURL)
         _ = initializeSecretGatePolicies(hardeners: hardenerMetadata, service: policyService)
         let hardenedTools = loadHardenedTools(
@@ -650,26 +654,66 @@ public enum StoredSecretAccessibility: Equatable, Sendable {
     }
 }
 
+public enum StoredSecretValueSource: Codable, Equatable, Hashable, Sendable {
+    case global
+    case projectDirectory(String)
+
+    public var displayName: String {
+        switch self {
+        case .global: "Global Value"
+        case .projectDirectory(let path): path
+        }
+    }
+}
+
+public struct StoredSecretValue: Equatable, Identifiable, Sendable {
+    public let source: StoredSecretValueSource
+    public let keychainAccount: String
+    public let accessibility: StoredSecretAccessibility
+    public let keychainProperties: [String]
+    public var id: String { keychainAccount }
+
+    public init(
+        source: StoredSecretValueSource,
+        keychainAccount: String,
+        accessibility: StoredSecretAccessibility,
+        keychainProperties: [String]
+    ) {
+        self.source = source
+        self.keychainAccount = keychainAccount
+        self.accessibility = accessibility
+        self.keychainProperties = keychainProperties
+    }
+}
+
 public struct StoredSecret: Equatable, Sendable {
     public let account: String
     public let accessibility: StoredSecretAccessibility
     public let keychainProperties: [String]
     public let directAccessLaunchers: [BlessedScriptLauncher]
+    public let values: [StoredSecretValue]
 
     public init(
         account: String,
         accessibility: StoredSecretAccessibility = .whenUnlocked,
         keychainProperties: [String] = [],
-        directAccessLaunchers: [BlessedScriptLauncher] = []
+        directAccessLaunchers: [BlessedScriptLauncher] = [],
+        values: [StoredSecretValue] = []
     ) {
         self.account = account
         self.accessibility = accessibility
         self.keychainProperties = keychainProperties
         self.directAccessLaunchers = directAccessLaunchers
+        self.values = values
+    }
+
+    public var hasConsistentAccessibility: Bool {
+        values.allSatisfy { $0.accessibility == accessibility }
     }
 
     public var subtitle: String {
-        keychainProperties.isEmpty ? "Keychain secret" : keychainProperties.joined(separator: " • ")
+        let storage = keychainProperties.isEmpty ? "Keychain secret" : keychainProperties.joined(separator: " • ")
+        return values.count > 1 ? "\(values.count) values • \(storage)" : storage
     }
 }
 
@@ -688,6 +732,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
     public let cwd: String
     public let keys: [String]
     public let detail: String?
+    public let secretValueSources: [String: String]?
 
     public init(
         id: UUID = UUID(),
@@ -703,7 +748,8 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         target: String,
         cwd: String,
         keys: [String],
-        detail: String?
+        detail: String?,
+        secretValueSources: [String: String]? = nil
     ) {
         self.id = id
         self.date = date
@@ -719,6 +765,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         self.cwd = cwd
         self.keys = keys
         self.detail = detail
+        self.secretValueSources = secretValueSources
     }
 
     public var commandForDisplay: String {
@@ -1329,6 +1376,41 @@ public func appendAccessRequestRecord(
     return loadAccessRequestRecords(defaults: defaults, key: key, service: service).first?.id == record.id
 }
 
+private let projectValueAccountPrefix = "AVProjectValueV1:"
+
+private struct StoredSecretAccount {
+    let secretName: String
+    let source: StoredSecretValueSource
+}
+
+public func storedSecretKeychainAccount(
+    secretName: String,
+    source: StoredSecretValueSource
+) -> String {
+    guard case .projectDirectory(let path) = source else { return secretName }
+    return projectValueAccountPrefix
+        + Data(secretName.utf8).base64EncodedString()
+        + ":"
+        + Data(path.utf8).base64EncodedString()
+}
+
+private func parseStoredSecretAccount(_ account: String) -> StoredSecretAccount? {
+    guard account.hasPrefix(projectValueAccountPrefix) else {
+        return StoredSecretAccount(secretName: account, source: .global)
+    }
+    let encoded = account.dropFirst(projectValueAccountPrefix.count)
+    let parts = encoded.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2,
+          let nameData = Data(base64Encoded: String(parts[0])),
+          let pathData = Data(base64Encoded: String(parts[1])),
+          let name = String(data: nameData, encoding: .utf8),
+          let path = String(data: pathData, encoding: .utf8),
+          !name.isEmpty,
+          path.hasPrefix("/")
+    else { return nil }
+    return StoredSecretAccount(secretName: name, source: .projectDirectory(path))
+}
+
 public func loadStoredSecrets(
     service: String = automicVaultKeychainService,
     directAccessRules: [DirectAccessRule] = []
@@ -1348,19 +1430,38 @@ public func loadStoredSecrets(
     else {
         return []
     }
-    return items.compactMap { item in
-        guard let account = item[kSecAttrAccount as String] as? String else { return nil }
-        return StoredSecret(
-            account: account,
+    let values = items.compactMap { item -> (String, StoredSecretValue)? in
+        guard let account = item[kSecAttrAccount as String] as? String,
+              let parsed = parseStoredSecretAccount(account)
+        else { return nil }
+        return (parsed.secretName, StoredSecretValue(
+            source: parsed.source,
+            keychainAccount: account,
             accessibility: StoredSecretAccessibility(
                 keychainValue: item[kSecAttrAccessible as String]
             ),
-            keychainProperties: keychainProperties(for: item, dataProtection: true),
+            keychainProperties: keychainProperties(for: item, dataProtection: true)
+        ))
+    }
+    return Dictionary(grouping: values, by: \.0).map { account, entries in
+        let values = entries.map(\.1).sorted { lhs, rhs in
+            switch (lhs.source, rhs.source) {
+            case (.global, .projectDirectory): true
+            case (.projectDirectory, .global): false
+            default: lhs.source.displayName.localizedStandardCompare(rhs.source.displayName) == .orderedAscending
+            }
+        }
+        let first = values[0]
+        return StoredSecret(
+            account: account,
+            accessibility: first.accessibility,
+            keychainProperties: first.keychainProperties,
             directAccessLaunchers: (directAccess[account] ?? [])
                 .map(\.launcher)
                 .sorted {
                     $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending
-                }
+                },
+            values: values
         )
     }
     .sorted { $0.account.localizedStandardCompare($1.account) == .orderedAscending }
@@ -1376,6 +1477,127 @@ public func storedSecretExists(account: String, service: String = automicVaultKe
     ]
     addCanonicalAccessGroup(to: &query)
     return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+}
+
+public enum ProjectDirectoryValidationError: Error, LocalizedError, Equatable {
+    case notAbsolute
+    case unavailable
+    case notDirectory
+    case notCanonical(String)
+    case filesystemIdentityUnavailable
+    case filesystemRoot
+
+    public var errorDescription: String? {
+        switch self {
+        case .notAbsolute: "project directory must be absolute"
+        case .unavailable: "project directory does not exist"
+        case .notDirectory: "project directory must be a directory"
+        case .notCanonical(let path): "project directory must be canonical: \(path)"
+        case .filesystemIdentityUnavailable: "project directory filesystem is unavailable"
+        case .filesystemRoot: "project directory cannot be a filesystem root"
+        }
+    }
+}
+
+private func canonicalDirectory(_ path: String) throws -> (path: String, device: UInt64) {
+    guard path.hasPrefix("/") else { throw ProjectDirectoryValidationError.notAbsolute }
+    var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(path, &resolved) != nil else { throw ProjectDirectoryValidationError.unavailable }
+    let end = resolved.firstIndex(of: 0) ?? resolved.endIndex
+    guard let canonical = String(
+        data: Data(resolved[..<end].map { UInt8(bitPattern: $0) }),
+        encoding: .utf8
+    ) else { throw ProjectDirectoryValidationError.unavailable }
+    let attributes: [FileAttributeKey: Any]
+    do {
+        attributes = try FileManager.default.attributesOfItem(atPath: canonical)
+    } catch {
+        throw ProjectDirectoryValidationError.unavailable
+    }
+    guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+        throw ProjectDirectoryValidationError.notDirectory
+    }
+    guard let device = attributes[.systemNumber] as? NSNumber else {
+        throw ProjectDirectoryValidationError.filesystemIdentityUnavailable
+    }
+    return (canonical, device.uint64Value)
+}
+
+public func validateCanonicalProjectDirectory(_ path: String) throws -> String {
+    let directory = try canonicalDirectory(path)
+    guard directory.path == path else {
+        throw ProjectDirectoryValidationError.notCanonical(directory.path)
+    }
+    let parent = URL(fileURLWithPath: path, isDirectory: true)
+        .deletingLastPathComponent().path
+    guard parent != path else { throw ProjectDirectoryValidationError.filesystemRoot }
+    let parentDirectory = try canonicalDirectory(parent)
+    guard parentDirectory.device == directory.device else {
+        throw ProjectDirectoryValidationError.filesystemRoot
+    }
+    return path
+}
+
+public func canonicalProjectDirectory(_ path: String) throws -> String {
+    let directory = try canonicalDirectory(path)
+    _ = try validateCanonicalProjectDirectory(directory.path)
+    return directory.path
+}
+
+public func physicalDirectoryAncestors(_ path: String) throws -> [String] {
+    let start = try canonicalDirectory(path)
+    guard start.path == path else {
+        throw ProjectDirectoryValidationError.notCanonical(start.path)
+    }
+    var result = [start.path]
+    var current = start.path
+    while true {
+        let parent = URL(fileURLWithPath: current, isDirectory: true)
+            .deletingLastPathComponent().path
+        guard parent != current else { break }
+        let parentDirectory = try canonicalDirectory(parent)
+        guard parentDirectory.device == start.device else { break }
+        result.append(parentDirectory.path)
+        current = parentDirectory.path
+    }
+    return result
+}
+
+public enum StoredSecretSelectionError: Error, LocalizedError, Equatable {
+    case inconsistentAvailability(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .inconsistentAvailability(let name):
+            "secret \(name) has inconsistent availability and must be repaired"
+        }
+    }
+}
+
+public func resolveStoredSecretValues(
+    names: [String],
+    cwd: String,
+    secrets: [StoredSecret]
+) throws -> [String: StoredSecretValue] {
+    let rank = Dictionary(
+        uniqueKeysWithValues: try physicalDirectoryAncestors(cwd).enumerated().map { ($1, $0) }
+    )
+    let byName = Dictionary(uniqueKeysWithValues: secrets.map { ($0.account, $0) })
+    var selected: [String: StoredSecretValue] = [:]
+    for name in names {
+        guard let secret = byName[name] else { continue }
+        guard secret.hasConsistentAccessibility else {
+            throw StoredSecretSelectionError.inconsistentAvailability(name)
+        }
+        let project = secret.values.compactMap { value -> (Int, StoredSecretValue)? in
+            guard case .projectDirectory(let path) = value.source,
+                  let rank = rank[path]
+            else { return nil }
+            return (rank, value)
+        }.min { $0.0 < $1.0 }?.1
+        selected[name] = project ?? secret.values.first { $0.source == .global }
+    }
+    return selected
 }
 
 private func keychainProperties(for item: [String: Any], dataProtection: Bool) -> [String] {
@@ -1423,12 +1645,13 @@ public func saveStoredSecret(
     account: String,
     value: String,
     accessibility: StoredSecretAccessibility = .whenUnlocked,
+    source: StoredSecretValueSource = .global,
     service: String = automicVaultKeychainService
 ) -> OSStatus {
     saveKeychainData(
         Data(value.utf8),
         service: service,
-        account: account,
+        account: storedSecretKeychainAccount(secretName: account, source: source),
         accessibility: accessibility
     )
 }
@@ -1438,10 +1661,13 @@ public func saveStoredSecretIfAbsentOrEqual(
     value: String,
     service: String = automicVaultKeychainService
 ) -> OSStatus {
-    saveKeychainDataIfAbsentOrEqual(
+    let existing = loadStoredSecrets(service: service).first { $0.account == account }
+    guard existing?.hasConsistentAccessibility != false else { return errSecDecode }
+    return saveKeychainDataIfAbsentOrEqual(
         Data(value.utf8),
         service: service,
-        account: account
+        account: account,
+        accessibility: existing?.accessibility ?? .whenUnlocked
     )
 }
 
@@ -1450,18 +1676,165 @@ public func setStoredSecretAccessibility(
     accessibility: StoredSecretAccessibility,
     service: String = automicVaultKeychainService
 ) -> OSStatus {
-    setKeychainAccessibility(accessibility, service: service, account: account)
+    guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == account })
+    else { return errSecItemNotFound }
+    guard secret.values.count > 1 else {
+        return setKeychainAccessibility(
+            accessibility,
+            service: service,
+            account: secret.values[0].keychainAccount
+        )
+    }
+    return beginPendingSecretMutation(
+        .setAccessibility(account: account, accessibility: accessibility),
+        service: service
+    )
 }
 
 public func renameStoredSecret(account: String, to newAccount: String, service: String = automicVaultKeychainService) -> OSStatus {
+    let secrets = loadStoredSecrets(service: service)
+    guard !secrets.contains(where: { $0.account == newAccount }),
+          let secret = secrets.first(where: { $0.account == account })
+    else { return secrets.contains(where: { $0.account == newAccount }) ? errSecDuplicateItem : errSecItemNotFound }
+    guard secret.values.count > 1 else {
+        return renameStoredSecretValue(
+            secret.values[0],
+            to: newAccount,
+            service: service
+        )
+    }
+    return beginPendingSecretMutation(
+        .rename(account: account, newAccount: newAccount),
+        service: service
+    )
+}
+
+private enum PendingSecretMutation: Codable {
+    case rename(account: String, newAccount: String)
+    case setAccessibility(account: String, accessibility: StoredSecretAccessibility)
+    case delete(account: String)
+
+    var affectedNames: Set<String> {
+        switch self {
+        case .rename(let account, let newAccount): [account, newAccount]
+        case .setAccessibility(let account, _): [account]
+        case .delete(let account): [account]
+        }
+    }
+}
+
+extension StoredSecretAccessibility: Codable {}
+
+// ponytail: one journal serializes rare multi-value mutations; add per-Secret journals only if contention appears.
+private func beginPendingSecretMutation(
+    _ mutation: PendingSecretMutation,
+    service: String
+) -> OSStatus {
+    let journalAccount = secretMutationJournalAccount(for: service)
+    guard loadKeychainData(
+        service: secretMutationKeychainService,
+        account: journalAccount
+    ) == nil else { return errSecInteractionNotAllowed }
+    guard let data = try? JSONEncoder().encode(mutation) else { return errSecParam }
+    let status = saveKeychainData(
+        data,
+        service: secretMutationKeychainService,
+        account: journalAccount,
+        accessibility: .afterFirstUnlock
+    )
+    guard status == errSecSuccess else { return status }
+    return resumePendingSecretMutation(service: service)
+}
+
+private func secretMutationJournalAccount(for service: String) -> String {
+    guard service != automicVaultKeychainService else { return secretMutationKeychainAccount }
+    return secretMutationKeychainAccount + ":" + Data(service.utf8).base64EncodedString()
+}
+
+private func pendingSecretMutation(service: String) -> PendingSecretMutation? {
+    guard let data = loadKeychainData(
+        service: secretMutationKeychainService,
+        account: secretMutationJournalAccount(for: service)
+    ) else { return nil }
+    return try? JSONDecoder().decode(PendingSecretMutation.self, from: data)
+}
+
+public func pendingSecretMutationNames() -> Set<String>? {
+    guard storedSecretExists(
+        account: secretMutationKeychainAccount,
+        service: secretMutationKeychainService
+    ) else { return [] }
+    return pendingSecretMutation(service: automicVaultKeychainService)?.affectedNames
+}
+
+@discardableResult
+public func resumePendingSecretMutation(
+    service: String = automicVaultKeychainService
+) -> OSStatus {
+    let journalAccount = secretMutationJournalAccount(for: service)
+    guard storedSecretExists(
+        account: journalAccount,
+        service: secretMutationKeychainService
+    ) else { return errSecSuccess }
+    guard let mutation = pendingSecretMutation(service: service) else { return errSecDecode }
+
+    let status: OSStatus
+    switch mutation {
+    case .setAccessibility(let account, let accessibility):
+        guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == account })
+        else { return errSecItemNotFound }
+        status = secret.values.reduce(errSecSuccess) { result, value in
+            guard result == errSecSuccess, value.accessibility != accessibility else { return result }
+            return setKeychainAccessibility(
+                accessibility,
+                service: service,
+                account: value.keychainAccount
+            )
+        }
+    case .rename(let account, let newAccount):
+        let secrets = loadStoredSecrets(service: service)
+        let old = secrets.first { $0.account == account }
+        let newSources = Set(
+            secrets.first(where: { $0.account == newAccount })?.values.map(\.source) ?? []
+        )
+        guard old?.values.contains(where: { newSources.contains($0.source) }) != true else {
+            return errSecDuplicateItem
+        }
+        status = old?.values.reduce(errSecSuccess) { result, value in
+            guard result == errSecSuccess else { return result }
+            return renameStoredSecretValue(value, to: newAccount, service: service)
+        } ?? errSecSuccess
+    case .delete(let account):
+        status = loadStoredSecrets(service: service).first(where: { $0.account == account })
+            .map { deleteStoredSecretValues($0, service: service) } ?? errSecSuccess
+    }
+    guard status == errSecSuccess else { return status }
+    return deleteStoredSecretValue(
+        secretName: journalAccount,
+        source: .global,
+        service: secretMutationKeychainService
+    )
+}
+
+private func renameStoredSecretValue(
+    _ value: StoredSecretValue,
+    to newAccount: String,
+    service: String
+) -> OSStatus {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: service,
-        kSecAttrAccount as String: account,
+        kSecAttrAccount as String: value.keychainAccount,
         kSecUseDataProtectionKeychain as String: true,
     ]
     addCanonicalAccessGroup(to: &query)
-    return SecItemUpdate(query as CFDictionary, [kSecAttrAccount as String: newAccount] as CFDictionary)
+    return SecItemUpdate(
+        query as CFDictionary,
+        [kSecAttrAccount as String: storedSecretKeychainAccount(
+            secretName: newAccount,
+            source: value.source
+        )] as CFDictionary
+    )
 }
 
 public func renameStoredSecretRevokingDirectAccess(
@@ -1481,14 +1854,64 @@ public func renameStoredSecretRevokingDirectAccess(
 }
 
 public func deleteStoredSecret(account: String, service: String = automicVaultKeychainService) -> OSStatus {
+    guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == account })
+    else { return errSecItemNotFound }
+    guard secret.values.count > 1 else {
+        return deleteStoredSecretValue(
+            secretName: account,
+            source: secret.values[0].source,
+            service: service
+        )
+    }
+    return beginPendingSecretMutation(.delete(account: account), service: service)
+}
+
+private func deleteStoredSecretValues(_ secret: StoredSecret, service: String) -> OSStatus {
+    for value in secret.values {
+        let status = deleteStoredSecretValue(
+            secretName: secret.account,
+            source: value.source,
+            service: service
+        )
+        guard status == errSecSuccess else { return status }
+    }
+    return errSecSuccess
+}
+
+public func deleteStoredSecretValue(
+    secretName: String,
+    source: StoredSecretValueSource,
+    service: String = automicVaultKeychainService
+) -> OSStatus {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: service,
-        kSecAttrAccount as String: account,
+        kSecAttrAccount as String: storedSecretKeychainAccount(secretName: secretName, source: source),
         kSecUseDataProtectionKeychain as String: true,
     ]
     addCanonicalAccessGroup(to: &query)
     return SecItemDelete(query as CFDictionary)
+}
+
+public func deleteStoredSecretValueRevokingDirectAccessIfLast(
+    secretName: String,
+    source: StoredSecretValueSource,
+    service: String = automicVaultKeychainService,
+    directAccessService: String = directAccessKeychainService,
+    directAccessAccount: String = directAccessKeychainAccount
+) -> OSStatus {
+    guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == secretName }),
+          secret.values.contains(where: { $0.source == source })
+    else { return errSecItemNotFound }
+    if secret.values.count == 1 {
+        let status = revokeDirectAccess(
+            to: secretName,
+            service: directAccessService,
+            account: directAccessAccount
+        )
+        guard status == errSecSuccess else { return status }
+    }
+    return deleteStoredSecretValue(secretName: secretName, source: source, service: service)
 }
 
 public func deleteStoredSecretRevokingDirectAccess(
@@ -1506,9 +1929,36 @@ public func deleteStoredSecretRevokingDirectAccess(
     return deleteStoredSecret(account: account, service: service)
 }
 
-public func loadStoredSecret(account: String, service: String = automicVaultKeychainService) -> String? {
-    guard let data = loadKeychainData(service: service, account: account) else { return nil }
+public func loadStoredSecret(
+    account: String,
+    source: StoredSecretValueSource = .global,
+    service: String = automicVaultKeychainService
+) -> String? {
+    let keychainAccount = storedSecretKeychainAccount(secretName: account, source: source)
+    guard let data = loadKeychainData(service: service, account: keychainAccount) else { return nil }
     return String(data: data, encoding: .utf8)
+}
+
+public enum StoredSecretValueLoad: Equatable {
+    case success(String)
+    case notFound
+    case failure(OSStatus)
+    case invalidUTF8
+}
+
+public func loadStoredSecretValue(
+    _ value: StoredSecretValue,
+    service: String = automicVaultKeychainService
+) -> StoredSecretValueLoad {
+    switch loadKeychainDataResult(service: service, account: value.keychainAccount) {
+    case .success(let data):
+        guard let text = String(data: data, encoding: .utf8) else { return .invalidUTF8 }
+        return .success(text)
+    case .notFound:
+        return .notFound
+    case .failure(let status):
+        return .failure(status)
+    }
 }
 
 private func loadKeychainData(service: String, account: String) -> Data? {
@@ -1792,7 +2242,8 @@ func saveKeychainData(
 func saveKeychainDataIfAbsentOrEqual(
     _ data: Data,
     service: String,
-    account: String
+    account: String,
+    accessibility: StoredSecretAccessibility = .whenUnlocked
 ) -> OSStatus {
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
@@ -1800,7 +2251,7 @@ func saveKeychainDataIfAbsentOrEqual(
         kSecAttrAccount as String: account,
         kSecUseDataProtectionKeychain as String: true,
         kSecValueData as String: data,
-        kSecAttrAccessible as String: StoredSecretAccessibility.whenUnlocked.keychainValue,
+        kSecAttrAccessible as String: accessibility.keychainValue,
     ]
     addCanonicalAccessGroup(to: &query)
     return verifyKeychainDataAfterConditionalAdd(

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -14,6 +14,7 @@ public let accessRequestLogDefaultsKey = "AccessRequestLog"
 public let accessRequestLogKeychainService = "com.automicvault.access-log"
 private let secretMutationKeychainService = "com.automicvault.secret-mutations"
 private let secretMutationKeychainAccount = "PendingSecretMutationV1"
+private let secretMutationLock = NSLock()
 private let accessRequestLogLock = NSLock()
 private let canonicalKeychainAccessGroup = "ZU76A67LGU.com.automicvault"
 
@@ -1415,6 +1416,22 @@ public func loadStoredSecrets(
     service: String = automicVaultKeychainService,
     directAccessRules: [DirectAccessRule] = []
 ) -> [StoredSecret] {
+    guard case .success(let secrets) = loadStoredSecretsResult(
+        service: service,
+        directAccessRules: directAccessRules
+    ) else { return [] }
+    return secrets
+}
+
+public enum StoredSecretsLoad {
+    case success([StoredSecret])
+    case failure(OSStatus)
+}
+
+public func loadStoredSecretsResult(
+    service: String = automicVaultKeychainService,
+    directAccessRules: [DirectAccessRule] = []
+) -> StoredSecretsLoad {
     let directAccess = Dictionary(grouping: directAccessRules, by: \.secretName)
     var query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
@@ -1425,32 +1442,35 @@ public func loadStoredSecrets(
     ]
     addCanonicalAccessGroup(to: &query)
     var result: CFTypeRef?
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    if status == errSecItemNotFound { return .success([]) }
+    guard status == errSecSuccess,
           let items = result as? [[String: Any]]
-    else {
-        return []
-    }
-    let values = items.compactMap { item -> (String, StoredSecretValue)? in
+    else { return .failure(status == errSecSuccess ? errSecDecode : status) }
+    var values: [(String, StoredSecretValue)] = []
+    for item in items {
         guard let account = item[kSecAttrAccount as String] as? String,
               let parsed = parseStoredSecretAccount(account)
-        else { return nil }
-        return (parsed.secretName, StoredSecretValue(
+        else { return .failure(errSecDecode) }
+        values.append((parsed.secretName, StoredSecretValue(
             source: parsed.source,
             keychainAccount: account,
             accessibility: StoredSecretAccessibility(
                 keychainValue: item[kSecAttrAccessible as String]
             ),
             keychainProperties: keychainProperties(for: item, dataProtection: true)
-        ))
+        )))
     }
-    return Dictionary(grouping: values, by: \.0).map { account, entries in
+    let grouped = Dictionary(grouping: values, by: \.0)
+    let secrets = grouped.compactMap { account, entries -> StoredSecret? in
         let values = entries.map(\.1).sorted { lhs, rhs in
             switch (lhs.source, rhs.source) {
             case (.global, .projectDirectory): true
             case (.projectDirectory, .global): false
             default: lhs.source.displayName.localizedStandardCompare(rhs.source.displayName) == .orderedAscending
-            }
+                }
         }
+        guard Set(values.map(\.source)).count == values.count else { return nil }
         let first = values[0]
         return StoredSecret(
             account: account,
@@ -1465,6 +1485,10 @@ public func loadStoredSecrets(
         )
     }
     .sorted { $0.account.localizedStandardCompare($1.account) == .orderedAscending }
+    guard secrets.count == grouped.count else {
+        return .failure(errSecDecode)
+    }
+    return .success(secrets)
 }
 
 public func storedSecretExists(account: String, service: String = automicVaultKeychainService) -> Bool {
@@ -1579,6 +1603,7 @@ public func resolveStoredSecretValues(
     cwd: String,
     secrets: [StoredSecret]
 ) throws -> [String: StoredSecretValue] {
+    guard !names.isEmpty else { return [:] }
     let rank = Dictionary(
         uniqueKeysWithValues: try physicalDirectoryAncestors(cwd).enumerated().map { ($1, $0) }
     )
@@ -1661,7 +1686,12 @@ public func saveStoredSecretIfAbsentOrEqual(
     value: String,
     service: String = automicVaultKeychainService
 ) -> OSStatus {
-    let existing = loadStoredSecrets(service: service).first { $0.account == account }
+    let secrets: [StoredSecret]
+    switch loadStoredSecretsResult(service: service) {
+    case .success(let loaded): secrets = loaded
+    case .failure(let status): return status
+    }
+    let existing = secrets.first { $0.account == account }
     guard existing?.hasConsistentAccessibility != false else { return errSecDecode }
     return saveKeychainDataIfAbsentOrEqual(
         Data(value.utf8),
@@ -1676,8 +1706,12 @@ public func setStoredSecretAccessibility(
     accessibility: StoredSecretAccessibility,
     service: String = automicVaultKeychainService
 ) -> OSStatus {
-    guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == account })
-    else { return errSecItemNotFound }
+    let secrets: [StoredSecret]
+    switch loadStoredSecretsResult(service: service) {
+    case .success(let loaded): secrets = loaded
+    case .failure(let status): return status
+    }
+    guard let secret = secrets.first(where: { $0.account == account }) else { return errSecItemNotFound }
     guard secret.values.count > 1 else {
         return setKeychainAccessibility(
             accessibility,
@@ -1692,10 +1726,15 @@ public func setStoredSecretAccessibility(
 }
 
 public func renameStoredSecret(account: String, to newAccount: String, service: String = automicVaultKeychainService) -> OSStatus {
-    let secrets = loadStoredSecrets(service: service)
+    let secrets: [StoredSecret]
+    switch loadStoredSecretsResult(service: service) {
+    case .success(let loaded): secrets = loaded
+    case .failure(let status): return status
+    }
     guard !secrets.contains(where: { $0.account == newAccount }),
           let secret = secrets.first(where: { $0.account == account })
     else { return secrets.contains(where: { $0.account == newAccount }) ? errSecDuplicateItem : errSecItemNotFound }
+    guard secret.hasConsistentAccessibility else { return errSecDecode }
     guard secret.values.count > 1 else {
         return renameStoredSecretValue(
             secret.values[0],
@@ -1709,7 +1748,7 @@ public func renameStoredSecret(account: String, to newAccount: String, service: 
     )
 }
 
-private enum PendingSecretMutation: Codable {
+private enum PendingSecretMutation: Codable, Equatable {
     case rename(account: String, newAccount: String)
     case setAccessibility(account: String, accessibility: StoredSecretAccessibility)
     case delete(account: String)
@@ -1723,6 +1762,12 @@ private enum PendingSecretMutation: Codable {
     }
 }
 
+private enum PendingSecretMutationLoad {
+    case none
+    case success(PendingSecretMutation)
+    case failure(OSStatus)
+}
+
 extension StoredSecretAccessibility: Codable {}
 
 // ponytail: one journal serializes rare multi-value mutations; add per-Secret journals only if contention appears.
@@ -1730,11 +1775,14 @@ private func beginPendingSecretMutation(
     _ mutation: PendingSecretMutation,
     service: String
 ) -> OSStatus {
+    secretMutationLock.lock()
+    defer { secretMutationLock.unlock() }
     let journalAccount = secretMutationJournalAccount(for: service)
-    guard loadKeychainData(
-        service: secretMutationKeychainService,
-        account: journalAccount
-    ) == nil else { return errSecInteractionNotAllowed }
+    switch loadPendingSecretMutation(service: service) {
+    case .none: break
+    case .success: return errSecInteractionNotAllowed
+    case .failure(let status): return status
+    }
     guard let data = try? JSONEncoder().encode(mutation) else { return errSecParam }
     let status = saveKeychainData(
         data,
@@ -1743,7 +1791,10 @@ private func beginPendingSecretMutation(
         accessibility: .afterFirstUnlock
     )
     guard status == errSecSuccess else { return status }
-    return resumePendingSecretMutation(service: service)
+    guard case .success(let persisted) = loadPendingSecretMutation(service: service),
+          persisted == mutation
+    else { return errSecDecode }
+    return resumePendingSecretMutationUnlocked(service: service)
 }
 
 private func secretMutationJournalAccount(for service: String) -> String {
@@ -1751,38 +1802,59 @@ private func secretMutationJournalAccount(for service: String) -> String {
     return secretMutationKeychainAccount + ":" + Data(service.utf8).base64EncodedString()
 }
 
-private func pendingSecretMutation(service: String) -> PendingSecretMutation? {
-    guard let data = loadKeychainData(
+private func loadPendingSecretMutation(service: String) -> PendingSecretMutationLoad {
+    switch loadKeychainDataResult(
         service: secretMutationKeychainService,
         account: secretMutationJournalAccount(for: service)
-    ) else { return nil }
-    return try? JSONDecoder().decode(PendingSecretMutation.self, from: data)
+    ) {
+    case .notFound:
+        return .none
+    case .failure(let status):
+        return .failure(status)
+    case .success(let data):
+        guard let mutation = try? JSONDecoder().decode(PendingSecretMutation.self, from: data)
+        else { return .failure(errSecDecode) }
+        return .success(mutation)
+    }
 }
 
 public func pendingSecretMutationNames() -> Set<String>? {
-    guard storedSecretExists(
-        account: secretMutationKeychainAccount,
-        service: secretMutationKeychainService
-    ) else { return [] }
-    return pendingSecretMutation(service: automicVaultKeychainService)?.affectedNames
+    secretMutationLock.lock()
+    defer { secretMutationLock.unlock() }
+    return switch loadPendingSecretMutation(service: automicVaultKeychainService) {
+    case .none: []
+    case .success(let mutation): mutation.affectedNames
+    case .failure: nil
+    }
 }
 
 @discardableResult
 public func resumePendingSecretMutation(
     service: String = automicVaultKeychainService
 ) -> OSStatus {
+    secretMutationLock.lock()
+    defer { secretMutationLock.unlock() }
+    return resumePendingSecretMutationUnlocked(service: service)
+}
+
+private func resumePendingSecretMutationUnlocked(service: String) -> OSStatus {
     let journalAccount = secretMutationJournalAccount(for: service)
-    guard storedSecretExists(
-        account: journalAccount,
-        service: secretMutationKeychainService
-    ) else { return errSecSuccess }
-    guard let mutation = pendingSecretMutation(service: service) else { return errSecDecode }
+    let mutation: PendingSecretMutation
+    switch loadPendingSecretMutation(service: service) {
+    case .none: return errSecSuccess
+    case .success(let loaded): mutation = loaded
+    case .failure(let status): return status
+    }
 
     let status: OSStatus
     switch mutation {
     case .setAccessibility(let account, let accessibility):
-        guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == account })
-        else { return errSecItemNotFound }
+        let secrets: [StoredSecret]
+        switch loadStoredSecretsResult(service: service) {
+        case .success(let loaded): secrets = loaded
+        case .failure(let status): return status
+        }
+        guard let secret = secrets.first(where: { $0.account == account }) else { return errSecItemNotFound }
         status = secret.values.reduce(errSecSuccess) { result, value in
             guard result == errSecSuccess, value.accessibility != accessibility else { return result }
             return setKeychainAccessibility(
@@ -1792,7 +1864,11 @@ public func resumePendingSecretMutation(
             )
         }
     case .rename(let account, let newAccount):
-        let secrets = loadStoredSecrets(service: service)
+        let secrets: [StoredSecret]
+        switch loadStoredSecretsResult(service: service) {
+        case .success(let loaded): secrets = loaded
+        case .failure(let status): return status
+        }
         let old = secrets.first { $0.account == account }
         let newSources = Set(
             secrets.first(where: { $0.account == newAccount })?.values.map(\.source) ?? []
@@ -1805,7 +1881,12 @@ public func resumePendingSecretMutation(
             return renameStoredSecretValue(value, to: newAccount, service: service)
         } ?? errSecSuccess
     case .delete(let account):
-        status = loadStoredSecrets(service: service).first(where: { $0.account == account })
+        let secrets: [StoredSecret]
+        switch loadStoredSecretsResult(service: service) {
+        case .success(let loaded): secrets = loaded
+        case .failure(let status): return status
+        }
+        status = secrets.first(where: { $0.account == account })
             .map { deleteStoredSecretValues($0, service: service) } ?? errSecSuccess
     }
     guard status == errSecSuccess else { return status }
@@ -1854,8 +1935,12 @@ public func renameStoredSecretRevokingDirectAccess(
 }
 
 public func deleteStoredSecret(account: String, service: String = automicVaultKeychainService) -> OSStatus {
-    guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == account })
-    else { return errSecItemNotFound }
+    let secrets: [StoredSecret]
+    switch loadStoredSecretsResult(service: service) {
+    case .success(let loaded): secrets = loaded
+    case .failure(let status): return status
+    }
+    guard let secret = secrets.first(where: { $0.account == account }) else { return errSecItemNotFound }
     guard secret.values.count > 1 else {
         return deleteStoredSecretValue(
             secretName: account,
@@ -1900,7 +1985,12 @@ public func deleteStoredSecretValueRevokingDirectAccessIfLast(
     directAccessService: String = directAccessKeychainService,
     directAccessAccount: String = directAccessKeychainAccount
 ) -> OSStatus {
-    guard let secret = loadStoredSecrets(service: service).first(where: { $0.account == secretName }),
+    let secrets: [StoredSecret]
+    switch loadStoredSecretsResult(service: service) {
+    case .success(let loaded): secrets = loaded
+    case .failure(let status): return status
+    }
+    guard let secret = secrets.first(where: { $0.account == secretName }),
           secret.values.contains(where: { $0.source == source })
     else { return errSecItemNotFound }
     if secret.values.count == 1 {
@@ -2130,12 +2220,15 @@ public func directAccessAllows(
     }
 }
 
-private enum DirectAccessRulesLoad {
+public enum DirectAccessRulesLoad {
     case success([DirectAccessRule])
     case failure(OSStatus)
 }
 
-private func loadDirectAccessRulesResult(service: String, account: String) -> DirectAccessRulesLoad {
+public func loadDirectAccessRulesResult(
+    service: String = directAccessKeychainService,
+    account: String = directAccessKeychainAccount
+) -> DirectAccessRulesLoad {
     switch loadKeychainDataResult(service: service, account: account) {
     case .notFound:
         return .success([])

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -886,6 +886,141 @@ func protectionPolicyMatrix(
     #expect(loadStoredSecrets(service: service).first?.accessibility == .afterFirstUnlock)
 }
 
+@Test func projectValuesGroupUnderOneSecretNameAndSelectNearestAncestor() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.project-values.\(UUID().uuidString)"
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("av-project-values-\(UUID().uuidString)", isDirectory: true)
+    let nested = root.appendingPathComponent("nested/work", isDirectory: true)
+    try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+    let rootPath = try canonicalProjectDirectory(root.path)
+    let nestedPath = try canonicalProjectDirectory(nested.deletingLastPathComponent().path)
+    defer {
+        _ = deleteStoredSecret(account: "TOKEN", service: service)
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    #expect(saveStoredSecret(account: "TOKEN", value: "global", service: service) == errSecSuccess)
+    #expect(saveStoredSecret(
+        account: "TOKEN",
+        value: "root",
+        source: .projectDirectory(rootPath),
+        service: service
+    ) == errSecSuccess)
+    #expect(saveStoredSecret(
+        account: "TOKEN",
+        value: "nested",
+        source: .projectDirectory(nestedPath),
+        service: service
+    ) == errSecSuccess)
+
+    let secret = try #require(loadStoredSecrets(service: service).first)
+    #expect(secret.account == "TOKEN")
+    #expect(secret.values.count == 3)
+    let selected = try #require(resolveStoredSecretValues(
+        names: ["TOKEN"], cwd: try canonicalProjectDirectory(nested.path), secrets: [secret]
+    )["TOKEN"])
+    #expect(selected.source == .projectDirectory(nestedPath))
+    #expect(loadStoredSecretValue(selected, service: service) == .success("nested"))
+}
+
+@Test func projectSelectionFallsBackToGlobalPerSecretName() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let global = StoredSecretValue(
+        source: .global,
+        keychainAccount: "GLOBAL",
+        accessibility: .whenUnlocked,
+        keychainProperties: []
+    )
+    let selected = try resolveStoredSecretValues(
+        names: ["GLOBAL", "MISSING"],
+        cwd: cwd,
+        secrets: [StoredSecret(account: "GLOBAL", values: [global])]
+    )
+    #expect(selected["GLOBAL"] == global)
+    #expect(selected["MISSING"] == nil)
+}
+
+@Test func projectDirectoryValidationUsesPhysicalCanonicalPathsAndRejectsRoots() throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("av-project-path-\(UUID().uuidString)", isDirectory: true)
+    let directory = root.appendingPathComponent("directory", isDirectory: true)
+    let symlink = root.appendingPathComponent("link", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: directory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let canonical = try canonicalProjectDirectory(symlink.path)
+    let canonicalDirectory = try canonicalProjectDirectory(directory.path)
+    #expect(canonical == canonicalDirectory)
+    #expect(throws: ProjectDirectoryValidationError.self) {
+        try validateCanonicalProjectDirectory(symlink.path)
+    }
+    #expect(throws: ProjectDirectoryValidationError.self) {
+        try validateCanonicalProjectDirectory("/")
+    }
+}
+
+@Test func multiValueAvailabilityAndRenameCompleteAsForwardOperations() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.project-mutation.\(UUID().uuidString)"
+    let directory = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    defer {
+        _ = deleteStoredSecret(account: "OLD_TOKEN", service: service)
+        _ = deleteStoredSecret(account: "NEW_TOKEN", service: service)
+    }
+    #expect(saveStoredSecret(account: "OLD_TOKEN", value: "global", service: service) == errSecSuccess)
+    #expect(saveStoredSecret(
+        account: "OLD_TOKEN",
+        value: "project",
+        source: .projectDirectory(directory),
+        service: service
+    ) == errSecSuccess)
+
+    #expect(setStoredSecretAccessibility(
+        account: "OLD_TOKEN",
+        accessibility: .afterFirstUnlock,
+        service: service
+    ) == errSecSuccess)
+    let updated = try #require(loadStoredSecrets(service: service).first)
+    #expect(updated.values.allSatisfy { $0.accessibility == .afterFirstUnlock })
+    #expect(pendingSecretMutationNames() == [])
+
+    #expect(renameStoredSecret(account: "OLD_TOKEN", to: "NEW_TOKEN", service: service) == errSecSuccess)
+    #expect(loadStoredSecrets(service: service).map(\.account) == ["NEW_TOKEN"])
+    #expect(loadStoredSecrets(service: service).first?.values.count == 2)
+    #expect(loadStoredSecret(account: "NEW_TOKEN", service: service) == "global")
+    #expect(loadStoredSecret(
+        account: "NEW_TOKEN",
+        source: .projectDirectory(directory),
+        service: service
+    ) == "project")
+}
+
+@Test func inconsistentMultiValueAvailabilityDeniesSelection() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let secret = StoredSecret(
+        account: "TOKEN",
+        values: [
+            StoredSecretValue(
+                source: .global,
+                keychainAccount: "TOKEN",
+                accessibility: .whenUnlocked,
+                keychainProperties: []
+            ),
+            StoredSecretValue(
+                source: .projectDirectory(cwd),
+                keychainAccount: "PROJECT_TOKEN",
+                accessibility: .afterFirstUnlock,
+                keychainProperties: []
+            ),
+        ]
+    )
+    #expect(throws: StoredSecretSelectionError.self) {
+        try resolveStoredSecretValues(names: ["TOKEN"], cwd: cwd, secrets: [secret])
+    }
+}
+
 @Test func backgroundMetadataMigratesWithoutChangingSecretAccessibility() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let policyService = "com.automicvault.tests.policy.\(UUID().uuidString)"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -1021,6 +1021,60 @@ func protectionPolicyMatrix(
     }
 }
 
+@Test func deletingOneValueRetainsDirectAccessUntilTheLastValueIsDeleted() throws {
+    guard dataProtectionKeychainAvailable() else { return }
+    let secretService = "com.automicvault.tests.project-delete.\(UUID().uuidString)"
+    let policyService = "com.automicvault.tests.project-delete-policy.\(UUID().uuidString)"
+    let policyAccount = "rules"
+    let directory = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let launcher = BlessedScriptLauncher(bundleIdentifier: "terminal", requirement: "identifier terminal")
+    defer {
+        _ = deleteStoredSecret(account: "TOKEN", service: secretService)
+        _ = deleteStoredSecret(account: policyAccount, service: policyService)
+    }
+    #expect(saveStoredSecret(account: "TOKEN", value: "global", service: secretService) == errSecSuccess)
+    #expect(saveStoredSecret(
+        account: "TOKEN",
+        value: "project",
+        source: .projectDirectory(directory),
+        service: secretService
+    ) == errSecSuccess)
+    #expect(allowDirectAccess(
+        to: "TOKEN", for: launcher, service: policyService, account: policyAccount
+    ) == errSecSuccess)
+
+    #expect(deleteStoredSecretValueRevokingDirectAccessIfLast(
+        secretName: "TOKEN",
+        source: .projectDirectory(directory),
+        service: secretService,
+        directAccessService: policyService,
+        directAccessAccount: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).count == 1)
+
+    #expect(deleteStoredSecretValueRevokingDirectAccessIfLast(
+        secretName: "TOKEN",
+        source: .global,
+        service: secretService,
+        directAccessService: policyService,
+        directAccessAccount: policyAccount
+    ) == errSecSuccess)
+    #expect(loadDirectAccessRules(service: policyService, account: policyAccount).isEmpty)
+}
+
+@Test func malformedProjectValueAccountsFailClosed() {
+    guard dataProtectionKeychainAvailable() else { return }
+    let service = "com.automicvault.tests.project-corruption.\(UUID().uuidString)"
+    let account = "AVProjectValueV1:not-valid"
+    defer { _ = deleteStoredSecretValue(secretName: account, source: .global, service: service) }
+    #expect(saveStoredSecret(account: account, value: "secret", service: service) == errSecSuccess)
+    guard case .failure(let status) = loadStoredSecretsResult(service: service) else {
+        Issue.record("malformed encoded account was accepted")
+        return
+    }
+    #expect(status == errSecDecode)
+}
+
 @Test func backgroundMetadataMigratesWithoutChangingSecretAccessibility() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let policyService = "com.automicvault.tests.policy.\(UUID().uuidString)"

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -24,6 +24,44 @@ pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {
     .map(|_| ())
 }
 
+pub(crate) fn store_project_secret(
+    account: &str,
+    value: &str,
+    project_directory: &str,
+) -> Result<(), String> {
+    if let Some(dir) = crate::test_keychain_dir() {
+        let path = test_project_secret_path(&dir, project_directory, account);
+        std::fs::create_dir_all(path.parent().unwrap())
+            .map_err(|err| format!("failed to create test project keychain dir: {err}"))?;
+        return std::fs::write(&path, value)
+            .map_err(|err| format!("failed to write {}: {err}", path.display()));
+    }
+    xpc_request_with_project_directory(
+        "save",
+        Some((b"key\0", account)),
+        Some((b"value\0", value)),
+        None,
+        None,
+        Some(project_directory),
+    )
+    .map(|_| ())
+}
+
+pub(crate) fn test_project_secret_path(
+    keychain_directory: &std::path::Path,
+    project_directory: &str,
+    account: &str,
+) -> PathBuf {
+    keychain_directory
+        .join(".project-values")
+        .join(hex(project_directory.as_bytes()))
+        .join(account)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
 pub(crate) fn store_secret_if_absent_or_equal(account: &str, value: &str) -> Result<(), String> {
     if let Some(dir) = crate::test_keychain_dir() {
         std::fs::create_dir_all(&dir)
@@ -160,6 +198,18 @@ fn xpc_request(
     bool_field: Option<&'static [u8]>,
     uint_field: Option<(&'static [u8], u64)>,
 ) -> Result<XpcReply, String> {
+    xpc_request_with_project_directory(operation, field, extra, bool_field, uint_field, None)
+}
+
+#[cfg(target_os = "macos")]
+fn xpc_request_with_project_directory(
+    operation: &str,
+    field: Option<(&'static [u8], &str)>,
+    extra: Option<(&'static [u8], &str)>,
+    bool_field: Option<&'static [u8]>,
+    uint_field: Option<(&'static [u8], u64)>,
+    project_directory: Option<&str>,
+) -> Result<XpcReply, String> {
     use std::ffi::CString;
     use std::os::raw::{c_char, c_int, c_void};
 
@@ -247,6 +297,9 @@ fn xpc_request(
         }
         if let Some((uint_field, value)) = uint_field {
             xpc_dictionary_set_uint64(message, uint_field.as_ptr().cast(), value);
+        }
+        if let Some(project_directory) = project_directory {
+            set_string(message, b"project_directory\0", project_directory)?;
         }
         xpc_dictionary_set_bool(message, b"interactive\0".as_ptr().cast(), true);
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 1;
 


### PR DESCRIPTION
Depends on #163.

## Summary
- model each Secret as one optional Global Value plus Project Values selected independently by physical ancestor traversal
- add `av save --project-directory=DIR NAME` and perform exact, service-side selection before authorization
- preserve name-based authority across all Values while binding the selected Value into prompts, transient approvals, history, and exact post-approval loads
- add Value management to the app, inherited-value warnings, and one Secret Availability setting across Values
- fail closed on malformed/inconsistent Keychain state and use a persisted forward-repair journal for multi-item rename, availability, and deletion
- document the domain model and security decision in ADR 0013

## Verification
- `cargo fmt --check`
- `cargo test` (851 unit tests plus integration suites)
- `swift test --package-path src/menu-helper` (108 tests)
- `git diff --check`