### PR TITLE
Deepen authorization boundaries

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/SecretProxy.swift
+++ b/src/menu-helper/Sources/MenubarHelper/SecretProxy.swift
@@ -99,6 +99,7 @@ actor SecretProxyCoordinator {
         let process: Process
         let input: FileHandle
         let output: FileHandle
+        let secretValueCustody: SecretValueCustody
         let approveDestination: DestinationApproval
         var identity: ProxyTargetIdentity
         var codeIdentity: Data?
@@ -112,11 +113,11 @@ actor SecretProxyCoordinator {
     private var pendingAuthorizations: [PendingAuthorizationID: ApprovalCancellation] = [:]
     private var destinationPromptActive = false
     private var destinationPromptWaiters: [CheckedContinuation<Void, Never>] = []
-    private let secretValueCustody = SecretValueCustody()
     private let maximumControlFrame = 4 * 1024 * 1024
 
     func start(
         launch: ProxySessionLaunch,
+        secretValueCustody: SecretValueCustody,
         approveDestination: @escaping DestinationApproval
     ) async throws -> ProxySessionMaterial {
         guard targetIsLive(launch.identity),
@@ -191,6 +192,7 @@ actor SecretProxyCoordinator {
                 process: process,
                 input: inputPipe.fileHandleForWriting,
                 output: outputPipe.fileHandleForReading,
+                secretValueCustody: secretValueCustody,
                 approveDestination: approveDestination,
                 identity: launch.identity,
                 codeIdentity: liveCodeIdentity(pid: launch.identity.pid),
@@ -435,7 +437,7 @@ actor SecretProxyCoordinator {
         guard !cancellation.isCanceled else { return }
         let secrets: [String: String]
         do {
-            secrets = try secretValueCustody.load(
+            secrets = try session.secretValueCustody.load(
                 session.launch.selectedSecretValues,
                 names: sortedNames
             )

--- a/src/menu-helper/Sources/MenubarHelper/SecretProxy.swift
+++ b/src/menu-helper/Sources/MenubarHelper/SecretProxy.swift
@@ -17,6 +17,7 @@ struct ProxySessionLaunch: Sendable {
     let target: String
     let arguments: [String]
     let cwd: String
+    let selectedSecretValues: SelectedSecretValues
     let targetCodeIdentity: Data?
     let identity: ProxyTargetIdentity
 }
@@ -37,6 +38,7 @@ struct ProxyDestinationRequest: Sendable {
     let path: String
     let queryNames: [String]
     let secretNames: [String]
+    let selectedSecretValues: SelectedSecretValues
 }
 
 enum ProxyDestinationDecision: Sendable {
@@ -110,6 +112,7 @@ actor SecretProxyCoordinator {
     private var pendingAuthorizations: [PendingAuthorizationID: ApprovalCancellation] = [:]
     private var destinationPromptActive = false
     private var destinationPromptWaiters: [CheckedContinuation<Void, Never>] = []
+    private let secretValueCustody = SecretValueCustody()
     private let maximumControlFrame = 4 * 1024 * 1024
 
     func start(
@@ -356,7 +359,10 @@ actor SecretProxyCoordinator {
               queryNames.allSatisfy({ !$0.isEmpty && $0.count <= 256 }),
               !secretNames.isEmpty,
               Set(secretNames).count == secretNames.count,
-              secretNames.allSatisfy({ session.references[$0] != nil })
+              secretNames.allSatisfy({
+                  session.references[$0] != nil
+                      && session.launch.selectedSecretValues.contains($0)
+              })
         else {
             deny(sessionID: sessionID, requestID: requestID, reason: "invalid or expired Proxy Session request")
             return
@@ -388,7 +394,10 @@ actor SecretProxyCoordinator {
                             origin: origin,
                             path: path,
                             queryNames: queryNames,
-                            secretNames: sortedNames
+                            secretNames: sortedNames,
+                            selectedSecretValues: current.launch.selectedSecretValues.selecting(
+                                names: sortedNames
+                            )
                         ),
                         cancellation
                     )
@@ -423,9 +432,37 @@ actor SecretProxyCoordinator {
             return
         }
         session = current
-        if decision == .allowForSession { session.rules.insert(rule) }
+        guard !cancellation.isCanceled else { return }
+        let secrets: [String: String]
+        do {
+            secrets = try secretValueCustody.load(
+                session.launch.selectedSecretValues,
+                names: sortedNames
+            )
+        } catch {
+            _ = appendAccessRequestRecord(proxyRecord(
+                session: session,
+                method: method,
+                origin: origin,
+                path: path,
+                queryNames: queryNames,
+                secretNames: sortedNames,
+                decision: "Failed",
+                approvalSource: approvalSource,
+                reason: error.localizedDescription
+            ))
+            deny(sessionID: sessionID, requestID: requestID, reason: error.localizedDescription)
+            return
+        }
+        guard refreshTargetIdentity(id: sessionID),
+              var liveSession = sessions[sessionID],
+              !cancellation.isCanceled
+        else {
+            deny(sessionID: sessionID, requestID: requestID, reason: "Proxy Session expired before release")
+            return
+        }
         let record = proxyRecord(
-            session: session,
+            session: liveSession,
             method: method,
             origin: origin,
             path: path,
@@ -440,21 +477,6 @@ actor SecretProxyCoordinator {
             return
         }
         guard !cancellation.isCanceled else { return }
-        var secrets: [String: String] = [:]
-        for name in sortedNames {
-            guard let value = loadStoredSecret(account: name), !value.isEmpty else {
-                deny(sessionID: sessionID, requestID: requestID, reason: "secret is unavailable")
-                return
-            }
-            secrets[name] = value
-        }
-        guard refreshTargetIdentity(id: sessionID),
-              var liveSession = sessions[sessionID],
-              !cancellation.isCanceled
-        else {
-            deny(sessionID: sessionID, requestID: requestID, reason: "Proxy Session expired before release")
-            return
-        }
         if decision == .allowForSession { liveSession.rules.insert(rule) }
         liveSession.authorizedRequestCount += 1
         liveSession.authorizedOrigins.insert(origin)
@@ -529,7 +551,10 @@ actor SecretProxyCoordinator {
             target: origin,
             cwd: session.launch.cwd,
             keys: secretNames,
-            detail: "Proxy Session \(session.id.uuidString.lowercased())"
+            detail: "Proxy Session \(session.id.uuidString.lowercased())",
+            secretValueSources: session.launch.selectedSecretValues
+                .selecting(names: secretNames)
+                .sourceDisplayNames
         )
     }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2570,7 +2570,7 @@ private struct AWSRegistrationCandidate {
     let useLongLivedCredentials: Bool
 }
 
-private struct AWSRegistration {
+private struct AWSRegistration: Sendable {
     let generation: AWSRuntimeGeneration
     let chain: AWSProfileChain
     let args: [String]
@@ -2601,9 +2601,14 @@ private struct StoredDockerCredential {
     let secret: String
 }
 
-private struct ApprovedPayload {
+private struct ApprovedPayload: Sendable {
     let secrets: [String: String]
     let value: String?
+}
+
+private struct ApprovedFulfillmentMaterial: Sendable {
+    let payload: ApprovedPayload
+    let awsRegistration: AWSRegistration?
 }
 
 private final class ApprovalServer: @unchecked Sendable {
@@ -3146,9 +3151,6 @@ private final class ApprovalServer: @unchecked Sendable {
            let (script, matchedLauncher) = effectiveBlessingMatch
         {
             do {
-                let payload = try approvedPayload(
-                    for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-                )
                 let accessRequestID = UUID()
                 let record = accessRequestRecord(
                     id: accessRequestID,
@@ -3159,33 +3161,46 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: "Blessed script \(script.path)",
                     launcher: matchedLauncher
                 )
-                guard onAccessRequest(record) else {
+                guard try fulfillApprovedRequest(
+                    request: request,
+                    awsRegistration: awsRegistration,
+                    pid: pid,
+                    identity: identity,
+                    record: record,
+                    launcher: matchedLauncher,
+                    activateAfterRecording: {
+                        registerBlessedExecution(script, pid: pid, identity: identity)
+                        rememberRetainedProvenance(
+                            at: blessingGate,
+                            launcher: matchedLauncher,
+                            chains: processChains,
+                            retainedMatch: currentBlessingMatch == nil
+                                ? retainedBlessingProvenance
+                                : nil
+                        )
+                        Task { @MainActor in
+                            self.onAutoApproval(autoApprovalRecord(
+                                accessRequestID: accessRequestID,
+                                request: request,
+                                script: scriptApproval,
+                                launcher: matchedLauncher
+                            ))
+                        }
+                    },
+                    release: { payload in
+                        reply(
+                            peer,
+                            to: message,
+                            ok: true,
+                            error: nil,
+                            secrets: payload.secrets,
+                            value: payload.value
+                        )
+                    }
+                ) else {
                     reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                     return
                 }
-                registerBlessedExecution(script, pid: pid, identity: identity)
-                rememberRetainedProvenance(
-                    at: blessingGate,
-                    launcher: matchedLauncher,
-                    chains: processChains,
-                    retainedMatch: currentBlessingMatch == nil ? retainedBlessingProvenance : nil
-                )
-                Task { @MainActor in
-                    self.onAutoApproval(autoApprovalRecord(
-                        accessRequestID: accessRequestID,
-                        request: request,
-                        script: scriptApproval,
-                        launcher: matchedLauncher
-                    ))
-                }
-                recordLiveSecretUse(
-                    request: request,
-                    payload: payload,
-                    launcher: matchedLauncher,
-                    pid: pid,
-                    identity: identity
-                )
-                reply(peer, to: message, ok: true, error: nil, secrets: payload.secrets, value: payload.value)
             } catch {
                 _ = onAccessRequest(accessRequestRecord(
                     request: request,
@@ -3323,9 +3338,6 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         if activeBlessing == nil, let directAccessLauncher {
             do {
-                let payload = try approvedPayload(
-                    for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-                )
                 let accessRequestID = UUID()
                 let record = accessRequestRecord(
                     id: accessRequestID,
@@ -3336,41 +3348,46 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: "Direct Access from \(shortAppName(directAccessLauncher.identifier))",
                     launcher: directAccessLauncher
                 )
-                guard onAccessRequest(record) else {
+                guard try fulfillApprovedRequest(
+                    request: request,
+                    awsRegistration: awsRegistration,
+                    pid: pid,
+                    identity: identity,
+                    record: record,
+                    launcher: directAccessLauncher,
+                    activateAfterRecording: {
+                        rememberRetainedProvenance(
+                            at: authorizationGate,
+                            launcher: directAccessLauncher,
+                            chains: processChains,
+                            retainedMatch: launchers.contains(where: {
+                                $0.designatedRequirement
+                                    == directAccessLauncher.designatedRequirement
+                            }) ? nil : retainedGateProvenance
+                        )
+                        Task { @MainActor in
+                            self.onAutoApproval(autoApprovalRecord(
+                                accessRequestID: accessRequestID,
+                                request: request,
+                                script: scriptApproval,
+                                launcher: directAccessLauncher
+                            ))
+                        }
+                    },
+                    release: { payload in
+                        reply(
+                            peer,
+                            to: message,
+                            ok: true,
+                            error: nil,
+                            secrets: payload.secrets,
+                            value: payload.value
+                        )
+                    }
+                ) else {
                     reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                     return
                 }
-                rememberRetainedProvenance(
-                    at: authorizationGate,
-                    launcher: directAccessLauncher,
-                    chains: processChains,
-                    retainedMatch: launchers.contains(where: {
-                        $0.designatedRequirement == directAccessLauncher.designatedRequirement
-                    }) ? nil : retainedGateProvenance
-                )
-                Task { @MainActor in
-                    self.onAutoApproval(autoApprovalRecord(
-                        accessRequestID: accessRequestID,
-                        request: request,
-                        script: scriptApproval,
-                        launcher: directAccessLauncher
-                    ))
-                }
-                recordLiveSecretUse(
-                    request: request,
-                    payload: payload,
-                    launcher: directAccessLauncher,
-                    pid: pid,
-                    identity: identity
-                )
-                reply(
-                    peer,
-                    to: message,
-                    ok: true,
-                    error: nil,
-                    secrets: payload.secrets,
-                    value: payload.value
-                )
             } catch {
                 _ = onAccessRequest(accessRequestRecord(
                     request: request,
@@ -3395,9 +3412,6 @@ private final class ApprovalServer: @unchecked Sendable {
         {
             let authorizingLauncher = resolvedPolicy.launcher ?? policyLauncher
             do {
-                let payload = try approvedPayload(
-                    for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-                )
                 let reason = "\(configuredGate.protectionTitle(resolvedPolicy.protection)) from \(resolvedPolicy.source)"
                 let accessRequestID = UUID()
                 let record = accessRequestRecord(
@@ -3409,36 +3423,48 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: reason,
                     launcher: authorizingLauncher
                 )
-                guard onAccessRequest(record) else {
+                guard try fulfillApprovedRequest(
+                    request: request,
+                    awsRegistration: awsRegistration,
+                    pid: pid,
+                    identity: identity,
+                    record: record,
+                    launcher: authorizingLauncher,
+                    activateAfterRecording: {
+                        if let authorizingLauncher {
+                            rememberRetainedProvenance(
+                                at: authorizationGate,
+                                launcher: authorizingLauncher,
+                                chains: processChains,
+                                retainedMatch: launchers.contains(where: {
+                                    $0.designatedRequirement
+                                        == authorizingLauncher.designatedRequirement
+                                }) ? nil : retainedGateProvenance
+                            )
+                            Task { @MainActor in
+                                self.onAutoApproval(autoApprovalRecord(
+                                    accessRequestID: accessRequestID,
+                                    request: request,
+                                    script: scriptApproval,
+                                    launcher: authorizingLauncher
+                                ))
+                            }
+                        }
+                    },
+                    release: { payload in
+                        reply(
+                            peer,
+                            to: message,
+                            ok: true,
+                            error: nil,
+                            secrets: payload.secrets,
+                            value: payload.value
+                        )
+                    }
+                ) else {
                     reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                     return
                 }
-                if let authorizingLauncher {
-                    rememberRetainedProvenance(
-                        at: authorizationGate,
-                        launcher: authorizingLauncher,
-                        chains: processChains,
-                        retainedMatch: launchers.contains(where: {
-                            $0.designatedRequirement == authorizingLauncher.designatedRequirement
-                        }) ? nil : retainedGateProvenance
-                    )
-                    Task { @MainActor in
-                        self.onAutoApproval(autoApprovalRecord(
-                            accessRequestID: accessRequestID,
-                            request: request,
-                            script: scriptApproval,
-                            launcher: authorizingLauncher
-                        ))
-                    }
-                }
-                recordLiveSecretUse(
-                    request: request,
-                    payload: payload,
-                    launcher: authorizingLauncher,
-                    pid: pid,
-                    identity: identity
-                )
-                reply(peer, to: message, ok: true, error: nil, secrets: payload.secrets, value: payload.value)
             } catch {
                 _ = onAccessRequest(accessRequestRecord(
                     request: request,
@@ -3563,9 +3589,6 @@ private final class ApprovalServer: @unchecked Sendable {
                     return
                 }
                 do {
-                    let payload = try self.approvedPayload(
-                        for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-                    )
                     let record = accessRequestRecord(
                         request: request,
                         callerPath: callerPath,
@@ -3574,18 +3597,27 @@ private final class ApprovalServer: @unchecked Sendable {
                         reason: "Reused recent approval",
                         launcher: promptLauncher
                     )
-                    guard self.onAccessRequest(record) else {
+                    guard try self.fulfillApprovedRequest(
+                        request: request,
+                        awsRegistration: awsRegistration,
+                        pid: pid,
+                        identity: identity,
+                        record: record,
+                        launcher: promptLauncher,
+                        release: { payload in
+                            self.reply(
+                                peer,
+                                to: message,
+                                ok: true,
+                                error: nil,
+                                secrets: payload.secrets,
+                                value: payload.value
+                            )
+                        }
+                    ) else {
                         self.reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                         return
                     }
-                    self.recordLiveSecretUse(
-                        request: request,
-                        payload: payload,
-                        launcher: promptLauncher,
-                        pid: pid,
-                        identity: identity
-                    )
-                    self.reply(peer, to: message, ok: true, error: nil, secrets: payload.secrets, value: payload.value)
                 } catch {
                     _ = self.onAccessRequest(accessRequestRecord(
                         request: request,
@@ -3700,20 +3732,40 @@ private final class ApprovalServer: @unchecked Sendable {
                     return
                 }
                 do {
-                    let payload = try self.approvedPayload(
-                        for: request,
-                        awsRegistration: awsRegistration,
-                        pid: pid,
-                        identity: identity
-                    )
-                    guard self.onAccessRequest(accessRequestRecord(
+                    let record = accessRequestRecord(
                         request: request,
                         callerPath: callerPath,
                         decision: "Approved",
                         approvalSource: "Manual",
                         reason: "Temporary Access Grant — Write Access",
                         launcher: refreshedCandidate.launcher
-                    )) else {
+                    )
+                    guard try self.fulfillApprovedRequest(
+                        request: request,
+                        awsRegistration: awsRegistration,
+                        pid: pid,
+                        identity: identity,
+                        record: record,
+                        launcher: refreshedCandidate.launcher,
+                        release: { payload in
+                            self.temporaryAccessGrants.startWithLease(
+                                scope: refreshedCandidate.scope,
+                                launcherName: refreshedCandidate.launcherName,
+                                authorizationGateName: refreshedCandidate.authorizationGateName
+                            ) { _ in
+                                self.reply(
+                                    peer,
+                                    to: message,
+                                    ok: true,
+                                    error: nil,
+                                    secrets: payload.secrets,
+                                    value: payload.value,
+                                    humanApprovalDecision: "approved"
+                                )
+                            }
+                            self.onTemporaryAccessGrantsChanged()
+                        }
+                    ) else {
                         self.reply(
                             peer,
                             to: message,
@@ -3723,29 +3775,6 @@ private final class ApprovalServer: @unchecked Sendable {
                         )
                         return
                     }
-                    self.recordLiveSecretUse(
-                        request: request,
-                        payload: payload,
-                        launcher: refreshedCandidate.launcher,
-                        pid: pid,
-                        identity: identity
-                    )
-                    self.temporaryAccessGrants.startWithLease(
-                        scope: refreshedCandidate.scope,
-                        launcherName: refreshedCandidate.launcherName,
-                        authorizationGateName: refreshedCandidate.authorizationGateName
-                    ) { _ in
-                        self.reply(
-                            peer,
-                            to: message,
-                            ok: true,
-                            error: nil,
-                            secrets: payload.secrets,
-                            value: payload.value,
-                            humanApprovalDecision: "approved"
-                        )
-                    }
-                    self.onTemporaryAccessGrantsChanged()
                 } catch {
                     _ = self.onAccessRequest(accessRequestRecord(
                         request: request,
@@ -3766,9 +3795,6 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             do {
-                let payload = try self.approvedPayload(
-                    for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-                )
                 let record = accessRequestRecord(
                     request: request,
                     callerPath: callerPath,
@@ -3777,7 +3803,40 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: "Approved in prompt",
                     launcher: promptLauncher
                 )
-                guard self.onAccessRequest(record) else {
+                guard try self.fulfillApprovedRequest(
+                    request: request,
+                    awsRegistration: awsRegistration,
+                    pid: pid,
+                    identity: identity,
+                    record: record,
+                    launcher: promptLauncher,
+                    activateAfterRecording: {
+                        if let scriptApproval,
+                           let script = self.matchingBlessedScript(
+                               request: request,
+                               approval: scriptApproval,
+                               launcher: nil
+                           )
+                        {
+                            self.registerBlessedExecution(script, pid: pid, identity: identity)
+                        }
+                        self.transientApprovals.remember(
+                            decision.reuseOutcome,
+                            for: transientApproval
+                        )
+                    },
+                    release: { payload in
+                        self.reply(
+                            peer,
+                            to: message,
+                            ok: true,
+                            error: nil,
+                            secrets: payload.secrets,
+                            value: payload.value,
+                            humanApprovalDecision: "approved"
+                        )
+                    }
+                ) else {
                     self.reply(
                         peer,
                         to: message,
@@ -3787,32 +3846,6 @@ private final class ApprovalServer: @unchecked Sendable {
                     )
                     return
                 }
-                if let scriptApproval,
-                   let script = self.matchingBlessedScript(
-                       request: request,
-                       approval: scriptApproval,
-                       launcher: nil
-                   )
-                {
-                    self.registerBlessedExecution(script, pid: pid, identity: identity)
-                }
-                self.transientApprovals.remember(decision.reuseOutcome, for: transientApproval)
-                self.recordLiveSecretUse(
-                    request: request,
-                    payload: payload,
-                    launcher: promptLauncher,
-                    pid: pid,
-                    identity: identity
-                )
-                self.reply(
-                    peer,
-                    to: message,
-                    ok: true,
-                    error: nil,
-                    secrets: payload.secrets,
-                    value: payload.value,
-                    humanApprovalDecision: "approved"
-                )
             } catch {
                 _ = self.onAccessRequest(accessRequestRecord(
                     request: request,
@@ -3858,14 +3891,8 @@ private final class ApprovalServer: @unchecked Sendable {
                     agentTaskContext: agentTaskContext,
                     classification: classification
                 ) { _ in
-                    let payload = try approvedPayload(
-                        for: request,
-                        awsRegistration: awsRegistration,
-                        pid: pid,
-                        identity: identity
-                    )
                     let accessRequestID = UUID()
-                    guard onAccessRequest(accessRequestRecord(
+                    let record = accessRequestRecord(
                         id: accessRequestID,
                         request: request,
                         callerPath: callerPath,
@@ -3873,39 +3900,45 @@ private final class ApprovalServer: @unchecked Sendable {
                         approvalSource: "Auto",
                         reason: "Temporary Access Grant — Write Access",
                         launcher: launcher
-                    )) else {
-                        reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
-                        return false
-                    }
-                    rememberRetainedProvenance(
-                        at: authorizationGate,
-                        launcher: launcher,
-                        chains: processChains,
-                        retainedMatch: nil
                     )
-                    Task { @MainActor in
-                        self.onAutoApproval(autoApprovalRecord(
-                            accessRequestID: accessRequestID,
-                            request: request,
-                            script: scriptApproval,
-                            launcher: launcher
-                        ))
-                    }
-                    recordLiveSecretUse(
+                    let committed = try fulfillApprovedRequest(
                         request: request,
-                        payload: payload,
-                        launcher: launcher,
+                        awsRegistration: awsRegistration,
                         pid: pid,
-                        identity: identity
+                        identity: identity,
+                        record: record,
+                        launcher: launcher,
+                        activateAfterRecording: {
+                            rememberRetainedProvenance(
+                                at: authorizationGate,
+                                launcher: launcher,
+                                chains: processChains,
+                                retainedMatch: nil
+                            )
+                            Task { @MainActor in
+                                self.onAutoApproval(autoApprovalRecord(
+                                    accessRequestID: accessRequestID,
+                                    request: request,
+                                    script: scriptApproval,
+                                    launcher: launcher
+                                ))
+                            }
+                        },
+                        release: { payload in
+                            reply(
+                                peer,
+                                to: message,
+                                ok: true,
+                                error: nil,
+                                secrets: payload.secrets,
+                                value: payload.value
+                            )
+                        }
                     )
-                    reply(
-                        peer,
-                        to: message,
-                        ok: true,
-                        error: nil,
-                        secrets: payload.secrets,
-                        value: payload.value
-                    )
+                    if !committed {
+                        reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
+                        return true
+                    }
                     return true
                 }
                 if handled == true { return true }
@@ -4111,31 +4144,41 @@ private final class ApprovalServer: @unchecked Sendable {
                     else {
                         throw AppError("Automic Vault returned an incomplete Secret set")
                     }
-                    guard self.onAccessRequest(accessRequestRecord(
-                        request: request,
-                        callerPath: callerPath,
-                        decision: "Approved",
-                        approvalSource: "Manual",
-                        reason: "Approved in prompt",
-                        launcher: launcher
-                    )) else {
+                    let transaction = AuthorizationFulfillmentTransaction(material: secrets)
+                    guard transaction.commit(
+                        record: {
+                            self.onAccessRequest(accessRequestRecord(
+                                request: request,
+                                callerPath: callerPath,
+                                decision: "Approved",
+                                approvalSource: "Manual",
+                                reason: "Approved in prompt",
+                                launcher: launcher
+                            ))
+                        },
+                        activate: { _ in },
+                        observe: { secrets in
+                            self.recordLiveSecretUse(
+                                request: request,
+                                secretNames: Set(secrets.keys),
+                                launcher: launcher,
+                                execution: applicationExecution
+                            )
+                        },
+                        release: { secrets in
+                            self.reply(
+                                peer,
+                                to: message,
+                                ok: true,
+                                error: nil,
+                                secrets: secrets,
+                                protocolVersion: varlockProtocolVersion,
+                                humanApprovalDecision: "approved"
+                            )
+                        }
+                    ) else {
                         throw AppError("approval audit log is unavailable")
                     }
-                    self.recordLiveSecretUse(
-                        request: request,
-                        secretNames: Set(secrets.keys),
-                        launcher: launcher,
-                        execution: applicationExecution
-                    )
-                    self.reply(
-                        peer,
-                        to: message,
-                        ok: true,
-                        error: nil,
-                        secrets: secrets,
-                        protocolVersion: varlockProtocolVersion,
-                        humanApprovalDecision: "approved"
-                    )
                 } catch {
                     _ = self.onAccessRequest(accessRequestRecord(
                         request: request,
@@ -4467,11 +4510,8 @@ private final class ApprovalServer: @unchecked Sendable {
         ) else { return false }
 
         do {
-            let payload = try approvedPayload(
-                for: request, awsRegistration: awsRegistration, pid: pid, identity: identity
-            )
             let accessRequestID = UUID()
-            guard onAccessRequest(accessRequestRecord(
+            let record = accessRequestRecord(
                 id: accessRequestID,
                 request: request,
                 callerPath: callerPath,
@@ -4479,28 +4519,43 @@ private final class ApprovalServer: @unchecked Sendable {
                 approvalSource: "Auto",
                 reason: "Blessed script \(script.path)",
                 launcher: launcher
-            )) else {
+            )
+            guard try fulfillApprovedRequest(
+                request: request,
+                awsRegistration: awsRegistration,
+                pid: pid,
+                identity: identity,
+                record: record,
+                launcher: launcher,
+                activateAfterRecording: {
+                    if let launcher {
+                        Task { @MainActor in
+                            self.onAutoApproval(autoApprovalRecord(
+                                accessRequestID: accessRequestID,
+                                request: request,
+                                script: ScriptApproval(
+                                    path: script.path,
+                                    checksum: script.checksum
+                                ),
+                                launcher: launcher
+                            ))
+                        }
+                    }
+                },
+                release: { payload in
+                    reply(
+                        peer,
+                        to: message,
+                        ok: true,
+                        error: nil,
+                        secrets: payload.secrets,
+                        value: payload.value
+                    )
+                }
+            ) else {
                 reply(peer, to: message, ok: false, error: "approval audit log is unavailable")
                 return true
             }
-            if let launcher {
-                Task { @MainActor in
-                    self.onAutoApproval(autoApprovalRecord(
-                        accessRequestID: accessRequestID,
-                        request: request,
-                        script: ScriptApproval(path: script.path, checksum: script.checksum),
-                        launcher: launcher
-                    ))
-                }
-            }
-            recordLiveSecretUse(
-                request: request,
-                payload: payload,
-                launcher: launcher,
-                pid: pid,
-                identity: identity
-            )
-            reply(peer, to: message, ok: true, error: nil, secrets: payload.secrets, value: payload.value)
         } catch {
             _ = onAccessRequest(accessRequestRecord(
                 request: request,
@@ -5126,12 +5181,10 @@ private final class ApprovalServer: @unchecked Sendable {
             && signing.runtimeProtection.allowsSecretGateAccess
     }
 
-    private func approvedPayload(
+    private func prepareApprovedFulfillment(
         for request: ApprovalRequest,
-        awsRegistration: AWSRegistrationCandidate?,
-        pid: pid_t,
-        identity: AVProcessIdentity
-    ) throws -> ApprovedPayload {
+        awsRegistration: AWSRegistrationCandidate?
+    ) throws -> AuthorizationFulfillmentTransaction<ApprovedFulfillmentMaterial> {
         let dockerParent: DockerCredentialParent?
         if request.op == "docker-get" {
             guard let serverURL = request.dockerServerURL,
@@ -5155,14 +5208,13 @@ private final class ApprovalServer: @unchecked Sendable {
                   credential.serverURL == serverURL
             else { throw AppError("Docker credential changed before Secret Application") }
         }
-        guard let awsRegistration else { return ApprovedPayload(secrets: secrets, value: nil) }
-        let key = BlessedExecutionKey(pid: pid, startUsec: identity.start_usec)
-        awsRegistrationsLock.lock()
-        awsRegistrations = awsRegistrations.filter { key, _ in
-            var current = AVProcessIdentity()
-            return av_process_identity(key.pid, &current) && current.start_usec == key.startUsec
+        guard let awsRegistration else {
+            return AuthorizationFulfillmentTransaction(material: ApprovedFulfillmentMaterial(
+                payload: ApprovedPayload(secrets: secrets, value: nil),
+                awsRegistration: nil
+            ))
         }
-        awsRegistrations[key] = AWSRegistration(
+        let registration = AWSRegistration(
             generation: awsRegistration.generation,
             chain: awsRegistration.chain,
             args: awsRegistration.args,
@@ -5172,7 +5224,6 @@ private final class ApprovalServer: @unchecked Sendable {
             secretValues: request.selectedSecretValues,
             credentials: nil
         )
-        awsRegistrationsLock.unlock()
         let section = awsRegistration.chain.selected.name == "default"
             ? "default"
             : "profile \(awsRegistration.chain.selected.name)"
@@ -5182,7 +5233,60 @@ private final class ApprovalServer: @unchecked Sendable {
         region = \(awsRegistration.chain.region)
 
         """
-        return ApprovedPayload(secrets: [:], value: config)
+        return AuthorizationFulfillmentTransaction(material: ApprovedFulfillmentMaterial(
+            payload: ApprovedPayload(secrets: [:], value: config),
+            awsRegistration: registration
+        ))
+    }
+
+    private func fulfillApprovedRequest(
+        request: ApprovalRequest,
+        awsRegistration: AWSRegistrationCandidate?,
+        pid: pid_t,
+        identity: AVProcessIdentity,
+        record: AccessRequestRecord,
+        launcher: LauncherIdentity?,
+        activateAfterRecording: () -> Void = {},
+        release: (ApprovedPayload) -> Void
+    ) throws -> Bool {
+        let transaction = try prepareApprovedFulfillment(
+            for: request,
+            awsRegistration: awsRegistration
+        )
+        return transaction.commit(
+            record: { onAccessRequest(record) },
+            activate: { material in
+                if let registration = material.awsRegistration {
+                    installAWSRegistration(registration, pid: pid, identity: identity)
+                }
+                activateAfterRecording()
+            },
+            observe: { material in
+                recordLiveSecretUse(
+                    request: request,
+                    payload: material.payload,
+                    launcher: launcher,
+                    pid: pid,
+                    identity: identity
+                )
+            },
+            release: { material in release(material.payload) }
+        )
+    }
+
+    private func installAWSRegistration(
+        _ registration: AWSRegistration,
+        pid: pid_t,
+        identity: AVProcessIdentity
+    ) {
+        let key = BlessedExecutionKey(pid: pid, startUsec: identity.start_usec)
+        awsRegistrationsLock.lock()
+        defer { awsRegistrationsLock.unlock() }
+        awsRegistrations = awsRegistrations.filter { key, _ in
+            var current = AVProcessIdentity()
+            return av_process_identity(key.pid, &current) && current.start_usec == key.startUsec
+        }
+        awsRegistrations[key] = registration
     }
 
     private func recordLiveSecretUse(

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -18,7 +18,6 @@ private let pendingMainWindowKey = "pendingMainWindow"
 private let pendingSecretGateKey = "pendingSecretGate"
 private let varlockProtocolVersion: UInt64 = 1
 let secCodeSignatureAdHoc: UInt32 = 0x2
-private let transientApprovalTTL: TimeInterval = 5 * 60
 private let scanMaximumDelay: TimeInterval = 5
 private let scanQueue = DispatchQueue(label: "com.automicvault.av2.scan")
 private let updateCheckInterval: Duration = .seconds(24 * 60 * 60)
@@ -1802,6 +1801,53 @@ private struct ApprovalRequest {
             selectedSecretValues: values
         )
     }
+
+    func decisionReuseRequest(
+        clientIdentity: AVProcessIdentity,
+        callerPath: String,
+        signing: SigningInfo
+    ) -> AuthorizationDecisionReuseRequest {
+        AuthorizationDecisionReuseRequest(
+            client: AuthorizationClientExecution(
+                pid: clientIdentity.pid,
+                pidVersion: clientIdentity.pidversion,
+                startUsec: clientIdentity.start_usec,
+                effectiveUserID: clientIdentity.euid,
+                auditSessionID: clientIdentity.audit_session_id
+            ),
+            callerPath: callerPath,
+            signingIdentifier: signing.identifier,
+            signingTeamIdentifier: signing.teamIdentifier,
+            operation: op,
+            secretNames: keys,
+            target: target,
+            arguments: args,
+            workingDirectory: cwd,
+            replaceExistingEnvironment: replaceExistingEnv,
+            allowMissingSecrets: allowMissingKeys,
+            environmentConflicts: envConflicts,
+            shebangScript: shebangScript,
+            scriptData: scriptData,
+            snapshotIncompatibleInterpreter: snapshotIncompatibleInterpreter,
+            tool: tool,
+            title: title,
+            detail: detail,
+            dockerServerURL: dockerServerURL,
+            dockerParent: dockerParent.map {
+                AuthorizationDockerParent(
+                    pid: $0.pid,
+                    startUsec: $0.startUsec,
+                    effectiveUserID: $0.euid,
+                    target: $0.target,
+                    arguments: $0.arguments
+                )
+            },
+            selectedSecretValues: selectedSecretValues,
+            policy: awsRequestMayUseLongLivedCredentials(self)
+                ? .freshApprovalRequired
+                : .reusable
+        )
+    }
 }
 
 enum SecretMutation {
@@ -1986,25 +2032,6 @@ enum SecretMutation {
     }
 }
 
-private struct TransientApprovalKey: Hashable {
-    let pid: Int32
-    let startUsec: UInt64
-    let callerPath: String
-    let signingIdentifier: String
-    let signingTeamIdentifier: String
-    let op: String
-    let keys: [String]
-    let target: String
-    let args: [String]
-    let cwd: String
-    let replaceExistingEnv: Bool
-    let allowMissingKeys: Bool
-    let envConflicts: [String]
-    let shebangScript: String?
-    let tool: String?
-    let selectedValueSources: [String]
-}
-
 private enum ApprovalDecision: Equatable {
     case canceled
     case interrupted
@@ -2012,6 +2039,19 @@ private enum ApprovalDecision: Equatable {
     case approved
     case alwaysApproved
     case temporaryWriteAccess
+}
+
+private extension ApprovalDecision {
+    var reuseOutcome: AuthorizationDecisionReuseOutcome {
+        switch self {
+        case .canceled: .canceled
+        case .interrupted: .interrupted
+        case .denied: .denied
+        case .approved: .approved
+        case .alwaysApproved: .alwaysApproved
+        case .temporaryWriteAccess: .temporaryAccessGrant
+        }
+    }
 }
 
 private func terminalApprovalDecision(
@@ -2167,6 +2207,18 @@ private func approvalEvent(
     humanApprovalAvailable && cachedDecision == nil ? humanApprovalRequiredEvent : nil
 }
 
+private func approvalDecision(
+    for reusedOutcome: AuthorizationDecisionReuseOutcome?
+) -> ApprovalDecision? {
+    switch reusedOutcome {
+    case .denied: .denied
+    case .approved, .alwaysApproved: .approved
+    case nil: nil
+    case .canceled, .interrupted, .temporaryAccessGrant:
+        preconditionFailure("the decision reuse cache returned a non-reusable outcome")
+    }
+}
+
 final class ApprovalCancellation: @unchecked Sendable {
     private let lock = NSLock()
     private var canceled = false
@@ -2217,43 +2269,6 @@ private func missingRequiredSecret(
     return request.keys.first {
         (request.replaceExistingEnv || !conflicts.contains($0))
             && !(exists?($0) ?? request.selectedSecretValues.contains($0))
-    }
-}
-
-private struct TransientApprovalCache {
-    private enum Key: Hashable {
-        case approval(TransientApprovalKey)
-        case denial(pid: Int32, startUsec: UInt64)
-    }
-
-    private var expirations: [Key: Date] = [:]
-
-    mutating func decision(
-        for key: TransientApprovalKey,
-        allowingApprovalReuse: Bool = true,
-        now: Date = Date()
-    ) -> ApprovalDecision? {
-        prune(now: now)
-        if expirations[.denial(pid: key.pid, startUsec: key.startUsec)] != nil {
-            return .denied
-        }
-        guard allowingApprovalReuse else { return nil }
-        return expirations[.approval(key)] == nil ? nil : .approved
-    }
-
-    mutating func remember(_ decision: ApprovalDecision, for key: TransientApprovalKey, now: Date = Date()) {
-        prune(now: now)
-        let cacheKey: Key
-        switch decision {
-        case .canceled, .interrupted, .temporaryWriteAccess: return
-        case .denied: cacheKey = .denial(pid: key.pid, startUsec: key.startUsec)
-        case .approved, .alwaysApproved: cacheKey = .approval(key)
-        }
-        expirations[cacheKey] = now.addingTimeInterval(transientApprovalTTL)
-    }
-
-    private mutating func prune(now: Date) {
-        expirations = expirations.filter { $0.value > now }
     }
 }
 
@@ -2611,7 +2626,7 @@ private final class ApprovalServer: @unchecked Sendable {
     private let canRequestMacInput: @MainActor () -> Bool
     private var listener: xpc_connection_t?
     // ponytail: helper-lifetime caches; persistent policy remains the cross-restart trust boundary.
-    private var transientApprovals = TransientApprovalCache()
+    private var transientApprovals = AuthorizationDecisionReuseCache()
     private let retainedProcessProvenanceLock = NSLock()
     private var retainedProcessProvenance = RetainedProcessProvenanceStore()
     private let blessedExecutionsLock = NSLock()
@@ -3444,23 +3459,10 @@ private final class ApprovalServer: @unchecked Sendable {
             launcher: launcher,
             agentTaskContext: currentAgentTaskContext
         )
-        let transientApproval = TransientApprovalKey(
-            pid: pid,
-            startUsec: identity.start_usec,
+        let transientApproval = request.decisionReuseRequest(
+            clientIdentity: identity,
             callerPath: callerPath,
-            signingIdentifier: signing.identifier,
-            signingTeamIdentifier: signing.teamIdentifier,
-            op: request.op,
-            keys: request.keys.sorted(),
-            target: request.target,
-            args: request.args,
-            cwd: request.cwd,
-            replaceExistingEnv: request.replaceExistingEnv,
-            allowMissingKeys: request.allowMissingKeys,
-            envConflicts: request.envConflicts.sorted(),
-            shebangScript: request.shebangScript,
-            tool: request.tool,
-            selectedValueSources: request.selectedSecretValues.identityComponents()
+            signing: signing
         )
         let promptBlessing: BlessedScriptPromptContext?
         if let activeBlessing {
@@ -3483,14 +3485,12 @@ private final class ApprovalServer: @unchecked Sendable {
         } else {
             promptBlessing = nil
         }
-        let requiresFreshOperationApproval = awsRequestMayUseLongLivedCredentials(request)
         RunLoop.main.perform(inModes: [.modalPanel, .default]) {
             MainActor.assumeIsolated {
                 guard !cancellation.isCanceled,
                       let event = approvalEvent(
-                          for: self.transientApprovals.decision(
-                              for: transientApproval,
-                              allowingApprovalReuse: !requiresFreshOperationApproval
+                          for: approvalDecision(
+                              for: self.transientApprovals.decision(for: transientApproval)
                           ),
                           humanApprovalAvailable: self.canRequestHumanApproval()
                       )
@@ -3548,10 +3548,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     return
                 }
             }
-            let cachedDecision = self.transientApprovals.decision(
-                for: transientApproval,
-                allowingApprovalReuse: !requiresFreshOperationApproval
-            )
+            let cachedDecision = self.transientApprovals.decision(for: transientApproval)
             if let decision = cachedDecision {
                 if decision == .denied {
                     _ = self.onAccessRequest(accessRequestRecord(
@@ -3799,9 +3796,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 {
                     self.registerBlessedExecution(script, pid: pid, identity: identity)
                 }
-                if !requiresFreshOperationApproval {
-                    self.transientApprovals.remember(.approved, for: transientApproval)
-                }
+                self.transientApprovals.remember(decision.reuseOutcome, for: transientApproval)
                 self.recordLiveSecretUse(
                     request: request,
                     payload: payload,
@@ -4312,6 +4307,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 do {
                     let material = try await SecretProxyCoordinator.shared.start(
                         launch: launch,
+                        secretValueCustody: self.secretValueCustody,
                         approveDestination: { destination, cancellation in
                             let destinationRequest = ApprovalRequest(
                                 op: "proxy-destination",
@@ -10399,68 +10395,74 @@ private func runBrewReadOnlySelfCheck() -> Int32 {
 }
 
 private func runTransientApprovalSelfCheck() -> Int32 {
-    func key(
+    func request(
         startUsec: UInt64 = 456,
         args: [String] = ["repo", "view"],
-        keys: [String] = ["GH_TOKEN_GITHUB_COM"]
-    ) -> TransientApprovalKey {
-        TransientApprovalKey(
-            pid: 123,
-            startUsec: startUsec,
+        keys: [String] = ["GH_TOKEN_GITHUB_COM"],
+        policy: AuthorizationDecisionReusePolicy = .reusable
+    ) -> AuthorizationDecisionReuseRequest {
+        AuthorizationDecisionReuseRequest(
+            client: AuthorizationClientExecution(
+                pid: 123,
+                pidVersion: 7,
+                startUsec: startUsec,
+                effectiveUserID: 501,
+                auditSessionID: 42
+            ),
             callerPath: "/opt/homebrew/bin/gh",
             signingIdentifier: "gh",
             signingTeamIdentifier: "TEAM",
-            op: "keys",
-            keys: keys,
+            operation: "keys",
+            secretNames: keys,
             target: "/opt/homebrew/Cellar/gh-cli/2.94.0/bin/gh",
-            args: args,
-            cwd: "/tmp",
-            replaceExistingEnv: true,
-            allowMissingKeys: false,
-            envConflicts: [],
+            arguments: args,
+            workingDirectory: "/tmp",
+            replaceExistingEnvironment: true,
+            allowMissingSecrets: false,
+            environmentConflicts: [],
             shebangScript: nil,
+            scriptData: nil,
+            snapshotIncompatibleInterpreter: nil,
             tool: "gh",
-            selectedValueSources: []
+            title: nil,
+            detail: nil,
+            dockerServerURL: nil,
+            dockerParent: nil,
+            selectedSecretValues: SelectedSecretValues(values: [:]),
+            policy: policy
         )
     }
-    let approval = key()
-    let denial = key(
+    let approval = request()
+    let denial = request(
         args: ["auth", "token"],
         keys: ["GH_TOKEN_GITHUB_COM_MXCL"]
     )
-    let temporaryGrant = key(startUsec: 987, args: ["repo", "create"])
-    let interrupted = key(startUsec: 988, args: ["repo", "delete"])
-    let fallbackAfterDenial = key(args: ["auth", "token"])
-    var cache = TransientApprovalCache()
+    let temporaryGrant = request(startUsec: 987, args: ["repo", "create"])
+    let interrupted = request(startUsec: 988, args: ["repo", "delete"])
+    let fallbackAfterDenial = request(args: ["auth", "token"])
+    let freshApproval = request(startUsec: 989, policy: .freshApprovalRequired)
+    var cache = AuthorizationDecisionReuseCache()
     cache.remember(.approved, for: approval, now: Date(timeIntervalSince1970: 100))
+    cache.remember(.approved, for: freshApproval, now: Date(timeIntervalSince1970: 100))
     guard cache.decision(for: approval, now: Date(timeIntervalSince1970: 200)) == .approved,
-          cache.decision(
-              for: approval,
-              allowingApprovalReuse: false,
-              now: Date(timeIntervalSince1970: 200)
-          ) == nil,
+          cache.decision(for: freshApproval, now: Date(timeIntervalSince1970: 200)) == nil,
           cache.decision(for: fallbackAfterDenial, now: Date(timeIntervalSince1970: 200)) == nil,
-          cache.decision(for: key(startUsec: 789), now: Date(timeIntervalSince1970: 200)) == nil
+          cache.decision(for: request(startUsec: 789), now: Date(timeIntervalSince1970: 200)) == nil
     else {
         return 1
     }
     cache.remember(.denied, for: denial, now: Date(timeIntervalSince1970: 200))
     cache.remember(
-        .temporaryWriteAccess,
+        .temporaryAccessGrant,
         for: temporaryGrant,
         now: Date(timeIntervalSince1970: 200)
     )
     cache.remember(.interrupted, for: interrupted, now: Date(timeIntervalSince1970: 200))
     guard cache.decision(for: denial, now: Date(timeIntervalSince1970: 300)) == .denied,
           cache.decision(for: fallbackAfterDenial, now: Date(timeIntervalSince1970: 300)) == .denied,
-          cache.decision(
-              for: fallbackAfterDenial,
-              allowingApprovalReuse: false,
-              now: Date(timeIntervalSince1970: 300)
-          ) == .denied,
           cache.decision(for: temporaryGrant, now: Date(timeIntervalSince1970: 300)) == nil,
           cache.decision(for: interrupted, now: Date(timeIntervalSince1970: 300)) == nil,
-          cache.decision(for: key(startUsec: 789), now: Date(timeIntervalSince1970: 300)) == nil,
+          cache.decision(for: request(startUsec: 789), now: Date(timeIntervalSince1970: 300)) == nil,
           cache.decision(for: fallbackAfterDenial, now: Date(timeIntervalSince1970: 501)) == nil
     else {
         return 1

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1529,7 +1529,7 @@ private func accessRequestRecord(
         cwd: request.cwd,
         keys: request.keys.sorted(),
         detail: request.detail,
-        secretValueSources: request.selectedValues.mapValues { $0.source.displayName }
+        secretValueSources: request.selectedSecretValues.sourceDisplayNames
     )
 }
 
@@ -1540,7 +1540,7 @@ private func automaticTargetRuntimeProtection(
 ) -> String? {
     guard decision == "Approved",
           approvalSource.caseInsensitiveCompare("Auto") == .orderedSame,
-          !request.selectedValues.isEmpty
+          !request.selectedSecretValues.isEmpty
     else { return nil }
 
     let protection: LauncherRuntimeProtection?
@@ -1741,7 +1741,7 @@ private struct ApprovalRequest {
     let detail: String?
     let dockerServerURL: String?
     let dockerParent: DockerCredentialParent?
-    let selectedValues: [String: StoredSecretValue]
+    let selectedSecretValues: SelectedSecretValues
 
     init(
         op: String,
@@ -1760,7 +1760,7 @@ private struct ApprovalRequest {
         detail: String?,
         dockerServerURL: String? = nil,
         dockerParent: DockerCredentialParent? = nil,
-        selectedValues: [String: StoredSecretValue] = [:]
+        selectedSecretValues: SelectedSecretValues = SelectedSecretValues(values: [:])
     ) {
         self.op = op
         self.keys = keys
@@ -1778,10 +1778,10 @@ private struct ApprovalRequest {
         self.detail = detail
         self.dockerServerURL = dockerServerURL
         self.dockerParent = dockerParent
-        self.selectedValues = selectedValues
+        self.selectedSecretValues = selectedSecretValues
     }
 
-    func selecting(_ values: [String: StoredSecretValue]) -> ApprovalRequest {
+    func selecting(_ values: SelectedSecretValues) -> ApprovalRequest {
         ApprovalRequest(
             op: op,
             keys: keys,
@@ -1799,7 +1799,7 @@ private struct ApprovalRequest {
             detail: detail,
             dockerServerURL: dockerServerURL,
             dockerParent: dockerParent,
-            selectedValues: values
+            selectedSecretValues: values
         )
     }
 }
@@ -1895,11 +1895,11 @@ enum SecretMutation {
         default: URL(fileURLWithPath: callerPath).lastPathComponent
         }
         let cwd: String
-        let selectedValues: [String: StoredSecretValue]
+        let selectedSecretValues: SelectedSecretValues
         switch self {
         case .saveProject(let account, _, let directory, let accessibility, _):
             cwd = directory
-            selectedValues = [account: StoredSecretValue(
+            selectedSecretValues = SelectedSecretValues(values: [account: StoredSecretValue(
                 source: .projectDirectory(directory),
                 keychainAccount: storedSecretKeychainAccount(
                     secretName: account,
@@ -1907,10 +1907,10 @@ enum SecretMutation {
                 ),
                 accessibility: accessibility,
                 keychainProperties: []
-            )]
+            )])
         default:
             cwd = ""
-            selectedValues = [:]
+            selectedSecretValues = SelectedSecretValues(values: [:])
         }
         return ApprovalRequest(
             op: properties.op,
@@ -1926,7 +1926,7 @@ enum SecretMutation {
             tool: tool,
             title: properties.title,
             detail: properties.detail,
-            selectedValues: selectedValues
+            selectedSecretValues: selectedSecretValues
         )
     }
 
@@ -2216,7 +2216,7 @@ private func missingRequiredSecret(
     let conflicts = Set(request.envConflicts)
     return request.keys.first {
         (request.replaceExistingEnv || !conflicts.contains($0))
-            && !(exists?($0) ?? (request.selectedValues[$0] != nil))
+            && !(exists?($0) ?? request.selectedSecretValues.contains($0))
     }
 }
 
@@ -2562,7 +2562,7 @@ private struct AWSRegistration {
     let target: String
     let interpreter: String
     let useLongLivedCredentials: Bool
-    let secretValues: [String: StoredSecretValue]
+    let secretValues: SelectedSecretValues
     var credentials: AWSCredentials?
 }
 
@@ -2607,6 +2607,7 @@ private final class ApprovalServer: @unchecked Sendable {
     private let canRequestHumanApproval: @MainActor () -> Bool
     private let temporaryAccessGrants: TemporaryAccessGrantController
     private let liveSecretUses: LiveSecretUseController<LiveSecretUseProcess>
+    private let secretValueCustody: SecretValueCustody
     private let canRequestMacInput: @MainActor () -> Bool
     private var listener: xpc_connection_t?
     // ponytail: helper-lifetime caches; persistent policy remains the cross-restart trust boundary.
@@ -2622,6 +2623,7 @@ private final class ApprovalServer: @unchecked Sendable {
         serviceName: String,
         temporaryAccessGrants: TemporaryAccessGrantController,
         liveSecretUses: LiveSecretUseController<LiveSecretUseProcess>,
+        secretValueCustody: SecretValueCustody = SecretValueCustody(),
         onAutoApproval: @escaping @MainActor (AutoApprovalRecord) -> Void = { _ in },
         onAccessRequest: @escaping @Sendable (AccessRequestRecord) -> Bool = { appendAccessRequestRecord($0) },
         onBlessRequest: @escaping @MainActor (
@@ -2640,6 +2642,7 @@ private final class ApprovalServer: @unchecked Sendable {
         self.serviceName = serviceName
         self.temporaryAccessGrants = temporaryAccessGrants
         self.liveSecretUses = liveSecretUses
+        self.secretValueCustody = secretValueCustody
         self.teamIdentifier = teamIdentifier
         self.secretGateDescriptors = try loadSecretGateDescriptors(
             avExecutableURL: avExecutableURL()
@@ -3053,37 +3056,10 @@ private final class ApprovalServer: @unchecked Sendable {
             let selectionNames = dockerRequest.keys.filter {
                 dockerRequest.replaceExistingEnv || !conflicts.contains($0)
             }
-            if !selectionNames.isEmpty {
-                let repairStatus = resumePendingSecretMutation()
-                if repairStatus != errSecSuccess {
-                    let names = pendingSecretMutationNames()
-                    if names.map({ !Set(selectionNames).isDisjoint(with: $0) }) ?? true {
-                        reply(
-                            peer,
-                            to: message,
-                            ok: false,
-                            error: "secret repair must complete before this request: \(repairStatus)"
-                        )
-                        return
-                    }
-                }
-            }
-            let selected: [String: StoredSecretValue]
-            if selectionNames.isEmpty {
-                selected = [:]
-            } else {
-                let storedSecrets: [StoredSecret]
-                switch loadStoredSecretsResult() {
-                case .success(let loaded): storedSecrets = loaded
-                case .failure(let status):
-                    throw AppError("failed to inspect stored Secrets: \(status)")
-                }
-                selected = try resolveStoredSecretValues(
-                    names: selectionNames,
-                    cwd: dockerRequest.cwd,
-                    secrets: storedSecrets
-                )
-            }
+            let selected = try secretValueCustody.bind(
+                names: selectionNames,
+                cwd: dockerRequest.cwd
+            )
             request = approvalRequestWithCredentialContext(dockerRequest.selecting(selected))
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
@@ -3484,9 +3460,7 @@ private final class ApprovalServer: @unchecked Sendable {
             envConflicts: request.envConflicts.sorted(),
             shebangScript: request.shebangScript,
             tool: request.tool,
-            selectedValueSources: request.selectedValues
-                .map { "\($0.key)=\($0.value.source.displayName)" }
-                .sorted()
+            selectedValueSources: request.selectedSecretValues.identityComponents()
         )
         let promptBlessing: BlessedScriptPromptContext?
         if let activeBlessing {
@@ -4032,23 +4006,14 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "Verified Launcher process is unavailable")
             return
         }
-        let selected: [String: StoredSecretValue]
+        let selected: SelectedSecretValues
         do {
-            let repairStatus = resumePendingSecretMutation()
-            guard repairStatus == errSecSuccess else {
-                throw AppError("secret repair must complete before this request: \(repairStatus)")
-            }
-            let storedSecrets: [StoredSecret]
-            switch loadStoredSecretsResult() {
-            case .success(let loaded): storedSecrets = loaded
-            case .failure(let status): throw AppError("failed to inspect stored Secrets: \(status)")
-            }
-            selected = try resolveStoredSecretValues(names: keys, cwd: cwd, secrets: storedSecrets)
+            selected = try secretValueCustody.bind(names: keys, cwd: cwd)
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
             return
         }
-        guard let missingKey = keys.first(where: { selected[$0] == nil }) else {
+        guard let missingKey = keys.first(where: { !selected.contains($0) }) else {
             let title = keys.count == 1
                 ? "Allow the Varlock plugin to receive \(keys[0])?"
                 : "Allow the Varlock plugin to receive \(keys.count) Secrets?"
@@ -4066,7 +4031,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 tool: "Varlock plugin",
                 title: title,
                 detail: "This Secret Disclosure returns the selected Secret Values to Varlock for one application process. Schema SHA-256: \(schemaDigest).",
-                selectedValues: selected
+                selectedSecretValues: selected
             )
             RunLoop.main.perform(inModes: [.modalPanel, .default]) {
                 MainActor.assumeIsolated {
@@ -4226,6 +4191,25 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid Proxy Session request")
             return
         }
+        let selectedSecretValues: SelectedSecretValues
+        do {
+            selectedSecretValues = try secretValueCustody.bind(
+                names: parsed.keys,
+                cwd: parsed.cwd
+            )
+        } catch {
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
+            return
+        }
+        if let missingName = parsed.keys.first(where: { !selectedSecretValues.contains($0) }) {
+            reply(
+                peer,
+                to: message,
+                ok: false,
+                error: "failed to load secret \(missingName): \(errSecItemNotFound)"
+            )
+            return
+        }
         let request = ApprovalRequest(
             op: parsed.op,
             keys: parsed.keys.sorted(),
@@ -4239,7 +4223,8 @@ private final class ApprovalServer: @unchecked Sendable {
             scriptData: nil,
             tool: "Secret Proxy",
             title: "Start this Proxy Session?",
-            detail: "The target receives random Secret References. Automic Vault will ask before releasing secrets to each new destination."
+            detail: "The target receives random Secret References. Automic Vault will ask before releasing secrets to each new destination.",
+            selectedSecretValues: selectedSecretValues
         )
         let launchers = launcherIdentities(for: identity)
         let ancestorFallbackPath = launcherFallbackPath(for: identity)
@@ -4313,6 +4298,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 target: request.target,
                 arguments: request.args,
                 cwd: request.cwd,
+                selectedSecretValues: request.selectedSecretValues,
                 targetCodeIdentity: targetCodeIdentity,
                 identity: ProxyTargetIdentity(
                     pid: identity.pid,
@@ -4342,7 +4328,8 @@ private final class ApprovalServer: @unchecked Sendable {
                                 title: "Allow secrets for \(destination.origin)?",
                                 detail: destination.queryNames.isEmpty
                                     ? "The proxy will request these secrets on demand for this URL."
-                                    : "The proxy will request these secrets on demand. Query values remain hidden; names: \(destination.queryNames.sorted().joined(separator: ", "))."
+                                    : "The proxy will request these secrets on demand. Query values remain hidden; names: \(destination.queryNames.sorted().joined(separator: ", ")).",
+                                selectedSecretValues: destination.selectedSecretValues
                             )
                             return switch showApprovalAlert(
                                 request: destinationRequest,
@@ -4918,7 +4905,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 detail: request.detail,
                 dockerServerURL: request.dockerServerURL,
                 dockerParent: request.dockerParent,
-                selectedValues: request.selectedValues
+                selectedSecretValues: request.selectedSecretValues
             )
         }
         DispatchQueue.main.async {
@@ -4979,24 +4966,14 @@ private final class ApprovalServer: @unchecked Sendable {
 
     private func approvedSecrets(for request: ApprovalRequest) throws -> [String: String] {
         let conflicts = Set(request.envConflicts)
-        var secrets: [String: String] = [:]
-        for key in request.keys where request.replaceExistingEnv || !conflicts.contains(key) {
-            guard let selected = request.selectedValues[key] else {
-                if request.allowMissingKeys { continue }
-                throw AppError("failed to load secret \(key): \(errSecItemNotFound)")
-            }
-            switch loadStoredSecretValue(selected) {
-            case .success(let value):
-                secrets[key] = value
-            case .notFound:
-                throw AppError("selected value for \(key) no longer exists")
-            case .failure(let status):
-                throw AppError("failed to load selected value for \(key): \(status)")
-            case .invalidUTF8:
-                throw AppError("selected value for \(key) is not valid UTF-8")
-            }
+        let names = request.keys.filter {
+            request.replaceExistingEnv || !conflicts.contains($0)
         }
-        return secrets
+        return try secretValueCustody.load(
+            request.selectedSecretValues,
+            names: names,
+            allowMissing: request.allowMissingKeys
+        )
     }
 
     private func awsRegistrationCandidate(
@@ -5196,7 +5173,7 @@ private final class ApprovalServer: @unchecked Sendable {
             target: awsRegistration.target,
             interpreter: awsRegistration.interpreter,
             useLongLivedCredentials: awsRegistration.useLongLivedCredentials,
-            secretValues: request.selectedValues,
+            secretValues: request.selectedSecretValues,
             credentials: nil
         )
         awsRegistrationsLock.unlock()
@@ -5221,7 +5198,7 @@ private final class ApprovalServer: @unchecked Sendable {
     ) {
         var secretNames = Set(payload.secrets.keys)
         if request.tool == "aws", payload.value != nil {
-            secretNames.formUnion(request.selectedValues.keys)
+            secretNames.formUnion(request.selectedSecretValues.names)
         }
         guard !secretNames.isEmpty else { return }
 
@@ -5359,10 +5336,17 @@ private final class ApprovalServer: @unchecked Sendable {
         _ registration: AWSRegistration,
         parentPID: pid_t
     ) async throws -> AWSCredentials {
-        guard let accessKeyValue = registration.secretValues["AWS_ACCESS_KEY_ID"],
-              let secretKeyValue = registration.secretValues["AWS_SECRET_ACCESS_KEY"],
-              case .success(let accessKey) = loadStoredSecretValue(accessKeyValue),
-              case .success(let secretKey) = loadStoredSecretValue(secretKeyValue)
+        let selectedKeys: [String: String]
+        do {
+            selectedKeys = try secretValueCustody.load(
+                registration.secretValues,
+                names: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+            )
+        } catch {
+            throw AppError("selected AWS access keys are unavailable: \(error.localizedDescription)")
+        }
+        guard let accessKey = selectedKeys["AWS_ACCESS_KEY_ID"],
+              let secretKey = selectedKeys["AWS_SECRET_ACCESS_KEY"]
         else { throw AppError("selected AWS access keys are unavailable") }
         var credentials = AWSCredentials(accessKeyID: accessKey, secretAccessKey: secretKey)
         if registration.useLongLivedCredentials { return credentials }
@@ -5976,7 +5960,7 @@ private func approvalRequestWithCredentialContext(_ request: ApprovalRequest) ->
         tool: request.tool,
         title: "Use long-lived AWS credentials?",
         detail: "AWS does not allow non-MFA GetSessionToken credentials to call this operation. Unless the selected profile uses MFA or assumes a role, Automic Vault will provide your original AWS access keys directly to AWS CLI; they retain every IAM permission assigned to those keys.",
-        selectedValues: request.selectedValues
+        selectedSecretValues: request.selectedSecretValues
     )
 }
 
@@ -7757,7 +7741,7 @@ private func approvalPromptSections(
             "Secret Values",
             "key.horizontal",
             request.keys.sorted().map { key in
-                let source = request.selectedValues[key]?.source
+                let source = request.selectedSecretValues.source(for: key)
                 let display = switch source {
                 case .global: "Global Value"
                 case .projectDirectory(let path): escapedSecurityPath(path)
@@ -8975,14 +8959,14 @@ private func runApprovalSelfCheck() -> Int32 {
         tool: nil,
         title: nil,
         detail: nil,
-        selectedValues: [
+        selectedSecretValues: SelectedSecretValues(values: [
             "TEST_SECRET": StoredSecretValue(
                 source: .global,
                 keychainAccount: "TEST_SECRET",
                 accessibility: .whenUnlocked,
                 keychainProperties: []
             ),
-        ]
+        ])
     )
     guard processEnvironmentValueSelfCheck() else {
         print("bounded peer environment self-check failed")

--- a/src/menu-helper/Sources/MenubarHelperCore/AuthorizationDecisionReuse.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AuthorizationDecisionReuse.swift
@@ -1,0 +1,182 @@
+import CryptoKit
+import Foundation
+
+public struct AuthorizationClientExecution: Hashable, Sendable {
+    public let pid: Int32
+    public let pidVersion: Int32
+    public let startUsec: UInt64
+    public let effectiveUserID: UInt32
+    public let auditSessionID: UInt32
+
+    public init(
+        pid: Int32,
+        pidVersion: Int32,
+        startUsec: UInt64,
+        effectiveUserID: UInt32,
+        auditSessionID: UInt32
+    ) {
+        self.pid = pid
+        self.pidVersion = pidVersion
+        self.startUsec = startUsec
+        self.effectiveUserID = effectiveUserID
+        self.auditSessionID = auditSessionID
+    }
+}
+
+public struct AuthorizationDockerParent: Hashable, Sendable {
+    public let pid: Int32
+    public let startUsec: UInt64
+    public let effectiveUserID: UInt32
+    public let target: String
+    public let arguments: [String]
+
+    public init(
+        pid: Int32,
+        startUsec: UInt64,
+        effectiveUserID: UInt32,
+        target: String,
+        arguments: [String]
+    ) {
+        self.pid = pid
+        self.startUsec = startUsec
+        self.effectiveUserID = effectiveUserID
+        self.target = target
+        self.arguments = arguments
+    }
+}
+
+public enum AuthorizationDecisionReusePolicy: Hashable, Sendable {
+    case reusable
+    case freshApprovalRequired
+}
+
+public enum AuthorizationDecisionReuseOutcome: Equatable, Sendable {
+    case canceled
+    case interrupted
+    case denied
+    case approved
+    case alwaysApproved
+    case temporaryAccessGrant
+}
+
+public struct AuthorizationDecisionReuseRequest: Hashable, Sendable {
+    fileprivate let client: AuthorizationClientExecution
+    fileprivate let policy: AuthorizationDecisionReusePolicy
+
+    private let callerPath: String
+    private let signingIdentifier: String
+    private let signingTeamIdentifier: String
+    private let operation: String
+    private let secretNames: [String]
+    private let target: String
+    private let arguments: [String]
+    private let workingDirectory: String
+    private let replaceExistingEnvironment: Bool
+    private let allowMissingSecrets: Bool
+    private let environmentConflicts: [String]
+    private let shebangScript: String?
+    private let scriptDataSHA256: Data?
+    private let snapshotIncompatibleInterpreter: String?
+    private let tool: String?
+    private let title: String?
+    private let detail: String?
+    private let dockerServerURL: String?
+    private let dockerParent: AuthorizationDockerParent?
+    private let selectedValueSources: [SelectedSecretValueSourceIdentity]
+
+    public init(
+        client: AuthorizationClientExecution,
+        callerPath: String,
+        signingIdentifier: String,
+        signingTeamIdentifier: String,
+        operation: String,
+        secretNames: [String],
+        target: String,
+        arguments: [String],
+        workingDirectory: String,
+        replaceExistingEnvironment: Bool,
+        allowMissingSecrets: Bool,
+        environmentConflicts: [String],
+        shebangScript: String?,
+        scriptData: Data?,
+        snapshotIncompatibleInterpreter: String?,
+        tool: String?,
+        title: String?,
+        detail: String?,
+        dockerServerURL: String?,
+        dockerParent: AuthorizationDockerParent?,
+        selectedSecretValues: SelectedSecretValues,
+        policy: AuthorizationDecisionReusePolicy
+    ) {
+        self.client = client
+        self.callerPath = callerPath
+        self.signingIdentifier = signingIdentifier
+        self.signingTeamIdentifier = signingTeamIdentifier
+        self.operation = operation
+        self.secretNames = Array(Set(secretNames)).sorted()
+        self.target = target
+        self.arguments = arguments
+        self.workingDirectory = workingDirectory
+        self.replaceExistingEnvironment = replaceExistingEnvironment
+        self.allowMissingSecrets = allowMissingSecrets
+        self.environmentConflicts = Array(Set(environmentConflicts)).sorted()
+        self.shebangScript = shebangScript
+        self.scriptDataSHA256 = scriptData.map { Data(SHA256.hash(data: $0)) }
+        self.snapshotIncompatibleInterpreter = snapshotIncompatibleInterpreter
+        self.tool = tool
+        self.title = title
+        self.detail = detail
+        self.dockerServerURL = dockerServerURL
+        self.dockerParent = dockerParent
+        self.selectedValueSources = selectedSecretValues.authorizationIdentity()
+        self.policy = policy
+    }
+}
+
+public struct AuthorizationDecisionReuseCache: Sendable {
+    private enum Key: Hashable, Sendable {
+        case approval(AuthorizationDecisionReuseRequest)
+        case denial(AuthorizationClientExecution)
+    }
+
+    private let ttl: TimeInterval
+    private var expirations: [Key: Date] = [:]
+
+    public init(ttl: TimeInterval = 5 * 60) {
+        precondition(ttl > 0)
+        self.ttl = ttl
+    }
+
+    public mutating func decision(
+        for request: AuthorizationDecisionReuseRequest,
+        now: Date = Date()
+    ) -> AuthorizationDecisionReuseOutcome? {
+        prune(now: now)
+        if expirations[.denial(request.client)] != nil { return .denied }
+        guard request.policy == .reusable else { return nil }
+        return expirations[.approval(request)] == nil ? nil : .approved
+    }
+
+    public mutating func remember(
+        _ outcome: AuthorizationDecisionReuseOutcome,
+        for request: AuthorizationDecisionReuseRequest,
+        now: Date = Date()
+    ) {
+        prune(now: now)
+        let key: Key
+        switch outcome {
+        case .canceled, .interrupted, .temporaryAccessGrant:
+            return
+        case .denied:
+            key = .denial(request.client)
+        case .approved, .alwaysApproved:
+            guard request.policy == .reusable else { return }
+            key = .approval(request)
+        }
+        expirations[key] = now.addingTimeInterval(ttl)
+    }
+
+    private mutating func prune(now: Date) {
+        expirations = expirations.filter { $0.value > now }
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/AuthorizationFulfillmentTransaction.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AuthorizationFulfillmentTransaction.swift
@@ -1,0 +1,22 @@
+/// Keeps staged authorization material private until its record has persisted.
+package struct AuthorizationFulfillmentTransaction<Material> {
+    private let material: Material
+
+    package init(material: Material) {
+        self.material = material
+    }
+
+    @discardableResult
+    package func commit(
+        record: () -> Bool,
+        activate: (Material) -> Void,
+        observe: (Material) -> Void,
+        release: (Material) -> Void
+    ) -> Bool {
+        guard record() else { return false }
+        activate(material)
+        observe(material)
+        release(material)
+        return true
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1480,7 +1480,7 @@ public func loadStoredSecrets(
     return secrets
 }
 
-public enum StoredSecretsLoad {
+public enum StoredSecretsLoad: Sendable {
     case success([StoredSecret])
     case failure(OSStatus)
 }
@@ -2099,7 +2099,7 @@ public func loadStoredSecret(
     return String(data: data, encoding: .utf8)
 }
 
-public enum StoredSecretValueLoad: Equatable {
+public enum StoredSecretValueLoad: Equatable, Sendable {
     case success(String)
     case notFound
     case failure(OSStatus)

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Security
+
+public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable {
+    case repairFailed(OSStatus)
+    case inventoryUnavailable(OSStatus)
+    case secretMissing(String)
+    case selectedValueMissing(String)
+    case selectedValueUnavailable(String, OSStatus)
+    case selectedValueInvalidUTF8(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .repairFailed(let status):
+            "secret repair must complete before this request: \(status)"
+        case .inventoryUnavailable(let status):
+            "failed to inspect stored Secrets: \(status)"
+        case .secretMissing(let name):
+            "failed to load secret \(name): \(errSecItemNotFound)"
+        case .selectedValueMissing(let name):
+            "selected value for \(name) no longer exists"
+        case .selectedValueUnavailable(let name, let status):
+            "failed to load selected value for \(name): \(status)"
+        case .selectedValueInvalidUTF8(let name):
+            "selected value for \(name) is not valid UTF-8"
+        }
+    }
+}
+
+public struct SelectedSecretValues: Equatable, Sendable {
+    private let values: [String: StoredSecretValue]
+
+    public init(values: [String: StoredSecretValue]) {
+        self.values = values
+    }
+
+    public var isEmpty: Bool { values.isEmpty }
+    public var names: Set<String> { Set(values.keys) }
+    public var sourceDisplayNames: [String: String] {
+        values.mapValues { $0.source.displayName }
+    }
+
+    public func selecting(names: [String]) -> SelectedSecretValues {
+        let requested = Set(names)
+        return SelectedSecretValues(values: values.filter { requested.contains($0.key) })
+    }
+
+    public func contains(_ name: String) -> Bool {
+        values[name] != nil
+    }
+
+    public func source(for name: String) -> StoredSecretValueSource? {
+        values[name]?.source
+    }
+
+    public func identityComponents() -> [String] {
+        values.map { "\($0.key)=\($0.value.source.displayName)" }.sorted()
+    }
+
+    func value(for name: String) -> StoredSecretValue? {
+        values[name]
+    }
+}
+
+protocol SecretValueCustodyAdapter: Sendable {
+    func repairPendingMutation() -> OSStatus
+    func pendingMutationNames() -> Set<String>?
+    func inventory() -> StoredSecretsLoad
+    func load(_ value: StoredSecretValue) -> StoredSecretValueLoad
+}
+
+private struct KeychainSecretValueCustodyAdapter: SecretValueCustodyAdapter {
+    func repairPendingMutation() -> OSStatus {
+        resumePendingSecretMutation()
+    }
+
+    func pendingMutationNames() -> Set<String>? {
+        MenubarHelperCore.pendingSecretMutationNames()
+    }
+
+    func inventory() -> StoredSecretsLoad {
+        loadStoredSecretsResult()
+    }
+
+    func load(_ value: StoredSecretValue) -> StoredSecretValueLoad {
+        loadStoredSecretValue(value)
+    }
+}
+
+public struct SecretValueCustody: Sendable {
+    private let adapter: any SecretValueCustodyAdapter
+
+    public init() {
+        adapter = KeychainSecretValueCustodyAdapter()
+    }
+
+    init(adapter: any SecretValueCustodyAdapter) {
+        self.adapter = adapter
+    }
+
+    public func bind(names: [String], cwd: String) throws -> SelectedSecretValues {
+        guard !names.isEmpty else { return SelectedSecretValues(values: [:]) }
+        let repairStatus = adapter.repairPendingMutation()
+        if repairStatus != errSecSuccess {
+            let pendingNames = adapter.pendingMutationNames()
+            if pendingNames.map({ !Set(names).isDisjoint(with: $0) }) ?? true {
+                throw SecretValueCustodyError.repairFailed(repairStatus)
+            }
+        }
+        let secrets: [StoredSecret]
+        switch adapter.inventory() {
+        case .success(let inventory):
+            secrets = inventory
+        case .failure(let status):
+            throw SecretValueCustodyError.inventoryUnavailable(status)
+        }
+        return SelectedSecretValues(
+            values: try resolveStoredSecretValues(names: names, cwd: cwd, secrets: secrets)
+        )
+    }
+
+    public func load(
+        _ selected: SelectedSecretValues,
+        names: [String],
+        allowMissing: Bool = false
+    ) throws -> [String: String] {
+        var loaded: [String: String] = [:]
+        for name in names {
+            guard let value = selected.value(for: name) else {
+                if allowMissing { continue }
+                throw SecretValueCustodyError.secretMissing(name)
+            }
+            switch adapter.load(value) {
+            case .success(let secret):
+                loaded[name] = secret
+            case .notFound:
+                throw SecretValueCustodyError.selectedValueMissing(name)
+            case .failure(let status):
+                throw SecretValueCustodyError.selectedValueUnavailable(name, status)
+            case .invalidUTF8:
+                throw SecretValueCustodyError.selectedValueInvalidUTF8(name)
+            }
+        }
+        return loaded
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -8,6 +8,7 @@ public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable 
     case selectedValueMissing(String)
     case selectedValueUnavailable(String, OSStatus)
     case selectedValueInvalidUTF8(String)
+    case selectedValueEmpty(String)
 
     public var errorDescription: String? {
         switch self {
@@ -23,6 +24,8 @@ public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable 
             "failed to load selected value for \(name): \(status)"
         case .selectedValueInvalidUTF8(let name):
             "selected value for \(name) is not valid UTF-8"
+        case .selectedValueEmpty(let name):
+            "selected value for \(name) is empty"
         }
     }
 }
@@ -142,6 +145,9 @@ public struct SecretValueCustody: Sendable {
             }
             switch adapter.load(value) {
             case .success(let secret):
+                guard !secret.isEmpty else {
+                    throw SecretValueCustodyError.selectedValueEmpty(name)
+                }
                 loaded[name] = secret
             case .notFound:
                 throw SecretValueCustodyError.selectedValueMissing(name)

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -30,7 +30,7 @@ public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable 
 public struct SelectedSecretValues: Equatable, Sendable {
     private let values: [String: StoredSecretValue]
 
-    public init(values: [String: StoredSecretValue]) {
+    package init(values: [String: StoredSecretValue]) {
         self.values = values
     }
 
@@ -53,13 +53,23 @@ public struct SelectedSecretValues: Equatable, Sendable {
         values[name]?.source
     }
 
-    public func identityComponents() -> [String] {
-        values.map { "\($0.key)=\($0.value.source.displayName)" }.sorted()
+    func authorizationIdentity() -> [SelectedSecretValueSourceIdentity] {
+        values.map {
+            SelectedSecretValueSourceIdentity(name: $0.key, source: $0.value.source)
+        }.sorted { lhs, rhs in
+            if lhs.name != rhs.name { return lhs.name < rhs.name }
+            return String(describing: lhs.source) < String(describing: rhs.source)
+        }
     }
 
     func value(for name: String) -> StoredSecretValue? {
         values[name]
     }
+}
+
+struct SelectedSecretValueSourceIdentity: Hashable, Sendable {
+    let name: String
+    let source: StoredSecretValueSource
 }
 
 protocol SecretValueCustodyAdapter: Sendable {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationDecisionReuseTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationDecisionReuseTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+enum RequestMutation: CaseIterable {
+    case pid, pidVersion, startUsec, effectiveUserID, auditSessionID
+    case callerPath, signingIdentifier, signingTeamIdentifier
+    case operation, keys, target, arguments, workingDirectory
+    case replaceExistingEnvironment, allowMissingSecrets, environmentConflicts
+    case shebangScript, scriptData, snapshotIncompatibleInterpreter, tool, title, detail
+    case dockerServerURL, dockerParentPID, dockerParentStartUsec, dockerParentEUID
+    case dockerParentTarget, dockerParentArguments, selectedValueSource
+}
+
+@Test("an allowed decision is reused only for the complete request", arguments: RequestMutation.allCases)
+func authorizationDecisionReuseBindsEveryRequestField(_ mutation: RequestMutation) {
+    let approved = reuseRequest()
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(.approved, for: approved, now: Date(timeIntervalSince1970: 100))
+
+    #expect(
+        cache.decision(
+            for: reuseRequest(mutation),
+            now: Date(timeIntervalSince1970: 101)
+        ) == nil,
+        "mutation unexpectedly reused approval: \(mutation)"
+    )
+}
+
+@Test func authorizationDecisionReuseNormalizesSetsButPreservesArgumentOrder() {
+    let approved = reuseRequest(keys: ["B", "A", "A"], conflicts: ["Y", "X", "X"])
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(.approved, for: approved, now: Date(timeIntervalSince1970: 100))
+
+    let normalized = reuseRequest(keys: ["A", "B"], conflicts: ["X", "Y"])
+    #expect(cache.decision(for: normalized, now: Date(timeIntervalSince1970: 101)) == .approved)
+    #expect(
+        cache.decision(
+            for: reuseRequest(arguments: ["--region", "us-east-1"]),
+            now: Date(timeIntervalSince1970: 101)
+        ) == nil
+    )
+}
+
+@Test func authorizationDecisionReuseNeverCachesFreshOnlyApproval() {
+    let request = reuseRequest(policy: .freshApprovalRequired)
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(.approved, for: request, now: Date(timeIntervalSince1970: 100))
+    cache.remember(.alwaysApproved, for: request, now: Date(timeIntervalSince1970: 100))
+
+    #expect(cache.decision(for: request, now: Date(timeIntervalSince1970: 101)) == nil)
+}
+
+@Test func authorizationDecisionReuseDenialQuarantinesTheLiveGateClient() {
+    let denied = reuseRequest()
+    let differentRequest = reuseRequest(.arguments)
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(.denied, for: denied, now: Date(timeIntervalSince1970: 100))
+
+    #expect(cache.decision(for: differentRequest, now: Date(timeIntervalSince1970: 399)) == .denied)
+    #expect(cache.decision(for: differentRequest, now: Date(timeIntervalSince1970: 400)) == nil)
+    #expect(
+        cache.decision(
+            for: reuseRequest(.pidVersion),
+            now: Date(timeIntervalSince1970: 101)
+        ) == nil
+    )
+}
+
+@Test(
+    "non-terminal authorization outcomes are never cached",
+    arguments: [
+        AuthorizationDecisionReuseOutcome.canceled,
+        .interrupted,
+        .temporaryAccessGrant,
+    ]
+)
+func authorizationDecisionReuseIgnoresNonTerminalOutcomes(
+    _ outcome: AuthorizationDecisionReuseOutcome
+) {
+    let request = reuseRequest()
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(outcome, for: request, now: Date(timeIntervalSince1970: 100))
+
+    #expect(cache.decision(for: request, now: Date(timeIntervalSince1970: 101)) == nil)
+}
+
+@Test func authorizationDecisionReuseExpiresAllowedDecisionAtTTLBoundary() {
+    let request = reuseRequest()
+    var cache = AuthorizationDecisionReuseCache(ttl: 300)
+    cache.remember(.alwaysApproved, for: request, now: Date(timeIntervalSince1970: 100))
+
+    #expect(cache.decision(for: request, now: Date(timeIntervalSince1970: 399)) == .approved)
+    #expect(cache.decision(for: request, now: Date(timeIntervalSince1970: 400)) == nil)
+}
+
+private func reuseRequest(
+    _ mutation: RequestMutation? = nil,
+    keys: [String] = ["API_TOKEN"],
+    conflicts: [String] = ["PATH"],
+    arguments: [String] = ["repo", "view"],
+    policy: AuthorizationDecisionReusePolicy = .reusable
+) -> AuthorizationDecisionReuseRequest {
+    let client = AuthorizationClientExecution(
+        pid: mutation == .pid ? 124 : 123,
+        pidVersion: mutation == .pidVersion ? 8 : 7,
+        startUsec: mutation == .startUsec ? 457 : 456,
+        effectiveUserID: mutation == .effectiveUserID ? 502 : 501,
+        auditSessionID: mutation == .auditSessionID ? 43 : 42
+    )
+    let dockerParent = AuthorizationDockerParent(
+        pid: mutation == .dockerParentPID ? 778 : 777,
+        startUsec: mutation == .dockerParentStartUsec ? 889 : 888,
+        effectiveUserID: mutation == .dockerParentEUID ? 502 : 501,
+        target: mutation == .dockerParentTarget ? "/usr/local/bin/docker-2" : "/usr/local/bin/docker",
+        arguments: mutation == .dockerParentArguments ? ["pull"] : ["login"]
+    )
+    let source: StoredSecretValueSource = mutation == .selectedValueSource
+        ? .projectDirectory("/tmp/project-2")
+        : .projectDirectory("/tmp/project")
+    let selected = SelectedSecretValues(values: [
+        "API_TOKEN": StoredSecretValue(
+            source: source,
+            keychainAccount: "bound-api-token",
+            accessibility: .whenUnlocked,
+            keychainProperties: []
+        ),
+    ])
+    return AuthorizationDecisionReuseRequest(
+        client: client,
+        callerPath: mutation == .callerPath ? "/usr/local/bin/other" : "/usr/local/bin/gh",
+        signingIdentifier: mutation == .signingIdentifier ? "other" : "gh",
+        signingTeamIdentifier: mutation == .signingTeamIdentifier ? "OTHER" : "TEAM",
+        operation: mutation == .operation ? "value" : "keys",
+        secretNames: mutation == .keys ? ["OTHER_TOKEN"] : keys,
+        target: mutation == .target ? "/usr/bin/other" : "/usr/bin/gh",
+        arguments: mutation == .arguments ? ["repo", "list"] : arguments,
+        workingDirectory: mutation == .workingDirectory ? "/private/tmp" : "/tmp",
+        replaceExistingEnvironment: mutation == .replaceExistingEnvironment,
+        allowMissingSecrets: mutation == .allowMissingSecrets,
+        environmentConflicts: mutation == .environmentConflicts ? ["HOME"] : conflicts,
+        shebangScript: mutation == .shebangScript ? "/tmp/two.swift" : "/tmp/one.swift",
+        scriptData: mutation == .scriptData ? Data("two".utf8) : Data("one".utf8),
+        snapshotIncompatibleInterpreter: mutation == .snapshotIncompatibleInterpreter ? "ruby" : "python",
+        tool: mutation == .tool ? "git" : "gh",
+        title: mutation == .title ? "Other request" : "Request",
+        detail: mutation == .detail ? "Other detail" : "Detail",
+        dockerServerURL: mutation == .dockerServerURL ? "registry-2.example" : "registry.example",
+        dockerParent: dockerParent,
+        selectedSecretValues: selected,
+        policy: policy
+    )
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationFulfillmentTransactionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationFulfillmentTransactionTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import MenubarHelperCore
+
+@Test func authorizationFulfillmentRecordsBeforeActivationObservationAndRelease() {
+    var events: [String] = []
+    let transaction = AuthorizationFulfillmentTransaction(material: "secret-material")
+
+    let committed = transaction.commit(
+        record: {
+            events.append("record")
+            return true
+        },
+        activate: { material in
+            events.append("aws-registration:\(material)")
+            events.append("authority-bookkeeping:\(material)")
+        },
+        observe: { material in events.append("live-use:\(material)") },
+        release: { material in events.append("successful-reply:\(material)") }
+    )
+
+    #expect(committed)
+    #expect(events == [
+        "record",
+        "aws-registration:secret-material",
+        "authority-bookkeeping:secret-material",
+        "live-use:secret-material",
+        "successful-reply:secret-material",
+    ])
+}
+
+@Test func authorizationFulfillmentRecordFailurePreventsEverySideEffect() {
+    var events: [String] = []
+    let transaction = AuthorizationFulfillmentTransaction(material: "secret-material")
+
+    let committed = transaction.commit(
+        record: {
+            events.append("record-failed")
+            return false
+        },
+        activate: { _ in
+            events.append("aws-registration")
+            events.append("grant-blessing-or-provenance")
+        },
+        observe: { _ in events.append("live-use") },
+        release: { _ in events.append("successful-reply") }
+    )
+
+    #expect(!committed)
+    #expect(events == ["record-failed"])
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Security
+import Testing
+@testable import MenubarHelperCore
+
+private struct InMemorySecretValueCustodyAdapter: SecretValueCustodyAdapter {
+    let repairStatus: OSStatus
+    let pendingNames: Set<String>?
+    let inventoryResult: StoredSecretsLoad
+    let loadedValues: [String: StoredSecretValueLoad]
+
+    init(
+        repairStatus: OSStatus = errSecSuccess,
+        pendingNames: Set<String>? = [],
+        secrets: [StoredSecret],
+        loadedValues: [String: StoredSecretValueLoad]
+    ) {
+        self.repairStatus = repairStatus
+        self.pendingNames = pendingNames
+        self.inventoryResult = .success(secrets)
+        self.loadedValues = loadedValues
+    }
+
+    init(inventoryFailure: OSStatus) {
+        repairStatus = errSecSuccess
+        pendingNames = []
+        inventoryResult = .failure(inventoryFailure)
+        loadedValues = [:]
+    }
+
+    func repairPendingMutation() -> OSStatus { repairStatus }
+    func pendingMutationNames() -> Set<String>? { pendingNames }
+    func inventory() -> StoredSecretsLoad { inventoryResult }
+    func load(_ value: StoredSecretValue) -> StoredSecretValueLoad {
+        loadedValues[value.keychainAccount] ?? .notFound
+    }
+}
+
+@Test func secretValueCustodyBindsAndLoadsTheNearestProjectValue() throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("av-custody-\(UUID().uuidString)", isDirectory: true)
+    let project = root.appendingPathComponent("project", isDirectory: true)
+    let workingDirectory = project.appendingPathComponent("Sources", isDirectory: true)
+    try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let projectPath = try canonicalProjectDirectory(project.path)
+    let cwd = try canonicalProjectDirectory(workingDirectory.path)
+    let global = storedValue(source: .global, account: "global")
+    let projectValue = storedValue(source: .projectDirectory(projectPath), account: "project")
+    let adapter = InMemorySecretValueCustodyAdapter(
+        secrets: [StoredSecret(account: "API_TOKEN", values: [global, projectValue])],
+        loadedValues: ["global": .success("global-secret"), "project": .success("project-secret")]
+    )
+    let custody = SecretValueCustody(adapter: adapter)
+
+    let selected = try custody.bind(names: ["API_TOKEN"], cwd: cwd)
+
+    #expect(selected.source(for: "API_TOKEN") == .projectDirectory(projectPath))
+    #expect(selected.sourceDisplayNames == ["API_TOKEN": projectPath])
+    #expect(try custody.load(selected, names: ["API_TOKEN"]) == ["API_TOKEN": "project-secret"])
+}
+
+@Test func secretValueCustodyNeverFallsBackAfterBinding() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let global = storedValue(source: .global, account: "global")
+    let project = storedValue(source: .projectDirectory(cwd), account: "project")
+    let adapter = InMemorySecretValueCustodyAdapter(
+        secrets: [StoredSecret(account: "API_TOKEN", values: [global, project])],
+        loadedValues: ["global": .success("global-secret"), "project": .notFound]
+    )
+    let custody = SecretValueCustody(adapter: adapter)
+    let selected = try custody.bind(names: ["API_TOKEN"], cwd: cwd)
+
+    #expect(throws: SecretValueCustodyError.selectedValueMissing("API_TOKEN")) {
+        try custody.load(selected, names: ["API_TOKEN"])
+    }
+}
+
+@Test func secretValueCustodyFailsClosedBeforeBindingWhenRepairFails() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let adapter = InMemorySecretValueCustodyAdapter(
+        repairStatus: errSecDecode,
+        pendingNames: ["API_TOKEN"],
+        secrets: [],
+        loadedValues: [:]
+    )
+
+    #expect(throws: SecretValueCustodyError.repairFailed(errSecDecode)) {
+        try SecretValueCustody(adapter: adapter).bind(names: ["API_TOKEN"], cwd: cwd)
+    }
+}
+
+@Test func secretValueCustodyAllowsUnaffectedSecretsWhileRepairIsPending() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let global = storedValue(source: .global, account: "other")
+    let adapter = InMemorySecretValueCustodyAdapter(
+        repairStatus: errSecDecode,
+        pendingNames: ["BROKEN_TOKEN"],
+        secrets: [StoredSecret(account: "API_TOKEN", values: [global])],
+        loadedValues: ["other": .success("secret")]
+    )
+    let custody = SecretValueCustody(adapter: adapter)
+
+    let selected = try custody.bind(names: ["API_TOKEN"], cwd: cwd)
+
+    #expect(try custody.load(selected, names: ["API_TOKEN"]) == ["API_TOKEN": "secret"])
+}
+
+@Test func secretValueCustodyFailsClosedWhenInventoryIsUnavailable() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+
+    #expect(throws: SecretValueCustodyError.inventoryUnavailable(errSecNotAvailable)) {
+        try SecretValueCustody(
+            adapter: InMemorySecretValueCustodyAdapter(inventoryFailure: errSecNotAvailable)
+        ).bind(names: ["API_TOKEN"], cwd: cwd)
+    }
+}
+
+private func storedValue(source: StoredSecretValueSource, account: String) -> StoredSecretValue {
+    StoredSecretValue(
+        source: source,
+        keychainAccount: account,
+        accessibility: .whenUnlocked,
+        keychainProperties: []
+    )
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
@@ -77,6 +77,21 @@ private struct InMemorySecretValueCustodyAdapter: SecretValueCustodyAdapter {
     }
 }
 
+@Test func secretValueCustodyRejectsEmptySelectedValue() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let global = storedValue(source: .global, account: "global")
+    let adapter = InMemorySecretValueCustodyAdapter(
+        secrets: [StoredSecret(account: "API_TOKEN", values: [global])],
+        loadedValues: ["global": .success("")]
+    )
+    let custody = SecretValueCustody(adapter: adapter)
+    let selected = try custody.bind(names: ["API_TOKEN"], cwd: cwd)
+
+    #expect(throws: SecretValueCustodyError.selectedValueEmpty("API_TOKEN")) {
+        try custody.load(selected, names: ["API_TOKEN"])
+    }
+}
+
 @Test func secretValueCustodyFailsClosedBeforeBindingWhenRepairFails() throws {
     let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
     let adapter = InMemorySecretValueCustodyAdapter(


### PR DESCRIPTION
## Summary

- bind selected Secret Value sources before authorization and load only the exact bound source after a decision
- centralize complete-request identity and policy for in-memory authorization decision reuse
- enforce Authorization Record persistence as the commit point before AWS registration, grants, bookkeeping, or Secret release
- route inject, Varlock, Secret Proxy, Temporary Access Grant, blessed, direct-access, and reused-decision flows through these boundaries

## Security properties

- Project and Global Value selection is immutable across authorization, with no fallback after a decision
- reusable approvals bind to the complete live client and operation identity while transport metadata remains non-authoritative
- long-lived AWS credential requests always require fresh approval
- fulfillment order is record, activate, observe, release; record failure produces no authority or successful reply
- Temporary Access Grant leases remain held through load, record, provenance, and reply

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked` — 937 tests
- `swift test --package-path src/menu-helper --disable-automatic-resolution` — 165 tests
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/build.sh` including release signing, entitlement, nested-helper, and sandbox checks
- all 14 non-sleep release-binary self-checks
- live signed XPC Secret Name listing and Secret injection
- live reference-only Secret Proxy flow
- local macOS Approve Once UI flow with successful injected-process execution

A fresh architecture review found no remaining Strong or Worth-exploring recommendation that survived the deletion test.