### PR TITLE
Recheck temporary grants for queued approvals

### DIFF
--- a/docs/adr/0016-agent-scoped-temporary-access-grants.md
+++ b/docs/adr/0016-agent-scoped-temporary-access-grants.md
@@ -37,12 +37,16 @@ and persists the required Authorization Record before starting the grant and
 replying. Failure denies release and creates no grant. The decision does not
 enter the transient Approval cache.
 
-Future requests first complete ordinary Gate Client, Target, request, Secret,
-gate, Launcher, and runtime verification. A valid Blessing continues to
-authorize first. A grant may exceed a narrower Blessing only when the gate,
-designated requirement, runtime posture, provider, task UUID, protection, and
-operation all match exactly. Elevated Secret Application, Secret Disclosure,
-Unknown operations, the Direct Secret Gate, Secret mutation operations, and
+Requests first complete ordinary Gate Client, Target, request, Secret, gate,
+Launcher, and runtime verification. Before presenting a queued Approval, the
+service checks the current grants again using the still-live Gate Client,
+current Agent Task Context, and freshly verified Launcher and runtime posture.
+A request received before a grant began may therefore use it when its
+Authorization Decision is made. A valid Blessing continues to authorize first.
+A grant may exceed a narrower Blessing only when the gate, designated
+requirement, runtime posture, provider, task UUID, protection, and operation all
+match exactly. Elevated Secret Application, Secret Disclosure, Unknown
+operations, the Direct Secret Gate, Secret mutation operations, and
 unverifiable Launchers are excluded.
 
 The grant controller uses wall-clock and monotonic deadlines. Duplicate scopes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,6 +192,11 @@ An active Blessing is evaluated before a Temporary Access Grant. A matching
 grant may authorize a recognized operation beyond a narrower Blessing only
 inside the grant's exact scope. Matching happens after ordinary Gate Client,
 Target, request, Secret, gate, Launcher, and runtime verification succeeds.
+Before presenting a queued Approval, the service checks Temporary Access Grants
+again against the still-live Gate Client, current Agent Task Context, and
+freshly verified Launcher and runtime posture. This permits a matching request
+received before grant activation to receive its Authorization Decision under
+the now-active grant without trusting stale eligibility evidence.
 Each use persists its Authorization Record as policy-authorized by “Temporary
 Access Grant — Write Access” before release. The controller holds a
 generation-bound lease through payload loading, record persistence, retained

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -328,6 +328,11 @@ user end each grant immediately, and revokes all grants when the user session
 becomes inactive, displays sleep, an update begins, or the service terminates.
 Expiry uses both wall and monotonic clocks.
 
+Grant matching occurs when Automic Vault makes the Authorization Decision. A
+still-live request received before the grant began may therefore use it when
+the request reaches that decision point, but only after every live identity,
+runtime, task-context, operation, recording, and release check succeeds.
+
 ### Fail Closed
 
 Uncertainty about policy or operation risk disables automic authorization and requires Approval. Uncertainty about identity, integrity, request completeness, Secret matching, selected Secret Value, or required Authorization Record persistence denies the request. An error must not fall back to another Secret Value or broader access.

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3526,6 +3526,34 @@ private final class ApprovalServer: @unchecked Sendable {
                 ))
                 return
             }
+            var currentLaunchers = launcherIdentities(for: identity)
+            if currentLaunchers.isEmpty,
+               let currentLauncher = launcherIdentity(pid: pid, identity: identity)
+            {
+                currentLaunchers.append(currentLauncher)
+            }
+            if let configuredGate,
+               let classification,
+               let currentAgentTaskContext = agentTaskContext(pid: pid),
+               self.handleTemporaryAccessGrant(
+                   request: request,
+                   gate: configuredGate,
+                   classification: classification,
+                   agentTaskContext: currentAgentTaskContext,
+                   launchers: currentLaunchers,
+                   callerPath: callerPath,
+                   awsRegistration: awsRegistration,
+                   scriptApproval: scriptApproval,
+                   authorizationGate: authorizationGate,
+                   processChains: retainedProcessChains(for: identity),
+                   pid: pid,
+                   identity: identity,
+                   peer: peer,
+                   message: message
+               )
+            {
+                return
+            }
             let cachedDecision = self.transientApprovals.decision(
                 for: transientApproval,
                 allowingApprovalReuse: !requiresFreshHumanApproval

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3526,33 +3526,48 @@ private final class ApprovalServer: @unchecked Sendable {
                 ))
                 return
             }
-            var currentLaunchers = launcherIdentities(for: identity)
-            if currentLaunchers.isEmpty,
-               let currentLauncher = launcherIdentity(pid: pid, identity: identity)
+            var currentIdentity = AVProcessIdentity()
+            if av_process_identity(pid, &currentIdentity),
+               sameProcessIdentity(identity, currentIdentity),
+               let currentLiveSigning = liveSigningInfo(pid: pid)
             {
-                currentLaunchers.append(currentLauncher)
-            }
-            if let configuredGate,
-               let classification,
-               let currentAgentTaskContext = agentTaskContext(pid: pid),
-               self.handleTemporaryAccessGrant(
-                   request: request,
-                   gate: configuredGate,
-                   classification: classification,
-                   agentTaskContext: currentAgentTaskContext,
-                   launchers: currentLaunchers,
-                   callerPath: callerPath,
-                   awsRegistration: awsRegistration,
-                   scriptApproval: scriptApproval,
-                   authorizationGate: authorizationGate,
-                   processChains: retainedProcessChains(for: identity),
-                   pid: pid,
-                   identity: identity,
-                   peer: peer,
-                   message: message
-               )
-            {
-                return
+                let currentCallerPath = pathString(currentIdentity)
+                let currentSigning = SigningInfo(
+                    identifier: currentLiveSigning.identifier,
+                    teamIdentifier: currentLiveSigning.teamIdentifier
+                )
+                var currentLaunchers = launcherIdentities(for: currentIdentity)
+                if currentLaunchers.isEmpty,
+                   let currentLauncher = launcherIdentity(pid: pid, identity: currentIdentity)
+                {
+                    currentLaunchers.append(currentLauncher)
+                }
+                if currentLiveSigning.mainExecutable == currentCallerPath,
+                   currentSigning.identifier == signing.identifier,
+                   currentSigning.teamIdentifier == signing.teamIdentifier,
+                   isAllowedCaller(path: currentCallerPath, signing: currentSigning),
+                   let configuredGate,
+                   let classification,
+                   let currentAgentTaskContext = agentTaskContext(pid: pid),
+                   self.handleTemporaryAccessGrant(
+                       request: request,
+                       gate: configuredGate,
+                       classification: classification,
+                       agentTaskContext: currentAgentTaskContext,
+                       launchers: currentLaunchers,
+                       callerPath: currentCallerPath,
+                       awsRegistration: awsRegistration,
+                       scriptApproval: scriptApproval,
+                       authorizationGate: authorizationGate,
+                       processChains: retainedProcessChains(for: currentIdentity),
+                       pid: pid,
+                       identity: currentIdentity,
+                       peer: peer,
+                       message: message
+                   )
+                {
+                    return
+                }
             }
             let cachedDecision = self.transientApprovals.decision(
                 for: transientApproval,
@@ -6353,6 +6368,17 @@ private func pathString(_ identity: AVProcessIdentity) -> String {
     }
 }
 
+private func sameProcessIdentity(
+    _ expected: AVProcessIdentity,
+    _ current: AVProcessIdentity
+) -> Bool {
+    expected.pid == current.pid
+        && expected.pidversion == current.pidversion
+        && expected.start_usec == current.start_usec
+        && expected.euid == current.euid
+        && expected.audit_session_id == current.audit_session_id
+}
+
 private func signingInfo(path: String) -> SigningInfo {
     var staticCode: SecStaticCode?
     let url = URL(fileURLWithPath: path) as CFURL
@@ -8703,6 +8729,11 @@ private func runApprovalSelfCheck() -> Int32 {
     guard av_process_identity(getpid(), &selfIdentity), liveSigningInfo(pid: getpid()) != nil else {
         return 1
     }
+    var reusedIdentity = selfIdentity
+    reusedIdentity.start_usec &+= 1
+    guard sameProcessIdentity(selfIdentity, selfIdentity),
+          !sameProcessIdentity(selfIdentity, reusedIdentity)
+    else { return 1 }
     guard let liveUse = liveSecretUseProcess(pid: getpid(), identity: selfIdentity),
           liveSecretUseProcessIsLive(liveUse),
           !liveSecretUseProcessIsLive(LiveSecretUseProcess(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
@@ -153,6 +153,39 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
     #expect(afterSuccess.lastUsedAt == start.addingTimeInterval(10))
 }
 
+@Test func requestQueuedBeforeGrantIsEligibleWhenAuthorizationDecisionRuns() throws {
+    let controller = TemporaryAccessGrantController()
+    let start = Date(timeIntervalSince1970: 1_000)
+    let attempt = { (wallNow: Date, monotonicNow: TimeInterval) in
+        controller.withActiveLease(
+            authorizationGateID: "aws",
+            launcherDesignatedRequirement: "identifier com.example.launcher",
+            launcherRuntimeProtection: .hardened,
+            agentTaskContext: AgentTaskContext(provider: .codex, id: codexID),
+            classification: .mutating,
+            wallNow: wallNow,
+            monotonicNow: monotonicNow
+        ) { _ in true }
+    }
+
+    #expect(attempt(start, 10) == nil)
+    controller.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start.addingTimeInterval(5),
+        monotonicNow: 15
+    )
+    #expect(attempt(start.addingTimeInterval(6), 16) == true)
+
+    let grant = try #require(controller.snapshots(
+        wallNow: start.addingTimeInterval(6),
+        monotonicNow: 16
+    ).first)
+    #expect(grant.useCount == 2)
+    #expect(grant.lastUsedAt == start.addingTimeInterval(6))
+}
+
 @Test func exactScopeAndWriteClassificationAreRequired() {
     let controller = TemporaryAccessGrantController()
     let start = Date(timeIntervalSince1970: 1_000)


### PR DESCRIPTION
## Summary

- recheck Temporary Access Grants when a queued request reaches its Authorization Decision
- refresh the Gate Client task context, Launcher identity, runtime posture, and retained process evidence before automatic authorization
- document the timing rule and cover requests queued before grant activation

## Security

The recheck uses the existing exact-scope grant lease and audit-before-release path. Expired, canceled, mismatched, unknown, or unverifiable requests continue to require Approval or fail closed.

## Testing

- `swift test` (151 tests)
- `AutomicVaultMenubar --self-check-approvals`
- `AutomicVaultMenubar --self-check-gh-read-only`