### PR TITLE
Record Target runtime posture for automic Secret Use

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,6 +314,13 @@ inspection or migration.
 
 Authorization History is bounded local operational history. Same-user compromise or storage failure can damage it. Product copy must not promise an append-only audit trail or complete forensic evidence.
 
+For an automically authorized Secret Use, the Authorization Record includes the
+Target's available Hardened Runtime posture at authorization time. Ordinary
+`av inject` requests inspect the resolved Target executable because it has not
+started yet; integrations with an existing Target process inspect that live
+process. Missing or unsafe posture is recorded as exposure information without
+changing the Authorization Decision.
+
 The exact Agent Task Context UUID is not part of the Authorization Record or
 telemetry. History identifies the Temporary Access Grant decision source,
 Verified Launcher, Authorization Gate, and operation without persisting the

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -391,7 +391,7 @@ Permission for one Verified Launcher to execute an exact Blessing with automic a
 
 ### Authorization Record
 
-A local record of an Authorization Request and its Authorization Decision. It includes the decision source, Launcher, Gate Client, Target, Secret Names, and operation.
+A local record of an Authorization Request and its Authorization Decision. It includes the decision source, Launcher, Gate Client, Target, Secret Names, and operation. For an automically authorized Secret Use, it also records the Target's available Hardened Runtime posture at authorization time. This posture is diagnostic metadata, not Target identity evidence or an authorization input.
 
 Automic Vault persists and verifies a record of allowed Secret Use before releasing a Secret. Failure to persist that required record denies the request. Records of denials and failures are best effort. Authorization History is bounded and local; it is not an append-only, tamper-proof, or complete forensic log.
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2947,6 +2947,9 @@ private struct AccessRequestRow: View {
                     }
                     AccessMetaLine("Gate client", record.callerPath)
                     AccessMetaLine("Target", record.target)
+                    if let runtime = record.targetRuntimeProtection {
+                        AccessMetaLine("Target runtime", runtime)
+                    }
                     AccessMetaLine("Working directory", escapedSecurityPath(record.cwd))
                     if let detail = record.detail, !detail.isEmpty {
                         AccessMetaLine("Detail", detail)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1430,12 +1430,28 @@ private func automaticTargetRuntimeProtection(
 
     let protection: LauncherRuntimeProtection?
     if let parent = request.dockerParent {
-        protection = liveSigningInfo(pid: parent.pid)?.runtimeProtection
+        protection = liveSigningInfo(for: parent)?.runtimeProtection
     } else {
         protection = executableSigningInfo(path: request.target)?.runtimeProtection
     }
     return protection?.targetAuthorizationHistoryDescription
         ?? "Hardened Runtime could not be verified; Secret may be exposed to debugging or process-memory inspection"
+}
+
+private func liveSigningInfo(for parent: DockerCredentialParent) -> LiveSigningInfo? {
+    func matches(_ identity: AVProcessIdentity) -> Bool {
+        identity.start_usec == parent.startUsec
+            && identity.euid == parent.euid
+            && pathString(identity) == parent.target
+    }
+    var before = AVProcessIdentity()
+    guard av_process_identity(parent.pid, &before),
+          matches(before),
+          let signing = liveSigningInfo(pid: parent.pid),
+          signing.mainExecutable == parent.target
+    else { return nil }
+    var after = AVProcessIdentity()
+    return av_process_identity(parent.pid, &after) && matches(after) ? signing : nil
 }
 
 private func shortAppName(_ identifier: String) -> String {
@@ -7433,6 +7449,18 @@ private func runSecretMutationSelfCheck() -> Int32 {
 @MainActor
 private func runApprovalSelfCheck() -> Int32 {
     let helperSigning = SigningInfo(identifier: "com.automicvault", teamIdentifier: "TEAM")
+    var selfIdentity = AVProcessIdentity()
+    guard av_process_identity(getpid(), &selfIdentity), liveSigningInfo(pid: getpid()) != nil else {
+        return 1
+    }
+    let reusedDockerPID = DockerCredentialParent(
+        pid: getpid(),
+        startUsec: selfIdentity.start_usec &+ 1,
+        euid: selfIdentity.euid,
+        target: pathString(selfIdentity),
+        arguments: []
+    )
+    guard liveSigningInfo(for: reusedDockerPID) == nil else { return 1 }
     let targetRuntimeRequest = ApprovalRequest(
         op: "inject",
         keys: ["TEST_SECRET"],

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1406,11 +1406,36 @@ private func accessRequestRecord(
         launcher: launcher.map { approvalPromptRequester(launcher: $0, fallback: $0.path).name },
         callerPath: callerPath,
         target: request.target,
+        targetRuntimeProtection: automaticTargetRuntimeProtection(
+            request: request,
+            decision: decision,
+            approvalSource: approvalSource
+        ),
         cwd: request.cwd,
         keys: request.keys.sorted(),
         detail: request.detail,
         secretValueSources: request.selectedValues.mapValues { $0.source.displayName }
     )
+}
+
+private func automaticTargetRuntimeProtection(
+    request: ApprovalRequest,
+    decision: String,
+    approvalSource: String
+) -> String? {
+    guard decision == "Approved",
+          approvalSource.caseInsensitiveCompare("Auto") == .orderedSame,
+          !request.selectedValues.isEmpty
+    else { return nil }
+
+    let protection: LauncherRuntimeProtection?
+    if let parent = request.dockerParent {
+        protection = liveSigningInfo(pid: parent.pid)?.runtimeProtection
+    } else {
+        protection = executableSigningInfo(path: request.target)?.runtimeProtection
+    }
+    return protection?.targetAuthorizationHistoryDescription
+        ?? "Hardened Runtime could not be verified; Secret may be exposed to debugging or process-memory inspection"
 }
 
 private func shortAppName(_ identifier: String) -> String {
@@ -7408,11 +7433,45 @@ private func runSecretMutationSelfCheck() -> Int32 {
 @MainActor
 private func runApprovalSelfCheck() -> Int32 {
     let helperSigning = SigningInfo(identifier: "com.automicvault", teamIdentifier: "TEAM")
+    let targetRuntimeRequest = ApprovalRequest(
+        op: "inject",
+        keys: ["TEST_SECRET"],
+        target: "/bin/zsh",
+        args: [],
+        cwd: "/tmp",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        envConflicts: [],
+        shebangScript: nil,
+        scriptData: nil,
+        tool: nil,
+        title: nil,
+        detail: nil,
+        selectedValues: [
+            "TEST_SECRET": StoredSecretValue(
+                source: .global,
+                keychainAccount: "TEST_SECRET",
+                accessibility: .whenUnlocked,
+                keychainProperties: []
+            ),
+        ]
+    )
     guard processEnvironmentValueSelfCheck() else {
         print("bounded peer environment self-check failed")
         return 2
     }
-    guard !makeApprovalPanel().isMovableByWindowBackground else { return 1 }
+    guard automaticTargetRuntimeProtection(
+        request: targetRuntimeRequest,
+        decision: "Approved",
+        approvalSource: "Auto"
+    ) != nil,
+    automaticTargetRuntimeProtection(
+        request: targetRuntimeRequest,
+        decision: "Approved",
+        approvalSource: "Manual"
+    ) == nil,
+    !makeApprovalPanel().isMovableByWindowBackground
+    else { return 1 }
     guard isTrustedMenuHelperCaller(
         path: "/Applications/Automic Vault.app/Contents/MacOS/AutomicVaultMenubar",
         signing: helperSigning

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -494,6 +494,19 @@ public enum LauncherRuntimeProtection: Equatable, Sendable {
     }
 
     public var allowsSecretGateAccess: Bool { secretGateAdmissionRequirement != nil }
+
+    public var targetAuthorizationHistoryDescription: String {
+        switch self {
+        case .hardened:
+            "Hardened Runtime"
+        case .hardenedWithLibraryValidationDisabled:
+            "Hardened Runtime; library validation disabled; third-party code can run inside the Target"
+        case .hardenedRuntimeMissing:
+            "Hardened Runtime not enabled; Secret may be exposed to debugging or process-memory inspection"
+        case .unsafeEntitlements(let entitlements):
+            "Hardened Runtime weakened by \(entitlements.joined(separator: ", ")); Secret may be exposed to injected or debugging code"
+        }
+    }
 }
 
 public enum LauncherRuntimeRequirement: String, Codable, Hashable, Sendable {
@@ -730,6 +743,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
     public let launcher: String?
     public let callerPath: String
     public let target: String
+    public let targetRuntimeProtection: String?
     public let cwd: String
     public let keys: [String]
     public let detail: String?
@@ -747,6 +761,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         launcher: String?,
         callerPath: String,
         target: String,
+        targetRuntimeProtection: String? = nil,
         cwd: String,
         keys: [String],
         detail: String?,
@@ -763,6 +778,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         self.launcher = launcher
         self.callerPath = callerPath
         self.target = target
+        self.targetRuntimeProtection = targetRuntimeProtection
         self.cwd = cwd
         self.keys = keys
         self.detail = detail

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationCommandRedactorTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationCommandRedactorTests.swift
@@ -91,6 +91,7 @@ import Testing
         launcher: "Terminal",
         callerPath: "/usr/local/bin/av",
         target: "/usr/bin/curl",
+        targetRuntimeProtection: "Hardened Runtime",
         cwd: "/tmp",
         keys: [],
         detail: nil
@@ -99,6 +100,7 @@ import Testing
     let decoded = try JSONDecoder().decode(AccessRequestRecord.self, from: JSONEncoder().encode(record))
     #expect(decoded.command == "curl --api-key api-secret")
     #expect(decoded.commandForDisplay == "curl --api-key <redacted>")
+    #expect(decoded.targetRuntimeProtection == "Hardened Runtime")
     #expect(!decoded.commandForDisplay.contains("api-secret"))
 }
 
@@ -123,5 +125,6 @@ import Testing
     let record = try JSONDecoder().decode(AccessRequestRecord.self, from: data)
     #expect(record.command == "gh api --header Authorization:secret-value")
     #expect(record.commandForDisplay == "gh <arguments hidden>")
+    #expect(record.targetRuntimeProtection == nil)
     #expect(!record.commandForDisplay.contains("secret-value"))
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
@@ -72,3 +72,19 @@ import Testing
 
     #expect(LauncherRuntimeRequirement.legacyUnchecked.allows(.hardenedRuntimeMissing))
 }
+
+@Test func targetRuntimeHistoryExplainsSecretExposure() {
+    #expect(
+        LauncherRuntimeProtection.hardened.targetAuthorizationHistoryDescription
+            == "Hardened Runtime"
+    )
+    #expect(
+        LauncherRuntimeProtection.hardenedRuntimeMissing.targetAuthorizationHistoryDescription
+            .contains("Secret may be exposed to debugging or process-memory inspection")
+    )
+    #expect(
+        LauncherRuntimeProtection.unsafeEntitlements([
+            "com.apple.security.get-task-allow",
+        ]).targetAuthorizationHistoryDescription.contains("debugging code")
+    )
+}


### PR DESCRIPTION
## Summary

- record the Target’s Hardened Runtime posture for automically authorized Secret Use
- show the posture in Authorization History, including debugging and process-memory exposure when Hardened Runtime is absent or unverifiable
- inspect the resolved executable for ordinary `av inject` requests and the live process for integrations whose Target already exists

## Why

Authorization History identified the Target but did not preserve whether the process receiving the Secret was protected by Hardened Runtime. This made an automatically applied Secret entering an unhardened consumer such as `node` indistinguishable from a hardened Target.

This is diagnostic metadata only. It does not change the Authorization Decision, Target identity, or manual Approval behavior. The new optional record field remains compatible with existing Authorization History entries.

## Validation

- `swift test --package-path src/menu-helper --disable-automatic-resolution` — 131 tests passed
- `src/menu-helper/.build/debug/AutomicVaultMenubar --self-check-approvals` — passed
- `git diff --check origin/main...HEAD` — passed
