### PR TITLE
Remove Developer ID Launcher Bundle signing

### DIFF
--- a/docs/adr/0013-launcher-bundles.md
+++ b/docs/adr/0013-launcher-bundles.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-08-14
+- Amended: 2026-08-20
 
 ## Context
 
@@ -27,15 +28,14 @@ forwards its arguments and result, and executes only the payload sealed inside
 its bundle, never a command resolved through `PATH`. It remains the parent for
 ordinary payloads; a payload may deliberately daemonize and outlive it.
 
-Automic Vault signs nested code inside-out and enables Hardened Runtime. It uses
-either an Automic-created ad-hoc signature or a Developer ID Application
-identity selected by the user. Enrollment occurs only through an attended
-Automic Vault flow.
+Automic Vault signs nested code inside-out with an Automic-created ad-hoc
+signature and enables Hardened Runtime. Enrollment occurs only through an
+attended Automic Vault flow.
 
 Creation and enrollment are one attended transaction in the **Launcher
 Bundles** sidebar. Automic Vault builds and verifies a candidate in private
-temporary storage, shows the selected payload digest, signing identity, and
-effective entitlements, then installs it under
+temporary storage, shows the source and final payload digests and effective
+entitlements, then installs it under
 `/Applications/Automic Vault/` and enrolls it after the user confirms. The
 attended install uses administrator authorization so the directory, bundle, and
 command link are root-owned and protected from group or world writes. The
@@ -136,10 +136,13 @@ move the old file does not restore its enrollment or authority.
   or corrupt.
 - The ad-hoc signature supplies a code seal and Hardened Runtime posture, not a
   durable publisher identity. Re-signing changed code changes its exact signed
-  code identifier and invalidates enrollment. Developer ID-signed generations
-  are pinned the same way.
-- A user-selected Developer ID identity does not identify the CLI publisher and
-  never replaces payload pinning.
+  code identifier and invalidates enrollment.
+- A user-selected Developer ID identity would identify the user as the signer,
+  not the CLI publisher, and would not strengthen exact enrollment. New
+  generations therefore do not use the user's signing identities.
+- Developer ID-signed generations created by earlier releases retain their
+  persisted signing metadata and strict verification until replaced. Their
+  replacements use ad-hoc signing and follow the normal generation change.
 - The original unbundled executable remains a different, unverified Launcher
   and cannot match the Launcher Bundle's enrollment or Launcher-specific rules.
 - The root-owned command link preserves ordinary CLI invocation. The original

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,10 +121,11 @@ available in Automic Vault 3.9.0; either side rejects an incompatible version.
 Launcher Bundles let one unsigned Mach-O command-line tool participate as a
 Verified Launcher without treating its original path as identity. The attended
 app flow snapshots the selected file, applies Hardened Runtime, signs the
-payload and generated app inside-out, and displays both the source and final
-signed-payload SHA-256 values before enrollment. An attended privileged
-transaction installs the completed app under `/Applications/Automic Vault/`
-and its root-owned command link under `/usr/local/bin/`.
+payload and generated app inside-out with ad-hoc signatures, and displays both
+the source and final signed-payload SHA-256 values before enrollment. An attended
+privileged transaction installs the completed app under
+`/Applications/Automic Vault/` and its root-owned command link under
+`/usr/local/bin/`.
 
 The reviewed candidate is bound to that privileged transaction by a
 deterministic SHA-256 over every relative path and file byte in the completed
@@ -150,6 +151,10 @@ Identity or depend on Retained Launcher Provenance. Reserved Launcher Bundle
 identities that are moved, changed, re-signed, unenrolled, or unverifiable are
 denied before ordinary Launcher admission or Approval. See
 [ADR 0013](adr/0013-launcher-bundles.md).
+
+Developer ID-signed generations created by earlier releases retain their
+persisted signing metadata and the same strict enrollment checks. Replacing one
+creates a new ad-hoc-signed generation and revokes the old generation normally.
 
 ### Reviewed Automation
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -86,9 +86,9 @@ run inside its process and inherit its authority.
 An Automic Vault-generated macOS app bundle containing one fixed CLI payload
 and a minimal launcher executable. The launcher starts the payload as its parent
 process, and the bundle seals the payload. Enrollment binds the exact signed
-bundle generation and final bundled payload digest. Automic Vault may ad-hoc
-sign the bundle, or the user may select a Developer ID Application identity;
-either form uses Hardened Runtime and remains bound to that exact generation.
+bundle generation and final bundled payload digest. Automic Vault ad-hoc signs
+the bundle with Hardened Runtime. Developer ID-signed generations created by
+earlier releases remain bound to their exact enrollment until replaced.
 The bundled payload has its own reserved child identity and is reverified when
 live. It is not a separate Launcher Identity, but an exact live enrolled payload
 may represent its Launcher Bundle Identity after its launcher exits, including

--- a/docs/signed-cli-launchers.md
+++ b/docs/signed-cli-launchers.md
@@ -34,9 +34,10 @@ it eligible.
 
 For one unsigned Mach-O CLI executable, open **Launcher Bundles** in Automic
 Vault and choose **Create Launcher Bundle**. Choose the executable, name the
-bundle, and keep the default Automic Vault ad-hoc signing unless you have a
-Developer ID Application identity you want to use. Enable a compatibility
-exception only when the CLI requires it.
+bundle, and enable a compatibility exception only when the CLI requires it.
+Automic Vault ad-hoc signs every new Launcher Bundle, so creating one does not
+require an Apple Developer account or certificate. Older Developer ID-signed
+Launcher Bundles remain supported until replaced.
 
 Automic Vault snapshots the selected executable, signs the payload and generated
 app with Hardened Runtime, and then shows the source and final signed-payload

--- a/src/menu-helper/Sources/MenubarHelper/LauncherBundleBuilder.swift
+++ b/src/menu-helper/Sources/MenubarHelper/LauncherBundleBuilder.swift
@@ -7,8 +7,6 @@ struct LauncherBundleOptions: Sendable {
     let sourceURL: URL
     let displayName: String
     let commandName: String
-    let signingKind: LauncherBundleSigningKind
-    let signingIdentity: String?
     let allowJIT: Bool
     let allowUnsignedExecutableMemory: Bool
     let disableLibraryValidation: Bool
@@ -37,7 +35,6 @@ enum LauncherBundleCreationError: Error, LocalizedError {
     case invalidCommandName
     case commandOccupied
     case destinationOccupied
-    case invalidSigningIdentity
     case commandFailed(String)
     case invalidGeneratedCode
     case enrollmentFailed(OSStatus)
@@ -52,26 +49,10 @@ enum LauncherBundleCreationError: Error, LocalizedError {
         case .invalidCommandName: "Choose a command name without spaces or path separators"
         case .destinationOccupied: "A file already occupies the Launcher Bundle destination"
         case .commandOccupied: "A different file already occupies the Launcher Bundle command path"
-        case .invalidSigningIdentity: "Choose a valid Developer ID Application identity"
         case .commandFailed(let message): message
         case .invalidGeneratedCode: "The generated Launcher Bundle did not pass verification"
         case .enrollmentFailed(let status): "Could not enroll the Launcher Bundle: \(status)"
         }
-    }
-}
-
-func developerIDApplicationIdentities() -> [String] {
-    guard let output = try? runLauncherBundleCommand(
-        executable: "/usr/bin/security",
-        arguments: ["find-identity", "-v", "-p", "codesigning"]
-    ) else { return [] }
-    return output.split(separator: "\n").compactMap { line in
-        guard let first = line.firstIndex(of: "\""),
-              let last = line.lastIndex(of: "\""),
-              first < last
-        else { return nil }
-        let identity = String(line[line.index(after: first)..<last])
-        return identity.hasPrefix("Developer ID Application:") ? identity : nil
     }
 }
 
@@ -80,9 +61,6 @@ func prepareLauncherBundleCandidate(_ options: LauncherBundleOptions) throws -> 
     else { throw LauncherBundleCreationError.invalidDisplayName }
     guard let commandName = launcherBundleCommandName(from: options.commandName)
     else { throw LauncherBundleCreationError.invalidCommandName }
-    guard options.signingKind == .adHoc
-        || options.signingIdentity?.hasPrefix("Developer ID Application:") == true
-    else { throw LauncherBundleCreationError.invalidSigningIdentity }
     guard let runnerURL = Bundle.main.url(forResource: "AutomicVaultLauncher", withExtension: nil)
     else { throw LauncherBundleCreationError.runnerUnavailable }
     guard let iconURL = Bundle.main.url(forResource: "LauncherBundleIcon", withExtension: "icns")
@@ -139,7 +117,6 @@ func prepareLauncherBundleCandidate(_ options: LauncherBundleOptions) throws -> 
     try manager.copyItem(at: runnerURL, to: launcherURL)
     let source = try copyLauncherBundlePayload(from: options.sourceURL, to: payloadURL)
 
-    let identity = options.signingKind == .adHoc ? "-" : options.signingIdentity!
     let entitlementsURL = work.appendingPathComponent("payload-entitlements.plist")
     let entitlements: [String: Bool] = [
         "com.apple.security.cs.allow-jit": options.allowJIT,
@@ -156,7 +133,6 @@ func prepareLauncherBundleCandidate(_ options: LauncherBundleOptions) throws -> 
     }
     try signLauncherBundleCode(
         payloadURL,
-        identity: identity,
         identifier: "\(identifier).payload",
         entitlements: entitlements.isEmpty ? nil : entitlementsURL
     )
@@ -184,7 +160,6 @@ func prepareLauncherBundleCandidate(_ options: LauncherBundleOptions) throws -> 
         .write(to: contents.appendingPathComponent("Info.plist"), options: .atomic)
     try signLauncherBundleCode(
         appURL,
-        identity: identity,
         identifier: identifier,
         entitlements: nil
     )
@@ -194,9 +169,9 @@ func prepareLauncherBundleCandidate(_ options: LauncherBundleOptions) throws -> 
     guard bundle.identifier == identifier,
           launcher.identifier == launcherIdentifier,
           launcher.runtimeProtection == .hardened,
-          bundle.isAdHoc == (options.signingKind == .adHoc),
-          launcher.isAdHoc == bundle.isAdHoc,
-          payload.isAdHoc == bundle.isAdHoc
+          bundle.isAdHoc,
+          launcher.isAdHoc,
+          payload.isAdHoc
     else { throw LauncherBundleCreationError.invalidGeneratedCode }
 
     let enrollment = LauncherBundleEnrollment(
@@ -214,8 +189,8 @@ func prepareLauncherBundleCandidate(_ options: LauncherBundleOptions) throws -> 
         payloadSHA256: payloadSHA256,
         payloadEntitlements: entitlements.keys.sorted(),
         runtimeRequirement: runtimeRequirement,
-        signingKind: options.signingKind,
-        signingIdentity: options.signingIdentity,
+        signingKind: .adHoc,
+        signingIdentity: nil,
         createdAt: Date()
     )
     let treeSHA256 = try launcherBundleTreeSHA256(at: appURL)
@@ -361,13 +336,12 @@ private func runPrivilegedLauncherBundleOperation(_ arguments: [String]) throws 
 
 private func signLauncherBundleCode(
     _ url: URL,
-    identity: String,
     identifier: String,
     entitlements: URL?
 ) throws {
-    var arguments = ["--force", "--sign", identity, "--options", "runtime"]
-    if identity != "-" { arguments.append("--timestamp") }
-    arguments += ["--identifier", identifier]
+    var arguments = [
+        "--force", "--sign", "-", "--options", "runtime", "--identifier", identifier,
+    ]
     if let entitlements { arguments += ["--entitlements", entitlements.path] }
     arguments.append(url.path)
     _ = try runLauncherBundleCommand(executable: "/usr/bin/codesign", arguments: arguments)

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2070,12 +2070,9 @@ private struct CreateLauncherBundleView: View {
     @State private var sourceURL: URL?
     @State private var displayName = ""
     @State private var commandName = ""
-    @State private var signingKind = LauncherBundleSigningKind.adHoc
-    @State private var signingIdentity: String?
     @State private var allowJIT = false
     @State private var allowUnsignedExecutableMemory = false
     @State private var disableLibraryValidation = false
-    private let developerIDs = developerIDApplicationIdentities()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -2108,8 +2105,6 @@ private struct CreateLauncherBundleView: View {
                             sourceURL: sourceURL,
                             displayName: displayName,
                             commandName: commandName,
-                            signingKind: signingKind,
-                            signingIdentity: signingIdentity,
                             allowJIT: allowJIT,
                             allowUnsignedExecutableMemory: allowUnsignedExecutableMemory,
                             disableLibraryValidation: disableLibraryValidation
@@ -2152,23 +2147,6 @@ private struct CreateLauncherBundleView: View {
                 Text("Runs as \(launcherBundleCommandURL(named: command).path). Installation requests administrator approval.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            }
-
-            Picker("Signing", selection: $signingKind) {
-                Text("Automic Vault (Ad Hoc)").tag(LauncherBundleSigningKind.adHoc)
-                Text("Developer ID").tag(LauncherBundleSigningKind.developerID)
-            }
-            .pickerStyle(.segmented)
-            if signingKind == .developerID {
-                Picker("Identity", selection: $signingIdentity) {
-                    Text("Choose an identity").tag(String?.none)
-                    ForEach(developerIDs, id: \.self) { Text($0).tag(Optional($0)) }
-                }
-                if developerIDs.isEmpty {
-                    Text("No Developer ID Application identities were found.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
             }
 
             DisclosureGroup("Compatibility exceptions") {
@@ -2223,7 +2201,6 @@ private struct CreateLauncherBundleView: View {
         sourceURL != nil
             && launcherBundleDisplayName(from: displayName) != nil
             && launcherBundleCommandName(from: commandName) != nil
-            && (signingKind == .adHoc || signingIdentity != nil)
     }
 
     private func chooseSource() {

--- a/src/menu-helper/Sources/MenubarHelperCore/LauncherBundles.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/LauncherBundles.swift
@@ -12,8 +12,9 @@ public let launcherBundleCommandNameInfoKey = "AVLauncherBundleCommandName"
 public let launcherBundlePayloadName = "payload"
 public let launcherBundleMaximumPayloadBytes: Int64 = 512 * 1024 * 1024
 
-public enum LauncherBundleSigningKind: String, Codable, CaseIterable, Equatable, Sendable {
+public enum LauncherBundleSigningKind: String, Codable, Equatable, Sendable {
     case adHoc
+    // Compatibility with Developer ID-signed enrollments created by 3.9.0.
     case developerID
 
     public var title: String {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherBundlesTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherBundlesTests.swift
@@ -18,6 +18,14 @@ import Testing
     #expect(launcherBundleCommandName(from: "herdr cli") == nil)
 }
 
+@Test func launcherBundleSigningKindDecodesLegacyDeveloperID() throws {
+    let kind = try JSONDecoder().decode(
+        LauncherBundleSigningKind.self,
+        from: Data(#""developerID""#.utf8)
+    )
+    #expect(kind == .developerID)
+}
+
 @Test func launcherBundleTreeDigestIsDeterministicAndRejectsLinks() throws {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary
- ad-hoc sign every new Launcher Bundle
- remove Developer ID selection and certificate discovery from the creation flow
- preserve strict verification of existing Developer ID-signed enrollments
- update the canonical language, architecture, user guide, and ADR

## Testing
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-launcher-bundle-runner.sh`