### PR TITLE
Activate blessed capabilities after approval

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2531,7 +2531,7 @@ private func blessedScriptMatches(
     _ script: BlessedScript,
     request: ApprovalRequest,
     approval: ScriptApproval,
-    launcher: LauncherIdentity?
+    launcher: LauncherIdentity
 ) -> Bool {
     request.op == "inject"
         && request.scriptData != nil
@@ -2545,7 +2545,7 @@ private func blessedScriptMatches(
             target: request.target,
             replaceExistingEnv: request.replaceExistingEnv,
             allowMissingKeys: request.allowMissingKeys,
-            launcherRequirement: launcher?.designatedRequirement
+            launcherRequirement: launcher.designatedRequirement
         )
 }
 
@@ -3574,9 +3574,7 @@ private final class ApprovalServer: @unchecked Sendable {
         {
             promptBlessing = BlessedScriptPromptContext(
                 script: script,
-                explanation: script.launchers.isEmpty
-                    ? "Approval activates this stored authority for one execution."
-                    : "The current launcher isn’t endorsed. Approval permits this request once; the blessed capabilities remain inactive."
+                explanation: "Approval activates this stored authority for one execution."
             )
         } else {
             promptBlessing = nil
@@ -3882,10 +3880,9 @@ private final class ApprovalServer: @unchecked Sendable {
                     launcher: promptLauncher,
                     activateAfterRecording: {
                         if let scriptApproval,
-                           let script = self.matchingBlessedScript(
+                           let script = self.matchingBlessedScriptExecution(
                                request: request,
-                               approval: scriptApproval,
-                               launcher: nil
+                               approval: scriptApproval
                            )
                         {
                             self.registerBlessedExecution(script, pid: pid, identity: identity)
@@ -4489,16 +4486,6 @@ private final class ApprovalServer: @unchecked Sendable {
             }
         }
         return nil
-    }
-
-    private func matchingBlessedScript(
-        request: ApprovalRequest,
-        approval: ScriptApproval,
-        launcher: LauncherIdentity?
-    ) -> BlessedScript? {
-        loadBlessedScripts().first {
-            blessedScriptMatches($0, request: request, approval: approval, launcher: launcher)
-        }
     }
 
     private func matchingBlessedScriptExecution(

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -155,7 +155,7 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
         target: String,
         replaceExistingEnv: Bool,
         allowMissingKeys: Bool,
-        launcherRequirement: String?
+        launcherRequirement: String
     ) -> Bool {
         matchesExecution(
             path: path,
@@ -165,9 +165,7 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
             replaceExistingEnv: replaceExistingEnv,
             allowMissingKeys: allowMissingKeys
         )
-            && launcherRequirement.map { requirement in
-                launchers.contains { $0.requirement == requirement }
-            } ?? launchers.isEmpty
+            && launchers.contains { $0.requirement == launcherRequirement }
     }
 
     public init(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -68,7 +68,7 @@ import Testing
     #expect(declaration.manifest.capabilities == ["gh": .readOnly])
 }
 
-@Test func launcherlessBlessingRequiresOneManualApprovalPerExecution() {
+@Test func launcherEndorsementOnlyControlsAutomaticExecution() {
     let requirement = #"identifier "com.apple.Terminal""#
     let script = BlessedScript(
         path: "/tmp/script",
@@ -93,7 +93,11 @@ import Testing
             requirement: requirement
         )]
     )
-    func matches(_ script: BlessedScript, launcherRequirement: String?, checksum: String = "checksum") -> Bool {
+    func automaticallyMatches(
+        _ script: BlessedScript,
+        launcherRequirement: String,
+        checksum: String = "checksum"
+    ) -> Bool {
         script.matchesExecution(
             path: "/tmp/script",
             checksum: checksum,
@@ -104,7 +108,7 @@ import Testing
             launcherRequirement: launcherRequirement
         )
     }
-    func executionMatches(_ script: BlessedScript, checksum: String = "checksum") -> Bool {
+    func approvedExecutionMatches(_ script: BlessedScript, checksum: String = "checksum") -> Bool {
         script.matchesExecution(
             path: "/tmp/script",
             checksum: checksum,
@@ -115,13 +119,15 @@ import Testing
         )
     }
 
-    #expect(executionMatches(endorsedScript))
-    #expect(!executionMatches(endorsedScript, checksum: "changed"))
-    #expect(matches(script, launcherRequirement: nil))
-    #expect(!matches(script, launcherRequirement: requirement))
-    #expect(matches(endorsedScript, launcherRequirement: requirement))
-    #expect(!matches(endorsedScript, launcherRequirement: nil))
-    #expect(!matches(script, launcherRequirement: nil, checksum: "changed"))
+    #expect(approvedExecutionMatches(script))
+    #expect(approvedExecutionMatches(endorsedScript))
+    #expect(!approvedExecutionMatches(endorsedScript, checksum: "changed"))
+    #expect(!automaticallyMatches(script, launcherRequirement: requirement))
+    #expect(automaticallyMatches(endorsedScript, launcherRequirement: requirement))
+    #expect(!automaticallyMatches(
+        endorsedScript,
+        launcherRequirement: #"identifier "com.openai.codex""#
+    ))
 }
 
 @Test func blessingIdentityRequiresPathAndChecksum() {


### PR DESCRIPTION
## Summary
- activate exact Blessed Script authority after one manual Approval regardless of existing Launcher Endorsements
- require a concrete launcher identity for endorsement-based automic authorization
- correct Approval copy and add regression coverage

## Security
- Approval remains bound to the exact script path, checksum, and capability declaration
- Launcher Endorsement only skips the initial Approval; it does not widen post-Approval matching
- capability ceilings are unchanged

## Tests
- swift test --filter launcherEndorsementOnlyControlsAutomaticExecution
- swift test (178 tests)