### PR TITLE
Connect approval relay only while requests are pending

### DIFF
--- a/src/ios/ApprovalApp/ApprovalApp.swift
+++ b/src/ios/ApprovalApp/ApprovalApp.swift
@@ -105,7 +105,6 @@ final class ApprovalModel {
     }
 
     private(set) var pending: [PhoneApprovalRequest] = []
-    private(set) var connectedMacs: [String: String] = [:]
     private(set) var state: ConnectionState = .setup
     var errorMessage: String?
     var biometricProtectionEnabled = UserDefaults.standard.bool(forKey: biometricDefaultsKey) {
@@ -280,8 +279,8 @@ final class ApprovalModel {
                 case .cancel(let requestID):
                     pending.removeAll { $0.id == requestID }
                     await removeDeliveredNotifications(for: requestID)
-                case .presence(let presence):
-                    connectedMacs[presence.macID] = presence.macName
+                case .presence:
+                    break
                 case .sync:
                     break
                 }

--- a/src/ios/ApprovalApp/ApprovalViews.swift
+++ b/src/ios/ApprovalApp/ApprovalViews.swift
@@ -93,11 +93,8 @@ struct ApprovalRootView: View {
     private var connectionText: String {
         switch model.state {
         case .setup: "Enable notifications to receive Approval requests."
-        case .connecting: "Connecting to your Macs…"
-        case .connected where model.connectedMacs.isEmpty:
-            "Connected. Waiting to hear from an enrolled Mac."
-        case .connected:
-            "Connected Macs: \(model.connectedMacs.values.sorted().joined(separator: ", "))."
+        case .connecting: "Connecting…"
+        case .connected: "Ready for Approval requests."
         case .unavailable(let reason): reason
         case .reconnecting(let reason): reason
         }

--- a/src/menu-helper/Sources/ApprovalCore/ApprovalRelayClient.swift
+++ b/src/menu-helper/Sources/ApprovalCore/ApprovalRelayClient.swift
@@ -92,6 +92,20 @@ public actor ApprovalRelayClient {
         return try JSONDecoder().decode(ApprovalWireMessage.self, from: plaintext)
     }
 
+    public func ping() async throws {
+        guard let connection else { throw ApprovalRelayClientError.disconnected }
+        try await waitUntilReady(connection)
+        do {
+            try await Self.waitUntilReady(connection.socket)
+            guard self.connection?.id == connection.id else {
+                throw ApprovalRelayClientError.disconnected
+            }
+        } catch {
+            if self.connection?.id == connection.id { disconnect() }
+            throw error
+        }
+    }
+
     public func publish(_ request: PhoneApprovalRequest) async throws {
         guard let connection else { throw ApprovalRelayClientError.disconnected }
         try await waitUntilReady(connection)

--- a/src/menu-helper/Sources/MenubarHelper/PhoneApprovalCoordinator.swift
+++ b/src/menu-helper/Sources/MenubarHelper/PhoneApprovalCoordinator.swift
@@ -122,6 +122,7 @@ private actor PhoneApprovalRelayWorker {
     private var generation: UInt64
     private var pending: [UUID: PhoneApprovalRequest] = [:]
     private var canceled: Set<UUID> = []
+    private var published: Set<UUID> = []
     private var relay: ApprovalRelayClient?
     private var connectionTask: Task<Void, Never>?
     private var connectionID: UUID?
@@ -135,7 +136,6 @@ private actor PhoneApprovalRelayWorker {
     func start(generation: UInt64) async {
         guard generation >= self.generation else { return }
         if generation > self.generation { await reset(generation: generation) }
-        startConnectionIfNeeded()
     }
 
     func submit(_ request: PhoneApprovalRequest, generation: UInt64) async {
@@ -145,7 +145,7 @@ private actor PhoneApprovalRelayWorker {
         startConnectionIfNeeded()
         guard let relay else { return }
         do {
-            try await relay.publish(request)
+            try await publishIfNeeded(request, relay: relay)
         } catch {
             await relay.disconnect()
         }
@@ -156,6 +156,8 @@ private actor PhoneApprovalRelayWorker {
         canceled.insert(requestID)
         guard pending.removeValue(forKey: requestID) != nil else { return }
         if let relay { try? await relay.send(.cancel(requestID)) }
+        published.remove(requestID)
+        await disconnectIfIdle()
     }
 
     func stop(generation: UInt64) async {
@@ -172,10 +174,11 @@ private actor PhoneApprovalRelayWorker {
         relay = nil
         pending.removeAll()
         canceled.removeAll()
+        published.removeAll()
     }
 
     private func startConnectionIfNeeded() {
-        guard connectionTask == nil else { return }
+        guard !pending.isEmpty, connectionTask == nil else { return }
         let connectionID = UUID()
         self.connectionID = connectionID
         connectionTask = Task { [weak self] in
@@ -185,36 +188,95 @@ private actor PhoneApprovalRelayWorker {
 
     private func runConnection(connectionID: UUID) async {
         var retrySeconds: UInt64 = 1
-        while self.connectionID == connectionID && !Task.isCancelled {
+        while self.connectionID == connectionID && !Task.isCancelled && !pending.isEmpty {
+            var activeRelay: ApprovalRelayClient?
+            var heartbeatTask: Task<Void, Never>?
             do {
                 let key = try ICloudApprovalRootKey().loadOrCreate()
                 let relay = try ApprovalRelayClient(endpoint: phoneApprovalRelayURL, rootKeyData: key)
+                activeRelay = relay
                 try await relay.connect(peerID: "mac-\(macID)")
-                guard self.connectionID == connectionID else {
+                guard self.connectionID == connectionID, !pending.isEmpty else {
                     await relay.disconnect()
                     return
                 }
                 self.relay = relay
+                published.removeAll()
                 try await relay.send(.presence(try presence()))
-                for request in pending.values { try await relay.publish(request) }
+                for request in Array(pending.values) {
+                    try await publishIfNeeded(request, relay: relay)
+                }
                 retrySeconds = 1
-                while self.connectionID == connectionID && !Task.isCancelled {
+                heartbeatTask = Task { [weak self] in
+                    await self?.maintainConnection(relay, connectionID: connectionID)
+                }
+                while self.connectionID == connectionID && !Task.isCancelled && !pending.isEmpty {
                     try await handle(try await relay.receive(), relay: relay)
                 }
-            } catch {
-                if let relay = self.relay { await relay.disconnect() }
-                if self.connectionID == connectionID {
-                    self.relay = nil
-                    try? await Task.sleep(for: .seconds(retrySeconds))
-                    retrySeconds = min(retrySeconds * 2, 30)
-                }
+            } catch {}
+
+            heartbeatTask?.cancel()
+            if self.connectionID == connectionID {
+                self.relay = nil
+                published.removeAll()
             }
+            if let activeRelay { await activeRelay.disconnect() }
+            guard self.connectionID == connectionID,
+                  !Task.isCancelled,
+                  !pending.isEmpty else { break }
+            try? await Task.sleep(for: .seconds(retrySeconds))
+            retrySeconds = min(retrySeconds * 2, 30)
         }
         if self.connectionID == connectionID {
             self.relay = nil
             self.connectionID = nil
             connectionTask = nil
+            published.removeAll()
+            startConnectionIfNeeded()
         }
+    }
+
+    private func publishIfNeeded(
+        _ request: PhoneApprovalRequest,
+        relay: ApprovalRelayClient
+    ) async throws {
+        guard pending[request.id] != nil, published.insert(request.id).inserted else { return }
+        do {
+            try await relay.publish(request)
+        } catch {
+            published.remove(request.id)
+            throw error
+        }
+    }
+
+    private func maintainConnection(
+        _ relay: ApprovalRelayClient,
+        connectionID: UUID
+    ) async {
+        do {
+            while self.connectionID == connectionID && !Task.isCancelled && !pending.isEmpty {
+                try await Task.sleep(for: .seconds(30))
+                guard self.connectionID == connectionID,
+                      !Task.isCancelled,
+                      !pending.isEmpty else { return }
+                try await relay.ping()
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            await relay.disconnect()
+        }
+    }
+
+    private func disconnectIfIdle() async {
+        guard pending.isEmpty else { return }
+        connectionID = nil
+        connectionTask?.cancel()
+        connectionTask = nil
+        let relay = self.relay
+        self.relay = nil
+        published.removeAll()
+        if let relay { await relay.disconnect() }
     }
 
     private func handle(_ message: ApprovalWireMessage, relay: ApprovalRelayClient) async throws {
@@ -298,15 +360,6 @@ final class PhoneApprovalCoordinator {
         UserDefaults.standard.set(true, forKey: phoneApprovalEnabledDefaultsKey)
         workerGeneration += 1
         await worker.start(generation: workerGeneration)
-    }
-
-    func startIfEnabled() {
-        guard isEnabled else { return }
-        let worker = worker
-        let generation = workerGeneration
-        Task { @concurrent in
-            await worker.start(generation: generation)
-        }
     }
 
     func submit(

--- a/src/menu-helper/Sources/MenubarHelper/PhoneApprovalCoordinator.swift
+++ b/src/menu-helper/Sources/MenubarHelper/PhoneApprovalCoordinator.swift
@@ -155,6 +155,7 @@ private actor PhoneApprovalRelayWorker {
         guard self.generation == generation else { return }
         canceled.insert(requestID)
         guard pending.removeValue(forKey: requestID) != nil else { return }
+        canceled.remove(requestID)
         if let relay { try? await relay.send(.cancel(requestID)) }
         published.remove(requestID)
         await disconnectIfIdle()
@@ -285,6 +286,7 @@ private actor PhoneApprovalRelayWorker {
             guard let request = pending[response.requestID] else { return }
             try response.validate(for: request)
             pending.removeValue(forKey: response.requestID)
+            published.remove(response.requestID)
             let result: PhoneApprovalResult = switch response.outcome {
             case .approved: .approved
             case .denied: .denied

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -339,7 +339,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             try approval.start()
             self.approval = approval
-            PhoneApprovalCoordinator.shared.startIfEnabled()
             scheduleScan(after: 0)
             scanQueue.async { [weak self] in
                 let metadata = loadDetectorMetadata(avExecutableURL: avExecutableURL())

--- a/src/menu-helper/Tests/ApprovalCoreTests/ApprovalRelayClientTests.swift
+++ b/src/menu-helper/Tests/ApprovalCoreTests/ApprovalRelayClientTests.swift
@@ -2,6 +2,31 @@
 import Foundation
 import Testing
 
+private enum PongError: Error { case failed }
+
+@Test
+func pingRequiresAConnection() async throws {
+    let relay = try ApprovalRelayClient(
+        endpoint: URL(string: "https://example.com")!,
+        rootKeyData: Data(repeating: 7, count: ApprovalCrypto.rootKeyByteCount)
+    )
+    await #expect(throws: ApprovalRelayClientError.disconnected) {
+        try await relay.ping()
+    }
+}
+
+@Test
+func pongWaitSucceeds() async throws {
+    try await ApprovalRelayClient.waitForPong { completion in completion(nil) }
+}
+
+@Test
+func pongWaitPropagatesFailure() async {
+    await #expect(throws: PongError.failed) {
+        try await ApprovalRelayClient.waitForPong { completion in completion(PongError.failed) }
+    }
+}
+
 @Test
 func canceledPongWaitDoesNotHang() async {
     let pingStarted = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))


### PR DESCRIPTION
## Summary

- connect each Mac to the Approval relay only while it has pending Approvals
- establish the receive path before publishing, keep it live with pings, and reconnect and republish on failure
- remove the iPhone misleading idle Connected Macs status

## Security

- preserves fail-closed behavior and Mac-side response validation
- leaves the relay protocol and authority model unchanged

## Testing

- swift test --package-path src/menu-helper --disable-automatic-resolution: 147 tests passed
- iPhone simulator Debug build succeeded
- deployed to Maliwan, Pangolin, and Anshin; verified both idle Macs maintain zero relay sockets