### PR TITLE
Control temporary access grant countdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Launcher, Tool-specific gate, runtime posture, and current agent task.
 
 <img src="./docs/img/temporary-write-access.png" alt="Automic Vault temporary write access controls" style="width: 589px; height: auto" />
 
-The persistent strip shows every grant and lets you add ten minutes, pause or
+The persistent strip shows every grant and lets you add ten minutes, suspend or
 resume its active-time countdown and Write Access, or end it early. Automic
 Vault also revokes grants when the user session becomes inactive, displays
 sleep, an update begins, or the app stops.

--- a/README.md
+++ b/README.md
@@ -339,9 +339,10 @@ Launcher, Tool-specific gate, runtime posture, and current agent task.
 
 <img src="./docs/img/temporary-write-access.png" alt="Automic Vault temporary write access controls" style="width: 589px; height: auto" />
 
-The persistent strip shows active grants and lets you end them early. Automic
-Vault also revokes them when the user session becomes inactive, displays sleep,
-an update begins, or the app stops.
+The persistent strip shows every grant and lets you suspend or resume its
+active-time countdown and Write Access, or end it early. Automic Vault also
+revokes grants when the user session becomes inactive, displays sleep, an update
+begins, or the app stops.
 
 The Verified Launcher remains the identity boundary. The task identifier is a
 forgeable label that narrows the grant. Temporary Access Grants exclude the

--- a/README.md
+++ b/README.md
@@ -339,10 +339,10 @@ Launcher, Tool-specific gate, runtime posture, and current agent task.
 
 <img src="./docs/img/temporary-write-access.png" alt="Automic Vault temporary write access controls" style="width: 589px; height: auto" />
 
-The persistent strip shows every grant and lets you suspend or resume its
-active-time countdown and Write Access, or end it early. Automic Vault also
-revokes grants when the user session becomes inactive, displays sleep, an update
-begins, or the app stops.
+The persistent strip shows every grant and lets you add ten minutes, pause or
+resume its active-time countdown and Write Access, or end it early. Automic
+Vault also revokes grants when the user session becomes inactive, displays
+sleep, an update begins, or the app stops.
 
 The Verified Launcher remains the identity boundary. The task identifier is a
 forgeable label that narrows the grant. Temporary Access Grants exclude the

--- a/docs/adr/0025-suspend-temporary-access-grant-countdowns.md
+++ b/docs/adr/0025-suspend-temporary-access-grant-countdowns.md
@@ -1,0 +1,49 @@
+# ADR 0025: Suspend Temporary Access Grant countdowns
+
+Status: accepted
+
+## Context
+
+Temporary Access Grants currently expire after ten uninterrupted minutes. A
+user may need to preserve the unused portion while temporarily stepping away
+from an agent task. Leaving Write Access active while stopping its clock would
+turn a bounded escalation into indefinite active authority and weaken the
+grant's safety model.
+
+This decision amends the fixed-duration details of
+[ADR 0016](0016-agent-scoped-temporary-access-grants.md). Its scope, eligibility,
+recording, lease, and lifecycle-revocation decisions remain unchanged.
+
+## Decision
+
+Each Temporary Access Grant has ten minutes of active countdown time. The user
+may suspend or resume its countdown from the persistent strip. A suspended grant
+remains visible and memory-only but is ineligible to authorize any request.
+Resuming restores eligibility with exactly the frozen remaining duration.
+
+Suspension freezes the lesser remaining duration from the wall-clock and
+monotonic deadlines while holding the grant controller's existing lease lock.
+Resumption creates new paired deadlines from that frozen duration. Suspension
+and resumption therefore cannot race an in-progress release. An expired grant
+cannot be suspended or resumed, and a newly confirmed duplicate scope replaces
+any prior generation with a running ten-minute grant.
+
+Session inactivity, display sleep, update installation, service stop, app
+termination, and End continue to revoke suspended and running grants alike.
+Suspension and resumption require an explicit user action but no new Approval:
+suspension removes authority, while resumption restores only the unused portion
+of the already confirmed scope and active-time budget.
+
+The strip shows the frozen remaining time and an explicit suspended state. The
+countdown toggle is adjacent to End so immediate revocation remains continuously
+available.
+
+## Consequences
+
+Pausing work no longer consumes the grant's active-time budget. The wall-clock
+period during which a grant can be resumed may exceed ten minutes, but its total
+authorizing time cannot. Existing scope, runtime, task-context, operation,
+recording, and release checks still apply to every use after resumption.
+
+Stopping only the visible clock while retaining active Write Access was rejected
+because it would create unbounded authority behind temporary-access messaging.

--- a/docs/adr/0026-suspend-temporary-access-grant-countdowns.md
+++ b/docs/adr/0026-suspend-temporary-access-grant-countdowns.md
@@ -16,10 +16,11 @@ recording, lease, and lifecycle-revocation decisions remain unchanged.
 
 ## Decision
 
-Each Temporary Access Grant has ten minutes of active countdown time. The user
-may suspend or resume its countdown from the persistent strip. A suspended grant
-remains visible and memory-only but is ineligible to authorize any request.
-Resuming restores eligibility with exactly the frozen remaining duration.
+Each Temporary Access Grant starts with ten minutes of active countdown time.
+The user may explicitly add ten minutes or suspend or resume its countdown from
+the persistent strip. A suspended grant remains visible and memory-only but is
+ineligible to authorize any request. Resuming restores eligibility with exactly
+the frozen remaining duration.
 
 Suspension freezes the lesser remaining duration from the wall-clock and
 monotonic deadlines while holding the grant controller's existing lease lock.
@@ -28,11 +29,15 @@ and resumption therefore cannot race an in-progress release. An expired grant
 cannot be suspended or resumed, and a newly confirmed duplicate scope replaces
 any prior generation with a running ten-minute grant.
 
+Adding time holds the same lease lock and adds ten minutes to both running
+deadlines or to a suspended grant's frozen remainder. It does not restore Write
+Access to a suspended grant and cannot revive an expired grant.
+
 Session inactivity, display sleep, update installation, service stop, app
 termination, and End continue to revoke suspended and running grants alike.
-Suspension and resumption require an explicit user action but no new Approval:
-suspension removes authority, while resumption restores only the unused portion
-of the already confirmed scope and active-time budget.
+Suspension, resumption, and extension require an explicit user action but no new
+Approval. Suspension removes authority, resumption restores only the remaining
+confirmed scope, and extension changes only that same grant's active-time budget.
 
 The strip shows the frozen remaining time and an explicit suspended state. The
 countdown toggle is adjacent to End so immediate revocation remains continuously
@@ -41,9 +46,9 @@ available.
 ## Consequences
 
 Pausing work no longer consumes the grant's active-time budget. The wall-clock
-period during which a grant can be resumed may exceed ten minutes, but its total
-authorizing time cannot. Existing scope, runtime, task-context, operation,
-recording, and release checks still apply to every use after resumption.
+period and total authorizing time may exceed ten minutes only through explicit
+user actions. Existing scope, runtime, task-context, operation, recording, and
+release checks still apply to every use after resumption or extension.
 
 Stopping only the visible clock while retaining active Write Access was rejected
 because it would create unbounded authority behind temporary-access messaging.

--- a/docs/adr/0026-suspend-temporary-access-grant-countdowns.md
+++ b/docs/adr/0026-suspend-temporary-access-grant-countdowns.md
@@ -1,4 +1,4 @@
-# ADR 0025: Suspend Temporary Access Grant countdowns
+# ADR 0026: Suspend Temporary Access Grant countdowns
 
 Status: accepted
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,8 @@ Agent Task Context: same-user software can forge it, so the live Verified
 Launcher remains the identity boundary.
 
 An eligible live write-request Approval can create a Temporary Access Grant
-with ten minutes of active countdown time through an explicit prompt action.
+with an initial ten minutes of active countdown time through an explicit prompt
+action.
 The grant is limited to Write Access at the exact Tool-specific gate, Launcher
 designated requirement, accepted runtime posture, provider, and task UUID. The
 Direct Secret Gate, Secret mutations, Elevated Secret Application, Secret
@@ -255,8 +256,10 @@ cannot revoke Secret Values already released.
 Grants are memory-only and running countdowns use both wall-clock and monotonic
 deadlines. Suspending freezes the lesser remaining duration from those clocks
 and makes the grant ineligible to authorize requests. Resuming creates new
-paired deadlines from that frozen remainder. An exact duplicate scope is
-replaced by a newly confirmed, running ten-minute generation. The service
+paired deadlines from that frozen remainder. An explicit extension adds ten
+minutes to both running deadlines or to the frozen remainder; it cannot revive
+an expired grant. An exact duplicate scope is replaced by a newly confirmed,
+running ten-minute generation. The service
 revokes every grant on user session inactivity, display sleep, update
 installation, service stop, or app termination. Individual expiry, suspension,
 resumption, and explicit End actions require no authentication.
@@ -570,10 +573,10 @@ Launcher Provenance and does not require this setting.
 While any Temporary Access Grant exists, a non-activating strip remains visible
 directly below the menu-bar item with every scoped grant, second-accurate
 remaining active time, suspension state, successful-use count, last-use time,
-and End and countdown-toggle actions. The menu mirrors End actions and the shield
-turns orange. Automatic-request notifications stack below the strip. This
-continuous presentation is part of the temporary escalation's safety model, not
-a source of authority.
+and Add 10 Minutes, End, and countdown-toggle actions. The menu mirrors these
+actions and the shield turns orange. Automatic-request notifications stack
+below the strip. This continuous presentation is part of the temporary
+escalation's safety model, not a source of authority.
 
 ## Source of truth
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,8 +26,9 @@ Policies bind a Gate and Verified Launcher. Approval binds one complete request 
 
 Temporary Access Grants bind one Tool-specific Authorization Gate, one Verified
 Launcher and accepted runtime posture, and one Agent Task Context for a fixed
-ten-minute lifetime. Agent Task Context narrows matching but is not identity or
-a security boundary.
+ten-minute active-time budget. The user may suspend the countdown, which also
+suspends the grant's authority, and resume with the frozen remainder. Agent Task
+Context narrows matching but is not identity or a security boundary.
 
 Optional Retained Launcher Provenance binds one Authorization Gate, one Verified
 Launcher, and one exact live process execution. It preserves attribution after
@@ -99,12 +100,12 @@ provider and adds no client-controlled identity field to XPC. This label is an
 Agent Task Context: same-user software can forge it, so the live Verified
 Launcher remains the identity boundary.
 
-An eligible live write-request Approval can create a ten-minute Temporary
-Access Grant through an explicit prompt action. The grant is limited to
-Write Access at the exact Tool-specific gate, Launcher designated requirement,
-accepted runtime posture, provider, and task UUID. The Direct Secret Gate,
-Secret mutations, Elevated Secret Application, Secret Disclosure, Unknown
-operations, and unverifiable Launchers are excluded.
+An eligible live write-request Approval can create a Temporary Access Grant
+with ten minutes of active countdown time through an explicit prompt action.
+The grant is limited to Write Access at the exact Tool-specific gate, Launcher
+designated requirement, accepted runtime posture, provider, and task UUID. The
+Direct Secret Gate, Secret mutations, Elevated Secret Application, Secret
+Disclosure, Unknown operations, and unverifiable Launchers are excluded.
 
 The Varlock plugin collects every active, statically named Automic Vault
 resolver before resolution and submits one multi-Secret Authorization Request
@@ -251,11 +252,14 @@ menu shows any available Verified Launcher attribution, Target, and Secret
 Names. Process liveness changes display state only: it grants no authority and
 cannot revoke Secret Values already released.
 
-Grants are memory-only and use both wall-clock and monotonic deadlines. An exact
-duplicate scope is replaced by a newly confirmed ten-minute generation. The
-service revokes every grant on user session inactivity, display sleep, update
-installation, service stop, or app termination. Individual expiry and explicit
-End actions require no authentication.
+Grants are memory-only and running countdowns use both wall-clock and monotonic
+deadlines. Suspending freezes the lesser remaining duration from those clocks
+and makes the grant ineligible to authorize requests. Resuming creates new
+paired deadlines from that frozen remainder. An exact duplicate scope is
+replaced by a newly confirmed, running ten-minute generation. The service
+revokes every grant on user session inactivity, display sleep, update
+installation, service stop, or app termination. Individual expiry, suspension,
+resumption, and explicit End actions require no authentication.
 
 After a successful policy decision, Automic Vault may record Retained Launcher
 Provenance for signed intermediary process executions.
@@ -565,10 +569,11 @@ Launcher Provenance and does not require this setting.
 
 While any Temporary Access Grant exists, a non-activating strip remains visible
 directly below the menu-bar item with every scoped grant, second-accurate
-remaining time, successful-use count, last-use time, and an End action. The menu
-mirrors those actions and the shield turns orange. Automatic-request
-notifications stack below the strip. This continuous presentation is part of
-the temporary escalation's safety model, not a source of authority.
+remaining active time, suspension state, successful-use count, last-use time,
+and End and countdown-toggle actions. The menu mirrors End actions and the shield
+turns orange. Automatic-request notifications stack below the strip. This
+continuous presentation is part of the temporary escalation's safety model, not
+a source of authority.
 
 ## Source of truth
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -403,7 +403,8 @@ The final allow or deny result and its source. An allowed request is either **au
 
 An in-memory, user-confirmed delegation of Write Access to one exact
 Tool-specific Authorization Gate, Verified Launcher, accepted Launcher Runtime
-Requirement, and Agent Task Context with ten minutes of active countdown time.
+Requirement, and Agent Task Context with an initial ten minutes of active
+countdown time.
 It may automically authorize recognized read and write operations at that scope.
 Elevated Secret Application, Secret Disclosure, Unknown operations, the Direct
 Secret Gate, and Secret mutation operations remain outside the grant.
@@ -412,12 +413,13 @@ A Temporary Access Grant can begin only when the user selects its explicit
 action in an eligible live write-request Approval. It is not a
 durable Authorization Policy or Blessing. Automic Vault shows every active
 grant continuously with its successful-use count and last-use time, lets the
-user suspend or resume its countdown, lets the user end each grant immediately,
-and revokes all grants when the user session becomes inactive, displays sleep,
-an update begins, or the service terminates. A suspended countdown also suspends
-the grant's authority: requests cannot match it until the user resumes it. The
-remaining active time is preserved while suspended. Running countdowns and
-resumed deadlines use both wall and monotonic clocks.
+user add ten minutes of active countdown time, lets the user suspend or resume
+its countdown, lets the user end each grant immediately, and revokes all grants
+when the user session becomes inactive, displays sleep, an update begins, or the
+service terminates. A suspended countdown also suspends the grant's authority:
+requests cannot match it until the user resumes it. The remaining active time is
+preserved while suspended. Running countdowns and resumed deadlines use both
+wall and monotonic clocks.
 
 Grant matching occurs when Automic Vault makes the Authorization Decision. A
 still-live request received before the grant began may therefore use it when

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -403,18 +403,21 @@ The final allow or deny result and its source. An allowed request is either **au
 
 An in-memory, user-confirmed delegation of Write Access to one exact
 Tool-specific Authorization Gate, Verified Launcher, accepted Launcher Runtime
-Requirement, and Agent Task Context for ten minutes. It may automically
-authorize recognized read and write operations at that scope. Elevated Secret
-Application, Secret Disclosure, Unknown operations, the Direct Secret Gate, and
-Secret mutation operations remain outside the grant.
+Requirement, and Agent Task Context with ten minutes of active countdown time.
+It may automically authorize recognized read and write operations at that scope.
+Elevated Secret Application, Secret Disclosure, Unknown operations, the Direct
+Secret Gate, and Secret mutation operations remain outside the grant.
 
 A Temporary Access Grant can begin only when the user selects its explicit
 action in an eligible live write-request Approval. It is not a
 durable Authorization Policy or Blessing. Automic Vault shows every active
 grant continuously with its successful-use count and last-use time, lets the
-user end each grant immediately, and revokes all grants when the user session
-becomes inactive, displays sleep, an update begins, or the service terminates.
-Expiry uses both wall and monotonic clocks.
+user suspend or resume its countdown, lets the user end each grant immediately,
+and revokes all grants when the user session becomes inactive, displays sleep,
+an update begins, or the service terminates. A suspended countdown also suspends
+the grant's authority: requests cannot match it until the user resumes it. The
+remaining active time is preserved while suspended. Running countdowns and
+resumed deadlines use both wall and monotonic clocks.
 
 Grant matching occurs when Automic Vault makes the Authorization Decision. A
 still-live request received before the grant began may therefore use it when

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -38,10 +38,11 @@ Automic Vault decides whether a complete operation may use it.
   require Approval.
 - Optional iPhone Approval and Touch ID Approval move allow actions away from
   agent-controlled pointer and keyboard input.
-- An eligible agent write Approval can grant ten active minutes of Write Access
-  to one Verified Launcher, Tool-specific Authorization Gate, and agent task. A
-  persistent strip shows the grant and lets the user suspend its countdown or
-  end it; suspension also suspends its authority.
+- An eligible agent write Approval can grant an initial ten active minutes of
+  Write Access to one Verified Launcher, Tool-specific Authorization Gate, and
+  agent task. A persistent strip shows the grant and lets the user add ten
+  minutes, suspend its countdown, or end it; suspension also suspends its
+  authority.
 - Existing developer commands continue to work above the security boundary.
 - Git can keep its ordinary commit workflow while the GPG Signing Gate
   authorizes private-key use and may select an alternate credential for exact

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -38,9 +38,10 @@ Automic Vault decides whether a complete operation may use it.
   require Approval.
 - Optional iPhone Approval and Touch ID Approval move allow actions away from
   agent-controlled pointer and keyboard input.
-- An eligible agent write Approval can grant ten minutes of Write Access to one
-  Verified Launcher, Tool-specific Authorization Gate, and agent task. A
-  persistent strip shows the grant and provides an End action.
+- An eligible agent write Approval can grant ten active minutes of Write Access
+  to one Verified Launcher, Tool-specific Authorization Gate, and agent task. A
+  persistent strip shows the grant and lets the user suspend its countdown or
+  end it; suspension also suspends its authority.
 - Existing developer commands continue to work above the security boundary.
 - Git can keep its ordinary commit workflow while the GPG Signing Gate
   authorizes private-key use and may select an alternate credential for exact

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1243,6 +1243,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let self else { return }
                 _ = self.temporaryAccessGrants.cancel(id: id)
                 self.refreshTemporaryAccessGrants()
+            },
+            setCountdownSuspended: { [weak self] id, suspended in
+                guard let self else { return }
+                _ = self.temporaryAccessGrants.setCountdownSuspended(
+                    id: id,
+                    suspended: suspended
+                )
+                self.refreshTemporaryAccessGrants()
             }
         ))
         let size = hostingView.fittingSize
@@ -2508,7 +2516,7 @@ private func temporaryAccessGrantCandidate(
     guard let runtimeRequirement = launcher.runtimeProtection.secretGateAdmissionRequirement else {
         return nil
     }
-    let launcherName = approvalPromptRequester(launcher: launcher, fallback: launcher.path).name
+    let launcherName = temporaryAccessGrantLauncherName(launcher)
     return TemporaryAccessGrantCandidate(
         scope: TemporaryAccessGrantScope(
             authorizationGateID: gate.id,
@@ -7877,13 +7885,21 @@ private func approvalPromptRequester(
     if let appURL = appBundleURL(containing: launcher.path)
         ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: launcher.identifier)
     {
-        let bundle = Bundle(url: appURL)
-        let name = bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
-            ?? bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String
-            ?? appURL.deletingPathExtension().lastPathComponent
-        return (name, appURL.path)
+        return (appDisplayName(appURL), appURL.path)
     }
     return (shortAppName(launcher.identifier), launcher.path)
+}
+
+private func temporaryAccessGrantLauncherName(_ launcher: LauncherIdentity) -> String {
+    appBundleURLs(containing: launcher.path).last.map(appDisplayName)
+        ?? approvalPromptRequester(launcher: launcher, fallback: launcher.path).name
+}
+
+private func appDisplayName(_ appURL: URL) -> String {
+    let bundle = Bundle(url: appURL)
+    return bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+        ?? bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String
+        ?? appURL.deletingPathExtension().lastPathComponent
 }
 
 private func prettyShellCommand(target: String, args: [String]) -> String {
@@ -8780,7 +8796,8 @@ private func temporaryAccessGrantMenuTitle(
     let remaining = temporaryAccessGrantRemainingText(
         grant.remaining(wallNow: wallNow, monotonicNow: monotonicNow)
     )
-    return "\(grant.launcherName) → \(grant.authorizationGateName) · \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(remaining) · \(temporaryAccessGrantUsageText(grant)) — End"
+    let countdown = grant.isCountdownSuspended ? "\(remaining) suspended" : remaining
+    return "\(grant.launcherName) → \(grant.authorizationGateName) · \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(countdown) · \(temporaryAccessGrantUsageText(grant)) — End"
 }
 
 private final class TemporaryAccessGrantPanel: NSPanel {
@@ -8826,6 +8843,7 @@ private struct TemporaryAccessGrantStripView: View {
     let wallNow: Date
     let monotonicNow: TimeInterval
     let end: (UUID) -> Void
+    let setCountdownSuspended: (UUID, Bool) -> Void
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     var body: some View {
@@ -8844,7 +8862,8 @@ private struct TemporaryAccessGrantStripView: View {
                 TemporaryAccessGrantRow(
                     grant: grant,
                     remaining: grant.remaining(wallNow: wallNow, monotonicNow: monotonicNow),
-                    end: { end(grant.id) }
+                    end: { end(grant.id) },
+                    setCountdownSuspended: { setCountdownSuspended(grant.id, $0) }
                 )
                 if index != grants.indices.last {
                     Divider().padding(.leading, 42)
@@ -8870,6 +8889,12 @@ private struct TemporaryAccessGrantRow: View {
     let grant: TemporaryAccessGrantSnapshot
     let remaining: TimeInterval
     let end: () -> Void
+    let setCountdownSuspended: (Bool) -> Void
+
+    private var countdownStatus: String {
+        let remaining = "\(temporaryAccessGrantRemainingText(remaining)) remaining"
+        return grant.isCountdownSuspended ? "\(remaining) · Write Access suspended" : remaining
+    }
 
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
@@ -8882,7 +8907,7 @@ private struct TemporaryAccessGrantRow: View {
                     .font(.callout.weight(.semibold))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text("\(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(temporaryAccessGrantRemainingText(remaining)) remaining")
+                Text("\(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID) · \(countdownStatus)")
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
                 Text(temporaryAccessGrantUsageText(grant))
@@ -8892,15 +8917,28 @@ private struct TemporaryAccessGrantRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(
-                "\(grant.launcherName), \(grant.authorizationGateName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID), \(temporaryAccessGrantRemainingText(remaining)) remaining, \(temporaryAccessGrantUsageText(grant))"
+                "\(grant.launcherName), \(grant.authorizationGateName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID), \(countdownStatus), \(temporaryAccessGrantUsageText(grant))"
             )
 
-            Button("End", action: end)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .accessibilityLabel(
-                    "End temporary Write Access for \(grant.launcherName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID)"
-                )
+            ControlGroup {
+                Button("End", action: end)
+                    .accessibilityLabel(
+                        "End temporary Write Access for \(grant.launcherName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID)"
+                    )
+                Menu {
+                    Button(grant.isCountdownSuspended
+                        ? "Resume countdown and Write Access"
+                        : "Suspend countdown and Write Access"
+                    ) {
+                        setCountdownSuspended(!grant.isCountdownSuspended)
+                    }
+                } label: {
+                    Label("Temporary Write Access options", systemImage: "chevron.down")
+                        .labelStyle(.iconOnly)
+                }
+                .accessibilityHint("Opens an option to suspend or resume the countdown and Write Access")
+            }
+            .controlSize(.small)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -10085,6 +10123,7 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
           let liveBundleFallback,
           liveBundleFallback.isStandalone,
           liveBundleFallback.identifier == bundledDeveloperID.identifier,
+          temporaryAccessGrantLauncherName(liveBundleFallback) == "Example",
           pathOnlyBundleFallback == nil,
           launcherIdentity(pid: 43, path: adHoc.mainExecutable, signing: adHoc) == nil,
           launcherIdentity(pid: 43, path: rejected.mainExecutable, signing: rejected) == nil,
@@ -11086,7 +11125,8 @@ private func runMenuStatusSelfCheck() -> Int32 {
         grants: grantSnapshots,
         wallNow: grantWallNow,
         monotonicNow: grantMonotonicNow,
-        end: { _ in }
+        end: { _ in },
+        setCountdownSuspended: { _, _ in }
     ))
     let grantPanel = makeTemporaryAccessGrantPanel()
     let sampleStripFrame = NSRect(x: 200, y: 400, width: 430, height: 120)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1126,7 +1126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let toggle = NSMenuItem(
                 title: grant.isCountdownSuspended
                     ? "Resume Write Access"
-                    : "Pause Write Access",
+: "Suspend Write Access",
                 action: #selector(toggleTemporaryAccessGrantCountdown(_:)),
                 keyEquivalent: ""
             )

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -8854,7 +8854,9 @@ private struct TemporaryAccessGrantStripView: View {
                 .foregroundStyle(.orange)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
-                .accessibilityLabel("Warning: Temporary Write Access is active")
+                .accessibilityLabel(grants.allSatisfy { $0.isCountdownSuspended }
+                    ? "Temporary Write Access is suspended"
+                    : "Warning: Temporary Write Access is active")
 
             Divider()
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1114,10 +1114,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 accessibilityDescription: "Temporary access warning"
             )
             let submenu = NSMenu()
+            let addTenMinutes = NSMenuItem(
+                title: "Add 10 Minutes",
+                action: #selector(addTenMinutesToTemporaryAccessGrant(_:)),
+                keyEquivalent: ""
+            )
+            addTenMinutes.target = self
+            addTenMinutes.representedObject = grant.id.uuidString
+            submenu.addItem(addTenMinutes)
+            submenu.addItem(.separator())
             let toggle = NSMenuItem(
                 title: grant.isCountdownSuspended
-                    ? "Resume countdown and Write Access"
-                    : "Suspend countdown and Write Access",
+                    ? "Resume Write Access"
+                    : "Pause Write Access",
                 action: #selector(toggleTemporaryAccessGrantCountdown(_:)),
                 keyEquivalent: ""
             )
@@ -1151,6 +1160,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               let id = UUID(uuidString: rawID)
         else { return }
         _ = temporaryAccessGrants.cancel(id: id)
+        refreshTemporaryAccessGrants()
+    }
+
+    @objc private func addTenMinutesToTemporaryAccessGrant(_ sender: NSMenuItem) {
+        guard let rawID = sender.representedObject as? String,
+              let id = UUID(uuidString: rawID)
+        else { return }
+        _ = temporaryAccessGrants.addTenMinutes(id: id)
         refreshTemporaryAccessGrants()
     }
 
@@ -1269,6 +1286,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             grants: temporaryAccessGrantSnapshots,
             wallNow: wallNow,
             monotonicNow: monotonicNow,
+            addTenMinutes: { [weak self] id in
+                guard let self else { return }
+                _ = self.temporaryAccessGrants.addTenMinutes(id: id)
+                self.refreshTemporaryAccessGrants()
+            },
             end: { [weak self] id in
                 guard let self else { return }
                 _ = self.temporaryAccessGrants.cancel(id: id)
@@ -8875,6 +8897,7 @@ private struct TemporaryAccessGrantStripView: View {
     let grants: [TemporaryAccessGrantSnapshot]
     let wallNow: Date
     let monotonicNow: TimeInterval
+    let addTenMinutes: (UUID) -> Void
     let end: (UUID) -> Void
     let setCountdownSuspended: (UUID, Bool) -> Void
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -8897,6 +8920,7 @@ private struct TemporaryAccessGrantStripView: View {
                 TemporaryAccessGrantRow(
                     grant: grant,
                     remaining: grant.remaining(wallNow: wallNow, monotonicNow: monotonicNow),
+                    addTenMinutes: { addTenMinutes(grant.id) },
                     end: { end(grant.id) },
                     setCountdownSuspended: { setCountdownSuspended(grant.id, $0) }
                 )
@@ -8923,6 +8947,7 @@ private struct TemporaryAccessGrantStripView: View {
 private struct TemporaryAccessGrantRow: View {
     let grant: TemporaryAccessGrantSnapshot
     let remaining: TimeInterval
+    let addTenMinutes: () -> Void
     let end: () -> Void
     let setCountdownSuspended: (Bool) -> Void
 
@@ -8963,9 +8988,11 @@ private struct TemporaryAccessGrantRow: View {
                         "End temporary Write Access for \(grant.launcherName), \(grant.scope.agentTaskContext.provider.taskLabel) \(grant.scope.agentTaskContext.abbreviatedID)"
                     )
                 Menu {
+                    Button("Add 10 Minutes", action: addTenMinutes)
+                    Divider()
                     Button(grant.isCountdownSuspended
-                        ? "Resume countdown and Write Access"
-                        : "Suspend countdown and Write Access"
+                        ? "Resume Write Access"
+                        : "Pause Write Access"
                     ) {
                         setCountdownSuspended(!grant.isCountdownSuspended)
                     }
@@ -8973,7 +9000,8 @@ private struct TemporaryAccessGrantRow: View {
                     Label("Temporary Write Access options", systemImage: "chevron.down")
                         .labelStyle(.iconOnly)
                 }
-                .accessibilityHint("Opens an option to suspend or resume the countdown and Write Access")
+                .menuIndicator(.hidden)
+                .accessibilityHint("Opens options to add time or pause Write Access")
             }
             .controlSize(.small)
         }
@@ -11166,6 +11194,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
         grants: grantSnapshots,
         wallNow: grantWallNow,
         monotonicNow: grantMonotonicNow,
+        addTenMinutes: { _ in },
         end: { _ in },
         setCountdownSuspended: { _, _ in }
     ))

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1065,7 +1065,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func refreshTemporaryAccessGrants() {
         temporaryAccessGrantSnapshots = temporaryAccessGrants.snapshots()
-        if temporaryAccessGrantSnapshots.isEmpty {
+        if temporaryAccessGrantSnapshots.allSatisfy(\.isCountdownSuspended) {
             temporaryAccessGrantTimer?.invalidate()
             temporaryAccessGrantTimer = nil
         } else if temporaryAccessGrantTimer == nil {
@@ -1105,16 +1105,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     wallNow: wallNow,
                     monotonicNow: monotonicNow
                 ),
-                action: #selector(endTemporaryAccessGrant(_:)),
+                action: nil,
                 keyEquivalent: ""
             )
-            item.target = self
-            item.representedObject = grant.id.uuidString
             item.image = shieldImage(
                 symbolName: "exclamationmark.shield.fill",
                 color: .systemOrange,
                 accessibilityDescription: "Temporary access warning"
             )
+            let submenu = NSMenu()
+            let toggle = NSMenuItem(
+                title: grant.isCountdownSuspended
+                    ? "Resume countdown and Write Access"
+                    : "Suspend countdown and Write Access",
+                action: #selector(toggleTemporaryAccessGrantCountdown(_:)),
+                keyEquivalent: ""
+            )
+            toggle.target = self
+            toggle.representedObject = grant.id.uuidString
+            submenu.addItem(toggle)
+            let end = NSMenuItem(
+                title: "End temporary Write Access",
+                action: #selector(endTemporaryAccessGrant(_:)),
+                keyEquivalent: ""
+            )
+            end.target = self
+            end.representedObject = grant.id.uuidString
+            submenu.addItem(end)
+            item.submenu = submenu
             return item
         }
         for item in temporaryAccessGrantMenuItems.reversed() {
@@ -1133,6 +1151,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               let id = UUID(uuidString: rawID)
         else { return }
         _ = temporaryAccessGrants.cancel(id: id)
+        refreshTemporaryAccessGrants()
+    }
+
+    @objc private func toggleTemporaryAccessGrantCountdown(_ sender: NSMenuItem) {
+        guard let rawID = sender.representedObject as? String,
+              let id = UUID(uuidString: rawID),
+              let grant = temporaryAccessGrantSnapshots.first(where: { $0.id == id })
+        else { return }
+        _ = temporaryAccessGrants.setCountdownSuspended(
+            id: id,
+            suspended: !grant.isCountdownSuspended
+        )
         refreshTemporaryAccessGrants()
     }
 
@@ -7890,8 +7920,11 @@ private func approvalPromptRequester(
     return (shortAppName(launcher.identifier), launcher.path)
 }
 
-private func temporaryAccessGrantLauncherName(_ launcher: LauncherIdentity) -> String {
-    appBundleURLs(containing: launcher.path).last.map(appDisplayName)
+private func temporaryAccessGrantLauncherName(
+    _ launcher: LauncherIdentity,
+    displayName: (URL) -> String = appDisplayName
+) -> String {
+    appBundleURLs(containing: launcher.path).last.map(displayName)
         ?? approvalPromptRequester(launcher: launcher, fallback: launcher.path).name
 }
 
@@ -8894,8 +8927,10 @@ private struct TemporaryAccessGrantRow: View {
     let setCountdownSuspended: (Bool) -> Void
 
     private var countdownStatus: String {
-        let remaining = "\(temporaryAccessGrantRemainingText(remaining)) remaining"
-        return grant.isCountdownSuspended ? "\(remaining) · Write Access suspended" : remaining
+        let remainingText = "\(temporaryAccessGrantRemainingText(remaining)) remaining"
+        return grant.isCountdownSuspended
+            ? "\(remainingText) · Write Access suspended"
+            : remainingText
     }
 
     var body: some View {
@@ -10126,6 +10161,10 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
           liveBundleFallback.isStandalone,
           liveBundleFallback.identifier == bundledDeveloperID.identifier,
           temporaryAccessGrantLauncherName(liveBundleFallback) == "Example",
+          temporaryAccessGrantLauncherName(
+              liveBundleFallback,
+              displayName: { _ in "ChatGPT" }
+          ) == "ChatGPT",
           pathOnlyBundleFallback == nil,
           launcherIdentity(pid: 43, path: adHoc.mainExecutable, signing: adHoc) == nil,
           launcherIdentity(pid: 43, path: rejected.mainExecutable, signing: rejected) == nil,

--- a/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
@@ -241,9 +241,8 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         defer { lock.unlock() }
         removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
         guard var grant = grants[id] else { return nil }
-        guard grant.suspendedRemaining == nil ? suspended : !suspended else {
-            return grant.snapshot
-        }
+        let wasSuspended = grant.suspendedRemaining != nil
+        guard wasSuspended != suspended else { return grant.snapshot }
         if suspended {
             grant.suspendedRemaining = grant.remaining(
                 wallNow: wallNow,

--- a/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
@@ -263,6 +263,28 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         return grant.snapshot
     }
 
+    @discardableResult
+    public func addTenMinutes(
+        id: UUID,
+        wallNow: Date? = nil,
+        monotonicNow: TimeInterval? = nil
+    ) -> TemporaryAccessGrantSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        let wallNow = wallNow ?? Date()
+        let monotonicNow = monotonicNow ?? ProcessInfo.processInfo.systemUptime
+        removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
+        guard var grant = grants[id] else { return nil }
+        if let remaining = grant.suspendedRemaining {
+            grant.suspendedRemaining = remaining + Self.duration
+        } else {
+            grant.expiresAt.addTimeInterval(Self.duration)
+            grant.monotonicDeadline += Self.duration
+        }
+        grants[id] = grant
+        return grant.snapshot
+    }
+
     public func withActiveLease(
         authorizationGateID: String,
         launcherDesignatedRequirement: String,

--- a/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
@@ -94,9 +94,13 @@ public struct TemporaryAccessGrantSnapshot: Identifiable, Equatable, Sendable {
     public let monotonicDeadline: TimeInterval
     public let useCount: Int
     public let lastUsedAt: Date
+    public let suspendedRemaining: TimeInterval?
+
+    public var isCountdownSuspended: Bool { suspendedRemaining != nil }
 
     public func remaining(wallNow: Date, monotonicNow: TimeInterval) -> TimeInterval {
-        max(0, min(expiresAt.timeIntervalSince(wallNow), monotonicDeadline - monotonicNow))
+        suspendedRemaining
+            ?? max(0, min(expiresAt.timeIntervalSince(wallNow), monotonicDeadline - monotonicNow))
     }
 }
 
@@ -110,10 +114,11 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         let launcherName: String
         let authorizationGateName: String
         let grantedAt: Date
-        let expiresAt: Date
-        let monotonicDeadline: TimeInterval
+        var expiresAt: Date
+        var monotonicDeadline: TimeInterval
         var useCount: Int
         var lastUsedAt: Date
+        var suspendedRemaining: TimeInterval?
 
         var snapshot: TemporaryAccessGrantSnapshot {
             TemporaryAccessGrantSnapshot(
@@ -126,12 +131,23 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
                 expiresAt: expiresAt,
                 monotonicDeadline: monotonicDeadline,
                 useCount: useCount,
-                lastUsedAt: lastUsedAt
+                lastUsedAt: lastUsedAt,
+                suspendedRemaining: suspendedRemaining
             )
         }
 
-        func isActive(wallNow: Date, monotonicNow: TimeInterval) -> Bool {
-            wallNow < expiresAt && monotonicNow < monotonicDeadline
+        func remaining(wallNow: Date, monotonicNow: TimeInterval) -> TimeInterval {
+            suspendedRemaining
+                ?? max(0, min(expiresAt.timeIntervalSince(wallNow), monotonicDeadline - monotonicNow))
+        }
+
+        func isExpired(wallNow: Date, monotonicNow: TimeInterval) -> Bool {
+            suspendedRemaining == nil
+                && (wallNow >= expiresAt || monotonicNow >= monotonicDeadline)
+        }
+
+        func canAuthorize(wallNow: Date, monotonicNow: TimeInterval) -> Bool {
+            suspendedRemaining == nil && !isExpired(wallNow: wallNow, monotonicNow: monotonicNow)
         }
     }
 
@@ -180,7 +196,8 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
             expiresAt: wallNow.addingTimeInterval(Self.duration),
             monotonicDeadline: monotonicNow + Self.duration,
             useCount: 1,
-            lastUsedAt: wallNow
+            lastUsedAt: wallNow,
+            suspendedRemaining: nil
         )
         grants[id] = grant
         return try (grant.snapshot, body(grant.snapshot))
@@ -213,6 +230,34 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         grants.removeAll()
     }
 
+    @discardableResult
+    public func setCountdownSuspended(
+        id: UUID,
+        suspended: Bool,
+        wallNow: Date = Date(),
+        monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> TemporaryAccessGrantSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
+        guard var grant = grants[id] else { return nil }
+        guard grant.suspendedRemaining == nil ? suspended : !suspended else {
+            return grant.snapshot
+        }
+        if suspended {
+            grant.suspendedRemaining = grant.remaining(
+                wallNow: wallNow,
+                monotonicNow: monotonicNow
+            )
+        } else if let remaining = grant.suspendedRemaining {
+            grant.expiresAt = wallNow.addingTimeInterval(remaining)
+            grant.monotonicDeadline = monotonicNow + remaining
+            grant.suspendedRemaining = nil
+        }
+        grants[id] = grant
+        return grant.snapshot
+    }
+
     public func withActiveLease(
         authorizationGateID: String,
         launcherDesignatedRequirement: String,
@@ -234,6 +279,7 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
                 agentTaskContext: agentTaskContext,
                 classification: classification
             )
+                && $0.canAuthorize(wallNow: wallNow, monotonicNow: monotonicNow)
         }) else { return nil }
         if try didUse(grant.snapshot) {
             grant.useCount += 1
@@ -244,6 +290,6 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
     }
 
     private func removeExpired(wallNow: Date, monotonicNow: TimeInterval) {
-        grants = grants.filter { $0.value.isActive(wallNow: wallNow, monotonicNow: monotonicNow) }
+        grants = grants.filter { !$0.value.isExpired(wallNow: wallNow, monotonicNow: monotonicNow) }
     }
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/TemporaryAccessGrant.swift
@@ -161,8 +161,8 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         scope: TemporaryAccessGrantScope,
         launcherName: String,
         authorizationGateName: String,
-        wallNow: Date = Date(),
-        monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime
+        wallNow: Date? = nil,
+        monotonicNow: TimeInterval? = nil
     ) -> TemporaryAccessGrantSnapshot {
         startWithLease(
             scope: scope,
@@ -178,12 +178,14 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         scope: TemporaryAccessGrantScope,
         launcherName: String,
         authorizationGateName: String,
-        wallNow: Date = Date(),
-        monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime,
+        wallNow: Date? = nil,
+        monotonicNow: TimeInterval? = nil,
         _ body: (TemporaryAccessGrantSnapshot) throws -> Result
     ) rethrows -> (TemporaryAccessGrantSnapshot, Result) {
         lock.lock()
         defer { lock.unlock() }
+        let wallNow = wallNow ?? Date()
+        let monotonicNow = monotonicNow ?? ProcessInfo.processInfo.systemUptime
         removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
         let id = grants.values.first(where: { $0.scope == scope })?.id ?? UUID()
         let grant = Grant(
@@ -204,11 +206,13 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
     }
 
     public func snapshots(
-        wallNow: Date = Date(),
-        monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime
+        wallNow: Date? = nil,
+        monotonicNow: TimeInterval? = nil
     ) -> [TemporaryAccessGrantSnapshot] {
         lock.lock()
         defer { lock.unlock() }
+        let wallNow = wallNow ?? Date()
+        let monotonicNow = monotonicNow ?? ProcessInfo.processInfo.systemUptime
         removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
         return grants.values.map(\.snapshot).sorted {
             let left = $0.remaining(wallNow: wallNow, monotonicNow: monotonicNow)
@@ -234,11 +238,13 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
     public func setCountdownSuspended(
         id: UUID,
         suspended: Bool,
-        wallNow: Date = Date(),
-        monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime
+        wallNow: Date? = nil,
+        monotonicNow: TimeInterval? = nil
     ) -> TemporaryAccessGrantSnapshot? {
         lock.lock()
         defer { lock.unlock() }
+        let wallNow = wallNow ?? Date()
+        let monotonicNow = monotonicNow ?? ProcessInfo.processInfo.systemUptime
         removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
         guard var grant = grants[id] else { return nil }
         let wasSuspended = grant.suspendedRemaining != nil
@@ -263,12 +269,14 @@ public final class TemporaryAccessGrantController: @unchecked Sendable {
         launcherRuntimeProtection: LauncherRuntimeProtection,
         agentTaskContext: AgentTaskContext,
         classification: SecretGateRequestClassification,
-        wallNow: Date = Date(),
-        monotonicNow: TimeInterval = ProcessInfo.processInfo.systemUptime,
+        wallNow: Date? = nil,
+        monotonicNow: TimeInterval? = nil,
         _ didUse: (TemporaryAccessGrantSnapshot) throws -> Bool
     ) rethrows -> Bool? {
         lock.lock()
         defer { lock.unlock() }
+        let wallNow = wallNow ?? Date()
+        let monotonicNow = monotonicNow ?? ProcessInfo.processInfo.systemUptime
         removeExpired(wallNow: wallNow, monotonicNow: monotonicNow)
         guard var grant = grants.values.first(where: {
             $0.scope.matches(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
@@ -191,6 +191,55 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
     ) == nil)
 }
 
+@Test func tenMinuteExtensionsPreserveCountdownStateAndCannotReviveExpiry() throws {
+    let controller = TemporaryAccessGrantController()
+    let start = Date(timeIntervalSince1970: 1_000)
+    let grant = controller.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 50
+    )
+
+    let extended = try #require(controller.addTenMinutes(
+        id: grant.id,
+        wallNow: start.addingTimeInterval(100),
+        monotonicNow: 150
+    ))
+    #expect(extended.expiresAt == start.addingTimeInterval(1_200))
+    #expect(extended.monotonicDeadline == 1_250)
+    #expect(extended.remaining(wallNow: start.addingTimeInterval(100), monotonicNow: 150) == 1_100)
+
+    _ = controller.setCountdownSuspended(
+        id: grant.id,
+        suspended: true,
+        wallNow: start.addingTimeInterval(200),
+        monotonicNow: 250
+    )
+    let suspendedExtension = try #require(controller.addTenMinutes(
+        id: grant.id,
+        wallNow: start.addingTimeInterval(10_000),
+        monotonicNow: 10_050
+    ))
+    #expect(suspendedExtension.isCountdownSuspended)
+    #expect(suspendedExtension.suspendedRemaining == 1_600)
+
+    let expiredController = TemporaryAccessGrantController()
+    let expired = expiredController.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 50
+    )
+    #expect(expiredController.addTenMinutes(
+        id: expired.id,
+        wallNow: start.addingTimeInterval(600),
+        monotonicNow: 650
+    ) == nil)
+}
+
 @Test func multipleScopesCoexistAndDuplicateScopeRefreshesInPlace() throws {
     let controller = TemporaryAccessGrantController()
     let start = Date(timeIntervalSince1970: 1_000)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
@@ -127,6 +127,52 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
     ).isEmpty)
 }
 
+@Test func suspendedCountdownPreservesTheLesserClockRemainder() throws {
+    let start = Date(timeIntervalSince1970: 1_000)
+
+    let wallLimited = TemporaryAccessGrantController()
+    let wallGrant = wallLimited.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 50
+    )
+    let wallSuspended = try #require(wallLimited.setCountdownSuspended(
+        id: wallGrant.id,
+        suspended: true,
+        wallNow: start.addingTimeInterval(590),
+        monotonicNow: 150
+    ))
+    #expect(wallSuspended.suspendedRemaining == 10)
+
+    let monotonicLimited = TemporaryAccessGrantController()
+    let monotonicGrant = monotonicLimited.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 50
+    )
+    let monotonicSuspended = try #require(monotonicLimited.setCountdownSuspended(
+        id: monotonicGrant.id,
+        suspended: true,
+        wallNow: start.addingTimeInterval(100),
+        monotonicNow: 640
+    ))
+    #expect(monotonicSuspended.suspendedRemaining == 10)
+
+    let resumedAt = start.addingTimeInterval(10_000)
+    let resumed = try #require(monotonicLimited.setCountdownSuspended(
+        id: monotonicGrant.id,
+        suspended: false,
+        wallNow: resumedAt,
+        monotonicNow: 20_000
+    ))
+    #expect(resumed.expiresAt == resumedAt.addingTimeInterval(10))
+    #expect(resumed.monotonicDeadline == 20_010)
+}
+
 @Test func expiredCountdownCannotBeSuspended() {
     let controller = TemporaryAccessGrantController()
     let start = Date(timeIntervalSince1970: 1_000)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/TemporaryAccessGrantTests.swift
@@ -73,6 +73,78 @@ func malformedMissingOrAmbiguousAgentEnvironmentIsRejected(_ environment: [Strin
     #expect(controller.snapshots(wallNow: start, monotonicNow: 650).isEmpty)
 }
 
+@Test func suspendedCountdownFreezesRemainingTimeAndAuthority() throws {
+    let controller = TemporaryAccessGrantController()
+    let start = Date(timeIntervalSince1970: 1_000)
+    let grant = controller.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 50
+    )
+
+    let suspended = try #require(controller.setCountdownSuspended(
+        id: grant.id,
+        suspended: true,
+        wallNow: start.addingTimeInterval(100),
+        monotonicNow: 150
+    ))
+    #expect(suspended.isCountdownSuspended)
+    #expect(suspended.remaining(wallNow: start.addingTimeInterval(10_000), monotonicNow: 10_050) == 500)
+    #expect(controller.withActiveLease(
+        authorizationGateID: "aws",
+        launcherDesignatedRequirement: "identifier com.example.launcher",
+        launcherRuntimeProtection: .hardened,
+        agentTaskContext: AgentTaskContext(provider: .codex, id: codexID),
+        classification: .mutating,
+        wallNow: start.addingTimeInterval(10_000),
+        monotonicNow: 10_050
+    ) { _ in true } == nil)
+
+    let resumedAt = start.addingTimeInterval(10_000)
+    let resumed = try #require(controller.setCountdownSuspended(
+        id: grant.id,
+        suspended: false,
+        wallNow: resumedAt,
+        monotonicNow: 10_050
+    ))
+    #expect(!resumed.isCountdownSuspended)
+    #expect(resumed.expiresAt == resumedAt.addingTimeInterval(500))
+    #expect(resumed.monotonicDeadline == 10_550)
+    #expect(controller.withActiveLease(
+        authorizationGateID: "aws",
+        launcherDesignatedRequirement: "identifier com.example.launcher",
+        launcherRuntimeProtection: .hardened,
+        agentTaskContext: AgentTaskContext(provider: .codex, id: codexID),
+        classification: .mutating,
+        wallNow: resumedAt,
+        monotonicNow: 10_050
+    ) { _ in true } == true)
+    #expect(controller.snapshots(
+        wallNow: resumedAt.addingTimeInterval(500),
+        monotonicNow: 10_050
+    ).isEmpty)
+}
+
+@Test func expiredCountdownCannotBeSuspended() {
+    let controller = TemporaryAccessGrantController()
+    let start = Date(timeIntervalSince1970: 1_000)
+    let grant = controller.start(
+        scope: scope(),
+        launcherName: "Codex",
+        authorizationGateName: "AWS",
+        wallNow: start,
+        monotonicNow: 50
+    )
+    #expect(controller.setCountdownSuspended(
+        id: grant.id,
+        suspended: true,
+        wallNow: start.addingTimeInterval(600),
+        monotonicNow: 50
+    ) == nil)
+}
+
 @Test func multipleScopesCoexistAndDuplicateScopeRefreshesInPlace() throws {
     let controller = TemporaryAccessGrantController()
     let start = Date(timeIntervalSince1970: 1_000)


### PR DESCRIPTION
## Summary
- add an End-button dropdown with Add 10 Minutes and Pause or Resume Write Access actions
- extend running or paused countdowns without reviving expired grants
- disable grant authority while remaining active time is frozen
- show the enclosing app display name instead of its launcher path
- remove the duplicate dropdown chevron

## Security
Extensions are explicit and retain the same Tool-specific gate, Verified Launcher, runtime posture, and agent task scope. Pausing does not leave Write Access active, adding time to a paused grant does not resume it, and expired grants cannot be revived. Sleep, session, update, app-termination, and explicit-end revocations remain unchanged. ADR 0026 records the boundary change.

## Testing
- swift test --package-path src/menu-helper --disable-automatic-resolution (182 tests)
- AutomicVaultMenubar --self-check-standalone-launchers
- AutomicVaultMenubar --self-check-menu-status
- manually verified a GH local-write grant and Add 10 Minutes using gh repo clone mxcl/AppUpdater