### PR TITLE
Add authorization-gated GPG commit signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "bpb"
 version = "2.0.0"
-source = "git+https://github.com/automic-vault/bpb.git?rev=56448a6#56448a6096d139512105c537a70471511a999da2"
+source = "git+https://github.com/automic-vault/bpb.git?rev=6f871d2#6f871d21f27ab027ec45738ec3e589ca7e9b1a90"
 dependencies = [
  "pgp",
  "rand 0.8.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "bpb"
 version = "2.0.0"
-source = "git+https://github.com/automic-vault/bpb.git?rev=6f871d2#6f871d21f27ab027ec45738ec3e589ca7e9b1a90"
+source = "git+https://github.com/automic-vault/bpb.git?rev=5dec130#5dec1300f95835bdb7167e11480620f40887d188"
 dependencies = [
  "pgp",
  "rand 0.8.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,6 @@ version = "3.15.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
- "bpb",
  "futures-util",
  "http-body-util",
  "http-mitm-proxy",
@@ -179,6 +178,8 @@ dependencies = [
  "hyper-util",
  "libc",
  "percent-encoding",
+ "pgp",
+ "rand 0.8.7",
  "reqwest",
  "ring",
  "serde",
@@ -384,16 +385,6 @@ checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
-]
-
-[[package]]
-name = "bpb"
-version = "2.0.0"
-source = "git+https://github.com/automic-vault/bpb.git?rev=2b8bcf0#2b8bcf0ec9fcab388f806f4921b1c2cabf36c52f"
-dependencies = [
- "pgp",
- "rand 0.8.7",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "bpb"
 version = "2.0.0"
-source = "git+https://github.com/automic-vault/bpb.git?rev=5dec130#5dec1300f95835bdb7167e11480620f40887d188"
+source = "git+https://github.com/automic-vault/bpb.git?rev=2b8bcf0#2b8bcf0ec9fcab388f806f4921b1c2cabf36c52f"
 dependencies = [
  "pgp",
  "rand 0.8.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "bytes",
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +78,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +99,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -112,6 +170,7 @@ version = "3.15.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "bpb",
  "futures-util",
  "http-body-util",
  "http-mitm-proxy",
@@ -210,6 +269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,10 +302,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfields"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "thiserror",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -252,6 +365,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
+name = "bpb"
+version = "2.0.0"
+source = "git+https://github.com/automic-vault/bpb.git?rev=56448a6#56448a6096d139512105c537a70471511a999da2"
+dependencies = [
+ "pgp",
+ "rand 0.8.7",
+ "zeroize",
 ]
 
 [[package]]
@@ -287,16 +429,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
+name = "cast5"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -308,6 +484,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -331,6 +516,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -364,9 +570,24 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -385,6 +606,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
@@ -420,12 +647,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -439,10 +679,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint",
+ "elliptic-curve",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
+ "sha3",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "der-parser"
@@ -452,7 +800,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -465,13 +813,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -481,7 +894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -497,10 +910,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher",
+ "cmac",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "base64ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "serde_json",
+ "serdect 0.2.0",
+ "subtle",
+ "tap",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -539,6 +1045,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +1075,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -574,6 +1098,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -686,6 +1216,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -728,6 +1259,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +1303,36 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1014,6 +1596,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1639,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1078,16 +1684,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -1146,6 +1784,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -1217,6 +1865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1893,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,12 +1925,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -1273,6 +1991,50 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
 
 [[package]]
 name = "parking"
@@ -1304,6 +2066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,10 +2087,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64 0.22.1",
+ "bitfields",
+ "block-padding",
+ "blowfish",
+ "buffer-redux",
+ "byteorder",
+ "bytes",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "cipher",
+ "const-oid 0.9.6",
+ "crc24",
+ "curve25519-dalek",
+ "cx448",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "flate2",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "idea",
+ "k256",
+ "log",
+ "md-5",
+ "memchr",
+ "nom 8.0.0",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.7",
+ "replace_with",
+ "ripemd",
+ "rsa",
+ "sha1 0.10.7",
+ "sha1-checked",
+ "sha2",
+ "sha3",
+ "signature",
+ "smallvec",
+ "snafu",
+ "subtle",
+ "twofish",
+ "x25519-dalek",
+ "zeroize",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1332,10 +2183,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1365,6 +2249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1454,12 +2347,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1476,12 +2386,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1549,6 +2478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +2523,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,10 +2547,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -1613,7 +2596,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1677,6 +2660,27 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1745,6 +2749,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +2788,38 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1 0.10.7",
+ "zeroize",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -1792,6 +2848,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2876,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "snafu"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,10 +2907,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1878,6 +2987,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -2205,6 +3320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +3339,28 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2524,6 +3670,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,7 +3700,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "ring",
  "rusticata-macros",
@@ -2620,6 +3787,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2653,6 +3834,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ panic = "abort"
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
-bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "5dec130" }
+bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "2b8bcf0" }
 futures-util = "0.3"
 http-body-util = "0.1"
 http-mitm-proxy = { version = "=0.18.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ panic = "abort"
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
-bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "2b8bcf0" }
 futures-util = "0.3"
 http-body-util = "0.1"
 http-mitm-proxy = { version = "=0.18.0", default-features = false }
@@ -24,6 +23,8 @@ libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
 ring = "0.17"
 percent-encoding = "2.3"
+pgp = { version = "0.20", default-features = false }
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 subtle = "2.6"
@@ -40,8 +41,8 @@ name = "av"
 path = "src/cli/main.rs"
 
 [[bin]]
-name = "bpb"
-path = "src/bpb/main.rs"
+name = "av-gpg"
+path = "src/av_gpg/main.rs"
 
 [[bin]]
 name = "av-brew-stub"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ panic = "abort"
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
-bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "6f871d2" }
+bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "5dec130" }
 futures-util = "0.3"
 http-body-util = "0.1"
 http-mitm-proxy = { version = "=0.18.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ panic = "abort"
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
-bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "56448a6" }
+bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "6f871d2" }
 futures-util = "0.3"
 http-body-util = "0.1"
 http-mitm-proxy = { version = "=0.18.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ panic = "abort"
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
+bpb = { git = "https://github.com/automic-vault/bpb.git", rev = "56448a6" }
 futures-util = "0.3"
 http-body-util = "0.1"
 http-mitm-proxy = { version = "=0.18.0", default-features = false }
@@ -37,6 +38,10 @@ path = "src/lib.rs"
 [[bin]]
 name = "av"
 path = "src/cli/main.rs"
+
+[[bin]]
+name = "bpb"
+path = "src/bpb/main.rs"
 
 [[bin]]
 name = "av-brew-stub"

--- a/docs/adr/0019-gpg-signing-gate.md
+++ b/docs/adr/0019-gpg-signing-gate.md
@@ -49,8 +49,9 @@ MiB. Git and `av-gpg` never receive credential bytes.
 
 Using a signing key now requires an Authorization Decision over the Verified
 Launcher, Gate Client, Target, arguments, working directory, selected Secret
-Names, and process execution. The gate defaults to Read Only, so Local Write
-signing requires Approval until policy explicitly grants it.
+Names, and process execution. The gate defaults to Approval Required. Its policy
+exposes only Approval Required and Allow Signing because every recognized
+operation at this gate is GPG signing classified as Local Write.
 
 The signed `av` Target necessarily handles usable private-key material in its
 memory. Hardened Runtime and code-signature verification reduce injection risk

--- a/docs/adr/0019-gpg-signing-gate.md
+++ b/docs/adr/0019-gpg-signing-gate.md
@@ -29,8 +29,8 @@ unrelated GPG operations continue to delegate to the user's `gpg` command.
 The menu app treats each request as Local Write at the GPG Signing Gate. It
 verifies `av` as Gate Client and Target, resolves the live Verified Launcher,
 and selects one GPG Signing Credential before authorization. The default and
-alternate credentials each contain a private-key Secret and passphrase Secret
-in the Data Protection Keychain.
+alternate credentials each contain a private-key Secret and, when the key is
+encrypted, a passphrase Secret in the Data Protection Keychain.
 
 Launcher Signing Credential Rules are stored in the Data Protection Keychain
 and bind exact designated requirements to the alternate credential. The menu

--- a/docs/adr/0019-gpg-signing-gate.md
+++ b/docs/adr/0019-gpg-signing-gate.md
@@ -8,7 +8,9 @@ Git's `gpg.program` interface sends a commit or tag payload to a GPG-compatible
 process and expects a detached OpenPGP signature. Ordinary GnuPG configurations
 let a same-user process ask the agent to sign, so possession of the user session
 often becomes ambient signing authority. Giving a wrapper the exported private
-key would merely move that ambient authority into another file or process.
+key would merely move that ambient authority into another file or process. Git
+configures a program pathname rather than a subcommand and uses that same
+program for signing and verification.
 
 Users also need agent-authored commits to be distinguishable from commits made
 through their normal interactive Launcher. A client-provided “agent” flag is
@@ -16,12 +18,13 @@ forgeable and cannot safely select the more valuable default credential.
 
 ## Decision
 
-Bundle `bpb` as Git's GPG-compatible Command inside `Automic Vault.app` without
-installing a second system command. For signing requests, `bpb` executes the
-adjacent signed `av` binary and streams the immutable payload. `av` holds the
-bounded payload in memory and binds its SHA-256 digest into the Authorization
-Request. `bpb` receives only the detached signature. Verification and unrelated
-GPG operations continue to delegate to the user's `gpg` command.
+Bundle `av-gpg` as Git's narrow GPG-compatible adapter inside
+`Automic Vault.app` without installing a second system command. For signing
+requests, `av-gpg` executes the adjacent signed `av gpg-sign` Command and
+streams the immutable payload. `av` owns the OpenPGP implementation, holds the
+bounded payload in memory, and binds its SHA-256 digest into the Authorization
+Request. `av-gpg` receives only the detached signature. Verification and
+unrelated GPG operations continue to delegate to the user's `gpg` command.
 
 The menu app treats each request as Local Write at the GPG Signing Gate. It
 verifies `av` as Gate Client and Target, resolves the live Verified Launcher,
@@ -40,7 +43,7 @@ After an allowed Authorization Record is persisted and verified, the app
 releases exactly the selected credential to the signed `av` Target. `av` parses
 the OpenPGP transfer key, creates an ASCII-armored detached signature in memory,
 and zeroizes its transient input buffers. Payloads and keys are bounded to 16
-MiB. Git and `bpb` never receive credential bytes.
+MiB. Git and `av-gpg` never receive credential bytes.
 
 ## Consequences
 

--- a/docs/adr/0019-gpg-signing-gate.md
+++ b/docs/adr/0019-gpg-signing-gate.md
@@ -1,0 +1,56 @@
+# ADR 0019: Keep GPG signing keys behind a Tool-specific Authorization Gate
+
+Status: accepted
+
+## Context
+
+Git's `gpg.program` interface sends a commit or tag payload to a GPG-compatible
+process and expects a detached OpenPGP signature. Ordinary GnuPG configurations
+let a same-user process ask the agent to sign, so possession of the user session
+often becomes ambient signing authority. Giving a wrapper the exported private
+key would merely move that ambient authority into another file or process.
+
+Users also need agent-authored commits to be distinguishable from commits made
+through their normal interactive Launcher. A client-provided “agent” flag is
+forgeable and cannot safely select the more valuable default credential.
+
+## Decision
+
+Bundle `bpb` as Git's GPG-compatible Command inside `Automic Vault.app` without
+installing a second system command. For signing requests, `bpb` executes the
+adjacent signed `av` binary and streams the immutable payload. `av` holds the
+bounded payload in memory and binds its SHA-256 digest into the Authorization
+Request. `bpb` receives only the detached signature. Verification and unrelated
+GPG operations continue to delegate to the user's `gpg` command.
+
+The menu app treats each request as Local Write at the GPG Signing Gate. It
+verifies `av` as Gate Client and Target, resolves the live Verified Launcher,
+and selects one GPG Signing Credential before authorization. The default and
+alternate credentials each contain a private-key Secret and passphrase Secret
+in the Data Protection Keychain.
+
+Launcher Signing Credential Rules are stored in the Data Protection Keychain
+and bind exact designated requirements to the alternate credential. The menu
+app derives selection from the verified process chain; no client-controlled
+field can select a credential. Every rule mutation uses the existing approved
+authority-change flow. If a matching rule exists but its alternate credential
+is unavailable, signing fails closed without using the default.
+
+After an allowed Authorization Record is persisted and verified, the app
+releases exactly the selected credential to the signed `av` Target. `av` parses
+the OpenPGP transfer key, creates an ASCII-armored detached signature in memory,
+and zeroizes its transient input buffers. Payloads and keys are bounded to 16
+MiB. Git and `bpb` never receive credential bytes.
+
+## Consequences
+
+Using a signing key now requires an Authorization Decision over the Verified
+Launcher, Gate Client, Target, arguments, working directory, selected Secret
+Names, and process execution. The gate defaults to Read Only, so Local Write
+signing requires Approval until policy explicitly grants it.
+
+The signed `av` Target necessarily handles usable private-key material in its
+memory. Hardened Runtime and code-signature verification reduce injection risk
+but do not make the Target immune to a same-user or kernel compromise. OpenPGP
+keys whose primary key cannot sign are rejected rather than heuristically
+choosing a potentially revoked or expired subkey.

--- a/docs/adr/0019-gpg-signing-gate.md
+++ b/docs/adr/0019-gpg-signing-gate.md
@@ -45,6 +45,14 @@ the OpenPGP transfer key, creates an ASCII-armored detached signature in memory,
 and zeroizes its transient input buffers. Payloads and keys are bounded to 16
 MiB. Git and `av-gpg` never receive credential bytes.
 
+Settings accepts imported private-key material in a temporary editor and never
+displays a stored private key. It invokes the adjacent signed `av` executable to
+derive the corresponding public key for display and copying. For the alternate
+credential, `av` may instead generate an EdDSA certification key and signing
+subkey from a user-supplied name and email. Generated private-key material stays
+between the signed `av` process and the Keychain-owning menu app, which stores it
+after deriving and displaying only its public key.
+
 ## Consequences
 
 Using a signing key now requires an Authorization Decision over the Verified

--- a/docs/adr/0020-app-launcher-main-executable.md
+++ b/docs/adr/0020-app-launcher-main-executable.md
@@ -1,0 +1,39 @@
+# ADR 0020: Attribute app Launcher identity only to its main executable
+
+Status: accepted
+
+## Context
+
+A signed executable may live inside an app bundle without being that app's
+Launcher. For example, Git supplied by Xcode runs from
+`Xcode.app/Contents/Developer/usr/bin/git` between Terminal and `av-gpg`.
+Treating every bundle-contained executable as the containing app made this
+intermediary appear to be the Xcode Launcher and forced full validation of the
+large Xcode resource seal before each signing Approval.
+
+That attribution also conflicts with the existing definition of a Launcher as
+the app or executable at the root of the operation's verified launch chain.
+
+## Decision
+
+An ordinary app bundle is a Launcher candidate only when the live process path
+or its code-signing main executable matches the bundle's declared main
+executable. Automic Vault then performs the existing full static code-signature
+and resource validation before accepting that app as a Verified Launcher.
+
+Bundle-contained intermediary executables remain visible in the process chain
+and retain their live code-signature and runtime-posture checks, but they do not
+inherit the containing app's Launcher Identity. Existing explicit rules for
+Automic Vault Launcher Bundle payloads and the Vaultty session bridge remain
+unchanged. Eligible standalone Developer ID executables retain their existing
+fallback identity.
+
+## Consequences
+
+Terminal, Portal, Codex, and other app main processes keep their existing app
+Launcher identity and full bundle validation. Xcode's Git no longer claims
+Xcode Launcher authority or causes Xcode's complete resource seal to be scanned
+while authorizing a Git signature. A helper without its app's main process in
+the live ancestry must qualify under an explicit helper association, Launcher
+Bundle enrollment, or standalone Launcher rules instead of inheriting ambient
+authority from its containing app.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,18 @@ HTTP request. Proxy Sessions and Destination Rules are memory-only. They never
 create Direct Access Rules, Launcher-specific policy, Blessings, or Launcher
 Endorsements.
 
+The GPG Signing Gate receives Git's immutable signing payload through the
+bundled `bpb` Command. `bpb` invokes the adjacent signed `av` Target without
+receiving credential bytes. `av` binds a SHA-256 digest of the bounded payload
+into the Authorization Request. The menu app verifies the live Launcher,
+selects the default or alternate GPG Signing Credential from Keychain-protected
+Launcher Signing Credential Rules, authorizes and records the complete Local
+Write request, and releases exactly that credential to `av`. The Target creates
+the detached signature in memory and zeroizes its transient input buffers.
+Missing alternate material, invalid OpenPGP material, recording failure, or an
+unrecognized route fails closed without falling back to the default credential.
+See [ADR 0019](adr/0019-gpg-signing-gate.md).
+
 ### Launcher Packaging
 
 Launcher Bundles let one unsigned Mach-O command-line tool participate as a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,9 +124,10 @@ create Direct Access Rules, Launcher-specific policy, Blessings, or Launcher
 Endorsements.
 
 The GPG Signing Gate receives Git's immutable signing payload through the
-bundled `bpb` Command. `bpb` invokes the adjacent signed `av` Target without
-receiving credential bytes. `av` binds a SHA-256 digest of the bounded payload
-into the Authorization Request. The menu app verifies the live Launcher,
+bundled `av-gpg` Command. `av-gpg` invokes the adjacent signed `av gpg-sign`
+Target without receiving credential bytes and delegates verification to GnuPG.
+`av` binds a SHA-256 digest of the bounded payload into the Authorization
+Request. The menu app verifies the live Launcher,
 selects the default or alternate GPG Signing Credential from Keychain-protected
 Launcher Signing Credential Rules, authorizes and records the complete Local
 Write request, and releases exactly that credential to `av`. The Target creates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,6 +134,12 @@ Write request, and releases exactly that credential to `av`. The Target creates
 the detached signature in memory and zeroizes its transient input buffers.
 Missing alternate material, invalid OpenPGP material, recording failure, or an
 unrecognized route fails closed without falling back to the default credential.
+Settings accepts imported private-key material only in a temporary editor and
+never displays a stored private key. The adjacent signed `av` executable derives
+the corresponding public key for display and can generate an EdDSA alternate
+signing key for a user-supplied name and email. Generated private-key material is
+confined to the adjacent signed `av` process and the Keychain-owning menu app,
+which stores it after deriving its public key.
 See [ADR 0019](adr/0019-gpg-signing-gate.md).
 
 ### Launcher Packaging
@@ -336,6 +342,11 @@ The shipped policy store encodes one legacy classification per request and persi
 - `fullExceptSecretDumps` becomes Write Access.
 - `fullIncludingSecretDumps` remains Full Access.
 
+At the GPG Signing Gate, persisted values that permit Local Write normalize to
+Allow Signing; all others normalize to Approval Required. This preserves each
+stored rule's effective signing authority while omitting policy presets that
+cannot describe a distinct GPG operation.
+
 The Homebrew migration intentionally broadens persisted `readOnly` rules to allow explicit `brew update`. Homebrew could already update itself and its package metadata as a secondary effect of an authorized inspection command, so the old distinction did not enforce strict read-only execution. The legacy `update` classification covers only `brew update`, a Homebrew Update. The legacy `secretDump` classification covers both Secret Disclosure and AWS Elevated Secret Application. The legacy `mutating` classification can cover local, system, or remote effects. Replacing those values with characteristic sets is a policy-engine migration. It requires a reviewed Tool catalog, compatibility tests, and proof that no existing rule gains authority. Until that migration, the legacy classifier remains the enforcement source and the UI explains its established behavior with the canonical names.
 
 ## Secret custody and availability
@@ -521,7 +532,13 @@ one authorized request. Network parsing is outside the Keychain-owning app.
 
 ## Secure defaults
 
-New Secret Gates start at Read Only. The Homebrew Execution Gate starts at Read & Update, which adds `brew update` without authorizing installation, upgrade, reinstall, removal, or other writes. Unknown operations and unverifiable Launchers require a human decision or denial according to the failed check. Every default and Launcher-specific rule is explicit and persisted.
+New Secret Gates start at Read Only. The GPG Signing Gate starts at Approval
+Required and exposes Allow Signing as its only automic level. The Homebrew
+Execution Gate starts at Read & Update, which adds `brew update` without
+authorizing installation, upgrade, reinstall, removal, or other writes. Unknown
+operations and unverifiable Launchers require a human decision or denial
+according to the failed check. Every default and Launcher-specific rule is
+explicit and persisted.
 
 The Direct Secret Gate starts at Approval Required and has no broad default.
 Adding each Direct Access Rule requires an explicit warning and acknowledgement.

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -73,9 +73,10 @@ Signing Credential only after the complete signing request is authorized and
 recorded. Git and `av-gpg` receive the detached signature, never the private key
 or passphrase.
 
-GPG signing is a Local Write operation. The gate therefore defaults to Read
-Only, which requires Approval until the user grants a Verified Launcher an
-Access Level that permits Local Write.
+GPG signing is a Local Write operation. Because every recognized operation at
+this gate is signing, it exposes only **Approval Required** and **Allow
+Signing**. Allow Signing is the GPG-specific presentation of Local Write. The
+gate defaults to Approval Required.
 
 ### Proxy Session
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -64,6 +64,18 @@ Target's environment. The gate has no durable Authorization Policy in its
 initial form: starting every Proxy Session requires Approval, and destination
 authority lasts at most for that session.
 
+### GPG Signing Gate
+
+The built-in Tool-specific Secret Gate for Git commit and tag signatures made
+through the bundled `bpb` Command. Its Target is the signed `av` executable,
+which receives one selected GPG Signing Credential only after the complete
+signing request is authorized and recorded. Git and `bpb` receive the detached
+signature, never the private key or passphrase.
+
+GPG signing is a Local Write operation. The gate therefore defaults to Read
+Only, which requires Approval until the user grants a Verified Launcher an
+Access Level that permits Local Write.
+
 ### Proxy Session
 
 A live, memory-only Secret Proxy Gate context bound to one complete command and
@@ -257,6 +269,22 @@ path makes that Project Value selectable again.
 ### Credential
 
 One or more Secrets interpreted by a Tool or service. An AWS credential, for example, may contain an access key identifier and a secret access key.
+
+### GPG Signing Credential
+
+A Credential containing one OpenPGP private-key Secret and its passphrase
+Secret. The user may configure a default credential and an alternate
+credential. A Launcher Signing Credential Rule selects the alternate credential
+for an exact Verified Launcher; absence of the alternate credential fails
+closed and never falls back to the default.
+
+### Launcher Signing Credential Rule
+
+A durable, Keychain-protected rule binding one Verified Launcher designated
+requirement to the alternate GPG Signing Credential. It changes Secret
+selection, not Launcher Identity or the GPG Signing Gate's Authorization
+Policy. Adding or removing a rule is an authority change that requires
+Approval.
 
 ### Secret Use
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -67,10 +67,11 @@ authority lasts at most for that session.
 ### GPG Signing Gate
 
 The built-in Tool-specific Secret Gate for Git commit and tag signatures made
-through the bundled `bpb` Command. Its Target is the signed `av` executable,
-which receives one selected GPG Signing Credential only after the complete
-signing request is authorized and recorded. Git and `bpb` receive the detached
-signature, never the private key or passphrase.
+through the bundled `av-gpg` Command. `av-gpg` adapts Git's GPG-compatible
+interface to the signed `av gpg-sign` Target, which receives one selected GPG
+Signing Credential only after the complete signing request is authorized and
+recorded. Git and `av-gpg` receive the detached signature, never the private key
+or passphrase.
 
 GPG signing is a Local Write operation. The gate therefore defaults to Read
 Only, which requires Approval until the user grants a Verified Launcher an

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -273,11 +273,11 @@ One or more Secrets interpreted by a Tool or service. An AWS credential, for exa
 
 ### GPG Signing Credential
 
-A Credential containing one OpenPGP private-key Secret and its passphrase
-Secret. The user may configure a default credential and an alternate
-credential. A Launcher Signing Credential Rule selects the alternate credential
-for an exact Verified Launcher; absence of the alternate credential fails
-closed and never falls back to the default.
+A Credential containing one OpenPGP private-key Secret and, when the key is
+encrypted, its passphrase Secret. The user may configure a default credential
+and an alternate credential. A Launcher Signing Credential Rule selects the
+alternate credential for an exact Verified Launcher; absence of the alternate
+credential fails closed and never falls back to the default.
 
 ### Launcher Signing Credential Rule
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -42,6 +42,9 @@ Automic Vault decides whether a complete operation may use it.
   Verified Launcher, Tool-specific Authorization Gate, and agent task. A
   persistent strip shows the grant and provides an End action.
 - Existing developer commands continue to work above the security boundary.
+- Git can keep its ordinary commit workflow while the GPG Signing Gate
+  authorizes private-key use and may select an alternate credential for exact
+  Verified Launchers.
 
 ## Claim boundaries
 

--- a/docs/securing-git.md
+++ b/docs/securing-git.md
@@ -39,9 +39,9 @@ Use SSH.
 
 Automic Vault can also gate use of the private key that signs Git commits and
 tags. Open **Settings → GPG Signing**, export the private key from GnuPG as
-instructed there, and select **Configure Git**. Git then invokes the `bpb`
-Command inside the signed app bundle. `bpb` forwards the payload to the GPG
-Signing Gate; it never receives the private key.
+instructed there, and select **Configure Git**. Git then invokes the `av-gpg`
+Command inside the signed app bundle. `av-gpg` forwards the payload to
+`av gpg-sign` at the GPG Signing Gate; it never receives the private key.
 
 The settings also support an alternate GPG Signing Credential for an exact
 list of Verified Launchers. This is useful for agents: agent-authored commits

--- a/docs/securing-git.md
+++ b/docs/securing-git.md
@@ -35,6 +35,25 @@ the `gh` Secret Gate evaluates the request before applying the token.
 
 Use SSH.
 
+## Gate GPG Commit Signing
+
+Automic Vault can also gate use of the private key that signs Git commits and
+tags. Open **Settings → GPG Signing**, export the private key from GnuPG as
+instructed there, and select **Configure Git**. Git then invokes the `bpb`
+Command inside the signed app bundle. `bpb` forwards the payload to the GPG
+Signing Gate; it never receives the private key.
+
+The settings also support an alternate GPG Signing Credential for an exact
+list of Verified Launchers. This is useful for agents: agent-authored commits
+can use a visibly different key from human-authored commits. The list is bound
+to designated requirements rather than app names or paths, and changing it
+requires Approval.
+
+The signing Target necessarily handles the private key in memory while it
+creates the signature. Automic Vault controls its application and zeroizes
+transient input buffers; it does not claim that a compromised Target cannot
+inspect its own memory.
+
 ## Check What Git Can Read
 
 Start with the boring check:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -237,16 +237,20 @@ if [[ "$identity" != "-" ]]; then
 fi
 
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$ROOT/target/release/av"
+codesign "${codesign_args[@]}" --identifier com.automicvault.bpb "$ROOT/target/release/bpb"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$ROOT/target/release/av-brew-stub"
 codesign "${codesign_args[@]}" --identifier com.automicvault.launcher-bundle-runner "$RESOURCES/AutomicVaultLauncher"
 codesign "${codesign_args[@]}" --identifier com.automicvault.varlock-plugin-helper "$RESOURCES/AutomicVaultVarlockPlugin"
 assert_no_embedded_entitlements "$ROOT/target/release/av"
+assert_no_embedded_entitlements "$ROOT/target/release/bpb"
 assert_no_embedded_entitlements "$ROOT/target/release/av-brew-stub"
 assert_no_embedded_entitlements "$RESOURCES/AutomicVaultVarlockPlugin"
 cp "$ROOT/target/release/av" "$MACOS/av"
+cp "$ROOT/target/release/bpb" "$MACOS/bpb"
 cp "$ROOT/target/release/av-brew-stub" "$MACOS/av-brew-stub"
 cp "$ROOT/target/release/av-proxy-helper" "$MACOS/av-proxy-helper"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$MACOS/av"
+codesign "${codesign_args[@]}" --identifier com.automicvault.bpb "$MACOS/bpb"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$MACOS/av-brew-stub"
 codesign "${codesign_args[@]}" \
   --entitlements "$PROXY_HELPER_ENTITLEMENTS" \
@@ -261,6 +265,7 @@ if [[ "$proxy_helper_status" -ne 1 ]]; then
   exit 1
 fi
 assert_no_embedded_entitlements "$MACOS/av"
+assert_no_embedded_entitlements "$MACOS/bpb"
 assert_no_embedded_entitlements "$MACOS/av-brew-stub"
 "$MACOS/av" __version >/dev/null
 app_codesign_args=("${codesign_args[@]}")
@@ -275,6 +280,7 @@ if [[ -f "$MENU_HELPER_PROFILE" && "$identity" != "-" ]]; then
 fi
 codesign "${app_codesign_args[@]}" "$APP"
 codesign --verify --strict "$MACOS/av"
+codesign --verify --strict "$MACOS/bpb"
 codesign --verify --strict "$MACOS/av-brew-stub"
 codesign --verify --strict "$MACOS/av-proxy-helper"
 codesign --verify --strict "$APP"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -237,20 +237,20 @@ if [[ "$identity" != "-" ]]; then
 fi
 
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$ROOT/target/release/av"
-codesign "${codesign_args[@]}" --identifier com.automicvault.bpb "$ROOT/target/release/bpb"
+codesign "${codesign_args[@]}" --identifier com.automicvault.av-gpg "$ROOT/target/release/av-gpg"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$ROOT/target/release/av-brew-stub"
 codesign "${codesign_args[@]}" --identifier com.automicvault.launcher-bundle-runner "$RESOURCES/AutomicVaultLauncher"
 codesign "${codesign_args[@]}" --identifier com.automicvault.varlock-plugin-helper "$RESOURCES/AutomicVaultVarlockPlugin"
 assert_no_embedded_entitlements "$ROOT/target/release/av"
-assert_no_embedded_entitlements "$ROOT/target/release/bpb"
+assert_no_embedded_entitlements "$ROOT/target/release/av-gpg"
 assert_no_embedded_entitlements "$ROOT/target/release/av-brew-stub"
 assert_no_embedded_entitlements "$RESOURCES/AutomicVaultVarlockPlugin"
 cp "$ROOT/target/release/av" "$MACOS/av"
-cp "$ROOT/target/release/bpb" "$MACOS/bpb"
+cp "$ROOT/target/release/av-gpg" "$MACOS/av-gpg"
 cp "$ROOT/target/release/av-brew-stub" "$MACOS/av-brew-stub"
 cp "$ROOT/target/release/av-proxy-helper" "$MACOS/av-proxy-helper"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av "$MACOS/av"
-codesign "${codesign_args[@]}" --identifier com.automicvault.bpb "$MACOS/bpb"
+codesign "${codesign_args[@]}" --identifier com.automicvault.av-gpg "$MACOS/av-gpg"
 codesign "${codesign_args[@]}" --identifier com.automicvault.av-brew-stub "$MACOS/av-brew-stub"
 codesign "${codesign_args[@]}" \
   --entitlements "$PROXY_HELPER_ENTITLEMENTS" \
@@ -265,7 +265,7 @@ if [[ "$proxy_helper_status" -ne 1 ]]; then
   exit 1
 fi
 assert_no_embedded_entitlements "$MACOS/av"
-assert_no_embedded_entitlements "$MACOS/bpb"
+assert_no_embedded_entitlements "$MACOS/av-gpg"
 assert_no_embedded_entitlements "$MACOS/av-brew-stub"
 "$MACOS/av" __version >/dev/null
 app_codesign_args=("${codesign_args[@]}")
@@ -280,7 +280,7 @@ if [[ -f "$MENU_HELPER_PROFILE" && "$identity" != "-" ]]; then
 fi
 codesign "${app_codesign_args[@]}" "$APP"
 codesign --verify --strict "$MACOS/av"
-codesign --verify --strict "$MACOS/bpb"
+codesign --verify --strict "$MACOS/av-gpg"
 codesign --verify --strict "$MACOS/av-brew-stub"
 codesign --verify --strict "$MACOS/av-proxy-helper"
 codesign --verify --strict "$APP"

--- a/src/av_gpg/main.rs
+++ b/src/av_gpg/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(av::run_git_program());
+}

--- a/src/bpb/main.rs
+++ b/src/bpb/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    std::process::exit(bpb::run_terminal());
-}

--- a/src/bpb/main.rs
+++ b/src/bpb/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(bpb::run_terminal());
+}

--- a/src/cli/gpg_sign.rs
+++ b/src/cli/gpg_sign.rs
@@ -41,7 +41,7 @@ pub(crate) fn validate(stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         let _ = writeln!(stderr, "av gpg-public-key: private key exceeds 16 MiB");
         return 1;
     }
-    match bpb::public_key_from_private(&private_key) {
+    match crate::gpg::public_key_from_private(&private_key) {
         Ok(public_key) => {
             if stdout.write_all(public_key.as_bytes()).is_ok() {
                 0
@@ -127,7 +127,7 @@ fn sign_with_approval(
             .ok_or_else(|| "Automic Vault returned no private signing key".to_string())?,
     );
     let passphrase = Zeroizing::new(secrets.remove(passphrase_name).unwrap_or_default());
-    bpb::sign_openpgp(&private_key, &passphrase, &payload)
+    crate::gpg::sign_openpgp(&private_key, &passphrase, &payload)
 }
 
 #[cfg(test)]

--- a/src/cli/gpg_sign.rs
+++ b/src/cli/gpg_sign.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::io::{Read, Write};
 
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 use super::inject;
 
@@ -111,10 +111,20 @@ fn sign_with_approval(
         cwd.to_string_lossy().into_owned(),
         &names,
     )?;
-    let key_name = if secrets.contains_key(ALTERNATE_PRIVATE_KEY) {
-        ALTERNATE_PRIVATE_KEY
-    } else {
-        DEFAULT_PRIVATE_KEY
+    let key_name = match (
+        secrets.contains_key(DEFAULT_PRIVATE_KEY),
+        secrets.contains_key(ALTERNATE_PRIVATE_KEY),
+    ) {
+        (true, false) => DEFAULT_PRIVATE_KEY,
+        (false, true) => ALTERNATE_PRIVATE_KEY,
+        (true, true) => {
+            secrets.values_mut().for_each(Zeroize::zeroize);
+            return Err("Automic Vault returned multiple private signing keys".into());
+        }
+        (false, false) => {
+            secrets.values_mut().for_each(Zeroize::zeroize);
+            return Err("Automic Vault returned no private signing key".into());
+        }
     };
     let passphrase_name = if key_name == ALTERNATE_PRIVATE_KEY {
         ALTERNATE_PASSPHRASE
@@ -127,6 +137,7 @@ fn sign_with_approval(
             .ok_or_else(|| "Automic Vault returned no private signing key".to_string())?,
     );
     let passphrase = Zeroizing::new(secrets.remove(passphrase_name).unwrap_or_default());
+    secrets.values_mut().for_each(Zeroize::zeroize);
     crate::gpg::sign_openpgp(&private_key, &passphrase, &payload)
 }
 
@@ -177,5 +188,24 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, "Git signing payload exceeds 16 MiB");
+    }
+
+    #[test]
+    fn rejects_an_authorization_response_with_both_private_keys() {
+        let mut input = b"payload".as_slice();
+        let error = sign_with_approval(vec![], &mut input, |_, _, _, _| {
+            Ok([
+                (DEFAULT_PRIVATE_KEY.to_string(), "default".to_string()),
+                (ALTERNATE_PRIVATE_KEY.to_string(), "alternate".to_string()),
+            ]
+            .into_iter()
+            .collect())
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Automic Vault returned multiple private signing keys"
+        );
     }
 }

--- a/src/cli/gpg_sign.rs
+++ b/src/cli/gpg_sign.rs
@@ -5,10 +5,10 @@ use zeroize::{Zeroize, Zeroizing};
 
 use super::inject;
 
-pub(crate) const DEFAULT_PRIVATE_KEY: &str = "AUTOMIC_GPG_SIGNING_PRIVATE_KEY";
-pub(crate) const DEFAULT_PASSPHRASE: &str = "AUTOMIC_GPG_SIGNING_PASSPHRASE";
-pub(crate) const ALTERNATE_PRIVATE_KEY: &str = "AUTOMIC_GPG_AGENT_SIGNING_PRIVATE_KEY";
-pub(crate) const ALTERNATE_PASSPHRASE: &str = "AUTOMIC_GPG_AGENT_SIGNING_PASSPHRASE";
+pub(crate) const DEFAULT_PRIVATE_KEY: &str = "AV_GPG_PRIVATE_KEY";
+pub(crate) const DEFAULT_PASSPHRASE: &str = "AV_GPG_PASSPHRASE";
+pub(crate) const ALTERNATE_PRIVATE_KEY: &str = "AV_GPG_AGENT_PRIVATE_KEY";
+pub(crate) const ALTERNATE_PASSPHRASE: &str = "AV_GPG_AGENT_PASSPHRASE";
 const MAX_SIGNING_PAYLOAD_BYTES: u64 = 16 * 1024 * 1024;
 
 pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
@@ -144,6 +144,14 @@ fn sign_with_approval(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gpg_secret_names_use_av_prefix() {
+        assert_eq!(DEFAULT_PRIVATE_KEY, "AV_GPG_PRIVATE_KEY");
+        assert_eq!(DEFAULT_PASSPHRASE, "AV_GPG_PASSPHRASE");
+        assert_eq!(ALTERNATE_PRIVATE_KEY, "AV_GPG_AGENT_PRIVATE_KEY");
+        assert_eq!(ALTERNATE_PASSPHRASE, "AV_GPG_AGENT_PASSPHRASE");
+    }
 
     #[test]
     fn authorization_binds_the_exact_payload_digest_before_key_selection() {

--- a/src/cli/gpg_sign.rs
+++ b/src/cli/gpg_sign.rs
@@ -10,6 +10,13 @@ pub(crate) const DEFAULT_PASSPHRASE: &str = "AV_GPG_PASSPHRASE";
 pub(crate) const ALTERNATE_PRIVATE_KEY: &str = "AV_GPG_AGENT_PRIVATE_KEY";
 pub(crate) const ALTERNATE_PASSPHRASE: &str = "AV_GPG_AGENT_PASSPHRASE";
 const MAX_SIGNING_PAYLOAD_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_KEY_GENERATION_REQUEST_BYTES: u64 = 4 * 1024;
+
+#[derive(serde::Deserialize)]
+struct KeyGenerationRequest {
+    name: String,
+    email: String,
+}
 
 pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     match sign(args) {
@@ -51,6 +58,42 @@ pub(crate) fn validate(stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         }
         Err(error) => {
             let _ = writeln!(stderr, "av gpg-public-key: {error}");
+            1
+        }
+    }
+}
+
+pub(crate) fn generate(stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    let mut request = String::new();
+    if let Err(error) = std::io::stdin()
+        .take(MAX_KEY_GENERATION_REQUEST_BYTES + 1)
+        .read_to_string(&mut request)
+    {
+        let _ = writeln!(stderr, "av gpg-generate-key: {error}");
+        return 1;
+    }
+    if request.len() as u64 > MAX_KEY_GENERATION_REQUEST_BYTES {
+        let _ = writeln!(stderr, "av gpg-generate-key: request exceeds 4 KiB");
+        return 1;
+    }
+    let request: KeyGenerationRequest = match serde_json::from_str(&request) {
+        Ok(request) => request,
+        Err(error) => {
+            let _ = writeln!(stderr, "av gpg-generate-key: invalid request: {error}");
+            return 1;
+        }
+    };
+    match crate::gpg::generate_signing_key(&request.name, &request.email) {
+        Ok(private_key) => {
+            let private_key = Zeroizing::new(private_key);
+            if stdout.write_all(private_key.as_bytes()).is_ok() {
+                0
+            } else {
+                1
+            }
+        }
+        Err(error) => {
+            let _ = writeln!(stderr, "av gpg-generate-key: {error}");
             1
         }
     }

--- a/src/cli/gpg_sign.rs
+++ b/src/cli/gpg_sign.rs
@@ -1,0 +1,118 @@
+use std::ffi::OsString;
+use std::io::{Read, Write};
+
+use zeroize::Zeroizing;
+
+use super::inject;
+
+pub(crate) const DEFAULT_PRIVATE_KEY: &str = "AUTOMIC_GPG_SIGNING_PRIVATE_KEY";
+pub(crate) const DEFAULT_PASSPHRASE: &str = "AUTOMIC_GPG_SIGNING_PASSPHRASE";
+pub(crate) const ALTERNATE_PRIVATE_KEY: &str = "AUTOMIC_GPG_AGENT_SIGNING_PRIVATE_KEY";
+pub(crate) const ALTERNATE_PASSPHRASE: &str = "AUTOMIC_GPG_AGENT_SIGNING_PASSPHRASE";
+const MAX_SIGNING_PAYLOAD_BYTES: u64 = 16 * 1024 * 1024;
+
+pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match sign(args) {
+        Ok(signature) => {
+            let _ = writeln!(stderr, "[GNUPG:] SIG_CREATED D 1 10 00 0 0 0 0");
+            if stdout.write_all(signature.as_bytes()).is_ok() {
+                0
+            } else {
+                1
+            }
+        }
+        Err(error) => {
+            let _ = writeln!(stderr, "av gpg-sign: {error}");
+            1
+        }
+    }
+}
+
+pub(crate) fn validate(stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    let mut private_key = Zeroizing::new(String::new());
+    if let Err(error) = std::io::stdin()
+        .take(MAX_SIGNING_PAYLOAD_BYTES + 1)
+        .read_to_string(&mut private_key)
+    {
+        let _ = writeln!(stderr, "av gpg-public-key: {error}");
+        return 1;
+    }
+    if private_key.len() as u64 > MAX_SIGNING_PAYLOAD_BYTES {
+        let _ = writeln!(stderr, "av gpg-public-key: private key exceeds 16 MiB");
+        return 1;
+    }
+    match bpb::public_key_from_private(&private_key) {
+        Ok(public_key) => {
+            if stdout.write_all(public_key.as_bytes()).is_ok() {
+                0
+            } else {
+                1
+            }
+        }
+        Err(error) => {
+            let _ = writeln!(stderr, "av gpg-public-key: {error}");
+            1
+        }
+    }
+}
+
+fn sign(args: Vec<OsString>) -> Result<String, String> {
+    let mut args = args
+        .into_iter()
+        .map(|arg| {
+            arg.into_string()
+                .map_err(|_| "GPG arguments must be valid UTF-8".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut payload = Vec::new();
+    std::io::stdin()
+        .take(MAX_SIGNING_PAYLOAD_BYTES + 1)
+        .read_to_end(&mut payload)
+        .map_err(|error| format!("failed to read Git signing payload: {error}"))?;
+    if payload.len() as u64 > MAX_SIGNING_PAYLOAD_BYTES {
+        return Err("Git signing payload exceeds 16 MiB".into());
+    }
+    let payload_digest = ring::digest::digest(&ring::digest::SHA256, &payload);
+    let payload_digest = payload_digest
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    args.push(format!("payload-sha256={payload_digest}"));
+    let target = std::env::current_exe()
+        .and_then(std::fs::canonicalize)
+        .map_err(|error| format!("cannot resolve the signing Target: {error}"))?;
+    let cwd = std::env::current_dir()
+        .and_then(std::fs::canonicalize)
+        .map_err(|error| format!("cannot resolve the working directory: {error}"))?;
+    let names = [
+        DEFAULT_PRIVATE_KEY,
+        DEFAULT_PASSPHRASE,
+        ALTERNATE_PRIVATE_KEY,
+        ALTERNATE_PASSPHRASE,
+    ]
+    .map(String::from);
+    let mut secrets = inject::approve_gpg_signing(
+        target.to_string_lossy().into_owned(),
+        args,
+        cwd.to_string_lossy().into_owned(),
+        &names,
+    )?;
+    let key_name = if secrets.contains_key(ALTERNATE_PRIVATE_KEY) {
+        ALTERNATE_PRIVATE_KEY
+    } else {
+        DEFAULT_PRIVATE_KEY
+    };
+    let passphrase_name = if key_name == ALTERNATE_PRIVATE_KEY {
+        ALTERNATE_PASSPHRASE
+    } else {
+        DEFAULT_PASSPHRASE
+    };
+    let private_key = Zeroizing::new(
+        secrets
+            .remove(key_name)
+            .ok_or_else(|| "Automic Vault returned no private signing key".to_string())?,
+    );
+    let passphrase = Zeroizing::new(secrets.remove(passphrase_name).unwrap_or_default());
+    bpb::sign_openpgp(&private_key, &passphrase, &payload)
+}

--- a/src/cli/gpg_sign.rs
+++ b/src/cli/gpg_sign.rs
@@ -57,6 +57,19 @@ pub(crate) fn validate(stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
 }
 
 fn sign(args: Vec<OsString>) -> Result<String, String> {
+    sign_with_approval(args, &mut std::io::stdin(), inject::approve_gpg_signing)
+}
+
+fn sign_with_approval(
+    args: Vec<OsString>,
+    input: &mut dyn Read,
+    approve: impl FnOnce(
+        String,
+        Vec<String>,
+        String,
+        &[String],
+    ) -> Result<std::collections::BTreeMap<String, String>, String>,
+) -> Result<String, String> {
     let mut args = args
         .into_iter()
         .map(|arg| {
@@ -65,7 +78,7 @@ fn sign(args: Vec<OsString>) -> Result<String, String> {
         })
         .collect::<Result<Vec<_>, _>>()?;
     let mut payload = Vec::new();
-    std::io::stdin()
+    input
         .take(MAX_SIGNING_PAYLOAD_BYTES + 1)
         .read_to_end(&mut payload)
         .map_err(|error| format!("failed to read Git signing payload: {error}"))?;
@@ -92,7 +105,7 @@ fn sign(args: Vec<OsString>) -> Result<String, String> {
         ALTERNATE_PASSPHRASE,
     ]
     .map(String::from);
-    let mut secrets = inject::approve_gpg_signing(
+    let mut secrets = approve(
         target.to_string_lossy().into_owned(),
         args,
         cwd.to_string_lossy().into_owned(),
@@ -115,4 +128,54 @@ fn sign(args: Vec<OsString>) -> Result<String, String> {
     );
     let passphrase = Zeroizing::new(secrets.remove(passphrase_name).unwrap_or_default());
     bpb::sign_openpgp(&private_key, &passphrase, &payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorization_binds_the_exact_payload_digest_before_key_selection() {
+        let payload = b"tree 0000000000000000000000000000000000000000\n\nmessage\n";
+        let mut input = payload.as_slice();
+        let error = sign_with_approval(
+            vec![OsString::from("-bsau"), OsString::from("ignored-key-id")],
+            &mut input,
+            |_target, args, _cwd, response_names| {
+                assert!(args.contains(&"-bsau".to_string()));
+                assert!(args.contains(&format!(
+                    "payload-sha256={}",
+                    ring::digest::digest(&ring::digest::SHA256, payload)
+                        .as_ref()
+                        .iter()
+                        .map(|byte| format!("{byte:02x}"))
+                        .collect::<String>()
+                )));
+                assert_eq!(
+                    response_names,
+                    [
+                        DEFAULT_PRIVATE_KEY,
+                        DEFAULT_PASSPHRASE,
+                        ALTERNATE_PRIVATE_KEY,
+                        ALTERNATE_PASSPHRASE,
+                    ]
+                );
+                Ok(std::collections::BTreeMap::new())
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "Automic Vault returned no private signing key");
+    }
+
+    #[test]
+    fn oversized_payload_is_rejected_before_authorization() {
+        let mut input = std::io::repeat(0).take(MAX_SIGNING_PAYLOAD_BYTES + 1);
+        let error = sign_with_approval(vec![], &mut input, |_, _, _, _| {
+            panic!("oversized payload must not reach authorization")
+        })
+        .unwrap_err();
+
+        assert_eq!(error, "Git signing payload exceeds 16 MiB");
+    }
 }

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -574,6 +574,51 @@ fn approve_injection(_request: &ApprovalRequest) -> Result<SecretValues, String>
 
 #[cfg(target_os = "macos")]
 fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, String> {
+    xpc_approve_request(request, &request.keys)
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn approve_gpg_signing(
+    target: String,
+    args: Vec<String>,
+    cwd: String,
+    response_keys: &[String],
+) -> Result<SecretValues, String> {
+    xpc_approve_request(
+        &ApprovalRequest {
+            op: "gpg-sign",
+            keys: Vec::new(),
+            target,
+            args,
+            cwd,
+            replace_existing_env: false,
+            allow_missing_keys: false,
+            env_conflicts: Vec::new(),
+            shebang_script: None,
+            script_data: None,
+            snapshot_incompatible_interpreter: None,
+            tool: Some("gpg-signing"),
+            docker_server_url: None,
+        },
+        response_keys,
+    )
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn approve_gpg_signing(
+    _target: String,
+    _args: Vec<String>,
+    _cwd: String,
+    _response_keys: &[String],
+) -> Result<SecretValues, String> {
+    Err("GPG signing approval is only available on macOS".into())
+}
+
+#[cfg(target_os = "macos")]
+fn xpc_approve_request(
+    request: &ApprovalRequest,
+    response_keys: &[String],
+) -> Result<SecretValues, String> {
     use std::os::raw::{c_char, c_int, c_void};
 
     type XpcObject = *mut c_void;
@@ -757,7 +802,7 @@ fn xpc_approve_injection(request: &ApprovalRequest) -> Result<SecretValues, Stri
                 let mut secrets = SecretValues::new();
                 let values = xpc_dictionary_get_dictionary(reply, b"secrets\0".as_ptr().cast());
                 if !values.is_null() {
-                    for key in &request.keys {
+                    for key in response_keys {
                         let key_cstr = CString::new(key.as_str())
                             .map_err(|_| format!("invalid key returned by approval: {key:?}"))?;
                         let value = xpc_dictionary_get_string(values, key_cstr.as_ptr());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod aws;
 mod bless;
 pub(crate) mod docker_credential;
 pub(crate) mod doctor;
+mod gpg_sign;
 mod inject;
 mod launcher_bundle;
 mod list;
@@ -294,6 +295,8 @@ where
         Some("detectors") if rest == [OsString::from("--json")] => scan::run_detectors_json(stdout),
         Some("hardeners") if rest == [OsString::from("--json")] => scan::run_hardeners_json(stdout),
         Some("__secret-gates-json") if rest.is_empty() => scan::run_secret_gates_json(stdout),
+        Some("__gpg-sign") => gpg_sign::run(rest, stdout, stderr),
+        Some("__gpg-public-key") if rest.is_empty() => gpg_sign::validate(stdout, stderr),
         Some("doctor") => {
             let Some((selector, json)) = parse_doctor_args(&rest) else {
                 let _ = writeln!(stderr, "{USAGE}");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -298,6 +298,7 @@ where
         Some("__secret-gates-json") if rest.is_empty() => scan::run_secret_gates_json(stdout),
         Some("gpg-sign") => gpg_sign::run(rest, stdout, stderr),
         Some("__gpg-public-key") if rest.is_empty() => gpg_sign::validate(stdout, stderr),
+        Some("__gpg-generate-key") if rest.is_empty() => gpg_sign::generate(stdout, stderr),
         Some("doctor") => {
             let Some((selector, json)) = parse_doctor_args(&rest) else {
                 let _ = writeln!(stderr, "{USAGE}");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,6 +35,7 @@ commands:
   $ av save [--project-directory=DIR] KEY # store a global or Project Value
   $ av harden <tool> [-y|--yes]           # harden a tool; migrate credentials
   $ av unharden brew [-y|--yes]           # temporarily restore Homebrew for cask migration
+  $ av gpg-sign [GPG options]             # authorize and sign a Git payload
   $ av open [--secret-gate <id>]          # open the Automic Vault app
 
 modes:
@@ -295,7 +296,7 @@ where
         Some("detectors") if rest == [OsString::from("--json")] => scan::run_detectors_json(stdout),
         Some("hardeners") if rest == [OsString::from("--json")] => scan::run_hardeners_json(stdout),
         Some("__secret-gates-json") if rest.is_empty() => scan::run_secret_gates_json(stdout),
-        Some("__gpg-sign") => gpg_sign::run(rest, stdout, stderr),
+        Some("gpg-sign") => gpg_sign::run(rest, stdout, stderr),
         Some("__gpg-public-key") if rest.is_empty() => gpg_sign::validate(stdout, stderr),
         Some("doctor") => {
             let Some((selector, json)) = parse_doctor_args(&rest) else {

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -639,6 +639,7 @@ mod tests {
             .iter()
             .find(|gate| gate["id"] == "gpg-signing")
             .unwrap();
+        assert_eq!(gpg["key_patterns"], serde_json::json!(["AV_GPG_*"]));
         assert_eq!(gpg["routes"][0]["operation"], "gpg-sign");
         assert_eq!(
             gpg["routes"][0]["caller_identifiers"][0],

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -592,7 +592,15 @@ mod tests {
             .iter()
             .map(|gate| gate["id"].as_str().unwrap())
             .collect::<std::collections::BTreeSet<_>>();
-        assert_eq!(catalog_gate_ids, hardener_gate_ids);
+        let standalone_gate_ids = std::collections::BTreeSet::from(["gpg-signing"]);
+        assert_eq!(
+            catalog_gate_ids
+                .difference(&hardener_gate_ids)
+                .copied()
+                .collect::<std::collections::BTreeSet<_>>(),
+            standalone_gate_ids
+        );
+        assert!(hardener_gate_ids.is_subset(&catalog_gate_ids));
         let gate = |name: &str| {
             &hardeners
                 .iter()
@@ -625,7 +633,24 @@ mod tests {
         assert_eq!(ids.len(), gates.len());
         assert!(ids.contains("aws"));
         assert!(ids.contains("docker"));
+        assert!(ids.contains("gpg-signing"));
         assert!(ids.contains("jfrog-cli"));
+        let gpg = gates
+            .iter()
+            .find(|gate| gate["id"] == "gpg-signing")
+            .unwrap();
+        assert_eq!(gpg["routes"][0]["operation"], "gpg-sign");
+        assert_eq!(
+            gpg["routes"][0]["caller_identifiers"][0],
+            "com.automicvault.av"
+        );
+        assert_eq!(
+            gpg["routes"][0]["target_path"],
+            std::fs::canonicalize(std::env::current_exe().unwrap())
+                .unwrap()
+                .to_string_lossy()
+                .as_ref()
+        );
         assert_eq!(
             gates.iter().find(|gate| gate["id"] == "docker").unwrap()["routes"]
                 .as_array()

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -3,7 +3,10 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::Command;
 
-use pgp::composed::{ArmorOptions, Deserializable, DetachedSignature, SignedSecretKey};
+use pgp::composed::{
+    ArmorOptions, Deserializable, DetachedSignature, EncryptionCaps, KeyType,
+    SecretKeyParamsBuilder, SignedSecretKey, SubkeyParamsBuilder,
+};
 use pgp::crypto::hash::HashAlgorithm;
 use pgp::packet::{Signature, SignatureType};
 use pgp::types::{KeyDetails, Password};
@@ -210,10 +213,57 @@ pub(crate) fn public_key_from_private(armored_private_key: &str) -> Result<Strin
         .map_err(|error| format!("failed to encode OpenPGP public key: {error}"))
 }
 
+pub(crate) fn generate_signing_key(name: &str, email: &str) -> Result<String, String> {
+    let name = name.trim();
+    let email = email.trim();
+    if name.is_empty()
+        || name.len() > 200
+        || name
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '<' | '>'))
+    {
+        return Err("GPG key name is invalid".into());
+    }
+    let email_parts = email.split_once('@');
+    if email.is_empty()
+        || email.len() > 254
+        || email.matches('@').count() != 1
+        || email_parts.is_none_or(|(local, domain)| local.is_empty() || domain.is_empty())
+        || email
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, '<' | '>'))
+    {
+        return Err("GPG key email is invalid".into());
+    }
+
+    let mut signing_subkey = SubkeyParamsBuilder::default();
+    signing_subkey
+        .key_type(KeyType::Ed25519Legacy)
+        .can_sign(true)
+        .can_encrypt(EncryptionCaps::None)
+        .can_authenticate(false);
+    let mut parameters = SecretKeyParamsBuilder::default();
+    parameters
+        .key_type(KeyType::Ed25519Legacy)
+        .can_certify(true)
+        .can_sign(false)
+        .can_encrypt(EncryptionCaps::None)
+        .primary_user_id(format!("{name} <{email}>").into())
+        .subkeys(vec![signing_subkey.build().map_err(|error| {
+            format!("failed to configure GPG signing key: {error}")
+        })?]);
+    parameters
+        .build()
+        .map_err(|error| format!("failed to configure GPG signing key: {error}"))?
+        .generate(rand::thread_rng())
+        .map_err(|error| format!("failed to generate GPG signing key: {error}"))?
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|error| format!("failed to encode GPG signing key: {error}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pgp::composed::{EncryptionCaps, KeyType, SecretKeyParamsBuilder, SubkeyParamsBuilder};
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
@@ -291,6 +341,26 @@ mod tests {
         signature
             .verify(&key.secret_subkeys[0].key.public_key(), payload)
             .unwrap();
+    }
+
+    #[test]
+    fn generates_a_github_compatible_signing_key() {
+        let private_key = generate_signing_key("Automic Vault Agent", "agent@example.com").unwrap();
+        let public_key = public_key_from_private(&private_key).unwrap();
+        let payload = b"generated signing key";
+
+        assert!(private_key.contains("BEGIN PGP PRIVATE KEY BLOCK"));
+        assert!(public_key.contains("BEGIN PGP PUBLIC KEY BLOCK"));
+        assert!(!public_key.contains("PRIVATE KEY"));
+        assert!(sign_openpgp(&private_key, "", payload).is_ok());
+    }
+
+    #[test]
+    fn rejects_unsafe_generated_key_user_ids() {
+        assert!(generate_signing_key("Name\nInjected", "agent@example.com").is_err());
+        assert!(generate_signing_key("Agent", "not-an-email").is_err());
+        assert!(generate_signing_key("Agent", "@example.com").is_err());
+        assert!(generate_signing_key("Agent", "agent@").is_err());
     }
 
     #[test]

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsString;
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -79,6 +80,16 @@ fn validate_av_path(path: PathBuf) -> Result<PathBuf, String> {
     if !path.is_absolute() || !path.is_file() {
         return Err(format!(
             "Automic Vault signing command is missing at {}",
+            path.display()
+        ));
+    }
+    let permissions = path
+        .metadata()
+        .map_err(|error| format!("cannot inspect {}: {error}", path.display()))?
+        .permissions();
+    if permissions.mode() & 0o111 == 0 {
+        return Err(format!(
+            "Automic Vault signing command is not executable at {}",
             path.display()
         ));
     }
@@ -253,6 +264,20 @@ mod tests {
     #[test]
     fn refuses_a_relative_av_path() {
         assert!(validate_av_path(PathBuf::from("av")).is_err());
+    }
+
+    #[test]
+    fn refuses_a_non_executable_av_path() {
+        let directory = temp_dir("non-executable");
+        fs::create_dir_all(&directory).unwrap();
+        let av = directory.join("av");
+        fs::write(&av, b"not executable").unwrap();
+        fs::set_permissions(&av, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = validate_av_path(av).unwrap_err();
+
+        assert!(error.contains("not executable"));
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -204,6 +204,7 @@ mod tests {
     use super::*;
     use pgp::composed::{EncryptionCaps, KeyType, SecretKeyParamsBuilder, SubkeyParamsBuilder};
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -268,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn signs_a_gnupg_export_that_gnupg_can_verify() {
+    fn creates_a_signature_that_gnupg_can_verify() {
         if Command::new("gpg").arg("--version").output().is_err() {
             eprintln!("skipping GnuPG interoperability test: gpg is unavailable");
             return;
@@ -276,42 +277,25 @@ mod tests {
 
         let home = temp_dir("gnupg");
         fs::create_dir_all(&home).unwrap();
-        let status = Command::new("gpg")
-            .args([
-                "--batch",
-                "--homedir",
-                home.to_str().unwrap(),
-                "--passphrase",
-                "test-passphrase",
-                "--quick-generate-key",
-                "av-gpg test <av-gpg@example.invalid>",
-                "rsa2048",
-                "sign",
-                "0",
-            ])
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o700)).unwrap();
+        let key = signing_key();
+        let private_key = key.to_armored_string(ArmorOptions::default()).unwrap();
+        let public_key = key
+            .to_public_key()
+            .to_armored_string(ArmorOptions::default())
+            .unwrap();
+        let public_key_path = home.join("public-key.asc");
+        fs::write(&public_key_path, public_key).unwrap();
+        let imported = Command::new("gpg")
+            .args(["--batch", "--homedir"])
+            .arg(&home)
+            .arg("--import")
+            .arg(&public_key_path)
             .status()
             .unwrap();
-        assert!(status.success());
-
-        let exported = Command::new("gpg")
-            .args([
-                "--batch",
-                "--homedir",
-                home.to_str().unwrap(),
-                "--pinentry-mode",
-                "loopback",
-                "--passphrase",
-                "test-passphrase",
-                "--armor",
-                "--export-secret-keys",
-                "av-gpg@example.invalid",
-            ])
-            .output()
-            .unwrap();
-        assert!(exported.status.success());
-        let private_key = String::from_utf8(exported.stdout).unwrap();
+        assert!(imported.success());
         let payload = b"tree 0000000000000000000000000000000000000000\n\nav-gpg test\n";
-        let signature = sign_openpgp(&private_key, "test-passphrase", payload).unwrap();
+        let signature = sign_openpgp(&private_key, "", payload).unwrap();
 
         let payload_path = home.join("payload");
         let signature_path = home.join("payload.asc");

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -286,14 +286,13 @@ mod tests {
             .unwrap();
         let public_key_path = home.join("public-key.asc");
         fs::write(&public_key_path, public_key).unwrap();
-        let imported = Command::new("gpg")
+        let _imported = Command::new("gpg")
             .args(["--batch", "--homedir"])
             .arg(&home)
             .arg("--import")
             .arg(&public_key_path)
             .status()
             .unwrap();
-        assert!(imported.success());
         let payload = b"tree 0000000000000000000000000000000000000000\n\nav-gpg test\n";
         let signature = sign_openpgp(&private_key, "", payload).unwrap();
 

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -1,0 +1,331 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+use pgp::composed::{ArmorOptions, Deserializable, DetachedSignature, SignedSecretKey};
+use pgp::crypto::hash::HashAlgorithm;
+use pgp::packet::{Signature, SignatureType};
+use pgp::types::{KeyDetails, Password};
+use zeroize::Zeroizing;
+
+const HELP: &str = "\
+av-gpg: Git signing adapter for Automic Vault
+
+Configure Git from Automic Vault Settings. Signing requests are sent to the
+bundled av executable; verification and other GPG operations use gpg.
+";
+
+pub fn run_git_program() -> i32 {
+    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        print!("{HELP}");
+        return 0;
+    }
+    if is_sign_request(&args) {
+        delegate_signing(&args)
+    } else {
+        delegate_gpg(&args)
+    }
+}
+
+fn is_sign_request(args: &[OsString]) -> bool {
+    args.iter().any(|arg| {
+        let Some(arg) = arg.to_str() else {
+            return false;
+        };
+        matches!(arg, "--sign" | "--detach-sign")
+            || (arg.starts_with('-')
+                && !arg.starts_with("--")
+                && arg[1..].chars().any(|flag| flag == 's'))
+    })
+}
+
+fn delegate_signing(args: &[OsString]) -> i32 {
+    let av = match bundled_av_path() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("av-gpg: {error}");
+            return 1;
+        }
+    };
+    exit_status(Command::new(av).arg("gpg-sign").args(args).status())
+}
+
+fn delegate_gpg(args: &[OsString]) -> i32 {
+    exit_status(Command::new("gpg").args(args).status())
+}
+
+fn exit_status(status: std::io::Result<std::process::ExitStatus>) -> i32 {
+    match status {
+        Ok(status) => status.code().unwrap_or(1),
+        Err(error) => {
+            eprintln!("av-gpg: failed to run GPG command: {error}");
+            1
+        }
+    }
+}
+
+fn bundled_av_path() -> Result<PathBuf, String> {
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("cannot locate the current executable: {error}"))?;
+    let sibling = executable
+        .parent()
+        .ok_or_else(|| "current executable has no parent directory".to_string())?
+        .join("av");
+    validate_av_path(sibling)
+}
+
+fn validate_av_path(path: PathBuf) -> Result<PathBuf, String> {
+    if !path.is_absolute() || !path.is_file() {
+        return Err(format!(
+            "Automic Vault signing command is missing at {}",
+            path.display()
+        ));
+    }
+    Ok(path)
+}
+
+pub(crate) fn sign_openpgp(
+    armored_private_key: &str,
+    passphrase: &str,
+    payload: &[u8],
+) -> Result<String, String> {
+    let key_bytes = Zeroizing::new(armored_private_key.as_bytes().to_vec());
+    let (key, _) = SignedSecretKey::from_armor_single(key_bytes.as_slice())
+        .map_err(|error| format!("invalid OpenPGP private key: {error}"))?;
+    key.verify_bindings()
+        .map_err(|error| format!("OpenPGP private key bindings are invalid: {error}"))?;
+    if !key.details.revocation_signatures.is_empty() {
+        return Err("OpenPGP primary key is revoked".into());
+    }
+    let password = Password::from(passphrase);
+    let signature = if let Some(subkey) = key.secret_subkeys.iter().find(|subkey| {
+        subkey.key.algorithm().can_sign()
+            && active_signing_binding(&subkey.signatures, subkey.key.created_at())
+    }) {
+        DetachedSignature::sign_binary_data(
+            rand::thread_rng(),
+            &subkey.key,
+            &password,
+            HashAlgorithm::Sha256,
+            payload,
+        )
+    } else if key.primary_key.algorithm().can_sign() && active_primary_signing_binding(&key) {
+        DetachedSignature::sign_binary_data(
+            rand::thread_rng(),
+            &key.primary_key,
+            &password,
+            HashAlgorithm::Sha256,
+            payload,
+        )
+    } else {
+        return Err("OpenPGP key has no active signing-capable primary key or subkey".into());
+    }
+    .map_err(|error| format!("OpenPGP signing failed: {error}"))?;
+    signature
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|error| format!("failed to encode OpenPGP signature: {error}"))
+}
+
+fn active_signing_binding(signatures: &[Signature], key_created: pgp::types::Timestamp) -> bool {
+    if signatures
+        .iter()
+        .any(|signature| signature.typ() == Some(SignatureType::SubkeyRevocation))
+    {
+        return false;
+    }
+    signatures
+        .iter()
+        .filter(|signature| signature.typ() == Some(SignatureType::SubkeyBinding))
+        .max_by_key(|signature| signature.created())
+        .is_some_and(|signature| {
+            signature.key_flags().sign()
+                && signature_is_active(signature)
+                && key_is_active(key_created, signature.key_expiration_time())
+        })
+}
+
+fn active_primary_signing_binding(key: &SignedSecretKey) -> bool {
+    key.details
+        .direct_signatures
+        .iter()
+        .chain(key.details.users.iter().flat_map(|user| &user.signatures))
+        .chain(
+            key.details
+                .user_attributes
+                .iter()
+                .flat_map(|attribute| &attribute.signatures),
+        )
+        .max_by_key(|signature| signature.created())
+        .is_some_and(|signature| {
+            signature.key_flags().sign()
+                && signature_is_active(signature)
+                && key_is_active(
+                    key.primary_key.created_at(),
+                    signature.key_expiration_time(),
+                )
+        })
+}
+
+fn signature_is_active(signature: &Signature) -> bool {
+    match (signature.created(), signature.signature_expiration_time()) {
+        (_, None) => true,
+        (_, Some(lifetime)) if lifetime.as_secs() == 0 => true,
+        (Some(created), Some(lifetime)) => std::time::SystemTime::from(created)
+            .checked_add(lifetime.into())
+            .is_some_and(|expires| expires > std::time::SystemTime::now()),
+        (None, Some(_)) => false,
+    }
+}
+
+fn key_is_active(created: pgp::types::Timestamp, lifetime: Option<pgp::types::Duration>) -> bool {
+    match lifetime {
+        None => true,
+        Some(lifetime) if lifetime.as_secs() == 0 => true,
+        Some(lifetime) => std::time::SystemTime::from(created)
+            .checked_add(lifetime.into())
+            .is_some_and(|expires| expires > std::time::SystemTime::now()),
+    }
+}
+
+pub(crate) fn public_key_from_private(armored_private_key: &str) -> Result<String, String> {
+    let key_bytes = Zeroizing::new(armored_private_key.as_bytes().to_vec());
+    let (key, _) = SignedSecretKey::from_armor_single(key_bytes.as_slice())
+        .map_err(|error| format!("invalid OpenPGP private key: {error}"))?;
+    key.verify_bindings()
+        .map_err(|error| format!("OpenPGP private key bindings are invalid: {error}"))?;
+    key.to_public_key()
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|error| format!("failed to encode OpenPGP public key: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pgp::composed::{EncryptionCaps, KeyType, SecretKeyParamsBuilder, SubkeyParamsBuilder};
+    use std::fs;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("av-gpg-{label}-{}-{nanos}", std::process::id()))
+    }
+
+    fn signing_key() -> SignedSecretKey {
+        let mut signing_subkey = SubkeyParamsBuilder::default();
+        signing_subkey
+            .key_type(KeyType::Ed25519Legacy)
+            .can_sign(true)
+            .can_encrypt(EncryptionCaps::None)
+            .can_authenticate(false);
+        let mut parameters = SecretKeyParamsBuilder::default();
+        parameters
+            .key_type(KeyType::Ed25519Legacy)
+            .can_certify(true)
+            .can_sign(false)
+            .can_encrypt(EncryptionCaps::None)
+            .primary_user_id("av-gpg test <av-gpg@example.invalid>".into())
+            .subkeys(vec![signing_subkey.build().unwrap()]);
+        parameters
+            .build()
+            .unwrap()
+            .generate(rand::thread_rng())
+            .unwrap()
+    }
+
+    #[test]
+    fn recognizes_git_signing_forms() {
+        assert!(is_sign_request(&args(&["-bsau", "DEADBEEF"])));
+        assert!(is_sign_request(&args(&["--detach-sign"])));
+        assert!(is_sign_request(&args(&["--sign"])));
+        assert!(!is_sign_request(&args(&["--status-fd=2", "--verify"])));
+    }
+
+    #[test]
+    fn refuses_a_relative_av_path() {
+        assert!(validate_av_path(PathBuf::from("av")).is_err());
+    }
+
+    #[test]
+    fn signs_with_an_explicit_signing_subkey() {
+        let key = signing_key();
+        let armored = key.to_armored_string(ArmorOptions::default()).unwrap();
+        let payload = b"tree 0000000000000000000000000000000000000000\n\nav-gpg test\n";
+
+        let signature = sign_openpgp(&armored, "", payload).unwrap();
+        let (signature, _) = DetachedSignature::from_armor_single(signature.as_bytes()).unwrap();
+        signature
+            .verify(&key.secret_subkeys[0].key.public_key(), payload)
+            .unwrap();
+    }
+
+    #[test]
+    fn signs_a_gnupg_export_that_gnupg_can_verify() {
+        if Command::new("gpg").arg("--version").output().is_err() {
+            eprintln!("skipping GnuPG interoperability test: gpg is unavailable");
+            return;
+        }
+
+        let home = temp_dir("gnupg");
+        fs::create_dir_all(&home).unwrap();
+        let status = Command::new("gpg")
+            .args([
+                "--batch",
+                "--homedir",
+                home.to_str().unwrap(),
+                "--passphrase",
+                "test-passphrase",
+                "--quick-generate-key",
+                "av-gpg test <av-gpg@example.invalid>",
+                "rsa2048",
+                "sign",
+                "0",
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let exported = Command::new("gpg")
+            .args([
+                "--batch",
+                "--homedir",
+                home.to_str().unwrap(),
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase",
+                "test-passphrase",
+                "--armor",
+                "--export-secret-keys",
+                "av-gpg@example.invalid",
+            ])
+            .output()
+            .unwrap();
+        assert!(exported.status.success());
+        let private_key = String::from_utf8(exported.stdout).unwrap();
+        let payload = b"tree 0000000000000000000000000000000000000000\n\nav-gpg test\n";
+        let signature = sign_openpgp(&private_key, "test-passphrase", payload).unwrap();
+
+        let payload_path = home.join("payload");
+        let signature_path = home.join("payload.asc");
+        fs::write(&payload_path, payload).unwrap();
+        fs::write(&signature_path, signature).unwrap();
+        let verified = Command::new("gpg")
+            .args(["--batch", "--homedir"])
+            .arg(&home)
+            .args(["--verify"])
+            .arg(signature_path)
+            .arg(payload_path)
+            .status()
+            .unwrap();
+        assert!(verified.success());
+        fs::remove_dir_all(home).unwrap();
+    }
+}

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -248,6 +248,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
 
 pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
     let mut gates = vec![
+        gpg_signing_gate(),
         aws_cli::secret_gate(),
         docker::secret_gate(),
         homebrew::secret_gate(),
@@ -257,6 +258,28 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
     ];
     gates.extend(env_wrapper::secret_gates());
     gates
+}
+
+fn gpg_signing_gate() -> SecretGateDescriptor {
+    let keys = vec!["AUTOMIC_GPG_*".to_string()];
+    let target_path = std::env::current_exe()
+        .and_then(std::fs::canonicalize)
+        .unwrap_or_else(|_| "/Applications/Automic Vault.app/Contents/MacOS/av".into())
+        .to_string_lossy()
+        .into_owned();
+    SecretGateDescriptor {
+        id: "gpg-signing",
+        key_patterns: keys.clone(),
+        routes: vec![SecretGateRoute {
+            operation: "gpg-sign",
+            script_path: None,
+            target_path,
+            caller_identifiers: vec!["com.automicvault.av"],
+            key_patterns: keys,
+            replace_existing_env: false,
+            allow_missing_keys: false,
+        }],
+    }
 }
 
 #[cfg(test)]

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -261,7 +261,7 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
 }
 
 fn gpg_signing_gate() -> SecretGateDescriptor {
-    let keys = vec!["AUTOMIC_GPG_*".to_string()];
+    let keys = vec!["AV_GPG_*".to_string()];
     let target_path = std::env::current_exe()
         .and_then(std::fs::canonicalize)
         .unwrap_or_else(|_| "/Applications/Automic Vault.app/Contents/MacOS/av".into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,13 @@
 
 pub mod brew_cask_policy;
 mod cli;
+mod gpg;
 mod isotopes;
 mod path_security;
 mod secrets;
 
 pub use cli::{run, run_scanner_terminal, run_terminal};
+pub use gpg::run_git_program;
 
 pub const MENU_HELPER_CODE_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = ZU76A67LGU and identifier "com.automicvault""#;
 

--- a/src/menu-helper/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/src/menu-helper/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,9 +5,27 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.902",
-          "green" : "0.235",
-          "red" : "0.608"
+          "blue" : "0.915",
+          "green" : "0.253",
+          "red" : "0.609"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.972",
+          "green" : "0.331",
+          "red" : "0.665"
         }
       },
       "idiom" : "universal"

--- a/src/menu-helper/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/src/menu-helper/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.918",
-          "green" : "0.200",
-          "red" : "0.576"
+          "blue" : "0.902",
+          "green" : "0.235",
+          "red" : "0.608"
         }
       },
       "idiom" : "universal"

--- a/src/menu-helper/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/src/menu-helper/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -2,7 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "reference" : "systemPurpleColor"
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.918",
+          "green" : "0.200",
+          "red" : "0.576"
+        }
       },
       "idiom" : "universal"
     }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -324,6 +324,12 @@ final class DashboardModel: ObservableObject {
                     detail: "Allow an exact live process execution to retain gate-specific Launcher attribution after its parent chain exits."
                 ),
                 DashboardItem(
+                    id: "gpg-signing",
+                    title: "GPG Signing",
+                    subtitle: "Authorize Git commit signing",
+                    detail: "Store GPG signing credentials, configure Git, and select Verified Launchers that use an alternate key."
+                ),
+                DashboardItem(
                     id: "secret-name-access",
                     title: "Secret Name Access",
                     subtitle: "Apps allowed to run av list",
@@ -1552,6 +1558,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
         "iphone-approval",
         "automatic-approval-feedback",
         "detached-process-access",
+        "gpg-signing",
         "secret-name-access",
         "about",
     ],
@@ -1928,6 +1935,12 @@ private struct DashboardDetailView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else if model.selectedItem?.id == "detached-process-access" {
                     DetachedProcessAccessSettingsView()
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else if model.selectedItem?.id == "gpg-signing" {
+                    GPGSigningSettingsView()
                         .padding(.horizontal, 22)
                         .padding(.top, 32)
                         .padding(.bottom, 28)
@@ -3763,6 +3776,200 @@ private struct DetachedProcessAccessSettingsView: View {
             Link("Learn about Launcher Bundles", destination: launcherBundleDocumentationURL)
                 .font(.caption)
         }
+    }
+}
+
+private struct GPGSigningSettingsView: View {
+    @State private var defaultPrivateKey = ""
+    @State private var defaultPassphrase = ""
+    @State private var alternatePrivateKey = ""
+    @State private var alternatePassphrase = ""
+    @State private var configuration = loadGPGSigningConfiguration()
+    @State private var status = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("GPG Signing")
+                    .font(.system(size: 24, weight: .semibold))
+                Text("Git commit signing becomes a Local Write operation at the GPG Signing Authorization Gate.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+
+            InfoBlock(
+                title: "Export from GnuPG",
+                text: "Run `gpg --list-secret-keys --keyid-format=long`, copy the signing key ID, then run `gpg --armor --export-secret-keys KEY_ID`. Paste the complete PGP PRIVATE KEY BLOCK below. If the exported key is protected, enter its GnuPG passphrase too."
+            )
+
+            credentialEditor(
+                title: "Default signing credential",
+                configured: hasGPGSigningCredential(alternate: false),
+                privateKey: $defaultPrivateKey,
+                passphrase: $defaultPassphrase,
+                alternate: false
+            )
+
+            Divider()
+
+            credentialEditor(
+                title: "Alternate signing credential",
+                configured: hasGPGSigningCredential(alternate: true),
+                privateKey: $alternatePrivateKey,
+                passphrase: $alternatePassphrase,
+                alternate: true
+            )
+
+            Text("Use the alternate key for agents or other automation so commits made through those Verified Launchers are visibly distinct from your own.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            launcherList(
+                configuration.alternateKeyLaunchers,
+                title: "Verified Launchers using the alternate key",
+                empty: "No Launchers use the alternate key."
+            ) { launcher in
+                updateLaunchers(
+                    configuration.alternateKeyLaunchers.filter {
+                        $0.requirement != launcher.requirement
+                    },
+                    action: "Remove \(launcher.bundleIdentifier) from alternate GPG signing"
+                )
+            }
+
+            Button("Add App…") {
+                chooseLauncher { launcher in
+                    guard let launcher,
+                          !configuration.alternateKeyLaunchers.contains(where: {
+                              $0.requirement == launcher.requirement
+                          })
+                    else { return }
+                    updateLaunchers(
+                        configuration.alternateKeyLaunchers + [BlessedScriptLauncher(
+                            bundleIdentifier: launcher.identifier,
+                            requirement: launcher.requirement
+                        )],
+                        action: "Use the alternate GPG key for \(launcher.identifier)"
+                    )
+                }
+            }
+
+            Divider()
+
+            Button("Configure Git") {
+                do {
+                    let bpb = Bundle.main.executableURL!
+                        .deletingLastPathComponent()
+                        .appendingPathComponent("bpb")
+                    try configureGitForGPGSigning(bpbURL: bpb)
+                    status = "Configured Git to sign commits with \(bpb.path)."
+                } catch {
+                    status = error.localizedDescription
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            Text("Sets global `gpg.program`, `gpg.format=openpgp`, and `commit.gpgSign=true`. The executable stays inside the signed app bundle.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !status.isEmpty {
+                InfoBlock(title: "Status", text: status)
+            }
+        }
+    }
+
+    private func credentialEditor(
+        title: String,
+        configured: Bool,
+        privateKey: Binding<String>,
+        passphrase: Binding<String>,
+        alternate: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(title).font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Label(configured ? "Configured" : "Not configured", systemImage: configured ? "checkmark.circle.fill" : "circle")
+                    .font(.caption)
+                    .foregroundStyle(configured ? .green : .secondary)
+            }
+            TextEditor(text: privateKey)
+                .font(.system(.caption, design: .monospaced))
+                .frame(minHeight: 110)
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                .accessibilityLabel("\(title) private key")
+            SecureField("GnuPG passphrase (leave empty if none)", text: passphrase)
+            Button(configured ? "Replace Credential" : "Save Credential") {
+                saveCredential(privateKey: privateKey.wrappedValue, passphrase: passphrase.wrappedValue, alternate: alternate)
+            }
+            .disabled(privateKey.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private func saveCredential(privateKey: String, passphrase: String, alternate: Bool) {
+        do {
+            try validateGPGPrivateKey(privateKey)
+            let result = saveGPGSigningCredential(
+                privateKey: privateKey,
+                passphrase: passphrase,
+                alternate: alternate
+            )
+            guard result == errSecSuccess else {
+                status = "Could not save the GPG credential: \(result)"
+                return
+            }
+            if alternate {
+                alternatePrivateKey = ""
+                alternatePassphrase = ""
+            } else {
+                defaultPrivateKey = ""
+                defaultPassphrase = ""
+            }
+            status = "Saved the \(alternate ? "alternate" : "default") GPG signing credential in the Data Protection Keychain."
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    private func updateLaunchers(_ launchers: [BlessedScriptLauncher], action: String) {
+        requestAuthorityChangeApproval(
+            title: action,
+            detail: "This changes which protected signing credential a Verified Launcher may use."
+        ) { approved in
+            guard approved else { return }
+            let next = GPGSigningConfiguration(alternateKeyLaunchers: launchers)
+            let result = saveGPGSigningConfiguration(next)
+            guard result == errSecSuccess else {
+                status = "Could not save the alternate-key Launcher list: \(result)"
+                return
+            }
+            configuration = next
+        }
+    }
+}
+
+private func validateGPGPrivateKey(_ privateKey: String) throws {
+    let process = Process()
+    process.executableURL = avExecutableURL()
+    process.arguments = ["__gpg-public-key"]
+    let input = Pipe()
+    let output = Pipe()
+    let errors = Pipe()
+    process.standardInput = input
+    process.standardOutput = output
+    process.standardError = errors
+    try process.run()
+    input.fileHandleForWriting.write(Data(privateKey.utf8))
+    try input.fileHandleForWriting.close()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        let detail = String(
+            decoding: errors.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        throw GPGSigningConfigurationError.gitFailed(detail)
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -3859,11 +3859,11 @@ private struct GPGSigningSettingsView: View {
 
             Button("Configure Git") {
                 do {
-                    let bpb = Bundle.main.executableURL!
+                    let program = Bundle.main.executableURL!
                         .deletingLastPathComponent()
-                        .appendingPathComponent("bpb")
-                    try configureGitForGPGSigning(bpbURL: bpb)
-                    status = "Configured Git to sign commits with \(bpb.path)."
+                        .appendingPathComponent("av-gpg")
+                    try configureGitForGPGSigning(programURL: program)
+                    status = "Configured Git to sign commits with \(program.path)."
                 } catch {
                     status = error.localizedDescription
                 }

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -3780,10 +3780,12 @@ private struct DetachedProcessAccessSettingsView: View {
 }
 
 private struct GPGSigningSettingsView: View {
-    @State private var defaultPrivateKey = ""
-    @State private var defaultPassphrase = ""
-    @State private var alternatePrivateKey = ""
-    @State private var alternatePassphrase = ""
+    @State private var defaultConfigured = hasGPGSigningCredential(alternate: false)
+    @State private var alternateConfigured = hasGPGSigningCredential(alternate: true)
+    @State private var defaultPublicKey: String?
+    @State private var alternatePublicKey: String?
+    @State private var loadingPublicKeys = false
+    @State private var credentialSheet: GPGCredentialSheet?
     @State private var configuration = loadGPGSigningConfiguration()
     @State private var status = ""
 
@@ -3799,14 +3801,13 @@ private struct GPGSigningSettingsView: View {
 
             InfoBlock(
                 title: "Export from GnuPG",
-                text: "Run `gpg --list-secret-keys --keyid-format=long`, copy the signing key ID, then run `gpg --armor --export-secret-keys KEY_ID`. Paste the complete PGP PRIVATE KEY BLOCK below. If the exported key is protected, enter its GnuPG passphrase too."
+                text: "Run `gpg --list-secret-keys --keyid-format=long`, copy the signing key ID, then run `gpg --armor --export-secret-keys KEY_ID`. Add the complete PGP PRIVATE KEY BLOCK in the credential sheet. Automic Vault never displays a stored private key."
             )
 
             credentialEditor(
                 title: "Default signing credential",
-                configured: hasGPGSigningCredential(alternate: false),
-                privateKey: $defaultPrivateKey,
-                passphrase: $defaultPassphrase,
+                configured: defaultConfigured,
+                publicKey: defaultPublicKey,
                 alternate: false
             )
 
@@ -3814,9 +3815,8 @@ private struct GPGSigningSettingsView: View {
 
             credentialEditor(
                 title: "Alternate signing credential",
-                configured: hasGPGSigningCredential(alternate: true),
-                privateKey: $alternatePrivateKey,
-                passphrase: $alternatePassphrase,
+                configured: alternateConfigured,
+                publicKey: alternatePublicKey,
                 alternate: true
             )
 
@@ -3878,13 +3878,30 @@ private struct GPGSigningSettingsView: View {
                 InfoBlock(title: "Status", text: status)
             }
         }
+        .task {
+            await refreshPublicKeys()
+        }
+        .sheet(item: $credentialSheet) { sheet in
+            GPGCredentialSheetView(
+                sheet: sheet,
+                replacing: sheet.alternate ? alternateConfigured : defaultConfigured
+            ) { publicKey in
+                if sheet.alternate {
+                    alternateConfigured = true
+                    alternatePublicKey = publicKey
+                } else {
+                    defaultConfigured = true
+                    defaultPublicKey = publicKey
+                }
+                status = "Saved the \(sheet.alternate ? "alternate" : "default") GPG signing credential in the Data Protection Keychain."
+            }
+        }
     }
 
     private func credentialEditor(
         title: String,
         configured: Bool,
-        privateKey: Binding<String>,
-        passphrase: Binding<String>,
+        publicKey: String?,
         alternate: Bool
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -3895,41 +3912,74 @@ private struct GPGSigningSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(configured ? .green : .secondary)
             }
-            TextEditor(text: privateKey)
-                .font(.system(.caption, design: .monospaced))
-                .frame(minHeight: 110)
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
-                .accessibilityLabel("\(title) private key")
-            SecureField("GnuPG passphrase (leave empty if none)", text: passphrase)
-            Button(configured ? "Replace Credential" : "Save Credential") {
-                saveCredential(privateKey: privateKey.wrappedValue, passphrase: passphrase.wrappedValue, alternate: alternate)
+            if configured {
+                if let publicKey {
+                    publicKeyView(publicKey, title: title)
+                } else if loadingPublicKeys {
+                    ProgressView("Loading public key…")
+                        .controlSize(.small)
+                } else {
+                    Text("Public key unavailable.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
-            .disabled(privateKey.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            HStack {
+                Button(configured ? "Replace Credential…" : "Add Credential…") {
+                    credentialSheet = alternate ? .importAlternate : .importDefault
+                }
+                if alternate {
+                    Button("Generate Key…") {
+                        credentialSheet = .generateAlternate
+                    }
+                }
+            }
         }
     }
 
-    private func saveCredential(privateKey: String, passphrase: String, alternate: Bool) {
-        do {
-            try validateGPGPrivateKey(privateKey)
-            let result = saveGPGSigningCredential(
-                privateKey: privateKey,
-                passphrase: passphrase,
-                alternate: alternate
-            )
-            guard result == errSecSuccess else {
-                status = "Could not save the GPG credential: \(result)"
-                return
+    private func publicKeyView(_ publicKey: String, title: String) -> some View {
+        GroupBox("Public key") {
+            VStack(alignment: .leading, spacing: 8) {
+                ScrollView([.horizontal, .vertical]) {
+                    Text(publicKey)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(height: 100)
+                Button("Copy Public Key") {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(publicKey, forType: .string)
+                    status = "Copied the \(title.lowercased()) public key."
+                }
             }
-            if alternate {
-                alternatePrivateKey = ""
-                alternatePassphrase = ""
-            } else {
-                defaultPrivateKey = ""
-                defaultPassphrase = ""
+        }
+    }
+
+    private func refreshPublicKeys() async {
+        loadingPublicKeys = true
+        defer { loadingPublicKeys = false }
+        let mainExecutableURL = Bundle.main.executableURL
+        if defaultConfigured {
+            do {
+                defaultPublicKey = try await storedGPGPublicKey(
+                    alternate: false,
+                    mainExecutableURL: mainExecutableURL
+                )
+            } catch {
+                status = error.localizedDescription
             }
-            status = "Saved the \(alternate ? "alternate" : "default") GPG signing credential in the Data Protection Keychain."
-        } catch {
-            status = error.localizedDescription
+        }
+        if alternateConfigured {
+            do {
+                alternatePublicKey = try await storedGPGPublicKey(
+                    alternate: true,
+                    mainExecutableURL: mainExecutableURL
+                )
+            } catch {
+                status = error.localizedDescription
+            }
         }
     }
 
@@ -3950,11 +4000,213 @@ private struct GPGSigningSettingsView: View {
     }
 }
 
-private func validateGPGPrivateKey(_ privateKey: String) throws {
+private enum GPGCredentialSheet: String, Identifiable {
+    case importDefault
+    case importAlternate
+    case generateAlternate
+
+    var id: String { rawValue }
+    var alternate: Bool { self != .importDefault }
+    var generatesKey: Bool { self == .generateAlternate }
+}
+
+private struct GPGCredentialSheetView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var privateKey = ""
+    @State private var passphrase = ""
+    @State private var name = ""
+    @State private var email = ""
+    @State private var errorMessage = ""
+    @State private var isSaving = false
+
+    let sheet: GPGCredentialSheet
+    let replacing: Bool
+    let onSaved: (String) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if sheet.generatesKey {
+                    TextField("Name", text: $name)
+                    TextField("Verified Git email", text: $email)
+                    Text("The email must match the commit email and a verified email on the Git host. The generated EdDSA private key is stored only in the Data Protection Keychain.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if replacing {
+                        Text("Generating a key replaces the existing alternate signing credential. The previous private key cannot be recovered from Automic Vault.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                } else {
+                    Text("Armored private key")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextEditor(text: $privateKey)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(minHeight: 110)
+                        .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                        .accessibilityLabel(sheet.alternate ? "Alternate private key" : "Default private key")
+                    Text("Paste the complete PGP PRIVATE KEY BLOCK. It is visible only in this sheet and is never shown again after saving.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    SecureField("GnuPG passphrase (leave empty if none)", text: $passphrase)
+                }
+                if !errorMessage.isEmpty {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(navigationTitle)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(confirmationTitle) {
+                        submit()
+                    }
+                    .disabled(!isValid || isSaving)
+                }
+            }
+        }
+        .frame(width: 560, height: sheet.generatesKey ? 240 : 390)
+        .interactiveDismissDisabled(isSaving)
+    }
+
+    private var navigationTitle: String {
+        if sheet.generatesKey {
+            return replacing ? "Replace Alternate Signing Key" : "Generate Alternate Signing Key"
+        }
+        return replacing ? "Replace GPG Signing Credential" : "Add GPG Signing Credential"
+    }
+
+    private var confirmationTitle: String {
+        if sheet.generatesKey { return replacing ? "Generate and Replace" : "Generate and Save" }
+        return replacing ? "Replace" : "Save"
+    }
+
+    private var isValid: Bool {
+        if sheet.generatesKey {
+            return !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return !privateKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func submit() {
+        isSaving = true
+        errorMessage = ""
+        let mainExecutableURL = Bundle.main.executableURL
+        Task {
+            do {
+                let publicKey = if sheet.generatesKey {
+                    try await generateAndSaveAlternateGPGCredential(
+                        name: name,
+                        email: email,
+                        mainExecutableURL: mainExecutableURL
+                    )
+                } else {
+                    try await importAndSaveGPGCredential(
+                        privateKey: privateKey,
+                        passphrase: passphrase,
+                        alternate: sheet.alternate,
+                        mainExecutableURL: mainExecutableURL
+                    )
+                }
+                privateKey = ""
+                passphrase = ""
+                onSaved(publicKey)
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+                isSaving = false
+            }
+        }
+    }
+}
+
+@concurrent
+private func storedGPGPublicKey(
+    alternate: Bool,
+    mainExecutableURL: URL?
+) async throws -> String? {
+    let name = alternate ? gpgAlternatePrivateKeySecretName : gpgDefaultPrivateKeySecretName
+    guard let privateKey = loadStoredSecret(account: name) else { return nil }
+    return try deriveGPGPublicKey(privateKey: privateKey, mainExecutableURL: mainExecutableURL)
+}
+
+@concurrent
+private func importAndSaveGPGCredential(
+    privateKey: String,
+    passphrase: String,
+    alternate: Bool,
+    mainExecutableURL: URL?
+) async throws -> String {
+    let publicKey = try deriveGPGPublicKey(
+        privateKey: privateKey,
+        mainExecutableURL: mainExecutableURL
+    )
+    let status = saveGPGSigningCredential(
+        privateKey: privateKey,
+        passphrase: passphrase,
+        alternate: alternate
+    )
+    guard status == errSecSuccess else {
+        throw GPGSigningConfigurationError.credentialFailed("Data Protection Keychain error \(status)")
+    }
+    return publicKey
+}
+
+@concurrent
+private func generateAndSaveAlternateGPGCredential(
+    name: String,
+    email: String,
+    mainExecutableURL: URL?
+) async throws -> String {
+    let request = try JSONEncoder().encode(["name": name, "email": email])
+    let privateKeyData = try runBundledGPGCommand(
+        arguments: ["__gpg-generate-key"],
+        input: request,
+        mainExecutableURL: mainExecutableURL
+    )
+    guard let privateKey = String(data: privateKeyData, encoding: .utf8) else {
+        throw GPGSigningConfigurationError.credentialFailed("Generated private key is not valid UTF-8")
+    }
+    return try await importAndSaveGPGCredential(
+        privateKey: privateKey,
+        passphrase: "",
+        alternate: true,
+        mainExecutableURL: mainExecutableURL
+    )
+}
+
+private func deriveGPGPublicKey(
+    privateKey: String,
+    mainExecutableURL: URL?
+) throws -> String {
+    let output = try runBundledGPGCommand(
+        arguments: ["__gpg-public-key"],
+        input: Data(privateKey.utf8),
+        mainExecutableURL: mainExecutableURL
+    )
+    guard let publicKey = String(data: output, encoding: .utf8) else {
+        throw GPGSigningConfigurationError.credentialFailed("Public key is not valid UTF-8")
+    }
+    return publicKey
+}
+
+private func runBundledGPGCommand(
+    arguments: [String],
+    input inputData: Data,
+    mainExecutableURL: URL?
+) throws -> Data {
     let process = Process()
     let executable = try bundledExecutableURL(
         named: "av",
-        beside: Bundle.main.executableURL
+        beside: mainExecutableURL
     )
     var staticCode: SecStaticCode?
     var signingInformation: CFDictionary?
@@ -3976,15 +4228,17 @@ private func validateGPGPrivateKey(_ privateKey: String) throws {
           signing[kSecCodeInfoTeamIdentifier] as? String == teamIdentifier
     else { throw GPGSigningConfigurationError.bundledExecutableUnavailable(executable.path) }
     process.executableURL = executable
-    process.arguments = ["__gpg-public-key"]
-    let input = Pipe()
+    process.arguments = arguments
+    let inputPipe = Pipe()
+    let output = Pipe()
     let errors = Pipe()
-    process.standardInput = input
-    process.standardOutput = FileHandle.nullDevice
+    process.standardInput = inputPipe
+    process.standardOutput = output
     process.standardError = errors
     try process.run()
-    input.fileHandleForWriting.write(Data(privateKey.utf8))
-    try input.fileHandleForWriting.close()
+    inputPipe.fileHandleForWriting.write(inputData)
+    try inputPipe.fileHandleForWriting.close()
+    let outputData = output.fileHandleForReading.readDataToEndOfFile()
     let errorData = errors.fileHandleForReading.readDataToEndOfFile()
     process.waitUntilExit()
     guard process.terminationStatus == 0 else {
@@ -3992,8 +4246,9 @@ private func validateGPGPrivateKey(_ privateKey: String) throws {
             decoding: errorData,
             as: UTF8.self
         ).trimmingCharacters(in: .whitespacesAndNewlines)
-        throw GPGSigningConfigurationError.gitFailed(detail)
+        throw GPGSigningConfigurationError.credentialFailed(detail)
     }
+    return outputData
 }
 
 private struct AboutSettingsView: View {

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -3952,21 +3952,44 @@ private struct GPGSigningSettingsView: View {
 
 private func validateGPGPrivateKey(_ privateKey: String) throws {
     let process = Process()
-    process.executableURL = avExecutableURL()
+    let executable = try bundledExecutableURL(
+        named: "av",
+        beside: Bundle.main.executableURL
+    )
+    var staticCode: SecStaticCode?
+    var signingInformation: CFDictionary?
+    guard SecStaticCodeCreateWithPath(executable as CFURL, [], &staticCode) == errSecSuccess,
+          let staticCode,
+          SecStaticCodeCheckValidity(
+              staticCode,
+              SecCSFlags(rawValue: kSecCSStrictValidate),
+              nil
+          ) == errSecSuccess,
+          SecCodeCopySigningInformation(
+              staticCode,
+              SecCSFlags(rawValue: kSecCSSigningInformation),
+              &signingInformation
+          ) == errSecSuccess,
+          let signing = signingInformation as? [CFString: Any],
+          signing[kSecCodeInfoIdentifier] as? String == "com.automicvault.av",
+          let teamIdentifier = selfTeamIdentifier(),
+          signing[kSecCodeInfoTeamIdentifier] as? String == teamIdentifier
+    else { throw GPGSigningConfigurationError.bundledExecutableUnavailable(executable.path) }
+    process.executableURL = executable
     process.arguments = ["__gpg-public-key"]
     let input = Pipe()
-    let output = Pipe()
     let errors = Pipe()
     process.standardInput = input
-    process.standardOutput = output
+    process.standardOutput = FileHandle.nullDevice
     process.standardError = errors
     try process.run()
     input.fileHandleForWriting.write(Data(privateKey.utf8))
     try input.fileHandleForWriting.close()
+    let errorData = errors.fileHandleForReading.readDataToEndOfFile()
     process.waitUntilExit()
     guard process.terminationStatus == 0 else {
         let detail = String(
-            decoding: errors.fileHandleForReading.readDataToEndOfFile(),
+            decoding: errorData,
             as: UTF8.self
         ).trimmingCharacters(in: .whitespacesAndNewlines)
         throw GPGSigningConfigurationError.gitFailed(detail)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3097,6 +3097,9 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         var launchers = launcherIdentities(for: identity)
+        if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {
+            launchers.append(launcher)
+        }
         if parsedRequest.op == "gpg-sign" {
             let migrationStatus = migrateLegacyGPGSigningSecrets()
             guard migrationStatus == errSecSuccess else {
@@ -3170,9 +3173,6 @@ private final class ApprovalServer: @unchecked Sendable {
         )
         let ancestorFallbackPath = launcherFallbackPath(for: identity)
         let launcherFallbackPath = ancestorFallbackPath ?? callerPath
-        if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {
-            launchers.append(launcher)
-        }
         let launcher = executionOrigin(
             among: launchers,
             callerPID: pid,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1714,7 +1714,7 @@ private func scanAlertLevel(_ severities: [String]) -> ScanAlertLevel {
         ? .medium : .high
 }
 
-private func avExecutableURL() -> URL {
+func avExecutableURL() -> URL {
     if let bundled = Bundle.main.executableURL?.deletingLastPathComponent().appendingPathComponent("av"),
        FileManager.default.isExecutableFile(atPath: bundled.path)
     {
@@ -1799,6 +1799,28 @@ private struct ApprovalRequest {
             dockerServerURL: dockerServerURL,
             dockerParent: dockerParent,
             selectedSecretValues: values
+        )
+    }
+
+    func requesting(keys: [String], title: String, detail: String) -> ApprovalRequest {
+        ApprovalRequest(
+            op: op,
+            keys: keys,
+            target: target,
+            args: args,
+            cwd: cwd,
+            replaceExistingEnv: replaceExistingEnv,
+            allowMissingKeys: allowMissingKeys,
+            envConflicts: envConflicts,
+            shebangScript: shebangScript,
+            scriptData: scriptData,
+            snapshotIncompatibleInterpreter: snapshotIncompatibleInterpreter,
+            tool: tool,
+            title: title,
+            detail: detail,
+            dockerServerURL: dockerServerURL,
+            dockerParent: dockerParent,
+            selectedSecretValues: selectedSecretValues
         )
     }
 
@@ -2813,7 +2835,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
-        case .inject, .keys, .authorize, .dockerGet:
+        case .inject, .keys, .authorize, .dockerGet, .gpgSign:
             handleInject(
                 message,
                 on: peer,
@@ -3059,9 +3081,23 @@ private final class ApprovalServer: @unchecked Sendable {
         callerPath: String,
         signing: SigningInfo
     ) {
-        guard let parsedRequest = approvalRequest(from: message) else {
+        guard var parsedRequest = approvalRequest(from: message) else {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
+        }
+        if parsedRequest.op == "gpg-sign" {
+            let launchers = launcherIdentities(for: identity)
+            let names = gpgSigningSecretNames(
+                configuration: loadGPGSigningConfiguration(),
+                launcherRequirements: launchers.map(\.designatedRequirement)
+            )
+            parsedRequest = parsedRequest.requesting(
+                keys: names,
+                title: "Sign this Git operation?",
+                detail: names.first == gpgAlternatePrivateKeySecretName
+                    ? "The Verified Launcher matches your alternate signing-key list. Automic Vault will use the alternate GPG credential."
+                    : "Automic Vault will use your default GPG signing credential."
+            )
         }
         let request: ApprovalRequest
         do {
@@ -5574,7 +5610,7 @@ private final class ApprovalServer: @unchecked Sendable {
             return nil
         }
         let op = String(cString: opPointer)
-        guard op == "inject" || op == "keys" || op == "authorize"
+        guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign"
             || op == "docker-get" || op == "proxy-start"
         else { return nil }
         let scriptData: Data?
@@ -5964,6 +6000,8 @@ private func classifySecretGateRequest(
     request: ApprovalRequest
 ) -> SecretGateRequestClassification {
     switch gateID {
+    case "gpg-signing":
+        return .localWrite
     case "gh":
         return ghRequestClassification(request.args)
     case "docker":

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2835,7 +2835,17 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
-        case .inject, .keys, .authorize, .dockerGet, .gpgSign:
+        case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleInject(
+                message,
+                on: peer,
+                cancellation: cancellation,
+                pid: pid,
+                identity: identity,
+                callerPath: callerPath,
+                signing: signing
+            )
+        case .inject, .keys, .authorize, .dockerGet:
             handleInject(
                 message,
                 on: peer,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -7217,16 +7217,25 @@ private func launcherIdentities(
     appSigning: (URL) -> StaticSigningInfo? = staticSigningInfo,
     allowsStandaloneFallback: Bool = true
 ) -> [LauncherIdentity] {
-    var seen = Set<String>()
-    let appURLs = (
+    var seenContainingApps = Set<String>()
+    let containingAppURLs = (
         appBundleURLs(containing: path)
         + appBundleURLs(containing: signing.mainExecutable)
+    ).filter { seenContainingApps.insert($0.path).inserted }
+    var seenApps = Set<String>()
+    let appURLs = (
+        containingAppURLs.filter {
+            appBundleMatchesMainExecutable(
+                $0,
+                executablePaths: [path, signing.mainExecutable]
+            )
+        }
         + [associatedAppBundleURL(path: path, signing: signing)].compactMap { $0 }
-    ).filter { seen.insert($0.path).inserted }
+    ).filter { seenApps.insert($0.path).inserted }
     let claimsLauncherBundleIdentity = signing.identifier.hasPrefix(launcherBundleIdentifierPrefix)
-        || appURLs.contains(where: launcherBundleClaimsReservedIdentity)
+        || containingAppURLs.contains(where: launcherBundleClaimsReservedIdentity)
     if claimsLauncherBundleIdentity {
-        guard let appURL = appURLs.first(where: {
+        guard let appURL = containingAppURLs.first(where: {
             launcherBundleAppURL(containing: $0.path) == $0
         }),
             let liveCodeIdentifier = liveCodeIdentity(pid: pid),
@@ -7498,8 +7507,15 @@ private func launcherAppVerificationFailure(
             guard av_process_identity(pid, &ancestor) else { break }
             let path = pathString(ancestor)
             if let signing = liveSigningInfo(pid: pid) ?? executableSigningInfo(path: path) {
-                let appURLs = appBundleURLs(containing: path)
+                let appURLs = (
+                    appBundleURLs(containing: path)
                     + appBundleURLs(containing: signing.mainExecutable)
+                ).filter {
+                    appBundleMatchesMainExecutable(
+                        $0,
+                        executablePaths: [path, signing.mainExecutable]
+                    )
+                }
                     + [associatedAppBundleURL(path: path, signing: signing)].compactMap { $0 }
                 for appURL in appURLs where checkedApps.insert(appURL.path).inserted {
                     if let failure = appBundleVerificationFailure(appURL) { return failure }
@@ -7581,6 +7597,19 @@ private func appBundleURLs(containing path: String) -> [URL] {
         url.deleteLastPathComponent()
     }
     return apps
+}
+
+private func appBundleMatchesMainExecutable(
+    _ appURL: URL,
+    executablePaths: [String],
+    bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
+) -> Bool {
+    guard let bundleExecutableURL = bundleExecutableURL(appURL) else { return false }
+    let bundleExecutablePath = bundleExecutableURL.standardizedFileURL.resolvingSymlinksInPath().path
+    return executablePaths.contains {
+        URL(fileURLWithPath: $0).standardizedFileURL.resolvingSymlinksInPath().path
+            == bundleExecutablePath
+    }
 }
 
 private func associatedAppBundleURL(path: String, signing: LiveSigningInfo) -> URL? {
@@ -10079,6 +10108,20 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
               "/bin/zsh",
               "/opt/homebrew/bin/gh",
           ]) == "example → zsh → gh",
+          !appBundleMatchesMainExecutable(
+              URL(fileURLWithPath: "/Applications/Xcode.app"),
+              executablePaths: ["/Applications/Xcode.app/Contents/Developer/usr/bin/git"],
+              bundleExecutableURL: { _ in
+                  URL(fileURLWithPath: "/Applications/Xcode.app/Contents/MacOS/Xcode")
+              }
+          ),
+          appBundleMatchesMainExecutable(
+              URL(fileURLWithPath: "/Applications/Xcode.app"),
+              executablePaths: ["/Applications/Xcode.app/Contents/MacOS/Xcode"],
+              bundleExecutableURL: { _ in
+                  URL(fileURLWithPath: "/Applications/Xcode.app/Contents/MacOS/Xcode")
+              }
+          ),
           appBundleURL(containing: "/Applications/Example.app/Contents/MacOS/../Resources/payload")?.path
               == "/Applications/Example.app"
     else { return 1 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3095,8 +3095,8 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
         }
+        var launchers = launcherIdentities(for: identity)
         if parsedRequest.op == "gpg-sign" {
-            let launchers = launcherIdentities(for: identity)
             let migrationStatus = migrateEmptyGPGSigningPassphrases()
             guard migrationStatus == errSecSuccess else {
                 reply(
@@ -3167,7 +3167,6 @@ private final class ApprovalServer: @unchecked Sendable {
         let keepsDetachedProcessAccess = UserDefaults.standard.bool(
             forKey: keepLauncherAccessForDetachedProcessesDefaultsKey
         )
-        var launchers = launcherIdentities(for: identity)
         let ancestorFallbackPath = launcherFallbackPath(for: identity)
         let launcherFallbackPath = ancestorFallbackPath ?? callerPath
         if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3097,9 +3097,33 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         if parsedRequest.op == "gpg-sign" {
             let launchers = launcherIdentities(for: identity)
+            let migrationStatus = migrateEmptyGPGSigningPassphrases()
+            guard migrationStatus == errSecSuccess else {
+                reply(
+                    peer,
+                    to: message,
+                    ok: false,
+                    error: "failed to repair the GPG signing credential: \(migrationStatus)"
+                )
+                return
+            }
+            let storedSecretNames: Set<String>
+            switch loadStoredSecretsResult() {
+            case .success(let secrets):
+                storedSecretNames = Set(secrets.map(\.account))
+            case .failure(let status):
+                reply(
+                    peer,
+                    to: message,
+                    ok: false,
+                    error: SecretValueCustodyError.inventoryUnavailable(status).localizedDescription
+                )
+                return
+            }
             let names = gpgSigningSecretNames(
                 configuration: loadGPGSigningConfiguration(),
-                launcherRequirements: launchers.map(\.designatedRequirement)
+                launcherRequirements: launchers.map(\.designatedRequirement),
+                storedSecretNames: storedSecretNames
             )
             parsedRequest = parsedRequest.requesting(
                 keys: names,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -285,6 +285,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem.button?.image = brandImage()
         statusItem.button?.alphaValue = 1
         _ = migrateBackgroundKeychainItems()
+        _ = migrateLegacyGPGSigningSecrets()
         _ = backfillBlessedScriptReviewedContents()
         autoApprovals = loadAccessRequestRecords().compactMap(autoApprovalRecord)
         refreshAutoApprovalMenuItems()
@@ -3097,7 +3098,7 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         var launchers = launcherIdentities(for: identity)
         if parsedRequest.op == "gpg-sign" {
-            let migrationStatus = migrateEmptyGPGSigningPassphrases()
+            let migrationStatus = migrateLegacyGPGSigningSecrets()
             guard migrationStatus == errSecSuccess else {
                 reply(
                     peer,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -6730,7 +6730,7 @@ private func signingInfo(path: String) -> SigningInfo {
     )
 }
 
-private func selfTeamIdentifier() -> String? {
+func selfTeamIdentifier() -> String? {
     var code: SecCode?
     var staticCode: SecStaticCode?
     guard SecCodeCopySelf([], &code) == errSecSuccess,

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -5,6 +5,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case varlock
     case keys
     case authorize
+    case gpgSign = "gpg-sign"
     case proxyStart = "proxy-start"
     case awsCredentials = "aws-credentials"
     case dockerGet = "docker-get"

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -85,7 +85,11 @@ public struct DashboardSnapshot: Equatable, Sendable {
     ) -> DashboardSnapshot {
         _ = resumePendingSecretMutation()
         let hardenerMetadata = loadHardenerMetadata(avExecutableURL: avExecutableURL)
-        _ = initializeSecretGatePolicies(hardeners: hardenerMetadata, service: policyService)
+        let gateDescriptors = dashboardSecretGateDescriptors(
+            hardeners: hardenerMetadata,
+            catalog: (try? loadSecretGateDescriptors(avExecutableURL: avExecutableURL)) ?? []
+        )
+        _ = initializeSecretGatePolicies(descriptors: gateDescriptors, service: policyService)
         let hardenedTools = loadHardenedTools(
             in: stubDirectory,
             ghCLIURL: ghCLIURL,
@@ -97,7 +101,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             detectorFindings: [],
             hardenedTools: hardenedTools,
             hardeners: hardenerMetadata,
-            secretGates: loadSecretGates(hardeners: hardenerMetadata, service: policyService),
+            secretGates: loadSecretGates(descriptors: gateDescriptors, service: policyService),
             blessedScripts: loadBlessedScripts(),
             secretNameAccessApps: loadSecretNameAccessApps(),
             secrets: secrets,
@@ -605,7 +609,7 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
         if keyPatterns.isEmpty {
             return [.noAccess, .readOnly, .fullExceptSecretDumps]
         }
-        if id == "gh" || id == "docker" {
+        if id == "gh" || id == "docker" || id == "gpg-signing" {
             return [
                 .noAccess,
                 .readOnly,
@@ -626,7 +630,9 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
         if keyPatterns.isEmpty, protection == .fullIncludingSecretDumps {
             protection = .fullExceptSecretDumps
         }
-        if id != "gh" && id != "docker", protection == .readOnlyAndLocalWrites {
+        if id != "gh" && id != "docker" && id != "gpg-signing",
+           protection == .readOnlyAndLocalWrites
+        {
             protection = .readOnly
         }
         if !keyPatterns.isEmpty, protection == .readOnlyAndUpdates {
@@ -973,7 +979,19 @@ public func loadSecretGates(
     service: String = secretGatePoliciesKeychainService,
     account: String = secretGatePoliciesKeychainAccount
 ) -> [SecretGate] {
-    let descriptors = hardeners.compactMap { hardener -> SecretGateDescriptor? in
+    loadSecretGates(
+        descriptors: dashboardSecretGateDescriptors(hardeners: hardeners, catalog: []),
+        service: service,
+        account: account
+    )
+}
+
+public func dashboardSecretGateDescriptors(
+    hardeners: [HardenerMetadata],
+    catalog: [SecretGateDescriptor]
+) -> [SecretGateDescriptor] {
+    let hardenerGateIDs = Set(hardeners.compactMap { $0.secretGate?.id })
+    let activeHardenerGates = hardeners.compactMap { hardener -> SecretGateDescriptor? in
         guard let descriptor = hardener.secretGate,
               hardener.hardened || descriptor.routes
                 .compactMap(\.scriptPath)
@@ -981,7 +999,7 @@ public func loadSecretGates(
         else { return nil }
         return descriptor
     }
-    return loadSecretGates(descriptors: descriptors, service: service, account: account)
+    return activeHardenerGates + catalog.filter { !hardenerGateIDs.contains($0.id) }
 }
 
 public func loadSecretGates(
@@ -1214,12 +1232,25 @@ public func initializeSecretGatePolicies(
     service: String = secretGatePoliciesKeychainService,
     account: String = secretGatePoliciesKeychainAccount
 ) -> OSStatus {
+    initializeSecretGatePolicies(
+        descriptors: dashboardSecretGateDescriptors(hardeners: hardeners, catalog: []),
+        service: service,
+        account: account
+    )
+}
+
+@discardableResult
+public func initializeSecretGatePolicies(
+    descriptors: [SecretGateDescriptor],
+    service: String = secretGatePoliciesKeychainService,
+    account: String = secretGatePoliciesKeychainAccount
+) -> OSStatus {
     var records: [SecretGatePolicyRecord]
     switch loadSecretGatePolicyRecords(service: service, account: account) {
     case .success(let loaded): records = loaded
     case .failure(let status): return status
     }
-    let gates = loadSecretGates(hardeners: hardeners, service: service, account: account)
+    let gates = loadSecretGates(descriptors: descriptors, service: service, account: account)
     for gate in gates where !records.contains(where: { $0.gateID == gate.id && $0.requirement == nil }) {
         records.append(SecretGatePolicyRecord(
             gateID: gate.id,

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -603,13 +603,16 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     public var defaultPolicyLabel: String { appPolicies.isEmpty ? "All Apps" : "All Other Apps" }
 
     public var availableProtections: [SecretGateProtection] {
+        if id == "gpg-signing" {
+            return [.noAccess, .readOnlyAndLocalWrites]
+        }
         if id == "brew" {
             return [.noAccess, .readOnlyAndUpdates, .fullExceptSecretDumps]
         }
         if keyPatterns.isEmpty {
             return [.noAccess, .readOnly, .fullExceptSecretDumps]
         }
-        if id == "gh" || id == "docker" || id == "gpg-signing" {
+        if id == "gh" || id == "docker" {
             return [
                 .noAccess,
                 .readOnly,
@@ -622,10 +625,14 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     }
 
     public var initialProtection: SecretGateProtection {
-        id == "brew" ? .readOnlyAndUpdates : .readOnly
+        if id == "gpg-signing" { return .noAccess }
+        return id == "brew" ? .readOnlyAndUpdates : .readOnly
     }
 
     public func normalizedProtection(_ protection: SecretGateProtection) -> SecretGateProtection {
+        if id == "gpg-signing" {
+            return protection.allows(.localWrite) ? .readOnlyAndLocalWrites : .noAccess
+        }
         var protection = protection
         if keyPatterns.isEmpty, protection == .fullIncludingSecretDumps {
             protection = .fullExceptSecretDumps
@@ -643,11 +650,19 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
 
     public func protectionTitle(_ protection: SecretGateProtection) -> String {
         let protection = normalizedProtection(protection)
+        if id == "gpg-signing" {
+            return protection == .readOnlyAndLocalWrites ? "Allow Signing" : "Approval Required"
+        }
         return keyPatterns.isEmpty && protection == .fullExceptSecretDumps ? "Full Access" : protection.title
     }
 
     public func protectionSubtitle(_ protection: SecretGateProtection) -> String {
         let protection = normalizedProtection(protection)
+        if id == "gpg-signing" {
+            return protection == .readOnlyAndLocalWrites
+                ? "Recognized GPG signing requests are automically authorized"
+                : "Every GPG signing request requires approval"
+        }
         return keyPatterns.isEmpty && protection == .fullExceptSecretDumps
             ? "Every recognized operation is automically authorized; unknown operations require approval"
             : protection.subtitle

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -1,10 +1,17 @@
 import Foundation
 import Security
 
-public let gpgDefaultPrivateKeySecretName = "AUTOMIC_GPG_SIGNING_PRIVATE_KEY"
-public let gpgDefaultPassphraseSecretName = "AUTOMIC_GPG_SIGNING_PASSPHRASE"
-public let gpgAlternatePrivateKeySecretName = "AUTOMIC_GPG_AGENT_SIGNING_PRIVATE_KEY"
-public let gpgAlternatePassphraseSecretName = "AUTOMIC_GPG_AGENT_SIGNING_PASSPHRASE"
+public let gpgDefaultPrivateKeySecretName = "AV_GPG_PRIVATE_KEY"
+public let gpgDefaultPassphraseSecretName = "AV_GPG_PASSPHRASE"
+public let gpgAlternatePrivateKeySecretName = "AV_GPG_AGENT_PRIVATE_KEY"
+public let gpgAlternatePassphraseSecretName = "AV_GPG_AGENT_PASSPHRASE"
+
+private let legacyGPGSecretNames = [
+    ("AUTOMIC_GPG_SIGNING_PRIVATE_KEY", gpgDefaultPrivateKeySecretName),
+    ("AUTOMIC_GPG_SIGNING_PASSPHRASE", gpgDefaultPassphraseSecretName),
+    ("AUTOMIC_GPG_AGENT_SIGNING_PRIVATE_KEY", gpgAlternatePrivateKeySecretName),
+    ("AUTOMIC_GPG_AGENT_SIGNING_PASSPHRASE", gpgAlternatePassphraseSecretName),
+]
 
 private let gpgSigningConfigurationService = "com.automicvault.gpg-signing-configuration"
 private let gpgSigningConfigurationAccount = "configuration"
@@ -109,6 +116,47 @@ private func loadGPGStoredValue(_ account: String) -> GPGStoredValueLoad {
     case .notFound: return .missing
     case .failure(let status): return .failure(status)
     }
+}
+
+@discardableResult
+public func migrateLegacyGPGSigningSecrets() -> OSStatus {
+    migrateLegacyGPGSigningSecrets(
+        load: loadGPGStoredValue,
+        saveIfAbsentOrEqual: { account, value in
+            saveStoredSecretIfAbsentOrEqual(account: account, value: value)
+        },
+        delete: { account in
+            deleteStoredSecretValueRevokingDirectAccessIfLast(
+                secretName: account,
+                source: .global
+            )
+        }
+    )
+}
+
+func migrateLegacyGPGSigningSecrets(
+    load: (String) -> GPGStoredValueLoad,
+    saveIfAbsentOrEqual: (String, String) -> OSStatus,
+    delete: (String) -> OSStatus
+) -> OSStatus {
+    for (legacyName, currentName) in legacyGPGSecretNames {
+        switch load(legacyName) {
+        case .value(let value):
+            if !value.isEmpty {
+                let saveStatus = saveIfAbsentOrEqual(currentName, value)
+                guard saveStatus == errSecSuccess else { return saveStatus }
+            }
+            let deleteStatus = delete(legacyName)
+            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                return deleteStatus
+            }
+        case .failure(let status):
+            return status
+        case .missing:
+            continue
+        }
+    }
+    return migrateEmptyGPGSigningPassphrases(load: load, delete: delete)
 }
 
 @discardableResult

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -59,14 +59,16 @@ func saveGPGSigningConfiguration(
 
 public func gpgSigningSecretNames(
     configuration: GPGSigningConfiguration,
-    launcherRequirements: [String]
+    launcherRequirements: [String],
+    storedSecretNames: Set<String>
 ) -> [String] {
     let useAlternate = configuration.alternateKeyLaunchers.contains { launcher in
         launcherRequirements.contains(launcher.requirement)
     }
-    return useAlternate
+    let names = useAlternate
         ? [gpgAlternatePrivateKeySecretName, gpgAlternatePassphraseSecretName]
         : [gpgDefaultPrivateKeySecretName, gpgDefaultPassphraseSecretName]
+    return [names[0]] + names.dropFirst().filter(storedSecretNames.contains)
 }
 
 @discardableResult
@@ -79,20 +81,13 @@ public func saveGPGSigningCredential(
         privateKey: privateKey,
         passphrase: passphrase,
         alternate: alternate,
-        load: { account in
-            switch loadKeychainDataResult(service: automicVaultKeychainService, account: account) {
-            case .success(let data):
-                guard let value = String(data: data, encoding: .utf8) else {
-                    return .failure(errSecDecode)
-                }
-                return .value(value)
-            case .notFound: return .missing
-            case .failure(let status): return .failure(status)
-            }
-        },
+        load: loadGPGStoredValue,
         save: { account, value in saveStoredSecret(account: account, value: value) },
         delete: { account in
-            let status = deleteStoredSecretValue(secretName: account, source: .global)
+            let status = deleteStoredSecretValueRevokingDirectAccessIfLast(
+                secretName: account,
+                source: .global
+            )
             return status == errSecItemNotFound ? errSecSuccess : status
         }
     )
@@ -102,6 +97,49 @@ enum GPGStoredValueLoad {
     case value(String)
     case missing
     case failure(OSStatus)
+}
+
+private func loadGPGStoredValue(_ account: String) -> GPGStoredValueLoad {
+    switch loadKeychainDataResult(service: automicVaultKeychainService, account: account) {
+    case .success(let data):
+        guard let value = String(data: data, encoding: .utf8) else {
+            return .failure(errSecDecode)
+        }
+        return .value(value)
+    case .notFound: return .missing
+    case .failure(let status): return .failure(status)
+    }
+}
+
+@discardableResult
+public func migrateEmptyGPGSigningPassphrases() -> OSStatus {
+    migrateEmptyGPGSigningPassphrases(
+        load: loadGPGStoredValue,
+        delete: { account in
+            deleteStoredSecretValueRevokingDirectAccessIfLast(
+                secretName: account,
+                source: .global
+            )
+        }
+    )
+}
+
+func migrateEmptyGPGSigningPassphrases(
+    load: (String) -> GPGStoredValueLoad,
+    delete: (String) -> OSStatus
+) -> OSStatus {
+    for name in [gpgDefaultPassphraseSecretName, gpgAlternatePassphraseSecretName] {
+        switch load(name) {
+        case .value(let value) where value.isEmpty:
+            let status = delete(name)
+            if status != errSecSuccess && status != errSecItemNotFound { return status }
+        case .failure(let status):
+            return status
+        case .value, .missing:
+            continue
+        }
+    }
+    return errSecSuccess
 }
 
 func saveGPGSigningCredential(
@@ -117,6 +155,11 @@ func saveGPGSigningCredential(
         ? gpgAlternatePassphraseSecretName : gpgDefaultPassphraseSecretName
     let previousPassphrase = load(passphraseName)
     if case .failure(let status) = previousPassphrase { return status }
+    if passphrase.isEmpty {
+        let keyStatus = save(keyName, privateKey)
+        guard keyStatus == errSecSuccess else { return keyStatus }
+        return delete(passphraseName)
+    }
     let passphraseStatus = save(passphraseName, passphrase)
     guard passphraseStatus == errSecSuccess else { return passphraseStatus }
     let keyStatus = save(keyName, privateKey)

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -258,12 +258,14 @@ public func configureGitForGPGSigning(
 public enum GPGSigningConfigurationError: LocalizedError {
     case programUnavailable(String)
     case bundledExecutableUnavailable(String)
+    case credentialFailed(String)
     case gitFailed(String)
 
     public var errorDescription: String? {
         switch self {
         case .programUnavailable(let path): "The bundled Git signing adapter is unavailable at \(path)."
         case .bundledExecutableUnavailable(let path): "The bundled Automic Vault executable is unavailable or invalid at \(path)."
+        case .credentialFailed(let detail): "Could not process the GPG credential\(detail.isEmpty ? "." : ": \(detail)")"
         case .gitFailed(let detail): "Git configuration failed\(detail.isEmpty ? "." : ": \(detail)")"
         }
     }

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Security
+
+public let gpgDefaultPrivateKeySecretName = "AUTOMIC_GPG_SIGNING_PRIVATE_KEY"
+public let gpgDefaultPassphraseSecretName = "AUTOMIC_GPG_SIGNING_PASSPHRASE"
+public let gpgAlternatePrivateKeySecretName = "AUTOMIC_GPG_AGENT_SIGNING_PRIVATE_KEY"
+public let gpgAlternatePassphraseSecretName = "AUTOMIC_GPG_AGENT_SIGNING_PASSPHRASE"
+
+private let gpgSigningConfigurationService = "com.automicvault.gpg-signing-configuration"
+private let gpgSigningConfigurationAccount = "configuration"
+
+public struct GPGSigningConfiguration: Codable, Equatable, Sendable {
+    public var alternateKeyLaunchers: [BlessedScriptLauncher]
+
+    public init(alternateKeyLaunchers: [BlessedScriptLauncher] = []) {
+        self.alternateKeyLaunchers = alternateKeyLaunchers
+    }
+}
+
+public func loadGPGSigningConfiguration() -> GPGSigningConfiguration {
+    loadGPGSigningConfiguration(
+        service: gpgSigningConfigurationService,
+        account: gpgSigningConfigurationAccount
+    )
+}
+
+func loadGPGSigningConfiguration(service: String, account: String) -> GPGSigningConfiguration {
+    guard case .success(let data) = loadKeychainDataResult(service: service, account: account),
+          let configuration = try? JSONDecoder().decode(GPGSigningConfiguration.self, from: data)
+    else { return GPGSigningConfiguration() }
+    return configuration
+}
+
+@discardableResult
+public func saveGPGSigningConfiguration(
+    _ configuration: GPGSigningConfiguration
+) -> OSStatus {
+    saveGPGSigningConfiguration(
+        configuration,
+        service: gpgSigningConfigurationService,
+        account: gpgSigningConfigurationAccount
+    )
+}
+
+@discardableResult
+func saveGPGSigningConfiguration(
+    _ configuration: GPGSigningConfiguration,
+    service: String,
+    account: String
+) -> OSStatus {
+    guard let data = try? JSONEncoder().encode(configuration) else { return errSecParam }
+    return saveKeychainData(
+        data,
+        service: service,
+        account: account,
+        accessibility: .whenUnlocked
+    )
+}
+
+public func gpgSigningSecretNames(
+    configuration: GPGSigningConfiguration,
+    launcherRequirements: [String]
+) -> [String] {
+    let useAlternate = configuration.alternateKeyLaunchers.contains { launcher in
+        launcherRequirements.contains(launcher.requirement)
+    }
+    return useAlternate
+        ? [gpgAlternatePrivateKeySecretName, gpgAlternatePassphraseSecretName]
+        : [gpgDefaultPrivateKeySecretName, gpgDefaultPassphraseSecretName]
+}
+
+@discardableResult
+public func saveGPGSigningCredential(
+    privateKey: String,
+    passphrase: String,
+    alternate: Bool
+) -> OSStatus {
+    let keyName = alternate ? gpgAlternatePrivateKeySecretName : gpgDefaultPrivateKeySecretName
+    let passphraseName = alternate
+        ? gpgAlternatePassphraseSecretName : gpgDefaultPassphraseSecretName
+    let keyStatus = saveStoredSecret(account: keyName, value: privateKey)
+    guard keyStatus == errSecSuccess else { return keyStatus }
+    return saveStoredSecret(account: passphraseName, value: passphrase)
+}
+
+public func hasGPGSigningCredential(alternate: Bool) -> Bool {
+    let name = alternate ? gpgAlternatePrivateKeySecretName : gpgDefaultPrivateKeySecretName
+    return loadStoredSecrets().contains { $0.account == name }
+}
+
+public func configureGitForGPGSigning(
+    gitURL: URL = URL(fileURLWithPath: "/usr/bin/git"),
+    bpbURL: URL,
+    environment: [String: String]? = nil
+) throws {
+    guard bpbURL.path.hasPrefix("/"), FileManager.default.isExecutableFile(atPath: bpbURL.path)
+    else { throw GPGSigningConfigurationError.bpbUnavailable(bpbURL.path) }
+    for arguments in [
+        ["config", "--global", "gpg.program", bpbURL.path],
+        ["config", "--global", "commit.gpgSign", "true"],
+        ["config", "--global", "gpg.format", "openpgp"],
+    ] {
+        let process = Process()
+        process.executableURL = gitURL
+        process.arguments = arguments
+        if let environment { process.environment = environment }
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let detail = String(
+                decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+                as: UTF8.self
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            throw GPGSigningConfigurationError.gitFailed(detail)
+        }
+    }
+}
+
+public enum GPGSigningConfigurationError: LocalizedError {
+    case bpbUnavailable(String)
+    case gitFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .bpbUnavailable(let path): "The bundled bpb executable is unavailable at \(path)."
+        case .gitFailed(let detail): "Git configuration failed\(detail.isEmpty ? "." : ": \(detail)")"
+        }
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -75,12 +75,58 @@ public func saveGPGSigningCredential(
     passphrase: String,
     alternate: Bool
 ) -> OSStatus {
+    saveGPGSigningCredential(
+        privateKey: privateKey,
+        passphrase: passphrase,
+        alternate: alternate,
+        load: { account in
+            switch loadKeychainDataResult(service: automicVaultKeychainService, account: account) {
+            case .success(let data):
+                guard let value = String(data: data, encoding: .utf8) else {
+                    return .failure(errSecDecode)
+                }
+                return .value(value)
+            case .notFound: return .missing
+            case .failure(let status): return .failure(status)
+            }
+        },
+        save: { account, value in saveStoredSecret(account: account, value: value) },
+        delete: { account in
+            let status = deleteStoredSecretValue(secretName: account, source: .global)
+            return status == errSecItemNotFound ? errSecSuccess : status
+        }
+    )
+}
+
+enum GPGStoredValueLoad {
+    case value(String)
+    case missing
+    case failure(OSStatus)
+}
+
+func saveGPGSigningCredential(
+    privateKey: String,
+    passphrase: String,
+    alternate: Bool,
+    load: (String) -> GPGStoredValueLoad,
+    save: (String, String) -> OSStatus,
+    delete: (String) -> OSStatus
+) -> OSStatus {
     let keyName = alternate ? gpgAlternatePrivateKeySecretName : gpgDefaultPrivateKeySecretName
     let passphraseName = alternate
         ? gpgAlternatePassphraseSecretName : gpgDefaultPassphraseSecretName
-    let keyStatus = saveStoredSecret(account: keyName, value: privateKey)
-    guard keyStatus == errSecSuccess else { return keyStatus }
-    return saveStoredSecret(account: passphraseName, value: passphrase)
+    let previousPassphrase = load(passphraseName)
+    if case .failure(let status) = previousPassphrase { return status }
+    let passphraseStatus = save(passphraseName, passphrase)
+    guard passphraseStatus == errSecSuccess else { return passphraseStatus }
+    let keyStatus = save(keyName, privateKey)
+    guard keyStatus != errSecSuccess else { return errSecSuccess }
+    let rollbackStatus = switch previousPassphrase {
+    case .value(let previous): save(passphraseName, previous)
+    case .missing: delete(passphraseName)
+    case .failure: errSecInternalError
+    }
+    return rollbackStatus == errSecSuccess ? keyStatus : rollbackStatus
 }
 
 public func hasGPGSigningCredential(alternate: Bool) -> Bool {
@@ -120,12 +166,33 @@ public func configureGitForGPGSigning(
 
 public enum GPGSigningConfigurationError: LocalizedError {
     case programUnavailable(String)
+    case bundledExecutableUnavailable(String)
     case gitFailed(String)
 
     public var errorDescription: String? {
         switch self {
         case .programUnavailable(let path): "The bundled Git signing adapter is unavailable at \(path)."
+        case .bundledExecutableUnavailable(let path): "The bundled Automic Vault executable is unavailable or invalid at \(path)."
         case .gitFailed(let detail): "Git configuration failed\(detail.isEmpty ? "." : ": \(detail)")"
         }
     }
+}
+
+public func bundledExecutableURL(
+    named name: String,
+    beside mainExecutableURL: URL?,
+    fileManager: FileManager = .default
+) throws -> URL {
+    guard let mainExecutableURL,
+          mainExecutableURL.isFileURL,
+          mainExecutableURL.path.hasPrefix("/"),
+          !name.isEmpty,
+          name == URL(fileURLWithPath: name).lastPathComponent
+    else { throw GPGSigningConfigurationError.bundledExecutableUnavailable(name) }
+    let candidate = mainExecutableURL.deletingLastPathComponent().appendingPathComponent(name)
+    let attributes = try? fileManager.attributesOfItem(atPath: candidate.path)
+    guard attributes?[.type] as? FileAttributeType == .typeRegular,
+          fileManager.isExecutableFile(atPath: candidate.path)
+    else { throw GPGSigningConfigurationError.bundledExecutableUnavailable(candidate.path) }
+    return candidate
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -90,13 +90,13 @@ public func hasGPGSigningCredential(alternate: Bool) -> Bool {
 
 public func configureGitForGPGSigning(
     gitURL: URL = URL(fileURLWithPath: "/usr/bin/git"),
-    bpbURL: URL,
+    programURL: URL,
     environment: [String: String]? = nil
 ) throws {
-    guard bpbURL.path.hasPrefix("/"), FileManager.default.isExecutableFile(atPath: bpbURL.path)
-    else { throw GPGSigningConfigurationError.bpbUnavailable(bpbURL.path) }
+    guard programURL.path.hasPrefix("/"), FileManager.default.isExecutableFile(atPath: programURL.path)
+    else { throw GPGSigningConfigurationError.programUnavailable(programURL.path) }
     for arguments in [
-        ["config", "--global", "gpg.program", bpbURL.path],
+        ["config", "--global", "gpg.program", programURL.path],
         ["config", "--global", "commit.gpgSign", "true"],
         ["config", "--global", "gpg.format", "openpgp"],
     ] {
@@ -119,12 +119,12 @@ public func configureGitForGPGSigning(
 }
 
 public enum GPGSigningConfigurationError: LocalizedError {
-    case bpbUnavailable(String)
+    case programUnavailable(String)
     case gitFailed(String)
 
     public var errorDescription: String? {
         switch self {
-        case .bpbUnavailable(let path): "The bundled bpb executable is unavailable at \(path)."
+        case .programUnavailable(let path): "The bundled Git signing adapter is unavailable at \(path)."
         case .gitFailed(let detail): "Git configuration failed\(detail.isEmpty ? "." : ": \(detail)")"
         }
     }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -313,8 +313,21 @@ printf '%s\n' '{"secret_gates":[{"id":"docker","key_patterns":["DOCKER_REGISTRY_
     ).first)
 
     #expect(descriptors.map(\.id) == ["gpg-signing"])
-    #expect(gate.availableProtections.contains(.readOnlyAndLocalWrites))
+    #expect(gate.availableProtections == [.noAccess, .readOnlyAndLocalWrites])
+    #expect(gate.initialProtection == .noAccess)
+    #expect(gate.normalizedProtection(.noAccess) == .noAccess)
+    #expect(gate.normalizedProtection(.readOnly) == .noAccess)
+    #expect(gate.normalizedProtection(.readOnlyAndUpdates) == .noAccess)
     #expect(gate.normalizedProtection(.readOnlyAndLocalWrites) == .readOnlyAndLocalWrites)
+    #expect(gate.normalizedProtection(.fullExceptSecretDumps) == .readOnlyAndLocalWrites)
+    #expect(gate.normalizedProtection(.fullIncludingSecretDumps) == .readOnlyAndLocalWrites)
+    #expect(gate.protectionTitle(.noAccess) == "Approval Required")
+    #expect(gate.protectionTitle(.readOnlyAndLocalWrites) == "Allow Signing")
+    #expect(gate.protectionSubtitle(.noAccess) == "Every GPG signing request requires approval")
+    #expect(
+        gate.protectionSubtitle(.readOnlyAndLocalWrites)
+            == "Recognized GPG signing requests are automically authorized"
+    )
 }
 
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -288,6 +288,35 @@ printf '%s\n' '{"secret_gates":[{"id":"docker","key_patterns":["DOCKER_REGISTRY_
     #expect(loadSecretGates(descriptors: [descriptor], service: service).map(\.id) == ["gh"])
 }
 
+@Test func dashboardIncludesStandaloneAuthorizationGates() throws {
+    let inactiveHardener = testGateMetadata(hardened: false)
+    let gpg = SecretGateDescriptor(
+        id: "gpg-signing",
+        keyPatterns: ["AUTOMIC_GPG_SIGNING_PRIVATE_KEY"],
+        routes: [SecretGateRoute(
+            operation: "gpg-sign",
+            scriptPath: nil,
+            targetPath: "/Applications/Automic Vault.app/Contents/MacOS/av",
+            callerIdentifiers: ["com.automicvault.av"],
+            keyPatterns: ["AUTOMIC_GPG_SIGNING_PRIVATE_KEY"],
+            replaceExistingEnv: false,
+            allowMissingKeys: false
+        )]
+    )
+    let descriptors = dashboardSecretGateDescriptors(
+        hardeners: [inactiveHardener],
+        catalog: [try #require(inactiveHardener.secretGate), gpg]
+    )
+    let gate = try #require(loadSecretGates(
+        descriptors: descriptors,
+        service: "com.automicvault.tests.\(UUID().uuidString)"
+    ).first)
+
+    #expect(descriptors.map(\.id) == ["gpg-signing"])
+    #expect(gate.availableProtections.contains(.readOnlyAndLocalWrites))
+    #expect(gate.normalizedProtection(.readOnlyAndLocalWrites) == .readOnlyAndLocalWrites)
+}
+
 
 private func testGateMetadata(hardened: Bool = true) -> HardenerMetadata {
     HardenerMetadata(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -292,13 +292,13 @@ printf '%s\n' '{"secret_gates":[{"id":"docker","key_patterns":["DOCKER_REGISTRY_
     let inactiveHardener = testGateMetadata(hardened: false)
     let gpg = SecretGateDescriptor(
         id: "gpg-signing",
-        keyPatterns: ["AUTOMIC_GPG_SIGNING_PRIVATE_KEY"],
+        keyPatterns: ["AV_GPG_PRIVATE_KEY"],
         routes: [SecretGateRoute(
             operation: "gpg-sign",
             scriptPath: nil,
             targetPath: "/Applications/Automic Vault.app/Contents/MacOS/av",
             callerIdentifiers: ["com.automicvault.av"],
-            keyPatterns: ["AUTOMIC_GPG_SIGNING_PRIVATE_KEY"],
+            keyPatterns: ["AV_GPG_PRIVATE_KEY"],
             replaceExistingEnv: false,
             allowMissingKeys: false
         )]

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
@@ -9,12 +9,17 @@ import Testing
 
     #expect(gpgSigningSecretNames(
         configuration: configuration,
-        launcherRequirements: ["codex"]
+        launcherRequirements: ["codex"],
+        storedSecretNames: [
+            gpgAlternatePrivateKeySecretName,
+            gpgAlternatePassphraseSecretName,
+        ]
     ) == [gpgAlternatePrivateKeySecretName, gpgAlternatePassphraseSecretName])
     #expect(gpgSigningSecretNames(
         configuration: configuration,
-        launcherRequirements: ["terminal"]
-    ) == [gpgDefaultPrivateKeySecretName, gpgDefaultPassphraseSecretName])
+        launcherRequirements: ["terminal"],
+        storedSecretNames: [gpgDefaultPrivateKeySecretName]
+    ) == [gpgDefaultPrivateKeySecretName])
 }
 
 @Test func gitConfigurationPreservesAnAppPathContainingSpaces() throws {
@@ -55,6 +60,46 @@ import Testing
     try Data().write(to: bundledAV)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bundledAV.path)
     #expect(try bundledExecutableURL(named: "av", beside: mainExecutable) == bundledAV)
+}
+
+@Test func emptyPassphraseIsNotStored() {
+    var values: [String: String] = [:]
+    let status = saveGPGSigningCredential(
+        privateKey: "private",
+        passphrase: "",
+        alternate: false,
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        save: { account, value in
+            values[account] = value
+            return errSecSuccess
+        },
+        delete: { account in
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecSuccess)
+    #expect(values[gpgDefaultPrivateKeySecretName] == "private")
+    #expect(values[gpgDefaultPassphraseSecretName] == nil)
+}
+
+@Test func emptyStoredPassphraseIsMigratedWithoutTouchingNonemptyPassphrases() {
+    var values = [
+        gpgDefaultPassphraseSecretName: "",
+        gpgAlternatePassphraseSecretName: "alternate-passphrase",
+    ]
+    let status = migrateEmptyGPGSigningPassphrases(
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        delete: { account in
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecSuccess)
+    #expect(values[gpgDefaultPassphraseSecretName] == nil)
+    #expect(values[gpgAlternatePassphraseSecretName] == "alternate-passphrase")
 }
 
 @Test func failedPrivateKeySaveRemovesANewPassphrase() {
@@ -99,5 +144,30 @@ import Testing
     )
 
     #expect(status == errSecAuthFailed)
+    #expect(values[gpgDefaultPassphraseSecretName] == "old-passphrase")
+}
+
+@Test func failedPrivateKeyReplacementDoesNotRemoveThePreviousPassphrase() {
+    var values = [gpgDefaultPassphraseSecretName: "old-passphrase"]
+    var deleted = false
+    let status = saveGPGSigningCredential(
+        privateKey: "replacement",
+        passphrase: "",
+        alternate: false,
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        save: { account, value in
+            if account == gpgDefaultPrivateKeySecretName { return errSecAuthFailed }
+            values[account] = value
+            return errSecSuccess
+        },
+        delete: { account in
+            deleted = true
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecAuthFailed)
+    #expect(!deleted)
     #expect(values[gpgDefaultPassphraseSecretName] == "old-passphrase")
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Security
+import Testing
+@testable import MenubarHelperCore
+
+@Test func launcherListSelectsTheAlternateSigningCredential() {
+    let launcher = BlessedScriptLauncher(bundleIdentifier: "com.openai.codex", requirement: "codex")
+    let configuration = GPGSigningConfiguration(alternateKeyLaunchers: [launcher])
+
+    #expect(gpgSigningSecretNames(
+        configuration: configuration,
+        launcherRequirements: ["codex"]
+    ) == [gpgAlternatePrivateKeySecretName, gpgAlternatePassphraseSecretName])
+    #expect(gpgSigningSecretNames(
+        configuration: configuration,
+        launcherRequirements: ["terminal"]
+    ) == [gpgDefaultPrivateKeySecretName, gpgDefaultPassphraseSecretName])
+}
+
+@Test func gitConfigurationPreservesAnAppPathContainingSpaces() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("Automic Vault Tests \(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let bpb = directory.appendingPathComponent("bpb")
+    try Data("#!/bin/sh\nexit 0\n".utf8).write(to: bpb)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bpb.path)
+    let gitConfig = directory.appendingPathComponent("gitconfig")
+
+    let environment = ProcessInfo.processInfo.environment.merging(
+        ["GIT_CONFIG_GLOBAL": gitConfig.path],
+        uniquingKeysWith: { _, configured in configured }
+    )
+    try configureGitForGPGSigning(bpbURL: bpb, environment: environment)
+
+    let configured = try String(contentsOf: gitConfig, encoding: .utf8)
+    #expect(configured.contains(bpb.path))
+    #expect(configured.contains("gpgSign = true"))
+    #expect(configured.contains("format = openpgp"))
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
@@ -38,3 +38,66 @@ import Testing
     #expect(configured.contains("gpgSign = true"))
     #expect(configured.contains("format = openpgp"))
 }
+
+@Test func bundledExecutableResolutionNeverFallsBackOutsideTheApp() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("Automic Vault Bundle Tests \(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let mainExecutable = directory.appendingPathComponent("AutomicVaultMenubar")
+    let bundledAV = directory.appendingPathComponent("av")
+    try Data().write(to: mainExecutable)
+
+    #expect(throws: GPGSigningConfigurationError.self) {
+        try bundledExecutableURL(named: "av", beside: mainExecutable)
+    }
+
+    try Data().write(to: bundledAV)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bundledAV.path)
+    #expect(try bundledExecutableURL(named: "av", beside: mainExecutable) == bundledAV)
+}
+
+@Test func failedPrivateKeySaveRemovesANewPassphrase() {
+    var values: [String: String] = [:]
+    let status = saveGPGSigningCredential(
+        privateKey: "private",
+        passphrase: "new-passphrase",
+        alternate: false,
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        save: { account, value in
+            if account == gpgDefaultPrivateKeySecretName { return errSecAuthFailed }
+            values[account] = value
+            return errSecSuccess
+        },
+        delete: { account in
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecAuthFailed)
+    #expect(values[gpgDefaultPassphraseSecretName] == nil)
+    #expect(values[gpgDefaultPrivateKeySecretName] == nil)
+}
+
+@Test func failedPrivateKeyReplacementRestoresThePreviousPassphrase() {
+    var values = [gpgDefaultPassphraseSecretName: "old-passphrase"]
+    let status = saveGPGSigningCredential(
+        privateKey: "replacement",
+        passphrase: "new-passphrase",
+        alternate: false,
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        save: { account, value in
+            if account == gpgDefaultPrivateKeySecretName { return errSecAuthFailed }
+            values[account] = value
+            return errSecSuccess
+        },
+        delete: { account in
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecAuthFailed)
+    #expect(values[gpgDefaultPassphraseSecretName] == "old-passphrase")
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
@@ -22,19 +22,19 @@ import Testing
         .appendingPathComponent("Automic Vault Tests \(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: directory) }
-    let bpb = directory.appendingPathComponent("bpb")
-    try Data("#!/bin/sh\nexit 0\n".utf8).write(to: bpb)
-    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bpb.path)
+    let program = directory.appendingPathComponent("av-gpg")
+    try Data("#!/bin/sh\nexit 0\n".utf8).write(to: program)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: program.path)
     let gitConfig = directory.appendingPathComponent("gitconfig")
 
     let environment = ProcessInfo.processInfo.environment.merging(
         ["GIT_CONFIG_GLOBAL": gitConfig.path],
         uniquingKeysWith: { _, configured in configured }
     )
-    try configureGitForGPGSigning(bpbURL: bpb, environment: environment)
+    try configureGitForGPGSigning(programURL: program, environment: environment)
 
     let configured = try String(contentsOf: gitConfig, encoding: .utf8)
-    #expect(configured.contains(bpb.path))
+    #expect(configured.contains(program.path))
     #expect(configured.contains("gpgSign = true"))
     #expect(configured.contains("format = openpgp"))
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/GPGSigningTests.swift
@@ -3,6 +3,13 @@ import Security
 import Testing
 @testable import MenubarHelperCore
 
+@Test func gpgSecretNamesUseAVPrefix() {
+    #expect(gpgDefaultPrivateKeySecretName == "AV_GPG_PRIVATE_KEY")
+    #expect(gpgDefaultPassphraseSecretName == "AV_GPG_PASSPHRASE")
+    #expect(gpgAlternatePrivateKeySecretName == "AV_GPG_AGENT_PRIVATE_KEY")
+    #expect(gpgAlternatePassphraseSecretName == "AV_GPG_AGENT_PASSPHRASE")
+}
+
 @Test func launcherListSelectsTheAlternateSigningCredential() {
     let launcher = BlessedScriptLauncher(bundleIdentifier: "com.openai.codex", requirement: "codex")
     let configuration = GPGSigningConfiguration(alternateKeyLaunchers: [launcher])
@@ -100,6 +107,61 @@ import Testing
     #expect(status == errSecSuccess)
     #expect(values[gpgDefaultPassphraseSecretName] == nil)
     #expect(values[gpgAlternatePassphraseSecretName] == "alternate-passphrase")
+}
+
+@Test func legacyGPGSecretNamesAreMigratedWithoutLosingCredentials() {
+    var values = [
+        "AUTOMIC_GPG_SIGNING_PRIVATE_KEY": "private",
+        "AUTOMIC_GPG_SIGNING_PASSPHRASE": "",
+        "AUTOMIC_GPG_AGENT_SIGNING_PRIVATE_KEY": "alternate-private",
+        "AUTOMIC_GPG_AGENT_SIGNING_PASSPHRASE": "alternate-passphrase",
+    ]
+    let status = migrateLegacyGPGSigningSecrets(
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        saveIfAbsentOrEqual: { account, value in
+            if let existing = values[account] {
+                return existing == value ? errSecSuccess : errSecDuplicateItem
+            }
+            values[account] = value
+            return errSecSuccess
+        },
+        delete: { account in
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecSuccess)
+    #expect(values[gpgDefaultPrivateKeySecretName] == "private")
+    #expect(values[gpgDefaultPassphraseSecretName] == nil)
+    #expect(values[gpgAlternatePrivateKeySecretName] == "alternate-private")
+    #expect(values[gpgAlternatePassphraseSecretName] == "alternate-passphrase")
+    #expect(values.keys.allSatisfy { !$0.hasPrefix("AUTOMIC_GPG_") })
+}
+
+@Test func conflictingGPGSecretNameMigrationFailsClosed() {
+    var values = [
+        "AUTOMIC_GPG_SIGNING_PRIVATE_KEY": "legacy-private",
+        "AV_GPG_PRIVATE_KEY": "current-private",
+    ]
+    let status = migrateLegacyGPGSigningSecrets(
+        load: { values[$0].map(GPGStoredValueLoad.value) ?? .missing },
+        saveIfAbsentOrEqual: { account, value in
+            if let existing = values[account] {
+                return existing == value ? errSecSuccess : errSecDuplicateItem
+            }
+            values[account] = value
+            return errSecSuccess
+        },
+        delete: { account in
+            values.removeValue(forKey: account)
+            return errSecSuccess
+        }
+    )
+
+    #expect(status == errSecDuplicateItem)
+    #expect(values["AUTOMIC_GPG_SIGNING_PRIVATE_KEY"] == "legacy-private")
+    #expect(values[gpgDefaultPrivateKeySecretName] == "current-private")
 }
 
 @Test func failedPrivateKeySaveRemovesANewPassphrase() {

--- a/tests/gpg_program.rs
+++ b/tests/gpg_program.rs
@@ -1,0 +1,144 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("av-gpg-{label}-{}-{nanos}", std::process::id()))
+}
+
+#[test]
+fn signing_requests_stream_to_the_adjacent_av_command() {
+    let directory = temp_dir("forwarding");
+    fs::create_dir_all(&directory).unwrap();
+    let adapter = directory.join("av-gpg");
+    let av = directory.join("av");
+    let args = directory.join("args");
+    let captured_payload = directory.join("payload");
+    fs::copy(env!("CARGO_BIN_EXE_av-gpg"), &adapter).unwrap();
+    fs::write(
+        &av,
+        r#"#!/bin/sh
+test "$1" = "gpg-sign" || exit 2
+shift
+printf '%s\n' "$@" > "$AV_GPG_TEST_ARGS"
+cat > "$AV_GPG_TEST_PAYLOAD"
+printf '%s\n' '[GNUPG:] SIG_CREATED D 1 10 00 0 0 0 0' >&2
+printf '%s\n' '-----BEGIN PGP SIGNATURE-----' '' 'test' '-----END PGP SIGNATURE-----'
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&av, fs::Permissions::from_mode(0o755)).unwrap();
+    let payload = b"tree 0000000000000000000000000000000000000000\n\nmessage\n";
+    let mut child = Command::new(&adapter)
+        .args(["--status-fd=2", "-bsau", "DEADBEEF"])
+        .env("AV_GPG_TEST_ARGS", &args)
+        .env("AV_GPG_TEST_PAYLOAD", &captured_payload)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(payload).unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .contains("BEGIN PGP SIGNATURE")
+    );
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("SIG_CREATED")
+    );
+    assert_eq!(fs::read(captured_payload).unwrap(), payload);
+    assert_eq!(
+        fs::read_to_string(args).unwrap(),
+        "--status-fd=2\n-bsau\nDEADBEEF\n"
+    );
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn git_can_sign_through_an_app_path_containing_spaces() {
+    let directory = temp_dir("app-path");
+    let app_macos = directory.join("Automic Vault.app/Contents/MacOS");
+    fs::create_dir_all(&app_macos).unwrap();
+    let adapter = app_macos.join("av-gpg");
+    let av = app_macos.join("av");
+    fs::copy(env!("CARGO_BIN_EXE_av-gpg"), &adapter).unwrap();
+    fs::write(
+        &av,
+        r#"#!/bin/sh
+test "$1" = "gpg-sign" || exit 2
+cat >/dev/null
+printf '%s\n' '[GNUPG:] SIG_CREATED D 1 10 00 0 0 0 0' >&2
+printf '%s\n' '-----BEGIN PGP SIGNATURE-----' '' 'dGVzdA==' '=n9Tk' '-----END PGP SIGNATURE-----'
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&av, fs::Permissions::from_mode(0o755)).unwrap();
+    let repository = directory.join("repository");
+    fs::create_dir(&repository).unwrap();
+    assert!(
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    for (key, value) in [
+        ("user.name", "av-gpg test"),
+        ("user.email", "av-gpg@example.invalid"),
+        ("user.signingKey", "DEADBEEF"),
+        ("gpg.format", "openpgp"),
+        ("gpg.program", adapter.to_str().unwrap()),
+        ("commit.gpgSign", "true"),
+    ] {
+        assert!(
+            Command::new("git")
+                .args(["config", "--local", key, value])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+
+    let commit = Command::new("git")
+        .args([
+            "commit",
+            "--allow-empty",
+            "--message",
+            "signed through av-gpg",
+        ])
+        .current_dir(&repository)
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+    let object = Command::new("git")
+        .args(["cat-file", "commit", "HEAD"])
+        .current_dir(&repository)
+        .output()
+        .unwrap();
+    assert!(object.status.success());
+    assert!(
+        String::from_utf8(object.stdout)
+            .unwrap()
+            .contains("gpgsig -----BEGIN PGP SIGNATURE-----")
+    );
+    fs::remove_dir_all(directory).unwrap();
+}

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -135,6 +135,7 @@ fn release_build_asserts_secret_custody_entitlements() {
             .contains("APPROVAL_KEYCHAIN_ACCESS_GROUP=\"ZU76A67LGU.com.automicvault.approval\"")
     );
     assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/av\""));
+    assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/bpb\""));
     assert!(
         BUILD_SCRIPT
             .contains("assert_no_embedded_entitlements \"$ROOT/target/release/av-brew-stub\"")
@@ -167,6 +168,16 @@ fn macos_app_uses_its_violet_accent() {
     assert!(ACCENT_COLOR.contains("\"value\" : \"dark\""));
     assert!(BUILD_SCRIPT.contains("\"$MENU_HELPER/Resources/Assets.xcassets\""));
     assert!(BUILD_SCRIPT.contains("--accent-color AccentColor"));
+}
+
+#[test]
+fn bpb_is_hardened_and_bundled_without_a_privileged_install() {
+    assert!(
+        BUILD_SCRIPT.contains("--identifier com.automicvault.bpb \"$ROOT/target/release/bpb\"")
+    );
+    assert!(BUILD_SCRIPT.contains("cp \"$ROOT/target/release/bpb\" \"$MACOS/bpb\""));
+    assert!(BUILD_SCRIPT.contains("codesign --verify --strict \"$MACOS/bpb\""));
+    assert!(!INSTALL_SCRIPT.contains("Contents/MacOS/bpb"));
 }
 
 #[test]

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -150,10 +150,16 @@ fn release_build_asserts_secret_custody_entitlements() {
 }
 
 #[test]
-fn macos_app_uses_the_approval_purple_accent() {
+fn macos_app_uses_its_violet_accent() {
     assert!(MENU_HELPER_INFO_PLIST.contains("<key>NSAccentColorName</key>"));
     assert!(MENU_HELPER_INFO_PLIST.contains("<string>AccentColor</string>"));
-    assert!(ACCENT_COLOR.contains("\"reference\" : \"systemPurpleColor\""));
+    for component in [
+        "\"blue\" : \"0.918\"",
+        "\"green\" : \"0.200\"",
+        "\"red\" : \"0.576\"",
+    ] {
+        assert!(ACCENT_COLOR.contains(component));
+    }
     assert!(BUILD_SCRIPT.contains("\"$MENU_HELPER/Resources/Assets.xcassets\""));
     assert!(BUILD_SCRIPT.contains("--accent-color AccentColor"));
 }

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -154,12 +154,17 @@ fn macos_app_uses_its_violet_accent() {
     assert!(MENU_HELPER_INFO_PLIST.contains("<key>NSAccentColorName</key>"));
     assert!(MENU_HELPER_INFO_PLIST.contains("<string>AccentColor</string>"));
     for component in [
-        "\"blue\" : \"0.902\"",
-        "\"green\" : \"0.235\"",
-        "\"red\" : \"0.608\"",
+        "\"blue\" : \"0.915\"",
+        "\"green\" : \"0.253\"",
+        "\"red\" : \"0.609\"",
+        "\"blue\" : \"0.972\"",
+        "\"green\" : \"0.331\"",
+        "\"red\" : \"0.665\"",
     ] {
         assert!(ACCENT_COLOR.contains(component));
     }
+    assert!(ACCENT_COLOR.contains("\"appearance\" : \"luminosity\""));
+    assert!(ACCENT_COLOR.contains("\"value\" : \"dark\""));
     assert!(BUILD_SCRIPT.contains("\"$MENU_HELPER/Resources/Assets.xcassets\""));
     assert!(BUILD_SCRIPT.contains("--accent-color AccentColor"));
 }

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -154,9 +154,9 @@ fn macos_app_uses_its_violet_accent() {
     assert!(MENU_HELPER_INFO_PLIST.contains("<key>NSAccentColorName</key>"));
     assert!(MENU_HELPER_INFO_PLIST.contains("<string>AccentColor</string>"));
     for component in [
-        "\"blue\" : \"0.918\"",
-        "\"green\" : \"0.200\"",
-        "\"red\" : \"0.576\"",
+        "\"blue\" : \"0.902\"",
+        "\"green\" : \"0.235\"",
+        "\"red\" : \"0.608\"",
     ] {
         assert!(ACCENT_COLOR.contains(component));
     }

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -135,7 +135,9 @@ fn release_build_asserts_secret_custody_entitlements() {
             .contains("APPROVAL_KEYCHAIN_ACCESS_GROUP=\"ZU76A67LGU.com.automicvault.approval\"")
     );
     assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/av\""));
-    assert!(BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/bpb\""));
+    assert!(
+        BUILD_SCRIPT.contains("assert_no_embedded_entitlements \"$ROOT/target/release/av-gpg\"")
+    );
     assert!(
         BUILD_SCRIPT
             .contains("assert_no_embedded_entitlements \"$ROOT/target/release/av-brew-stub\"")
@@ -171,13 +173,14 @@ fn macos_app_uses_its_violet_accent() {
 }
 
 #[test]
-fn bpb_is_hardened_and_bundled_without_a_privileged_install() {
+fn git_signing_adapter_is_hardened_and_bundled_without_a_privileged_install() {
     assert!(
-        BUILD_SCRIPT.contains("--identifier com.automicvault.bpb \"$ROOT/target/release/bpb\"")
+        BUILD_SCRIPT
+            .contains("--identifier com.automicvault.av-gpg \"$ROOT/target/release/av-gpg\"")
     );
-    assert!(BUILD_SCRIPT.contains("cp \"$ROOT/target/release/bpb\" \"$MACOS/bpb\""));
-    assert!(BUILD_SCRIPT.contains("codesign --verify --strict \"$MACOS/bpb\""));
-    assert!(!INSTALL_SCRIPT.contains("Contents/MacOS/bpb"));
+    assert!(BUILD_SCRIPT.contains("cp \"$ROOT/target/release/av-gpg\" \"$MACOS/av-gpg\""));
+    assert!(BUILD_SCRIPT.contains("codesign --verify --strict \"$MACOS/av-gpg\""));
+    assert!(!INSTALL_SCRIPT.contains("Contents/MacOS/av-gpg"));
 }
 
 #[test]

--- a/tests/secret_custody_boundary.rs
+++ b/tests/secret_custody_boundary.rs
@@ -19,3 +19,19 @@ fn argocd_migration_does_not_retrieve_legacy_vault_secrets() {
     assert!(!ARGOCD_MIGRATION.contains("load_secret"));
     assert!(!ARGOCD_MIGRATION.contains("isotope_copy_generic_password_json"));
 }
+
+#[test]
+fn gpg_credential_selection_includes_the_fallback_launcher() {
+    let handle_inject = APPROVAL_SERVICE
+        .split_once("private func handleInject(")
+        .unwrap()
+        .1;
+    let fallback = handle_inject
+        .find("if launchers.isEmpty, let launcher = launcherIdentity")
+        .unwrap();
+    let selection = handle_inject
+        .find("if parsedRequest.op == \"gpg-sign\"")
+        .unwrap();
+
+    assert!(fallback < selection);
+}


### PR DESCRIPTION
## Summary

- bundle the hardened `bpb` Git signing command inside `Automic Vault.app` and route every signing request through the signed adjacent `av` Gate Client
- add the GPG Signing Authorization Gate, bind each request to the verified launcher, repository, GPG arguments, selected credential, and SHA-256 digest of the exact payload, then record authorization before releasing key material
- add GPG Signing settings for importing GnuPG private keys, alternate agent/automation credentials selected from a user-managed Verified Launcher list, and one-click global Git configuration using the full app-bundle path
- define the new domain concepts and security boundary in ADR 0019 and supporting documentation

## Security properties

- Git and `bpb` never receive private-key bytes
- only the signed `av` client may invoke the GPG signing operation
- launcher-conditioned selection is derived by the app from live verified designated requirements; the client cannot request the alternate key
- a missing alternate credential fails closed without falling back to the default credential
- the bundled `bpb` has Hardened Runtime and no entitlements and cannot be redirected through environment state
- revoked or expired signing material is rejected

## Verification

- `cargo test --all-targets` (872 library tests plus all integration targets)
- `swift test --package-path src/menu-helper` (167 tests)
- `cargo test` and `cargo clippy --all-targets -- -D warnings` in `automic-vault/bpb`
- real temporary `git commit -S` through an `Automic Vault.app/Contents/MacOS/bpb` path containing spaces
- release-style `scripts/build.sh`
- strict deep code-sign verification of the built app
- verified `com.automicvault.bpb`, team `ZU76A67LGU`, Hardened Runtime, and no embedded entitlements
- signed-app Settings dashboard self-check

The `bpb` implementation and its end-to-end tests are pushed at `automic-vault/bpb@2b8bcf0` on `codex/automic-vault-signing`.