### PR TITLE
Reuse exact approvals across approval transports

### DIFF
--- a/docs/adr/0012-iphone-approval.md
+++ b/docs/adr/0012-iphone-approval.md
@@ -1,6 +1,6 @@
 # ADR 0012: Carry human Approval on iPhone
 
-Status: accepted; Mac-local fallback decision amended by ADR 0017
+Status: accepted; Mac-local fallback decision amended by ADR 0017; transient reuse clarified by ADR 0018
 
 ## Context
 

--- a/docs/adr/0017-touch-id-approval.md
+++ b/docs/adr/0017-touch-id-approval.md
@@ -1,6 +1,6 @@
 # ADR 0017: Permit explicit Touch ID Approval on Mac
 
-Status: accepted
+Status: accepted; transient reuse clarified by ADR 0018
 
 ## Context
 

--- a/docs/adr/0018-reuse-exact-authorization-decisions.md
+++ b/docs/adr/0018-reuse-exact-authorization-decisions.md
@@ -1,0 +1,12 @@
+# ADR 0018: Reuse exact Authorization Decisions across Approval transports
+
+Status: accepted
+
+An iPhone or Touch ID carries a human Approval for one complete Authorization
+Request, but the resulting Authorization Decision may receive the same
+memory-only transient reuse as a Mac-carried Approval. Reuse requires the same
+live process and complete request identity, expires after five minutes, and
+persists a fresh Authorization Record for every Secret Application; it reuses
+neither a phone response nor a biometric result. Operations that may receive
+long-lived AWS credentials remain excluded because their elevated credential
+exposure warrants fresh Approval.

--- a/docs/adr/0018-reuse-exact-authorization-decisions.md
+++ b/docs/adr/0018-reuse-exact-authorization-decisions.md
@@ -2,11 +2,16 @@
 
 Status: accepted
 
-An iPhone or Touch ID carries a human Approval for one complete Authorization
-Request, but the resulting Authorization Decision may receive the same
-memory-only transient reuse as a Mac-carried Approval. Reuse requires the same
-live process and complete request identity, expires after five minutes, and
-persists a fresh Authorization Record for every Secret Application; it reuses
-neither a phone response nor a biometric result. Operations that may receive
-long-lived AWS credentials remain excluded because their elevated credential
-exposure warrants fresh Approval.
+## Context
+
+An iPhone or Touch ID can carry a human Approval for one complete Authorization Request. Historically, transient reuse of an exact Authorization Decision has been independent of how the Approval was carried.
+
+## Decision
+
+The resulting Authorization Decision may receive the same memory-only transient reuse as a Mac-carried Approval. Reuse requires the same live process and complete request identity, expires after five minutes, and persists a fresh Authorization Record for every Secret Application; it reuses neither a phone response nor a biometric result. Operations that may receive long-lived AWS credentials remain excluded because their elevated credential exposure warrants fresh Approval.
+
+## Consequences
+
+- Fewer repeated prompts for identical requests within the existing transient reuse constraints.
+- No reuse of phone responses or Local Authentication biometric results.
+- AWS operations that may expose long-lived credentials still require fresh Approval.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,7 +198,13 @@ flowchart LR
     R --> T["Run Target or apply Secret"]
 ```
 
-The Authorization Request is immutable across this flow. A cached decision may be reused only for the same live process and complete request identity. Reuse still requires an Authorization Record before Secret Application.
+The Authorization Request is immutable across this flow. A cached decision may
+be reused only for the same live process and complete request identity. This is
+independent of whether the original Approval was carried on Mac, by iPhone, or
+with Touch ID: the Authorization Decision is reused, not the human-presence or
+biometric result. Reuse still requires an Authorization Record before Secret
+Application. Operations that may receive long-lived AWS credentials remain
+excluded and require fresh Approval.
 
 An active Blessing is evaluated before a Temporary Access Grant. A matching
 grant may authorize a recognized operation beyond a narrower Blessing only
@@ -455,7 +461,9 @@ reuse, and requests biometrics only. A password, passcode, Apple Watch, or
 pointer-driven allow action cannot satisfy it. When iPhone Approval is also
 enabled, either a valid phone response or a successful Touch ID evaluation may
 carry the Approval; the first result wins and the other pending transport is
-canceled. Relay state never toggles this choice.
+canceled. Relay state never toggles this choice. Memory-only reuse of the exact
+Authorization Decision under the ordinary live-process and complete-request
+constraints does not reuse the Local Authentication result.
 
 ## Recording before release
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -343,11 +343,20 @@ unverified subscription state fails closed but does not prevent denial. A
 subscription is product eligibility, not Authorization Policy or authority to
 release a Secret.
 
+iPhone Approval changes where the human decision occurs, not whether an exact
+Authorization Decision may receive memory-only transient reuse. Reuse is bound
+to the same live process and complete Authorization Request identity and does
+not reuse the phone response itself.
+
 ### Touch ID Approval
 
 An optional Mac-local Approval surface that requires a fresh Touch ID result for
 one exact Authorization Request. It has no password, passcode, Apple Watch, or
 pointer-driven allow fallback and does not reuse a prior biometric result.
+
+Transient reuse of the resulting exact Authorization Decision is not biometric
+result reuse. A later request may avoid another Approval only while the same
+live process and complete Authorization Request identity still match.
 
 Touch ID Approval is an explicit per-Mac choice stored in the macOS Data
 Protection Keychain. Enabling it requires the current human Approval surface and

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3509,19 +3509,14 @@ private final class ApprovalServer: @unchecked Sendable {
         } else {
             promptBlessing = nil
         }
-        let requiresFreshApproval = awsRequestMayUseLongLivedCredentials(request)
-        let usesIPhoneApproval = phoneApprovalIsEnabled()
-        let usesTouchIDApproval = touchIDApprovalIsEnabled()
-        let requiresFreshHumanApproval = requiresFreshApproval
-            || usesIPhoneApproval
-            || usesTouchIDApproval
+        let requiresFreshOperationApproval = awsRequestMayUseLongLivedCredentials(request)
         RunLoop.main.perform(inModes: [.modalPanel, .default]) {
             MainActor.assumeIsolated {
                 guard !cancellation.isCanceled,
                       let event = approvalEvent(
                           for: self.transientApprovals.decision(
                               for: transientApproval,
-                              allowingApprovalReuse: !requiresFreshHumanApproval
+                              allowingApprovalReuse: !requiresFreshOperationApproval
                           ),
                           humanApprovalAvailable: self.canRequestHumanApproval()
                       )
@@ -3581,7 +3576,7 @@ private final class ApprovalServer: @unchecked Sendable {
             }
             let cachedDecision = self.transientApprovals.decision(
                 for: transientApproval,
-                allowingApprovalReuse: !requiresFreshHumanApproval
+                allowingApprovalReuse: !requiresFreshOperationApproval
             )
             if let decision = cachedDecision {
                 if decision == .denied {
@@ -3830,7 +3825,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 {
                     self.registerBlessedExecution(script, pid: pid, identity: identity)
                 }
-                if !requiresFreshHumanApproval {
+                if !requiresFreshOperationApproval {
                     self.transientApprovals.remember(.approved, for: transientApproval)
                 }
                 self.recordLiveSecretUse(


### PR DESCRIPTION
## Summary

- reuse a recent exact Authorization Decision when its Approval was carried by iPhone or Touch ID
- keep reuse bound to the same live process and complete request identity
- document the transport-versus-decision boundary in ADR 0018 and the canonical model

## Security

This does not add PID-wide allow authority or reuse biometric authentication. The existing five-minute cache key, process start identity, complete request match, fresh Authorization Record, and long-lived AWS exclusion remain unchanged.

## Verification

- `swift test --package-path src/menu-helper` — 152 tests passed
- `--self-check-approvals`
- `--self-check-aws-read-only`
- `--self-check-transient-approvals`