### PR TITLE
Reject cyclic project directory ancestry

### DIFF
--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1565,6 +1565,7 @@ public enum ProjectDirectoryValidationError: Error, LocalizedError, Equatable {
     case notCanonical(String)
     case filesystemIdentityUnavailable
     case filesystemRoot
+    case filesystemCycle
 
     public var errorDescription: String? {
         switch self {
@@ -1574,6 +1575,7 @@ public enum ProjectDirectoryValidationError: Error, LocalizedError, Equatable {
         case .notCanonical(let path): "project directory must be canonical: \(path)"
         case .filesystemIdentityUnavailable: "project directory filesystem is unavailable"
         case .filesystemRoot: "project directory cannot be a filesystem root"
+        case .filesystemCycle: "project directory ancestry contains a filesystem cycle"
         }
     }
 }
@@ -1623,23 +1625,34 @@ public func canonicalProjectDirectory(_ path: String) throws -> String {
     return directory.path
 }
 
-public func physicalDirectoryAncestors(_ path: String) throws -> [String] {
-    let start = try canonicalDirectory(path)
+func physicalDirectoryAncestors(
+    _ path: String,
+    canonicalize: (String) throws -> (path: String, device: UInt64)
+) throws -> [String] {
+    let start = try canonicalize(path)
     guard start.path == path else {
         throw ProjectDirectoryValidationError.notCanonical(start.path)
     }
     var result = [start.path]
+    var seen = Set(result)
     var current = start.path
     while true {
         let parent = URL(fileURLWithPath: current, isDirectory: true)
             .deletingLastPathComponent().path
         guard parent != current else { break }
-        let parentDirectory = try canonicalDirectory(parent)
+        let parentDirectory = try canonicalize(parent)
         guard parentDirectory.device == start.device else { break }
+        guard seen.insert(parentDirectory.path).inserted else {
+            throw ProjectDirectoryValidationError.filesystemCycle
+        }
         result.append(parentDirectory.path)
         current = parentDirectory.path
     }
     return result
+}
+
+public func physicalDirectoryAncestors(_ path: String) throws -> [String] {
+    try physicalDirectoryAncestors(path, canonicalize: canonicalDirectory)
 }
 
 public enum StoredSecretSelectionError: Error, LocalizedError, Equatable {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -1001,6 +1001,18 @@ func protectionPolicyMatrix(
     }
 }
 
+@Test func physicalDirectoryAncestorsRejectsCanonicalizationCycles() {
+    #expect(throws: ProjectDirectoryValidationError.filesystemCycle) {
+        try physicalDirectoryAncestors("/cycle/child") { path in
+            switch path {
+            case "/cycle/child": (path, 1)
+            case "/cycle": ("/cycle/child", 1)
+            default: (path, 1)
+            }
+        }
+    }
+}
+
 @Test func multiValueAvailabilityAndRenameCompleteAsForwardOperations() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.project-mutation.\(UUID().uuidString)"


### PR DESCRIPTION
Fixes the hang and runaway memory growth reported in #176.

The reporter's sample holds the XPC request thread in `resolveStoredSecretValues` → `physicalDirectoryAncestors` → `canonicalDirectory` for the entire sample. A canonicalized parent can resolve to a directory already visited, so the loop never returns; the callback then continually allocates Foundation bridge objects without draining its autorelease pool. This also explains why a secretless `av inject` reaches Approval while a named-Secret request does not.

This change tracks canonical directories already visited and fails closed with `filesystemCycle` rather than selecting a Secret Value from ambiguous partial ancestry. The injected canonicalizer exists only to make the filesystem cycle deterministic in the focused regression test.

The ancestor implementation is unchanged between 3.8.0 and 3.9.0, so this appears to be a latent filesystem-dependent bug exposed around the upgrade rather than a 3.9-only regression.

Based directly on the `3.9.0` tag for inclusion in 3.9.1.

Verification:
- `swift test --package-path src/menu-helper --disable-automatic-resolution` (133 tests)