### PR TITLE
Harden Alibaba Cloud CLI credentials

### DIFF
--- a/docs/adr/0033-alibaba-cloud-external-credential-custody.md
+++ b/docs/adr/0033-alibaba-cloud-external-credential-custody.md
@@ -1,0 +1,34 @@
+# ADR 0033: Apply Alibaba Cloud credentials through its External provider
+
+Status: accepted
+
+## Context
+
+Alibaba Cloud CLI stores AccessKey and STS credentials in
+`~/.aliyun/config.json`. Version 3.3 and later can instead execute an External
+credential provider. The official macOS executable is Developer-ID signed, but
+its enabled runtime exceptions make it ineligible for Secret Application.
+
+## Decision
+
+The Alibaba Cloud Hardener migrates only complete AccessKey and STS profiles to
+profile-bound Secret Values and replaces their inline fields with a fixed
+`/usr/local/bin/av aliyun-credential <profile>` External provider command. The
+Gate accepts a request only from the trusted `av` helper whose live parent is
+the exact configured `aliyun` Target, signed by Automic Vault with Hardened
+Runtime and no enabled runtime exceptions. The requested profile and derived
+Secret Name must match exactly, and the credential JSON is validated again at
+Secret Application.
+
+The Isotope is built from the upstream source tag without a credential patch.
+It exists solely to supply an eligible Target identity and follows ADR 0031's
+Homebrew-first, executable-only fallback policy. OAuth, bearer-token,
+private-key, incomplete, and unknown credential modes fail closed.
+
+## Consequences
+
+Supported credentials are not written back to Alibaba Cloud configuration and
+are disclosed only to a verified live CLI process through its native provider
+protocol. Unsupported profiles remain detectable but cannot be partially
+hardened. Running an upstream configuration command that restores an inline
+secret makes the Detector report the file again.

--- a/src/cli/aliyun_credential.rs
+++ b/src/cli/aliyun_credential.rs
@@ -1,0 +1,190 @@
+use std::ffi::OsString;
+use std::io::Write;
+
+use ring::digest::{SHA256, digest};
+use serde_json::{Map, Value};
+
+use super::inject;
+
+const MAX_PROFILE_BYTES: usize = 128;
+const MAX_VALUE_BYTES: usize = 64 * 1024;
+const SECRET_PREFIX: &str = "ALIYUN_PROFILE_CREDENTIAL_";
+
+pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match run_with_io(&args, stdout) {
+        Ok(()) => 0,
+        Err(error) => {
+            let _ = writeln!(stderr, "aliyun-credential: {error}");
+            1
+        }
+    }
+}
+
+fn run_with_io(args: &[OsString], output: &mut dyn Write) -> Result<(), String> {
+    let [profile] = args else {
+        return Err("usage: av aliyun-credential <profile>".into());
+    };
+    let profile = normalize_profile(
+        profile
+            .to_str()
+            .ok_or_else(|| "Alibaba Cloud profile must be valid UTF-8".to_string())?,
+    )?;
+    crate::secrets::ensure_aliyun_helper_ready()?;
+    let account = secret_name(&profile);
+    let value = match inject::aliyun_credential(account.clone(), profile.clone()) {
+        Ok(value) => parse_credential(&value)?,
+        Err(error) if error == format!("failed to load secret {account}: -25300") => {
+            return Err(format!(
+                "no Alibaba Cloud credential is stored for profile {profile:?}"
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    writeln!(output, "{value}")
+        .map_err(|error| format!("failed to return Alibaba Cloud credential: {error}"))
+}
+
+pub(crate) fn normalize_profile(profile: &str) -> Result<String, String> {
+    if profile.is_empty()
+        || profile.len() > MAX_PROFILE_BYTES
+        || profile.trim() != profile
+        || !profile.is_ascii()
+        || profile.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err("invalid Alibaba Cloud profile name".into());
+    }
+    Ok(profile.to_string())
+}
+
+pub(crate) fn process_command(profile: &str) -> String {
+    format!(
+        "/usr/local/bin/av aliyun-credential '{}'",
+        profile.replace('\'', "'\\''")
+    )
+}
+
+pub(crate) fn secret_name(profile: &str) -> String {
+    let hash = digest(&SHA256, profile.as_bytes());
+    let hex = hash
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<String>();
+    format!("{SECRET_PREFIX}{hex}")
+}
+
+pub(crate) fn credential(
+    mode: &str,
+    access_key_id: &str,
+    access_key_secret: &str,
+    sts_token: Option<&str>,
+) -> Result<String, String> {
+    let mut object = Map::new();
+    object.insert("mode".into(), Value::String(mode.into()));
+    object.insert(
+        "access_key_id".into(),
+        Value::String(validate_value("AccessKey ID", access_key_id)?),
+    );
+    object.insert(
+        "access_key_secret".into(),
+        Value::String(validate_value("AccessKey secret", access_key_secret)?),
+    );
+    match (mode, sts_token) {
+        ("AK", None) => {}
+        ("StsToken", Some(token)) => {
+            object.insert(
+                "sts_token".into(),
+                Value::String(validate_value("STS token", token)?),
+            );
+        }
+        ("AK", Some(_)) => return Err("AK profile must not contain an STS token".into()),
+        ("StsToken", None) => return Err("StsToken profile requires an STS token".into()),
+        _ => return Err("unsupported Alibaba Cloud credential mode".into()),
+    }
+    Ok(Value::Object(object).to_string())
+}
+
+pub(crate) fn parse_credential(input: &str) -> Result<String, String> {
+    if input.len() > MAX_VALUE_BYTES {
+        return Err("Alibaba Cloud credential exceeds 64 KiB".into());
+    }
+    let value: Value = serde_json::from_str(input)
+        .map_err(|error| format!("invalid Alibaba Cloud credential JSON: {error}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Alibaba Cloud credential must be a JSON object".to_string())?;
+    let mode = object
+        .get("mode")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "Alibaba Cloud credential requires string field `mode`".to_string())?;
+    let access_key_id = field(object, "access_key_id")?;
+    let access_key_secret = field(object, "access_key_secret")?;
+    let sts_token = object
+        .get("sts_token")
+        .map(|_| field(object, "sts_token"))
+        .transpose()?;
+    let expected = if mode == "StsToken" { 4 } else { 3 };
+    if object.len() != expected {
+        return Err("Alibaba Cloud credential contains unsupported fields".into());
+    }
+    credential(mode, access_key_id, access_key_secret, sts_token)
+}
+
+fn field<'a>(object: &'a Map<String, Value>, name: &str) -> Result<&'a str, String> {
+    object
+        .get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("Alibaba Cloud credential requires string field `{name}`"))
+}
+
+fn validate_value(label: &str, value: &str) -> Result<String, String> {
+    if value.is_empty()
+        || value.len() > MAX_VALUE_BYTES
+        || value.bytes().any(|byte| matches!(byte, 0 | b'\n' | b'\r'))
+    {
+        return Err(format!(
+            "{label} must be non-empty and contain no NUL or line breaks"
+        ));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn credential_is_profile_bound_and_strict() {
+        assert_ne!(secret_name("prod"), secret_name("dev"));
+        assert_eq!(
+            process_command("team's prod"),
+            "/usr/local/bin/av aliyun-credential 'team'\\''s prod'"
+        );
+        let value = credential("StsToken", "id", "secret", Some("session")).unwrap();
+        assert_eq!(parse_credential(&value).unwrap(), value);
+        assert!(
+            parse_credential(
+                r#"{"mode":"AK","access_key_id":"id","access_key_secret":"secret","future":true}"#
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn helper_reads_only_the_selected_profile_secret() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-aliyun-helper-{}", std::process::id()));
+        let keychain = root.join("keychain");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&keychain).unwrap();
+        let value = credential("AK", "id", "secret", None).unwrap();
+        fs::write(keychain.join(secret_name("prod")), &value).unwrap();
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain) };
+        let mut output = Vec::new();
+        run_with_io(&["prod".into()], &mut output).unwrap();
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR") };
+        assert_eq!(String::from_utf8(output).unwrap(), format!("{value}\n"));
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1575,7 +1575,7 @@ mod tests {
                     assert!(
                         matches!(
                             hardener.name,
-                            "gh" | "goat"
+                            "aliyun-cli" | "gh" | "goat"
                                 | "ordercli"
                                 | "openhue-cli"
                                 | "plumber"

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1575,7 +1575,9 @@ mod tests {
                     assert!(
                         matches!(
                             hardener.name,
-                            "aliyun-cli" | "gh" | "goat"
+                            "aliyun-cli"
+                                | "gh"
+                                | "goat"
                                 | "ordercli"
                                 | "openhue-cli"
                                 | "plumber"

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -44,6 +44,7 @@ struct ApprovalRequest {
     tool: Option<&'static str>,
     docker_server_url: Option<String>,
     terraform_hostname: Option<String>,
+    aliyun_profile: Option<String>,
     oxide_scope: Option<String>,
     goat_scope: Option<String>,
     ordercli_scope: Option<String>,
@@ -358,6 +359,7 @@ fn approval_request(
         tool: None,
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -384,6 +386,7 @@ pub(super) fn docker_credential(key: String, server_url: String) -> Result<Strin
         tool: Some("docker"),
         docker_server_url: Some(server_url),
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -417,6 +420,7 @@ pub(super) fn terraform_credential(key: String, hostname: String) -> Result<Stri
         tool: Some("terraform"),
         docker_server_url: None,
         terraform_hostname: Some(hostname),
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -431,6 +435,40 @@ pub(super) fn terraform_credential(key: String, hostname: String) -> Result<Stri
     xpc_approve_injection(&request)?
         .remove(&key)
         .ok_or_else(|| format!("Automic Vault returned no Terraform credential for {key}"))
+}
+
+pub(super) fn aliyun_credential(key: String, profile: String) -> Result<String, String> {
+    validate_key_name(&key)?;
+    let request = ApprovalRequest {
+        op: "aliyun-get",
+        keys: vec![key.clone()],
+        target: String::new(),
+        args: Vec::new(),
+        cwd: crate::path_security::current_working_directory_utf8()?,
+        replace_existing_env: false,
+        allow_missing_keys: false,
+        env_conflicts: Vec::new(),
+        shebang_script: None,
+        script_data: None,
+        snapshot_incompatible_interpreter: None,
+        tool: Some("aliyun-cli"),
+        docker_server_url: None,
+        terraform_hostname: None,
+        aliyun_profile: Some(profile),
+        oxide_scope: None,
+        goat_scope: None,
+        ordercli_scope: None,
+        openhue_scope: None,
+        uaa_scope: None,
+        railway_scope: None,
+    };
+    if crate::test_keychain_dir().is_some() {
+        return load_test_secret_if_present(&key)?
+            .ok_or_else(|| format!("failed to load secret {key}: -25300"));
+    }
+    xpc_approve_injection(&request)?
+        .remove(&key)
+        .ok_or_else(|| format!("Automic Vault returned no Alibaba Cloud credential for {key}"))
 }
 
 pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, String> {
@@ -450,6 +488,7 @@ pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, Str
         tool: Some("oxide-cli"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: Some(scope),
         goat_scope: None,
         ordercli_scope: None,
@@ -483,6 +522,7 @@ pub(super) fn goat_credential(key: String, scope: String) -> Result<String, Stri
         tool: Some("goat"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: Some(scope),
         ordercli_scope: None,
@@ -516,6 +556,7 @@ pub(super) fn railway_credential(key: String, scope: String) -> Result<String, S
         tool: Some("railway"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -549,6 +590,7 @@ pub(super) fn ordercli_credential(key: String, scope: String) -> Result<String, 
         tool: Some("ordercli"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: Some(scope),
@@ -582,6 +624,7 @@ pub(super) fn uaa_credential(key: String, scope: String) -> Result<String, Strin
         tool: Some("uaa-cli"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -615,6 +658,7 @@ pub(super) fn openhue_credential(key: String, scope: String) -> Result<String, S
         tool: Some("openhue-cli"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -649,6 +693,7 @@ pub(super) fn plumber_credential(key: String, scope: String) -> Result<String, S
         tool: Some("plumber"),
         docker_server_url: None,
         terraform_hostname: None,
+        aliyun_profile: None,
         oxide_scope: None,
         goat_scope: None,
         ordercli_scope: None,
@@ -906,6 +951,7 @@ pub(super) fn approve_gpg_signing(
             tool: Some("gpg-signing"),
             docker_server_url: None,
             terraform_hostname: None,
+            aliyun_profile: None,
             oxide_scope: None,
             goat_scope: None,
             ordercli_scope: None,
@@ -1051,6 +1097,9 @@ fn xpc_approve_request(
         }
         if let Some(hostname) = &request.terraform_hostname {
             set_string(message, b"terraform_hostname\0", hostname)?;
+        }
+        if let Some(profile) = &request.aliyun_profile {
+            set_string(message, b"aliyun_profile\0", profile)?;
         }
         if let Some(scope) = &request.oxide_scope {
             set_string(message, b"oxide_scope\0", scope)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 
+pub(crate) mod aliyun_credential;
 mod aws;
 mod bless;
 pub(crate) mod docker_credential;
@@ -380,6 +381,10 @@ where
                 let result = hardeners::oxide_cli::run(stdout, yes);
                 return finish_hardening(result, "oxide-cli", stdout, stderr);
             }
+            if target == "aliyun" || target == "aliyun-cli" {
+                let result = hardeners::aliyun_cli::run(stdout, yes);
+                return finish_hardening(result, "aliyun-cli", stdout, stderr);
+            }
             if target == "goat" {
                 let result = hardeners::goat::run(stdout, yes);
                 return finish_hardening(result, "goat", stdout, stderr);
@@ -459,6 +464,7 @@ where
         }
         Some("docker-credential") => docker_credential::run(rest, stdout, stderr),
         Some("terraform-credential") => terraform_credential::run(rest, stdout, stderr),
+        Some("aliyun-credential") => aliyun_credential::run(rest, stdout, stderr),
         Some("oxide-credential") => oxide_credential::run(rest, stdout, stderr),
         Some("goat-credential") => goat_credential::run(rest, stdout, stderr),
         Some("ordercli-credential") => ordercli_credential::run(rest, stdout, stderr),

--- a/src/isotopes/detectors/aliyun_cli/detector.md
+++ b/src/isotopes/detectors/aliyun_cli/detector.md
@@ -8,14 +8,12 @@
 
 - `~/.aliyun/config.json`
 
-## Why This is not Yet Hardened
+## Hardening
 
-The retired `aliyun-cli` hardener moved the detected secret to the macOS
-Keychain, then recreated `~/.aliyun/config.json` inside a temporary directory
-for each run. We no longer consider a temporary plaintext file a sufficient
-security boundary, so this detector remains report-only.
+Run `av harden aliyun-cli` to migrate AccessKey and STS profiles into Automic
+Vault custody. The Hardener replaces inline credentials with Alibaba Cloud
+CLI's native External credential provider and installs an eligible Isotope as
+the gated Target.
 
-If a narrow environment-variable or credential-helper interface can cover this
-state without writing the secret back to disk, we can reconsider the hardener.
-
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+OAuth, bearer-token, and private-key profiles remain report-only and are refused
+by the Hardener.

--- a/src/isotopes/detectors/aliyun_cli/mod.rs
+++ b/src/isotopes/detectors/aliyun_cli/mod.rs
@@ -63,6 +63,7 @@ fn sensitive_field_names() -> &'static [&'static str] {
         "access_token",
         "oauth_access_token",
         "oauth_refresh_token",
+        "bearer_token",
     ]
 }
 
@@ -100,6 +101,16 @@ mod tests {
           ]
         }"#;
         assert!(!config_has_sensitive_profile_data(contents).unwrap());
+    }
+
+    #[test]
+    fn detects_bearer_tokens() {
+        assert!(
+            config_has_sensitive_profile_data(
+                r#"{"profiles":[{"name":"default","bearer_token":"secret"}]}"#
+            )
+            .unwrap()
+        );
     }
 }
 

--- a/src/isotopes/hardeners/aliyun_cli.md
+++ b/src/isotopes/hardeners/aliyun_cli.md
@@ -1,0 +1,10 @@
+# Alibaba Cloud CLI
+
+`av harden aliyun-cli` installs the Automic Vault signed, Hardened Runtime
+Alibaba Cloud CLI Isotope and moves AccessKey and STS profile credentials into
+Automic Vault custody. It configures Alibaba Cloud CLI's native External
+credential provider so only the verified live `aliyun` Target can request the
+credential for its exact profile.
+
+OAuth, bearer-token, and private-key profiles are refused until their protocols
+can be represented and validated without weakening the Secret Gate.

--- a/src/isotopes/hardeners/aliyun_cli.rs
+++ b/src/isotopes/hardeners/aliyun_cli.rs
@@ -1,0 +1,538 @@
+use std::collections::BTreeSet;
+use std::fs::{self, OpenOptions};
+use std::io::{self, IsTerminal, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use super::{
+    HardenerCommand, HardenerDetection, HardenerDiagnostic, RequiredExecutable,
+    SecretGateDescriptor, SecretGateRoute,
+};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+const PRIVILEGE_MODE: super::PrivilegeMode = super::PrivilegeMode::Mixed;
+const TEAM_IDENTIFIER: &str = "ZU76A67LGU";
+
+#[derive(Debug, PartialEq, Eq)]
+struct Credential {
+    profile: String,
+    value: String,
+}
+
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
+    let testing = test_config_path().is_some();
+    PRIVILEGE_MODE.require_user("aliyun-cli", testing)?;
+    if !testing {
+        crate::secrets::ensure_aliyun_helper_ready()?;
+    }
+    let path = config_path()?;
+    let original = read_config(&path)?;
+    let (sanitized, credentials, managed) = sanitize_config(&original)?;
+    let existing = crate::secrets::list_global_secret_names()?;
+    if let Some(name) = managed.iter().find(|name| !existing.contains(name)) {
+        return Err(format!(
+            "Alibaba Cloud External profile has no matching Secret Value: {name}"
+        ));
+    }
+    let plan = super::isotope::plan(super::isotope::ALIYUN)?;
+
+    writeln!(stdout, "╭─ harden aliyun-cli").ok();
+    writeln!(stdout, "│").ok();
+    plan.write(stdout, super::isotope::ALIYUN);
+    writeln!(
+        stdout,
+        "├─ migrate {} AccessKey/STS profile{} without printing them",
+        credentials.len(),
+        if credentials.len() == 1 { "" } else { "s" }
+    )
+    .ok();
+    writeln!(
+        stdout,
+        "├─ configure Alibaba Cloud's External credential provider"
+    )
+    .ok();
+    writeln!(stdout, "│").ok();
+    if !confirm(stdout, yes)? {
+        writeln!(stdout, "╰─ cancelled").ok();
+        return Ok(());
+    }
+
+    plan.apply(super::isotope::ALIYUN)?;
+    verify_target(&target())?;
+    if !testing {
+        verify_command_resolution()?;
+    }
+    for credential in &credentials {
+        crate::secrets::store_secret_if_absent_or_equal(
+            &crate::cli::aliyun_credential::secret_name(&credential.profile),
+            &credential.value,
+        )?;
+    }
+    if original != sanitized {
+        write_config(&path, &sanitized)?;
+    }
+    writeln!(stdout, "╰─ hardened aliyun-cli").ok();
+    super::write_secret_gate_notice(stdout, "aliyun-cli");
+    Ok(())
+}
+
+pub(crate) fn detect() -> HardenerDetection {
+    let target = target();
+    let target_valid = verify_target(&target).is_ok();
+    let command_resolves = test_config_path().is_some() || verify_command_resolution().is_ok();
+    let config = config_path().ok();
+    let config_valid = config.as_deref().is_some_and(|path| {
+        read_config(path).is_ok_and(|contents| {
+            sanitize_config(&contents).is_ok_and(|(sanitized, credentials, managed)| {
+                credentials.is_empty() && !managed.is_empty() && sanitized == contents
+            })
+        })
+    });
+    let hardened = target_valid && command_resolves && config_valid;
+    let isotope = super::isotope::detect(super::isotope::ALIYUN)
+        .commands
+        .into_iter()
+        .next()
+        .and_then(|command| command.isotope);
+    let command = HardenerCommand {
+        name: "aliyun".into(),
+        hardened,
+        stub_valid: true,
+        stub_path: None,
+        target_path: target.display().to_string(),
+        required_paths: if test_config_path().is_some() {
+            Vec::new()
+        } else {
+            vec![RequiredExecutable {
+                name: "Automic Vault CLI",
+                path: AV_PATH.into(),
+            }]
+        },
+        stub_requirements: None,
+        injected_keys: Vec::new(),
+        assignment_keys: Vec::new(),
+        isotope,
+    };
+    let mut detection = HardenerDetection::commands(hardened, vec![command]);
+    detection.applicable = config.as_deref().is_some_and(Path::exists) || target.exists();
+    if target.exists() && !target_valid && test_config_path().is_none() {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "aliyun_target_invalid",
+            message: verify_target(&target).unwrap_err(),
+            remediation: "Rerun `av harden aliyun-cli` to install the signed Isotope.".into(),
+            path: Some(target.display().to_string()),
+        });
+    }
+    if let Some(path) = config
+        && path.exists()
+        && read_config(&path)
+            .and_then(|contents| sanitize_config(&contents).map(|_| ()))
+            .is_err()
+    {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "aliyun_config_unsupported",
+            message: "Alibaba Cloud config contains unsupported or malformed credential state"
+                .into(),
+            remediation:
+                "Rerun `av harden aliyun-cli`; unsupported profiles must be resolved manually."
+                    .into(),
+            path: Some(path.display().to_string()),
+        });
+    }
+    detection
+}
+
+pub(crate) fn secret_gate() -> SecretGateDescriptor {
+    SecretGateDescriptor {
+        id: "aliyun-cli",
+        key_patterns: vec!["ALIYUN_PROFILE_CREDENTIAL_*".into()],
+        routes: vec![SecretGateRoute {
+            operation: "aliyun-get",
+            script_path: None,
+            target_path: target().display().to_string(),
+            caller_identifiers: vec!["com.automicvault.av"],
+            key_patterns: vec!["ALIYUN_PROFILE_CREDENTIAL_*".into()],
+            replace_existing_env: false,
+            allow_missing_keys: false,
+        }],
+    }
+}
+
+fn sanitize_config(contents: &str) -> Result<(String, Vec<Credential>, Vec<String>), String> {
+    let mut document: Value = serde_json::from_str(contents)
+        .map_err(|error| format!("invalid Alibaba Cloud config JSON: {error}"))?;
+    let root = document
+        .as_object_mut()
+        .ok_or_else(|| "Alibaba Cloud config must be a JSON object".to_string())?;
+    let profiles = root
+        .get_mut("profiles")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| "Alibaba Cloud config requires a `profiles` array".to_string())?;
+    let mut credentials = Vec::new();
+    let mut managed = Vec::new();
+    let mut names = BTreeSet::new();
+    for value in profiles {
+        let profile = value
+            .as_object_mut()
+            .ok_or_else(|| "Alibaba Cloud profiles must be JSON objects".to_string())?;
+        let name = profile
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "Alibaba Cloud profile requires string field `name`".to_string())?;
+        let name = crate::cli::aliyun_credential::normalize_profile(name)?;
+        if !names.insert(name.clone()) {
+            return Err(format!("duplicate Alibaba Cloud profile {name:?}"));
+        }
+        let mode = profile
+            .get("mode")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("Alibaba Cloud profile {name:?} requires string field `mode`"))?
+            .to_string();
+        for key in [
+            "private_key",
+            "access_token",
+            "oauth_access_token",
+            "oauth_refresh_token",
+            "bearer_token",
+        ] {
+            if nonempty_string(profile.get(key)) {
+                return Err(format!(
+                    "Alibaba Cloud profile {name:?} contains unsupported secret field {key:?}"
+                ));
+            }
+        }
+        let access_key_id = string_field(profile, "access_key_id")?;
+        let access_key_secret = string_field(profile, "access_key_secret")?;
+        let sts_token = string_field(profile, "sts_token")?;
+        let has_credential = [access_key_id, access_key_secret, sts_token]
+            .into_iter()
+            .any(|value| value.is_some_and(|value| !value.is_empty()));
+        if mode == "External" {
+            if has_credential {
+                return Err(format!(
+                    "Alibaba Cloud External profile {name:?} still contains inline credentials"
+                ));
+            }
+            let expected_command = crate::cli::aliyun_credential::process_command(&name);
+            if profile.get("process_command").and_then(Value::as_str)
+                != Some(expected_command.as_str())
+            {
+                return Err(format!(
+                    "Alibaba Cloud profile {name:?} uses a non-Automic External credential provider"
+                ));
+            }
+            managed.push(crate::cli::aliyun_credential::secret_name(&name));
+            continue;
+        }
+        if !matches!(mode.as_str(), "AK" | "StsToken") {
+            if has_credential {
+                return Err(format!(
+                    "Alibaba Cloud profile {name:?} uses unsupported credential mode {mode:?}"
+                ));
+            }
+            continue;
+        }
+        let access_key_id = access_key_id
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| format!("Alibaba Cloud profile {name:?} requires `access_key_id`"))?;
+        let access_key_secret = access_key_secret
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                format!("Alibaba Cloud profile {name:?} requires `access_key_secret`")
+            })?;
+        let sts_token = sts_token.filter(|value| !value.is_empty());
+        let credential = crate::cli::aliyun_credential::credential(
+            &mode,
+            access_key_id,
+            access_key_secret,
+            sts_token,
+        )?;
+        credentials.push(Credential {
+            profile: name.clone(),
+            value: credential,
+        });
+        for key in ["access_key_id", "access_key_secret", "sts_token"] {
+            profile.remove(key);
+        }
+        profile.insert("mode".into(), Value::String("External".into()));
+        profile.insert(
+            "process_command".into(),
+            Value::String(crate::cli::aliyun_credential::process_command(&name)),
+        );
+    }
+    let mut sanitized = serde_json::to_string_pretty(&document)
+        .map_err(|error| format!("failed to serialize Alibaba Cloud config: {error}"))?;
+    sanitized.push('\n');
+    Ok((sanitized, credentials, managed))
+}
+
+fn string_field<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    name: &str,
+) -> Result<Option<&'a str>, String> {
+    match object.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(format!("Alibaba Cloud field {name:?} must be a string")),
+    }
+}
+
+fn nonempty_string(value: Option<&Value>) -> bool {
+    value
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn config_path() -> Result<PathBuf, String> {
+    if let Some(path) = test_config_path() {
+        return Ok(path);
+    }
+    let home = std::env::var_os("HOME").ok_or_else(|| "HOME is not set".to_string())?;
+    Ok(PathBuf::from(home).join(".aliyun/config.json"))
+}
+
+fn test_config_path() -> Option<PathBuf> {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_ALIYUN_CONFIG").map(PathBuf::from)
+}
+
+fn target() -> PathBuf {
+    super::isotope::target(super::isotope::ALIYUN)
+}
+
+fn read_config(path: &Path) -> Result<String, String> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if !file
+        .metadata()
+        .is_ok_and(|metadata| metadata.file_type().is_file() && metadata.len() <= MAX_CONFIG_BYTES)
+    {
+        return Err(format!(
+            "refusing unsafe Alibaba Cloud config {}",
+            path.display()
+        ));
+    }
+    let mut contents = String::new();
+    file.take(MAX_CONFIG_BYTES + 1)
+        .read_to_string(&mut contents)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if contents.len() as u64 > MAX_CONFIG_BYTES {
+        return Err("Alibaba Cloud config exceeds 1 MiB".into());
+    }
+    Ok(contents)
+}
+
+fn write_config(path: &Path, contents: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Alibaba Cloud config has no parent: {}", path.display()))?;
+    let metadata = fs::symlink_metadata(parent)
+        .map_err(|error| format!("failed to inspect {}: {error}", parent.display()))?;
+    if !metadata.file_type().is_dir()
+        || metadata.uid() != super::effective_uid()
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(format!(
+            "refusing unsafe Alibaba Cloud directory {}",
+            parent.display()
+        ));
+    }
+    let staging = parent.join(format!(
+        ".config.json.av-{}.tmp",
+        super::isotope::now_nanos()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&staging)
+            .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+        file.write_all(contents.as_bytes())
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        fs::rename(&staging, path)
+            .map_err(|error| format!("failed to replace {}: {error}", path.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(staging);
+    }
+    result
+}
+
+fn verify_command_resolution() -> Result<(), String> {
+    let output = Command::new("/usr/bin/which")
+        .arg("aliyun")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("failed to resolve aliyun: {error}"))?;
+    let resolved = String::from_utf8(output.stdout)
+        .ok()
+        .filter(|_| output.status.success())
+        .map(|path| PathBuf::from(path.trim()))
+        .and_then(|path| path.canonicalize().ok());
+    if resolved.is_some() && resolved == target().canonicalize().ok() {
+        Ok(())
+    } else {
+        Err(format!(
+            "your PATH does not resolve `aliyun` to {}; unlink competing installations or adjust PATH",
+            target().display()
+        ))
+    }
+}
+
+pub(crate) fn verify_target(path: &Path) -> Result<(), String> {
+    if test_config_path().is_some() {
+        return path
+            .exists()
+            .then_some(())
+            .ok_or_else(|| format!("test Alibaba Cloud Target is missing: {}", path.display()));
+    }
+    if !super::isotope::signature_valid(path, "aliyun") {
+        return Err(format!(
+            "Alibaba Cloud Target signature is invalid: {}",
+            path.display()
+        ));
+    }
+    let output = Command::new("/usr/bin/codesign")
+        .args(["-d", "-vvv"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    let details = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success()
+        || !details.contains("flags=0x10000(runtime)")
+        || !details.contains(&format!("TeamIdentifier={TEAM_IDENTIFIER}"))
+        || !details.contains("Timestamp=")
+    {
+        return Err(
+            "Alibaba Cloud Target lacks the required Developer ID Hardened Runtime identity".into(),
+        );
+    }
+    let entitlements = Command::new("/usr/bin/codesign")
+        .args(["-d", "--entitlements", ":-"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect {} entitlements: {error}", path.display()))?;
+    if !entitlements.status.success() || !entitlements.stdout.is_empty() {
+        return Err("Alibaba Cloud Target has unexpected code-signing entitlements".into());
+    }
+    Ok(())
+}
+
+fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String> {
+    if yes {
+        writeln!(stdout, "◇ Continue? yes (--yes)").ok();
+        return Ok(true);
+    }
+    write!(stdout, "◇ Continue? [y/N] ").ok();
+    stdout
+        .flush()
+        .map_err(|error| format!("failed to flush prompt: {error}"))?;
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .map_err(|error| format!("failed to read confirmation: {error}"))?;
+    if !io::stdin().is_terminal() {
+        writeln!(stdout).ok();
+    }
+    Ok(matches!(
+        input.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_preserves_profile_metadata_and_rejects_unsupported_secrets() {
+        let input = r#"{
+  "current": "prod",
+  "profiles": [{
+    "name": "prod",
+    "mode": "StsToken",
+    "access_key_id": "id",
+    "access_key_secret": "secret",
+    "sts_token": "session",
+    "region_id": "cn-hangzhou"
+  }]
+}"#;
+        let (sanitized, credentials, managed) = sanitize_config(input).unwrap();
+        assert_eq!(credentials.len(), 1);
+        assert!(managed.is_empty());
+        assert!(sanitized.contains(r#""mode": "External""#));
+        assert!(sanitized.contains("aliyun-credential 'prod'"));
+        assert!(sanitized.contains(r#""region_id": "cn-hangzhou""#));
+        assert!(!sanitized.contains("session"));
+        let (_, second, managed) = sanitize_config(&sanitized).unwrap();
+        assert!(second.is_empty());
+        assert_eq!(
+            managed,
+            [crate::cli::aliyun_credential::secret_name("prod")]
+        );
+        assert!(
+            sanitize_config(&input.replace(
+                r#""access_key_secret": "secret","#,
+                r#""access_key_secret": "secret", "oauth_refresh_token": "refresh","#
+            ))
+            .is_err()
+        );
+        assert!(sanitize_config(
+            r#"{"profiles":[{"name":"prod","mode":"External","process_command":"other-helper"}]}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn hardener_migrates_without_installing_in_test_mode() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-aliyun-hardener-{}", std::process::id()));
+        let config = root.join("config.json");
+        let target = root.join("aliyun");
+        let keychain = root.join("keychain");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&target, "target").unwrap();
+        fs::write(
+            &config,
+            r#"{"profiles":[{"name":"prod","mode":"AK","access_key_id":"id","access_key_secret":"secret","region_id":"cn-hangzhou"}]}"#,
+        )
+        .unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ALIYUN_CONFIG", &config);
+            std::env::set_var("AUTOMIC_VAULT_TEST_ALIYUN_TARGET", &target);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        }
+        let mut output = Vec::new();
+        run(&mut output, true).unwrap();
+        assert!(detect().hardened);
+        assert!(!fs::read_to_string(&config).unwrap().contains("secret"));
+        assert!(
+            keychain
+                .join(crate::cli::aliyun_credential::secret_name("prod"))
+                .exists()
+        );
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ALIYUN_CONFIG");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ALIYUN_TARGET");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/isotopes/hardeners/isotope.rs
+++ b/src/isotopes/hardeners/isotope.rs
@@ -105,6 +105,14 @@ pub(crate) const PLUMBER: Spec = Spec {
     binaries: &["plumber"],
     test_path: "AUTOMIC_VAULT_TEST_PLUMBER_TARGET",
 };
+pub(crate) const ALIYUN: Spec = Spec {
+    hardener: "aliyun-cli",
+    formula: "aliyun-cli-isotope",
+    repository: "aliyun-cli",
+    primary: "aliyun",
+    binaries: &["aliyun"],
+    test_path: "AUTOMIC_VAULT_TEST_ALIYUN_TARGET",
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Spec {
@@ -721,6 +729,9 @@ fn installed(spec: Spec, path: &Path) -> bool {
     if spec.hardener == PLUMBER.hardener {
         return super::plumber::verify_target(path).is_ok();
     }
+    if spec.hardener == ALIYUN.hardener {
+        return super::aliyun_cli::verify_target(path).is_ok();
+    }
     true
 }
 
@@ -731,6 +742,7 @@ fn formula_url(spec: Spec) -> String {
 fn spec(hardener: &str) -> Option<Spec> {
     [
         GH, STRIPE, SUPABASE, OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
+        ALIYUN,
     ]
     .into_iter()
     .find(|spec| spec.hardener == hardener)

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod aliyun_cli;
 pub(crate) mod aws_cli;
 pub(crate) mod aws_release;
 pub(crate) mod codex;
@@ -295,6 +296,7 @@ macro_rules! ungated_hardener {
 
 pub(crate) fn metadata() -> Vec<HardenerMetadata> {
     let mut metadata = vec![
+        gated_hardener!(aliyun_cli, "aliyun-cli"),
         gated_hardener!(aws_cli, "aws"),
         ungated_hardener!(codex, "codex"),
         gated_hardener!(docker, "docker"),
@@ -330,6 +332,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
 pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
     let mut gates = vec![
         gpg_signing_gate(),
+        aliyun_cli::secret_gate(),
         aws_cli::secret_gate(),
         docker::secret_gate(),
         goat::secret_gate(),

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -7566,6 +7566,8 @@ private func classifySecretGateRequest(
         return oxideRequestClassification(request.args)
     case "terraform", "opentofu":
         return terraformRequestClassification(request.args)
+    case "aliyun-cli":
+        return aliyunRequestClassification(request.args)
     case "aws":
         if awsRequestMayUseLongLivedCredentials(request) { return .secretDump }
         return awsRequestIsReadOnly(awsCommandWords(request)) ? .readOnly : .mutating
@@ -7753,6 +7755,17 @@ private func terraformRequestClassification(_ args: [String]) -> SecretGateReque
     default:
         return .unknown
     }
+}
+
+private func aliyunRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
+    let words = args.map { $0.lowercased() }
+    if words == ["--version"] || words == ["version"] || words == ["help"] {
+        return .readOnly
+    }
+    if words.starts(with: ["sts", "getcalleridentity"]) {
+        return .readOnly
+    }
+    return .unknown
 }
 
 private func dockerRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
@@ -12673,7 +12686,9 @@ private func runTerraformCredentialSelfCheck() -> Int32 {
 }
 
 private func runAliyunCredentialSelfCheck() -> Int32 {
-    guard normalizeAliyunProfile("prod") == "prod",
+    guard aliyunRequestClassification(["sts", "GetCallerIdentity"]) == .readOnly,
+          aliyunRequestClassification(["ecs", "DescribeInstances"]) == .unknown,
+          normalizeAliyunProfile("prod") == "prod",
           normalizeAliyunProfile(" prod") == nil,
           normalizeAliyunProfile("prod\n") == nil,
           aliyunCredentialSecretName("prod")

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3127,6 +3127,13 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
+        case .aliyunHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
+            let requested = xpc_dictionary_get_uint64(message, "requested_version")
+            guard requested == 1 else {
+                reply(peer, to: message, ok: false, error: "Alibaba Cloud helper protocol upgrade is required")
+                return
+            }
+            reply(peer, to: message, ok: true, error: nil, value: "1")
         case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing):
             handleInject(
                 message,
@@ -3138,7 +3145,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 signing: signing
             )
         case .inject, .keys, .authorize, .dockerGet, .goatGet, .ordercliGet, .openhueGet, .plumberGet, .uaaGet, .railwayGet,
-             .oxideGet, .terraformGet:
+             .oxideGet, .terraformGet, .aliyunGet:
             handleInject(
                 message,
                 on: peer,
@@ -3522,9 +3529,16 @@ private final class ApprovalServer: @unchecked Sendable {
                 helperPath: callerPath,
                 helperSigning: signing
             )
-            let oxideRequest = try oxideCredentialRequest(
+            let aliyunRequest = try aliyunCredentialRequest(
                 from: message,
                 request: helperRequest,
+                helperIdentity: identity,
+                helperPath: callerPath,
+                helperSigning: signing
+            )
+            let oxideRequest = try oxideCredentialRequest(
+                from: message,
+                request: aliyunRequest,
                 helperIdentity: identity,
                 helperPath: callerPath,
                 helperSigning: signing
@@ -6429,8 +6443,77 @@ private final class ApprovalServer: @unchecked Sendable {
         )
     }
 
+    private func aliyunCredentialRequest(
+        from message: xpc_object_t,
+        request: ApprovalRequest,
+        helperIdentity: AVProcessIdentity,
+        helperPath: String,
+        helperSigning: SigningInfo
+    ) throws -> ApprovalRequest {
+        guard request.op == "aliyun-get" else { return request }
+        guard request.tool == "aliyun-cli",
+              isTrustedAvCaller(path: helperPath, signing: helperSigning),
+              request.target.isEmpty,
+              request.args.isEmpty,
+              request.keys.count == 1,
+              !request.replaceExistingEnv,
+              !request.allowMissingKeys,
+              request.envConflicts.isEmpty,
+              request.shebangScript == nil,
+              request.scriptData == nil,
+              let profilePointer = xpc_dictionary_get_string(message, "aliyun_profile")
+        else { throw AppError("invalid Alibaba Cloud credential request") }
+        let profile = String(cString: profilePointer)
+        guard normalizeAliyunProfile(profile) == profile,
+              request.keys == [aliyunCredentialSecretName(profile)]
+        else { throw AppError("Alibaba Cloud Secret Name does not match its profile") }
+        let parent = try aliyunCredentialParent(for: helperIdentity)
+        return ApprovalRequest(
+            op: request.op,
+            keys: request.keys,
+            target: parent.target,
+            args: Array(parent.arguments.dropFirst()),
+            cwd: request.cwd,
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "aliyun-cli",
+            title: "Use Alibaba Cloud credential for profile \(profile)?",
+            detail: "The verified Alibaba Cloud CLI Target will receive the credential in plaintext, as required by the External credential-provider protocol.",
+            credentialScope: profile,
+            credentialParent: parent
+        )
+    }
+
+    private func aliyunCredentialParent(
+        for helperIdentity: AVProcessIdentity
+    ) throws -> CredentialHelperParent {
+        let parentPID = helperIdentity.ppid
+        var parentIdentity = AVProcessIdentity()
+        guard parentPID > 1,
+              av_process_identity(parentPID, &parentIdentity),
+              parentIdentity.euid == helperIdentity.euid,
+              let arguments = processArguments(parentPID),
+              !arguments.isEmpty
+        else { throw AppError("Alibaba Cloud credential helper has no live parent") }
+        let target = pathString(parentIdentity)
+        guard aliyunTargetIdentityValid(pid: parentPID, path: target) else {
+            throw AppError("credential helper parent is not an eligible Alibaba Cloud CLI Target")
+        }
+        return CredentialHelperParent(
+            pid: parentPID,
+            startUsec: parentIdentity.start_usec,
+            euid: parentIdentity.euid,
+            target: target,
+            arguments: arguments
+        )
+    }
+
     private func credentialHelperTool(_ parent: CredentialHelperParent) -> String {
         switch URL(fileURLWithPath: parent.target).lastPathComponent {
+        case "aliyun": "aliyun-cli"
         case "docker": "docker"
         case "goat": "goat"
         case "openhue": "openhue-cli"
@@ -6457,6 +6540,9 @@ private final class ApprovalServer: @unchecked Sendable {
               processArguments(parent.pid) == parent.arguments
         else { return false }
         switch tool {
+        case "aliyun-cli":
+            return credentialHelperTool(parent) == tool
+                && aliyunTargetIdentityValid(pid: parent.pid, path: parent.target)
         case "docker": return dockerTargetIdentityValid(pid: parent.pid, path: parent.target)
         case "goat":
             return credentialHelperTool(parent) == tool
@@ -6491,6 +6577,16 @@ private final class ApprovalServer: @unchecked Sendable {
               let signing = liveSigningInfo(pid: pid), signing.mainExecutable == path
         else { return false }
         return signing.identifier == "goat"
+            && signing.teamIdentifier == "ZU76A67LGU"
+            && signing.isDeveloperID
+            && signing.runtimeProtection.allowsSecretGateAccess
+    }
+
+    private func aliyunTargetIdentityValid(pid: pid_t, path: String) -> Bool {
+        guard configuredSecretGateTarget("aliyun-cli", matches: path),
+              let signing = liveSigningInfo(pid: pid), signing.mainExecutable == path
+        else { return false }
+        return signing.identifier == "aliyun"
             && signing.teamIdentifier == "ZU76A67LGU"
             && signing.isDeveloperID
             && signing.runtimeProtection.allowsSecretGateAccess
@@ -6589,7 +6685,7 @@ private final class ApprovalServer: @unchecked Sendable {
         awsRegistration: AWSRegistrationCandidate?
     ) throws -> AuthorizationFulfillmentTransaction<ApprovedFulfillmentMaterial> {
         let credentialParent: CredentialHelperParent?
-        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get"]
+        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get", "aliyun-get"]
             .contains(request.op)
         {
             guard let scope = request.credentialScope,
@@ -6601,6 +6697,7 @@ private final class ApprovalServer: @unchecked Sendable {
             else { throw AppError("invalid credential-helper request") }
             let expected: String
             switch request.op {
+            case "aliyun-get": expected = aliyunCredentialSecretName(scope)
             case "docker-get": expected = dockerCredentialSecretName(scope)
             case "goat-get":
                 guard let goat = parseGoatCredentialScope(scope) else {
@@ -6676,6 +6773,10 @@ private final class ApprovalServer: @unchecked Sendable {
                       let value = secrets[scope.secretName],
                       parseOxideCredential(value) != nil
                 else { throw AppError("Oxide credential changed before Secret Application") }
+            } else if request.op == "aliyun-get" {
+                guard let value = secrets[aliyunCredentialSecretName(scope)],
+                      parseAliyunCredential(value)
+                else { throw AppError("Alibaba Cloud credential changed before Secret Application") }
             } else {
                 guard let value = secrets[terraformCredentialSecretName(scope)],
                       parseTerraformCredential(value) != nil
@@ -7053,7 +7154,7 @@ private final class ApprovalServer: @unchecked Sendable {
         let op = String(cString: opPointer)
         guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign"
             || op == "docker-get" || op == "goat-get" || op == "ordercli-get" || op == "openhue-get" || op == "plumber-get" || op == "uaa-get" || op == "railway-get"
-            || op == "oxide-get" || op == "terraform-get"
+            || op == "oxide-get" || op == "terraform-get" || op == "aliyun-get"
             || op == "proxy-start"
         else { return nil }
         let scriptData: Data?
@@ -8476,6 +8577,45 @@ private func terraformCredentialSecretName(_ hostname: String) -> String {
     return "TERRAFORM_HOST_CREDENTIAL_\(hash)"
 }
 
+private func normalizeAliyunProfile(_ profile: String) -> String? {
+    guard !profile.isEmpty,
+          profile.utf8.count <= 128,
+          profile.unicodeScalars.allSatisfy({
+              $0.isASCII && !((0...31).contains($0.value) || $0.value == 127)
+          })
+    else { return nil }
+    return profile.trimmingCharacters(in: .whitespacesAndNewlines) == profile ? profile : nil
+}
+
+private func aliyunCredentialSecretName(_ profile: String) -> String {
+    let hash = SHA256.hash(data: Data(profile.utf8)).map { String(format: "%02X", $0) }.joined()
+    return "ALIYUN_PROFILE_CREDENTIAL_\(hash)"
+}
+
+private func parseAliyunCredential(_ value: String) -> Bool {
+    guard value.utf8.count <= 64 * 1024,
+          let data = value.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let mode = object["mode"] as? String,
+          let accessKeyID = object["access_key_id"] as? String,
+          let accessKeySecret = object["access_key_secret"] as? String,
+          validAliyunCredentialValue(accessKeyID),
+          validAliyunCredentialValue(accessKeySecret)
+    else { return false }
+    if mode == "AK" {
+        return Set(object.keys) == Set(["mode", "access_key_id", "access_key_secret"])
+    }
+    guard mode == "StsToken", let token = object["sts_token"] as? String,
+          validAliyunCredentialValue(token)
+    else { return false }
+    return Set(object.keys) == Set(["mode", "access_key_id", "access_key_secret", "sts_token"])
+}
+
+private func validAliyunCredentialValue(_ value: String) -> Bool {
+    !value.isEmpty && value.utf8.count <= 64 * 1024
+        && !value.unicodeScalars.contains(where: { [0, 10, 13].contains($0.value) })
+}
+
 private func parseTerraformCredential(_ value: String) -> String? {
     guard value.utf8.count <= 64 * 1024,
           let data = value.data(using: .utf8),
@@ -9288,7 +9428,7 @@ private extension ApprovalServiceOperation {
         case .openWindow, .awsHelperVersion, .dockerHelperVersion, .goatHelperVersion,
              .ordercliHelperVersion, .openhueHelperVersion, .plumberHelperVersion, .uaaHelperVersion,
              .railwayHelperVersion, .oxideHelperVersion,
-             .terraformHelperVersion: false
+             .terraformHelperVersion, .aliyunHelperVersion: false
         default: true
         }
     }
@@ -12532,6 +12672,25 @@ private func runTerraformCredentialSelfCheck() -> Int32 {
     return 0
 }
 
+private func runAliyunCredentialSelfCheck() -> Int32 {
+    guard normalizeAliyunProfile("prod") == "prod",
+          normalizeAliyunProfile(" prod") == nil,
+          normalizeAliyunProfile("prod\n") == nil,
+          aliyunCredentialSecretName("prod")
+              == "ALIYUN_PROFILE_CREDENTIAL_6754AF9632A2745E85C293E5AAC0863370D9BD3330B9938C00CADFD215227D77",
+          parseAliyunCredential(
+              #"{"mode":"AK","access_key_id":"id","access_key_secret":"secret"}"#
+          ),
+          parseAliyunCredential(
+              #"{"mode":"StsToken","access_key_id":"id","access_key_secret":"secret","sts_token":"token"}"#
+          ),
+          !parseAliyunCredential(
+              #"{"mode":"AK","access_key_id":"id","access_key_secret":"secret","future":true}"#
+          )
+    else { return 1 }
+    return 0
+}
+
 private func runOxideCredentialSelfCheck() -> Int32 {
     let canonical = #"{"host":"https://oxide.example","profile":"prod"}"#
     guard oxideRequestClassification(["auth", "status"]) == .readOnly,
@@ -13633,6 +13792,10 @@ if CommandLine.arguments.contains("--self-check-docker-credentials") {
 
 if CommandLine.arguments.contains("--self-check-terraform-credentials") {
     exit(runTerraformCredentialSelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-aliyun-credentials") {
+    exit(runAliyunCredentialSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-oxide-credentials") {

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -9,6 +9,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case railwayHelperVersion = "railway-helper-version"
     case oxideHelperVersion = "oxide-helper-version"
     case terraformHelperVersion = "terraform-helper-version"
+    case aliyunHelperVersion = "aliyun-helper-version"
     case inject
     case varlock
     case keys
@@ -25,6 +26,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case railwayGet = "railway-get"
     case oxideGet = "oxide-get"
     case terraformGet = "terraform-get"
+    case aliyunGet = "aliyun-get"
     case dockerSave = "docker-save"
     case dockerDelete = "docker-delete"
     case goatSave = "goat-save"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -17,6 +17,11 @@ import Testing
     #expect(ApprovalServiceOperation.terraformGet.rawValue == "terraform-get")
 }
 
+@Test func aliyunCredentialGetHasADedicatedWireOperation() {
+    #expect(ApprovalServiceOperation.aliyunHelperVersion.rawValue == "aliyun-helper-version")
+    #expect(ApprovalServiceOperation.aliyunGet.rawValue == "aliyun-get")
+}
+
 @Test func oxideCredentialsHaveDedicatedWireOperations() {
     #expect(ApprovalServiceOperation.oxideGet.rawValue == "oxide-get")
     #expect(ApprovalServiceOperation.oxideSave.rawValue == "oxide-save")

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
+const ALIYUN_HELPER_PROTOCOL_VERSION: u64 = 1;
 const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 2;
 const OXIDE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const GOAT_HELPER_PROTOCOL_VERSION: u64 = 1;
@@ -14,6 +15,33 @@ const UAA_HELPER_PROTOCOL_VERSION: u64 = 1;
 struct XpcReply {
     value: Option<String>,
     names: Vec<String>,
+}
+
+pub(crate) fn ensure_aliyun_helper_ready() -> Result<(), String> {
+    if crate::test_keychain_dir().is_some() {
+        return Ok(());
+    }
+    let reply = xpc_request(
+        "aliyun-helper-version",
+        None,
+        None,
+        None,
+        Some((b"requested_version\0", ALIYUN_HELPER_PROTOCOL_VERSION)),
+    )
+    .map_err(|error| {
+        format!(
+            "Alibaba Cloud credential-helper protocol negotiation failed; update and open the Automic Vault app: {error}"
+        )
+    })?;
+    match reply.value.as_deref() {
+        Some("1") => Ok(()),
+        Some(version) => Err(format!(
+            "the running Automic Vault app reported unsupported Alibaba Cloud helper version {version}"
+        )),
+        None => {
+            Err("the running Automic Vault app returned no Alibaba Cloud helper version".into())
+        }
+    }
 }
 
 pub(crate) fn store_secret(account: &str, value: &str) -> Result<(), String> {


### PR DESCRIPTION
Part of #186.

## Summary
- migrate complete Alibaba Cloud AccessKey and STS profiles into profile-bound Secret Values
- configure the native External credential provider and bind each read to the verified live `aliyun` Target
- install the clean AV-signed Alibaba CLI Isotope through the Homebrew-first/direct-fallback policy
- reject OAuth, bearer-token, private-key, competing External-provider, incomplete, and unknown secret state
- add Detector/Doctor coverage and ADR 0033

## Release
- https://github.com/automic-vault/aliyun-cli/releases/tag/v3.4.11
- https://github.com/automic-vault/homebrew-isotopes/blob/main/Formula/aliyun-cli-isotope.rb

## Verification
- `cargo test --locked --lib -- --test-threads=1` (931 passed)
- `swift test` in `src/menu-helper` (197 passed)
- Alibaba helper protocol tests with pinned Go 1.23.8
- release digest, archive shape, Developer ID identity, Hardened Runtime, timestamp, and empty entitlement set verified