### PR TITLE
Show temporary access usage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -371,10 +371,10 @@ Launcher Provenance and does not require this setting.
 
 While any Temporary Access Grant exists, a non-activating strip remains visible
 directly below the menu-bar item with every scoped grant, second-accurate
-remaining time, and an End action. The menu mirrors those actions and the shield
-turns orange. Automatic-request notifications stack below the strip. This
-continuous presentation is part of the temporary escalation's safety model,
-not a source of authority.
+remaining time, successful-use count, last-use time, and an End action. The menu
+mirrors those actions and the shield turns orange. Automatic-request
+notifications stack below the strip. This continuous presentation is part of
+the temporary escalation's safety model, not a source of authority.
 
 ## Source of truth
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -269,9 +269,10 @@ Secret mutation operations remain outside the grant.
 A Temporary Access Grant can begin only when the user selects its explicit
 action in an eligible live write-request Approval. It is not a
 durable Authorization Policy or Blessing. Automic Vault shows every active
-grant continuously, lets the user end each grant immediately, and revokes all
-grants when the user session becomes inactive, displays sleep, an update begins,
-or the service terminates. Expiry uses both wall and monotonic clocks.
+grant continuously with its successful-use count and last-use time, lets the
+user end each grant immediately, and revokes all grants when the user session
+becomes inactive, displays sleep, an update begins, or the service terminates.
+Expiry uses both wall and monotonic clocks.
 
 ### Fail Closed
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3642,7 +3642,7 @@ private final class ApprovalServer: @unchecked Sendable {
                         launcher: launcher
                     )) else {
                         reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
-                        return true
+                        return false
                     }
                     rememberRetainedProvenance(
                         at: authorizationGate,
@@ -7384,6 +7384,11 @@ private func temporaryAccessGrantRemainingText(_ remaining: TimeInterval) -> Str
     return String(format: "%d:%02d", seconds / 60, seconds % 60)
 }
 
+private func temporaryAccessGrantUsageText(_ grant: TemporaryAccessGrantSnapshot) -> String {
+    let uses = grant.useCount == 1 ? "1 use" : "\(grant.useCount) uses"
+    return "Write Access: \(uses) · Last used \(grant.lastUsedAt.formatted(date: .omitted, time: .standard))"
+}
+
 private func temporaryAccessGrantMenuTitle(
     _ grant: TemporaryAccessGrantSnapshot,
     wallNow: Date,
@@ -7392,7 +7397,7 @@ private func temporaryAccessGrantMenuTitle(
     let remaining = temporaryAccessGrantRemainingText(
         grant.remaining(wallNow: wallNow, monotonicNow: monotonicNow)
     )
-    return "\(grant.launcherName) → \(grant.authorizationGateName) · \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(remaining) — End"
+    return "\(grant.launcherName) → \(grant.authorizationGateName) · \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(remaining) · \(temporaryAccessGrantUsageText(grant)) — End"
 }
 
 private final class TemporaryAccessGrantPanel: NSPanel {
@@ -7497,11 +7502,14 @@ private struct TemporaryAccessGrantRow: View {
                 Text("\(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(temporaryAccessGrantRemainingText(remaining)) remaining")
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
+                Text(temporaryAccessGrantUsageText(grant))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(
-                "\(grant.launcherName), \(grant.authorizationGateName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID), \(temporaryAccessGrantRemainingText(remaining)) remaining"
+                "\(grant.launcherName), \(grant.authorizationGateName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID), \(temporaryAccessGrantRemainingText(remaining)) remaining, \(temporaryAccessGrantUsageText(grant))"
             )
 
             Button("End", action: end)
@@ -9601,7 +9609,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
               grant,
               wallNow: grantWallNow,
               monotonicNow: grantMonotonicNow
-          ) == "Codex → AWS Authorization Gate · Codex task 11111111 · 10:00 — End",
+          ).contains("Codex → AWS Authorization Gate · Codex task 11111111 · 10:00 · Write Access: 1 use · Last used "),
           stripView.fittingSize.width == 430,
           stackedToastFrame.maxY == sampleStripFrame.minY - 4,
           grantPanel.styleMask.contains(.borderless),

--- a/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
@@ -92,6 +92,8 @@ public struct TemporaryAccessGrantSnapshot: Identifiable, Equatable, Sendable {
     public let grantedAt: Date
     public let expiresAt: Date
     public let monotonicDeadline: TimeInterval
+    public let useCount: Int
+    public let lastUsedAt: Date
 
     public func remaining(wallNow: Date, monotonicNow: TimeInterval) -> TimeInterval {
         max(0, min(expiresAt.timeIntervalSince(wallNow), monotonicDeadline - monotonicNow))
@@ -110,6 +112,8 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         let grantedAt: Date
         let expiresAt: Date
         let monotonicDeadline: TimeInterval
+        var useCount: Int
+        var lastUsedAt: Date
 
         var snapshot: TemporaryAccessGrantSnapshot {
             TemporaryAccessGrantSnapshot(
@@ -120,7 +124,9 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
                 authorizationGateName: authorizationGateName,
                 grantedAt: grantedAt,
                 expiresAt: expiresAt,
-                monotonicDeadline: monotonicDeadline
+                monotonicDeadline: monotonicDeadline,
+                useCount: useCount,
+                lastUsedAt: lastUsedAt
             )
         }
 
@@ -172,7 +178,9 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
             authorizationGateName: authorizationGateName,
             grantedAt: wallNow,
             expiresAt: wallNow.addingTimeInterval(Self.duration),
-            monotonicDeadline: monotonicNow + Self.duration
+            monotonicDeadline: monotonicNow + Self.duration,
+            useCount: 1,
+            lastUsedAt: wallNow
         )
         grants[id] = grant
         return try (grant.snapshot, body(grant.snapshot))
@@ -205,7 +213,7 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         grants.removeAll()
     }
 
-    public func withActiveLease<Result>(
+    public func withActiveLease(
         authorizationGateID: String,
         launcherDesignatedRequirement: String,
         launcherRuntimeProtection: LauncherRuntimeProtection,
@@ -213,12 +221,12 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         classification: SecretGateRequestClassification,
         wallNow: Date = Date(),
         monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime,
-        _ body: (TemporaryAccessGrantSnapshot) throws -> Result
-    ) rethrows -> Result? {
+        _ didUse: (TemporaryAccessGrantSnapshot) throws -> Bool
+    ) rethrows -> Bool? {
         lock.lock()
         defer { lock.unlock() }
         removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
-        guard let grant = grants.values.first(where: {
+        guard var grant = grants.values.first(where: {
             $0.scope.matches(
                 authorizationGateID: authorizationGateID,
                 launcherDesignatedRequirement: launcherDesignatedRequirement,
@@ -227,7 +235,12 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
                 classification: classification
             )
         }) else { return nil }
-        return try body(grant.snapshot)
+        if try didUse(grant.snapshot) {
+            grant.useCount += 1
+            grant.lastUsedAt = wallNow
+            grants[grant.id] = grant
+        }
+        return true
     }
 
     private func removeExpired(wallNow: Date, monotonicNow: TimeInterval) {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
@@ -102,7 +102,55 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
     #expect(refreshed.id == first.id)
     #expect(refreshed.generation != first.generation)
     #expect(refreshed.expiresAt == start.addingTimeInterval(620))
+    #expect(refreshed.useCount == 1)
+    #expect(refreshed.lastUsedAt == start.addingTimeInterval(20))
     #expect(controller.snapshots(wallNow: start, monotonicNow: 30).count == 2)
+}
+
+@Test func successfulUsesUpdateGrantUsage() throws {
+    let controller = TemporaryAccessGrantController()
+    let start = Date(timeIntervalSince1970: 1_000)
+    let grant = controller.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 10
+    )
+    #expect(grant.useCount == 1)
+    #expect(grant.lastUsedAt == start)
+
+    _ = controller.withActiveLease(
+        authorizationGateID: "aws",
+        launcherDesignatedRequirement: "identifier com.example.launcher",
+        launcherRuntimeProtection: .hardened,
+        agentTaskContext: AgentTaskContext(provider: .codex, id: codexID),
+        classification: .mutating,
+        wallNow: start.addingTimeInterval(5),
+        monotonicNow: 15
+    ) { _ in false }
+    let afterFailure = try #require(controller.snapshots(
+        wallNow: start.addingTimeInterval(5),
+        monotonicNow: 15
+    ).first)
+    #expect(afterFailure.useCount == 1)
+    #expect(afterFailure.lastUsedAt == start)
+
+    _ = controller.withActiveLease(
+        authorizationGateID: "aws",
+        launcherDesignatedRequirement: "identifier com.example.launcher",
+        launcherRuntimeProtection: .hardened,
+        agentTaskContext: AgentTaskContext(provider: .codex, id: codexID),
+        classification: .mutating,
+        wallNow: start.addingTimeInterval(10),
+        monotonicNow: 20
+    ) { _ in true }
+    let afterSuccess = try #require(controller.snapshots(
+        wallNow: start.addingTimeInterval(10),
+        monotonicNow: 20
+    ).first)
+    #expect(afterSuccess.useCount == 2)
+    #expect(afterSuccess.lastUsedAt == start.addingTimeInterval(10))
 }
 
 @Test func exactScopeAndWriteClassificationAreRequired() {
@@ -176,7 +224,7 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
     let release = DispatchSemaphore(value: 0)
     let leaseFinished = DispatchSemaphore(value: 0)
     Thread.detachNewThread {
-        controller.withActiveLease(
+        _ = controller.withActiveLease(
             authorizationGateID: "aws",
             launcherDesignatedRequirement: "identifier com.example.launcher",
             launcherRuntimeProtection: .hardened,
@@ -187,6 +235,7 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
         ) { _ in
             entered.signal()
             _ = release.wait(timeout: .now() + 5)
+            return true
         }
         leaseFinished.signal()
     }


### PR DESCRIPTION
## Summary

- Show each Temporary Access Grant’s successful-use count and last-use timestamp in the persistent strip and menu.
- Count the activating request as the first use, reset usage for a newly confirmed generation, and increment only after payload loading and Authorization Record persistence succeed.
- Update the canonical domain language and architecture documentation for the expanded continuous presentation.

## Why

Temporary Write Access is a visible security escalation. Showing how often it has been exercised and when it was last used gives the user live context while deciding whether to end it.

## Validation

- `swift test` — 133 tests passed
- `.build/debug/AutomicVaultMenubar --self-check-menu-status`
