### PR TITLE
Add WakaTime CLI isotope hardener

### DIFF
--- a/docs/adr/0033-wakatime-credential-custody.md
+++ b/docs/adr/0033-wakatime-credential-custody.md
@@ -1,0 +1,29 @@
+# ADR 0033: WakaTime Credential Custody
+
+## Decision
+
+WakaTime's global API key is a Global Value applied only through the
+`wakatime-cli` Authorization Gate. The Target must be the Automic Vault Isotope,
+signed by the Automic Vault team with Hardened Runtime and no entitlements. The
+Isotope invokes `/usr/local/bin/av wakatime-credential` directly and accepts the
+key only for `https://api.wakatime.com/api/v1` with ordinary TLS verification,
+no proxy, and no alternate key source.
+
+The hardener configures WakaTime's native credential-helper setting and points
+the editor-plugin executable path at that verified Target. It rejects project
+keys, per-project API routes, imported credential config, alternate API URLs,
+proxies, custom certificate files, and disabled TLS verification.
+
+## Context
+
+The upstream helper command is executed through a shell and receives no
+destination context. WakaTime also loads per-project `.wakatime` configuration
+after launch. A Gate around the unmodified binary therefore cannot prove the
+effective destination and credential sources at Secret Application time.
+
+## Consequences
+
+The source patch and live Target verification close that gap. Unsupported
+configurations fail closed instead of receiving the Global Value. Editor plugin
+updaters may replace the managed link; Doctor will then report that the tool is
+no longer in Hardened State and the replacement binary cannot use the Gate.

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1584,6 +1584,7 @@ mod tests {
                                 | "oxide-cli"
                                 | "stripe"
                                 | "supabase"
+                                | "wakatime-cli"
                         ),
                         "{}:{} needs explicit target-only Doctor coverage review",
                         hardener.name,

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -50,6 +50,7 @@ struct ApprovalRequest {
     openhue_scope: Option<String>,
     uaa_scope: Option<String>,
     railway_scope: Option<String>,
+    wakatime_api_url: Option<String>,
 }
 
 unsafe extern "C" {
@@ -364,6 +365,7 @@ fn approval_request(
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     })
 }
 
@@ -390,6 +392,7 @@ pub(super) fn docker_credential(key: String, server_url: String) -> Result<Strin
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -423,6 +426,7 @@ pub(super) fn terraform_credential(key: String, hostname: String) -> Result<Stri
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -431,6 +435,40 @@ pub(super) fn terraform_credential(key: String, hostname: String) -> Result<Stri
     xpc_approve_injection(&request)?
         .remove(&key)
         .ok_or_else(|| format!("Automic Vault returned no Terraform credential for {key}"))
+}
+
+pub(super) fn wakatime_credential(key: String, api_url: String) -> Result<String, String> {
+    validate_key_name(&key)?;
+    let request = ApprovalRequest {
+        op: "wakatime-get",
+        keys: vec![key.clone()],
+        target: String::new(),
+        args: Vec::new(),
+        cwd: crate::path_security::current_working_directory_utf8()?,
+        replace_existing_env: false,
+        allow_missing_keys: false,
+        env_conflicts: Vec::new(),
+        shebang_script: None,
+        script_data: None,
+        snapshot_incompatible_interpreter: None,
+        tool: Some("wakatime-cli"),
+        docker_server_url: None,
+        terraform_hostname: None,
+        oxide_scope: None,
+        goat_scope: None,
+        ordercli_scope: None,
+        openhue_scope: None,
+        uaa_scope: None,
+        railway_scope: None,
+        wakatime_api_url: Some(api_url),
+    };
+    if crate::test_keychain_dir().is_some() {
+        return load_test_secret_if_present(&key)?
+            .ok_or_else(|| format!("failed to load secret {key}: -25300"));
+    }
+    xpc_approve_injection(&request)?
+        .remove(&key)
+        .ok_or_else(|| format!("Automic Vault returned no WakaTime credential for {key}"))
 }
 
 pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, String> {
@@ -456,6 +494,7 @@ pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, Str
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -489,6 +528,7 @@ pub(super) fn goat_credential(key: String, scope: String) -> Result<String, Stri
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -522,6 +562,7 @@ pub(super) fn railway_credential(key: String, scope: String) -> Result<String, S
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: Some(scope),
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -555,6 +596,7 @@ pub(super) fn ordercli_credential(key: String, scope: String) -> Result<String, 
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -588,6 +630,7 @@ pub(super) fn uaa_credential(key: String, scope: String) -> Result<String, Strin
         openhue_scope: None,
         uaa_scope: Some(scope),
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -621,6 +664,7 @@ pub(super) fn openhue_credential(key: String, scope: String) -> Result<String, S
         openhue_scope: Some(scope),
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -655,6 +699,7 @@ pub(super) fn plumber_credential(key: String, scope: String) -> Result<String, S
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
         return load_test_secret_if_present(&key)?
@@ -912,6 +957,7 @@ pub(super) fn approve_gpg_signing(
             openhue_scope: None,
             uaa_scope: None,
             railway_scope: None,
+            wakatime_api_url: None,
         },
         response_keys,
     )
@@ -1069,6 +1115,9 @@ fn xpc_approve_request(
         }
         if let Some(scope) = &request.railway_scope {
             set_string(message, b"railway_scope\0", scope)?;
+        }
+        if let Some(api_url) = &request.wakatime_api_url {
+            set_string(message, b"wakatime_api_url\0", api_url)?;
         }
         xpc_dictionary_set_bool(
             message,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,6 +23,7 @@ mod scan;
 mod shell_secrets;
 pub(crate) mod terraform_credential;
 pub(crate) mod uaa_credential;
+pub(crate) mod wakatime_credential;
 
 use crate::isotopes::hardeners;
 
@@ -53,7 +54,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 38;
+pub(crate) const INSTALL_REVISION: u32 = 39;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -404,6 +405,10 @@ where
                 let result = hardeners::plumber::run(stdout, yes);
                 return finish_hardening(result, "plumber", stdout, stderr);
             }
+            if target == "wakatime" || target == "wakatime-cli" {
+                let result = hardeners::wakatime_cli::run(stdout, yes);
+                return finish_hardening(result, "wakatime-cli", stdout, stderr);
+            }
             if target == "gh" || target == "gh-cli" {
                 let result = hardeners::gh_cli::run(stdout, yes);
                 return finish_hardening(result, "gh", stdout, stderr);
@@ -466,6 +471,7 @@ where
         Some("plumber-credential") => plumber_credential::run(rest, stdout, stderr),
         Some("uaa-credential") => uaa_credential::run(rest, stdout, stderr),
         Some("railway-credential") => railway_credential::run(rest, stdout, stderr),
+        Some("wakatime-credential") => wakatime_credential::run(rest, stdout, stderr),
         Some("list" | "ls") => list::run(rest, stdout, stderr),
         Some("bless") => bless::run(rest, stderr),
         Some("open") => {

--- a/src/cli/wakatime_credential.rs
+++ b/src/cli/wakatime_credential.rs
@@ -1,0 +1,67 @@
+use std::ffi::OsString;
+use std::io::Write;
+
+use super::inject;
+
+pub(crate) const API_URL: &str = "https://api.wakatime.com/api/v1";
+pub(crate) const SECRET_NAME: &str = "WAKATIME_API_KEY";
+
+pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match run_inner(&args, stdout) {
+        Ok(()) => 0,
+        Err(error) => {
+            let _ = writeln!(stderr, "wakatime-credential: {error}");
+            1
+        }
+    }
+}
+
+fn run_inner(args: &[OsString], stdout: &mut dyn Write) -> Result<(), String> {
+    let [version, api_url] = args else {
+        return Err("usage: av wakatime-credential 1 https://api.wakatime.com/api/v1".into());
+    };
+    if version != "1" || api_url != API_URL {
+        return Err("unsupported WakaTime credential request".into());
+    }
+    crate::secrets::ensure_wakatime_helper_ready()?;
+    let key = inject::wakatime_credential(SECRET_NAME.into(), API_URL.into())?;
+    validate_api_key(&key)?;
+    writeln!(stdout, "{key}").map_err(|error| format!("failed to return WakaTime API key: {error}"))
+}
+
+pub(crate) fn validate_api_key(value: &str) -> Result<(), String> {
+    let key = value.strip_prefix("waka_").unwrap_or(value);
+    let bytes = key.as_bytes();
+    let hyphens = [8, 13, 18, 23];
+    if bytes.len() != 36
+        || bytes[14] != b'4'
+        || !matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+        || bytes.iter().enumerate().any(|(index, byte)| {
+            if hyphens.contains(&index) {
+                *byte != b'-'
+            } else {
+                !byte.is_ascii_hexdigit() || byte.is_ascii_uppercase()
+            }
+        })
+    {
+        return Err("invalid WakaTime API key".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_wakatime_v4_api_keys() {
+        let valid = ["waka_01234567", "89ab", "4cde", "8fab", "0123456789ab"].join("-");
+        let bare = ["01234567", "89ab", "4cde", "bfab", "0123456789ab"].join("-");
+        let wrong_version = ["01234567", "89ab", "3cde", "8fab", "0123456789ab"].join("-");
+        let uppercase = ["01234567", "89AB", "4cde", "8fab", "0123456789ab"].join("-");
+        assert!(validate_api_key(&valid).is_ok());
+        assert!(validate_api_key(&bare).is_ok());
+        assert!(validate_api_key(&wrong_version).is_err());
+        assert!(validate_api_key(&uppercase).is_err());
+    }
+}

--- a/src/isotopes/detectors/wakatime_cli/detector.md
+++ b/src/isotopes/detectors/wakatime_cli/detector.md
@@ -8,14 +8,11 @@
 
 - `~/.wakatime.cfg`
 
-## Why This is not Yet Hardened
+## Remediation
 
-The retired `wakatime-cli` hardener moved the detected secret to the macOS
-Keychain, then recreated `~/.wakatime.cfg` inside a temporary directory for each
-run. We no longer consider a temporary plaintext file a sufficient security
-boundary, so this detector remains report-only.
+Run `av harden wakatime-cli`. The hardener installs the signed WakaTime CLI
+Isotope, stores the global API key in Automic Vault, configures the native
+credential helper, and points editor plugins at the verified Target.
 
-If a narrow environment-variable or credential-helper interface can cover this
-state without writing the secret back to disk, we can reconsider the hardener.
-
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+Project-specific API keys and alternate credential destinations are rejected;
+remove them manually before hardening.

--- a/src/isotopes/detectors/wakatime_cli/mod.rs
+++ b/src/isotopes/detectors/wakatime_cli/mod.rs
@@ -18,7 +18,9 @@ pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
 }
 
 fn wakatime_config_path() -> Result<PathBuf, String> {
-    let home = std::env::var_os("HOME")
+    let home = std::env::var_os("WAKATIME_HOME")
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var_os("HOME"))
         .map(PathBuf::from)
         .ok_or_else(|| "HOME is not set".to_string())?;
     Ok(home.join(".wakatime.cfg"))
@@ -63,7 +65,7 @@ fn line_has_secret(line: &str, section: &str) -> bool {
         return false;
     }
 
-    key == "api_key"
+    matches!(key.as_str(), "api_key" | "apikey" | "key")
         || (section == "project_api_key" && !key.is_empty())
         || (section == "api_urls"
             && value
@@ -85,6 +87,7 @@ mod tests {
         assert!(config_contains_api_key(
             "[api_urls]\n^/work = https://example.invalid/api/v1|fake-work-key\n"
         ));
+        assert!(config_contains_api_key("[settings]\napikey = fake-key\n"));
     }
 
     #[test]
@@ -106,8 +109,10 @@ mod tests {
         std::fs::create_dir_all(&home).unwrap();
 
         let previous_home = std::env::var_os("HOME");
+        let previous_wakatime_home = std::env::var_os("WAKATIME_HOME");
         unsafe {
             std::env::set_var("HOME", &home);
+            std::env::remove_var("WAKATIME_HOME");
         }
 
         let result = install_is_insecure().unwrap();
@@ -116,6 +121,10 @@ mod tests {
             match previous_home {
                 Some(value) => std::env::set_var("HOME", value),
                 None => std::env::remove_var("HOME"),
+            }
+            match previous_wakatime_home {
+                Some(value) => std::env::set_var("WAKATIME_HOME", value),
+                None => std::env::remove_var("WAKATIME_HOME"),
             }
         }
 
@@ -129,10 +138,22 @@ mod tests {
         let home =
             std::env::temp_dir().join(format!("wakatime-detect-home-{}", std::process::id()));
         let previous_home = std::env::var_os("HOME");
+        let previous_wakatime_home = std::env::var_os("WAKATIME_HOME");
         unsafe {
             std::env::set_var("HOME", &home);
+            std::env::remove_var("WAKATIME_HOME");
         }
         assert_eq!(wakatime_config_path().unwrap(), home.join(".wakatime.cfg"));
+        unsafe {
+            std::env::set_var("WAKATIME_HOME", home.join("custom"));
+        }
+        assert_eq!(
+            wakatime_config_path().unwrap(),
+            home.join("custom/.wakatime.cfg")
+        );
+        unsafe {
+            std::env::remove_var("WAKATIME_HOME");
+        }
         unsafe {
             std::env::remove_var("HOME");
         }
@@ -141,6 +162,10 @@ mod tests {
             match previous_home {
                 Some(value) => std::env::set_var("HOME", value),
                 None => std::env::remove_var("HOME"),
+            }
+            match previous_wakatime_home {
+                Some(value) => std::env::set_var("WAKATIME_HOME", value),
+                None => std::env::remove_var("WAKATIME_HOME"),
             }
         }
 
@@ -158,8 +183,10 @@ mod tests {
         let config = home.join(".wakatime.cfg");
         fs::write(&config, "[settings]\napi_key = fake-key\n").unwrap();
         let previous_home = std::env::var_os("HOME");
+        let previous_wakatime_home = std::env::var_os("WAKATIME_HOME");
         unsafe {
             std::env::set_var("HOME", &home);
+            std::env::remove_var("WAKATIME_HOME");
         }
 
         let reasons = install_insecurity_reasons().unwrap();
@@ -168,6 +195,10 @@ mod tests {
             match previous_home {
                 Some(value) => std::env::set_var("HOME", value),
                 None => std::env::remove_var("HOME"),
+            }
+            match previous_wakatime_home {
+                Some(value) => std::env::set_var("WAKATIME_HOME", value),
+                None => std::env::remove_var("WAKATIME_HOME"),
             }
         }
 

--- a/src/isotopes/hardeners/isotope.rs
+++ b/src/isotopes/hardeners/isotope.rs
@@ -105,6 +105,14 @@ pub(crate) const PLUMBER: Spec = Spec {
     binaries: &["plumber"],
     test_path: "AUTOMIC_VAULT_TEST_PLUMBER_TARGET",
 };
+pub(crate) const WAKATIME: Spec = Spec {
+    hardener: "wakatime-cli",
+    formula: "wakatime-cli-isotope",
+    repository: "wakatime-cli",
+    primary: "wakatime-cli",
+    binaries: &["wakatime-cli"],
+    test_path: "AUTOMIC_VAULT_TEST_WAKATIME_TARGET",
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Spec {
@@ -331,6 +339,9 @@ pub(crate) fn install_privileged(
         }
         if spec.hardener == PLUMBER.hardener {
             super::plumber::verify_target(&stage)?;
+        }
+        if spec.hardener == WAKATIME.hardener {
+            super::wakatime_cli::verify_target(&stage)?;
         }
         staged.push((stage, bin_dir.join(binary)));
     }
@@ -721,6 +732,9 @@ fn installed(spec: Spec, path: &Path) -> bool {
     if spec.hardener == PLUMBER.hardener {
         return super::plumber::verify_target(path).is_ok();
     }
+    if spec.hardener == WAKATIME.hardener {
+        return super::wakatime_cli::verify_target(path).is_ok();
+    }
     true
 }
 
@@ -731,6 +745,7 @@ fn formula_url(spec: Spec) -> String {
 fn spec(hardener: &str) -> Option<Spec> {
     [
         GH, STRIPE, SUPABASE, OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
+        WAKATIME,
     ]
     .into_iter()
     .find(|spec| spec.hardener == hardener)
@@ -838,7 +853,7 @@ mod tests {
     #[test]
     fn every_executable_isotope_is_registered_for_direct_fallback() {
         for expected in [
-            OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
+            OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER, WAKATIME,
         ] {
             assert_eq!(
                 spec(expected.hardener).map(|value| value.hardener),
@@ -858,6 +873,7 @@ mod tests {
             (UAA, "uaa-cli-isotope", "uaa-cli"),
             (OPENHUE, "openhue-cli-isotope", "openhue-cli"),
             (PLUMBER, "plumber-isotope", "plumber"),
+            (WAKATIME, "wakatime-cli-isotope", "wakatime-cli"),
         ] {
             assert_eq!(isotope.formula, formula);
             assert_eq!(isotope.repository, repository);
@@ -876,6 +892,7 @@ mod tests {
         }
         for isotope in [
             GH, STRIPE, SUPABASE, OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
+            WAKATIME,
         ] {
             let missing =
                 std::env::temp_dir().join(format!("av-test-missing-{}-isotope", isotope.hardener));

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod supabase;
 pub(crate) mod terraform;
 pub(crate) mod terraform_release;
 pub(crate) mod uaa_cli;
+pub(crate) mod wakatime_cli;
 
 unsafe extern "C" {
     fn geteuid() -> u32;
@@ -310,6 +311,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
         gated_hardener!(stripe_cli, "stripe"),
         ungated_hardener!(sudo, "sudo"),
         gated_hardener!(supabase, "supabase"),
+        gated_hardener!(wakatime_cli, "wakatime-cli"),
         HardenerMetadata {
             name: "terraform",
             documentation: include_str!("terraform.md"),
@@ -343,6 +345,7 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
         gh_cli::secret_gate(),
         stripe_cli::secret_gate(),
         supabase::secret_gate(),
+        wakatime_cli::secret_gate(),
         terraform::secret_gate(terraform::Tool::Terraform),
         terraform::secret_gate(terraform::Tool::OpenTofu),
     ];

--- a/src/isotopes/hardeners/wakatime_cli.md
+++ b/src/isotopes/hardeners/wakatime_cli.md
@@ -1,0 +1,10 @@
+# WakaTime CLI
+
+The hardener installs the signed WakaTime CLI Isotope, migrates the global API
+key into Automic Vault, and configures WakaTime's native credential helper.
+Editor plugins are pointed at the verified Target without storing the key in a
+file.
+
+The Isotope accepts the global key only for WakaTime's official API endpoint.
+Project-specific keys, alternate API URLs, proxies, custom certificate files,
+and disabled TLS verification must be removed before hardening.

--- a/src/isotopes/hardeners/wakatime_cli.rs
+++ b/src/isotopes/hardeners/wakatime_cli.rs
@@ -1,0 +1,608 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, IsTerminal, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt, symlink};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use super::{
+    HardenerCommand, HardenerDetection, HardenerDiagnostic, RequiredExecutable,
+    SecretGateDescriptor, SecretGateRoute,
+};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const HELPER: &str = "/usr/local/bin/av wakatime-credential";
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+const TEAM_IDENTIFIER: &str = "ZU76A67LGU";
+
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
+    let testing = test_config_path().is_some();
+    super::PrivilegeMode::Mixed.require_user("wakatime-cli", testing)?;
+    if std::env::var_os("WAKATIME_API_KEY").is_some_and(|value| !value.is_empty()) {
+        return Err("unset WAKATIME_API_KEY before hardening WakaTime CLI".into());
+    }
+    if !testing {
+        crate::secrets::ensure_wakatime_helper_ready()?;
+    }
+    let config_path = config_path()?;
+    let original = read_config(&config_path)?;
+    let (sanitized, api_key) = sanitize_config(&original)?;
+    let target = target();
+    let command_path = plugin_command_path()?;
+    let plan = super::isotope::plan(super::isotope::WAKATIME)?;
+
+    writeln!(stdout, "╭─ harden wakatime-cli").ok();
+    writeln!(stdout, "│").ok();
+    plan.write(stdout, super::isotope::WAKATIME);
+    writeln!(
+        stdout,
+        "├─ point {} at the verified Target",
+        command_path.display()
+    )
+    .ok();
+    if api_key.is_some() {
+        writeln!(
+            stdout,
+            "├─ migrate the global WakaTime API key without printing it"
+        )
+        .ok();
+    }
+    writeln!(
+        stdout,
+        "├─ restrict credential use to WakaTime's official API endpoint"
+    )
+    .ok();
+    writeln!(stdout, "│").ok();
+    if !confirm(stdout, yes)? {
+        writeln!(stdout, "╰─ cancelled").ok();
+        return Ok(());
+    }
+
+    plan.apply(super::isotope::WAKATIME)?;
+    verify_target(&target)?;
+    if let Some(api_key) = api_key {
+        crate::secrets::store_secret_if_absent_or_equal(
+            crate::cli::wakatime_credential::SECRET_NAME,
+            &api_key,
+        )?;
+    }
+    install_plugin_link(&command_path, &target)?;
+    if original != sanitized {
+        write_config(&config_path, &sanitized)?;
+    }
+    writeln!(stdout, "╰─ hardened wakatime-cli").ok();
+    super::write_secret_gate_notice(stdout, "wakatime-cli");
+    Ok(())
+}
+
+pub(crate) fn detect() -> HardenerDetection {
+    let testing = test_config_path().is_some();
+    let target = target();
+    let target_valid = verify_target(&target).is_ok();
+    let command = plugin_command_path().ok();
+    let command_valid = command
+        .as_deref()
+        .is_some_and(|path| plugin_link_valid(path, &target));
+    let config = config_path().ok();
+    let config_valid = config.as_deref().is_some_and(|path| {
+        read_config(path).is_ok_and(|contents| {
+            sanitize_config(&contents).is_ok_and(|(sanitized, key)| {
+                key.is_none() && sanitized == contents && helper_configured(&contents)
+            })
+        })
+    });
+    let hardened = target_valid && command_valid && config_valid;
+    let isotope = super::isotope::detect(super::isotope::WAKATIME)
+        .commands
+        .into_iter()
+        .next()
+        .and_then(|command| command.isotope);
+    let hardener_command = HardenerCommand {
+        name: "wakatime-cli".into(),
+        hardened,
+        stub_valid: true,
+        stub_path: None,
+        target_path: target.display().to_string(),
+        required_paths: if testing {
+            Vec::new()
+        } else {
+            vec![RequiredExecutable {
+                name: "Automic Vault CLI",
+                path: AV_PATH.into(),
+            }]
+        },
+        stub_requirements: None,
+        injected_keys: Vec::new(),
+        assignment_keys: Vec::new(),
+        isotope,
+    };
+    let mut detection = HardenerDetection::commands(hardened, vec![hardener_command]);
+    detection.applicable = config.as_deref().is_some_and(Path::exists)
+        || command.as_deref().is_some_and(Path::exists)
+        || target.exists();
+    if target.exists() && !target_valid && !testing {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "wakatime_target_invalid",
+            message: verify_target(&target).unwrap_err(),
+            remediation:
+                "Rerun `av harden wakatime-cli` to install the signed WakaTime CLI Isotope.".into(),
+            path: Some(target.display().to_string()),
+        });
+    }
+    if target_valid && !command_valid {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "wakatime_plugin_command_invalid",
+            message: "the WakaTime editor-plugin command does not resolve to the verified Target."
+                .into(),
+            remediation: "Rerun `av harden wakatime-cli`.".into(),
+            path: command.map(|path| path.display().to_string()),
+        });
+    }
+    if config.as_deref().is_some_and(Path::exists) && !config_valid {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "wakatime_plaintext_or_unsupported_config",
+            message: "WakaTime configuration is not in the supported Hardened State.".into(),
+            remediation: "Rerun `av harden wakatime-cli`; unsupported credential routes must be removed manually."
+                .into(),
+            path: config.map(|path| path.display().to_string()),
+        });
+    }
+    detection
+}
+
+pub(crate) fn secret_gate() -> SecretGateDescriptor {
+    SecretGateDescriptor {
+        id: "wakatime-cli",
+        key_patterns: vec![crate::cli::wakatime_credential::SECRET_NAME.into()],
+        routes: vec![SecretGateRoute {
+            operation: "wakatime-get",
+            script_path: None,
+            target_path: target().display().to_string(),
+            caller_identifiers: vec!["com.automicvault.av"],
+            key_patterns: vec![crate::cli::wakatime_credential::SECRET_NAME.into()],
+            replace_existing_env: false,
+            allow_missing_keys: false,
+        }],
+    }
+}
+
+fn sanitize_config(contents: &str) -> Result<(String, Option<String>), String> {
+    let mut section = String::new();
+    let mut output = Vec::new();
+    let mut key = None;
+    let mut helper_seen = false;
+    let mut settings_seen = false;
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if let Some(name) = trimmed
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+        {
+            if section == "settings" && !helper_seen {
+                output.push(format!("api_key_vault_cmd = {HELPER}"));
+                helper_seen = true;
+            }
+            section = name.trim().to_ascii_lowercase();
+            settings_seen |= section == "settings";
+            output.push(line.to_string());
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            output.push(line.to_string());
+            continue;
+        }
+        let Some((raw_name, raw_value)) = line.split_once('=') else {
+            return Err("invalid WakaTime config line".into());
+        };
+        let name = raw_name.trim().to_ascii_lowercase().replace('-', "_");
+        let value = raw_value.trim().trim_matches(['\'', '"']);
+        if section == "project_api_key" && !value.is_empty() {
+            return Err("project-specific WakaTime API keys are not supported".into());
+        }
+        if section == "api_urls" && !value.is_empty() {
+            return Err("per-project WakaTime API routes are not supported".into());
+        }
+        if section.is_empty() || section == "settings" {
+            match name.as_str() {
+                "api_key" | "apikey" | "key" => {
+                    if !value.is_empty() {
+                        crate::cli::wakatime_credential::validate_api_key(value)?;
+                        if key.replace(value.to_string()).is_some() {
+                            return Err("multiple WakaTime API keys are configured".into());
+                        }
+                    }
+                    continue;
+                }
+                "api_key_vault_cmd" => {
+                    if helper_seen || !value.is_empty() && value != HELPER {
+                        return Err("WakaTime uses a competing credential helper".into());
+                    }
+                    if section != "settings" {
+                        return Err("WakaTime credential helper must be in [settings]".into());
+                    }
+                    output.push(format!("api_key_vault_cmd = {HELPER}"));
+                    helper_seen = true;
+                    continue;
+                }
+                "api_url" | "apiurl"
+                    if !value.is_empty()
+                        && value.trim_end_matches('/')
+                            != crate::cli::wakatime_credential::API_URL =>
+                {
+                    return Err("WakaTime alternate API URLs are not supported".into());
+                }
+                "proxy" | "https_proxy" | "ssl_certs_file" | "import_cfg" if !value.is_empty() => {
+                    return Err(format!(
+                        "WakaTime `{name}` is not supported by this hardener"
+                    ));
+                }
+                "no_ssl_verify"
+                    if matches!(
+                        value.to_ascii_lowercase().as_str(),
+                        "true" | "yes" | "1" | "on"
+                    ) =>
+                {
+                    return Err("WakaTime TLS verification cannot be disabled".into());
+                }
+                _ => {}
+            }
+        }
+        output.push(line.to_string());
+    }
+    if !helper_seen {
+        if !contents.is_empty() && !contents.ends_with('\n') {
+            output.push(String::new());
+        }
+        if !settings_seen {
+            output.push("[settings]".into());
+        }
+        output.push(format!("api_key_vault_cmd = {HELPER}"));
+    }
+    let mut sanitized = output.join("\n");
+    if contents.ends_with('\n') || contents.is_empty() {
+        sanitized.push('\n');
+    }
+    Ok((sanitized, key))
+}
+
+fn helper_configured(contents: &str) -> bool {
+    contents
+        .lines()
+        .any(|line| line.trim() == format!("api_key_vault_cmd = {HELPER}"))
+}
+
+fn waka_home() -> Result<(PathBuf, bool), String> {
+    if let Some(value) = std::env::var_os("WAKATIME_HOME").filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(value);
+        let path = if let Ok(rest) = path.strip_prefix("~") {
+            home()?.join(rest)
+        } else {
+            path
+        };
+        if !path.is_absolute() {
+            return Err("WAKATIME_HOME must resolve to an absolute path".into());
+        }
+        return Ok((path, true));
+    }
+    Ok((home()?, false))
+}
+
+fn home() -> Result<PathBuf, String> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is not set".into())
+}
+
+fn config_path() -> Result<PathBuf, String> {
+    test_config_path().map_or_else(
+        || waka_home().map(|(home, _)| home.join(".wakatime.cfg")),
+        Ok,
+    )
+}
+
+fn plugin_command_path() -> Result<PathBuf, String> {
+    if let Some(path) = crate::test_env_var("AUTOMIC_VAULT_TEST_WAKATIME_COMMAND") {
+        return Ok(path.into());
+    }
+    let (home, custom) = waka_home()?;
+    Ok(if custom {
+        home.join("wakatime-cli")
+    } else {
+        home.join(".wakatime/wakatime-cli")
+    })
+}
+
+fn test_config_path() -> Option<PathBuf> {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_WAKATIME_CONFIG").map(PathBuf::from)
+}
+
+fn target() -> PathBuf {
+    super::isotope::target(super::isotope::WAKATIME)
+}
+
+fn read_config(path: &Path) -> Result<String, String> {
+    let file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(error) => return Err(format!("failed to read {}: {error}", path.display())),
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    if !metadata.file_type().is_file()
+        || metadata.len() > MAX_CONFIG_BYTES
+        || metadata.uid() != super::effective_uid()
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(format!(
+            "refusing unsafe WakaTime config {}",
+            path.display()
+        ));
+    }
+    let mut contents = String::new();
+    file.take(MAX_CONFIG_BYTES + 1)
+        .read_to_string(&mut contents)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if contents.len() as u64 > MAX_CONFIG_BYTES {
+        return Err("WakaTime config exceeds 1 MiB".into());
+    }
+    Ok(contents)
+}
+
+fn write_config(path: &Path, contents: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "WakaTime config has no parent".to_string())?;
+    secure_directory(parent)?;
+    let staging = parent.join(format!(
+        ".wakatime.cfg.av-{}.tmp",
+        super::isotope::now_nanos()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&staging)
+            .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+        file.write_all(contents.as_bytes())
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        fs::rename(&staging, path)
+            .map_err(|error| format!("failed to replace {}: {error}", path.display()))?;
+        OpenOptions::new()
+            .read(true)
+            .open(parent)
+            .and_then(|dir| dir.sync_all())
+            .map_err(|error| format!("failed to sync {}: {error}", parent.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(staging);
+    }
+    result
+}
+
+fn secure_directory(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent()
+        && !parent.exists()
+    {
+        secure_directory(parent)?;
+    }
+    match fs::symlink_metadata(path) {
+        Ok(metadata)
+            if metadata.file_type().is_dir()
+                && metadata.uid() == super::effective_uid()
+                && metadata.permissions().mode() & 0o022 == 0 =>
+        {
+            Ok(())
+        }
+        Ok(_) => Err(format!(
+            "refusing unsafe WakaTime directory {}",
+            path.display()
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            fs::create_dir(path)
+                .map_err(|error| format!("failed to create {}: {error}", path.display()))?;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+                .map_err(|error| format!("failed to protect {}: {error}", path.display()))
+        }
+        Err(error) => Err(format!("failed to inspect {}: {error}", path.display())),
+    }
+}
+
+fn plugin_link_valid(path: &Path, target: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+        && path.canonicalize().ok() == target.canonicalize().ok()
+}
+
+fn install_plugin_link(path: &Path, target: &Path) -> Result<(), String> {
+    if plugin_link_valid(path, target) {
+        return Ok(());
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| "WakaTime command has no parent".to_string())?;
+    secure_directory(parent)?;
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(format!("failed to inspect {}: {error}", path.display())),
+    };
+    if let Some(metadata) = &metadata
+        && !metadata.file_type().is_symlink()
+        && !(metadata.file_type().is_file() && metadata.uid() == super::effective_uid())
+    {
+        return Err(format!(
+            "refusing unsafe WakaTime command {}",
+            path.display()
+        ));
+    }
+    let staging = parent.join(format!(
+        ".wakatime-cli.av-{}.tmp",
+        super::isotope::now_nanos()
+    ));
+    symlink(target, &staging)
+        .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+    let mut backup_path = None;
+    if let Some(metadata) = metadata {
+        if metadata.file_type().is_file() {
+            let backup = path.with_extension("av-backup");
+            if backup.exists() {
+                let _ = fs::remove_file(&staging);
+                return Err(format!(
+                    "refusing to overwrite existing backup {}",
+                    backup.display()
+                ));
+            }
+            if let Err(error) = fs::rename(path, &backup) {
+                let _ = fs::remove_file(&staging);
+                return Err(format!("failed to back up {}: {error}", path.display()));
+            }
+            backup_path = Some(backup);
+        }
+    }
+    if let Err(error) = fs::rename(&staging, path) {
+        let _ = fs::remove_file(&staging);
+        if let Some(backup) = backup_path
+            && let Err(rollback) = fs::rename(&backup, path)
+        {
+            return Err(format!(
+                "failed to install {}: {error}; failed to restore {}: {rollback}",
+                path.display(),
+                backup.display()
+            ));
+        }
+        return Err(format!("failed to install {}: {error}", path.display()));
+    }
+    Ok(())
+}
+
+pub(crate) fn verify_target(path: &Path) -> Result<(), String> {
+    if test_config_path().is_some() {
+        return path
+            .exists()
+            .then_some(())
+            .ok_or_else(|| format!("test WakaTime Target is missing: {}", path.display()));
+    }
+    let requirement = format!(
+        "=identifier \"wakatime-cli\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{TEAM_IDENTIFIER}\""
+    );
+    let status = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--strict", "-R", &requirement])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to verify {}: {error}", path.display()))?;
+    if !status.success() {
+        return Err(format!(
+            "WakaTime Target signature is invalid: {}",
+            path.display()
+        ));
+    }
+    let output = Command::new("/usr/bin/codesign")
+        .args(["-d", "-vvv"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    let details = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success()
+        || !details.contains("flags=0x10000(runtime)")
+        || !details.contains(&format!("TeamIdentifier={TEAM_IDENTIFIER}"))
+        || !details.contains("Timestamp=")
+    {
+        return Err(
+            "WakaTime Target lacks the required Developer ID Hardened Runtime identity".into(),
+        );
+    }
+    let entitlements = Command::new("/usr/bin/codesign")
+        .args(["-d", "--entitlements", ":-"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect WakaTime entitlements: {error}"))?;
+    if !entitlements.status.success() || !entitlements.stdout.is_empty() {
+        return Err("WakaTime Target has unexpected code-signing entitlements".into());
+    }
+    Ok(())
+}
+
+fn confirm(stdout: &mut dyn Write, yes: bool) -> Result<bool, String> {
+    if yes {
+        writeln!(stdout, "◇ Continue? yes (--yes)").ok();
+        return Ok(true);
+    }
+    write!(stdout, "◇ Continue? [y/N] ").ok();
+    stdout
+        .flush()
+        .map_err(|error| format!("failed to flush prompt: {error}"))?;
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .map_err(|error| format!("failed to read confirmation: {error}"))?;
+    if !io::stdin().is_terminal() {
+        writeln!(stdout).ok();
+    }
+    Ok(matches!(
+        input.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrates_only_the_supported_global_key() {
+        let api_key = ["waka_01234567", "89ab", "4cde", "8fab", "0123456789ab"].join("-");
+        let input = format!("[settings]\napi_key = {api_key}\ndebug = true\n");
+        let (sanitized, key) = sanitize_config(&input).unwrap();
+        assert_eq!(key.as_deref(), Some(api_key.as_str()));
+        assert_eq!(
+            sanitized,
+            format!("[settings]\ndebug = true\napi_key_vault_cmd = {HELPER}\n")
+        );
+        assert_eq!(sanitize_config(&sanitized).unwrap(), (sanitized, None));
+        assert!(sanitize_config("[settings]\napi_url = https://example.com\n").is_err());
+        assert!(sanitize_config(&format!("[project_api_key]\n/work = {api_key}\n")).is_err());
+        assert!(sanitize_config("[settings]\nproxy = https://user:pass@example.com\n").is_err());
+    }
+
+    #[test]
+    fn editor_plugin_binary_is_backed_up_and_replaced_by_a_target_link() {
+        let directory = std::env::temp_dir().join(format!(
+            "av-wakatime-link-{}-{}",
+            std::process::id(),
+            super::super::isotope::now_nanos()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let target = directory.join("target");
+        let command = directory.join("wakatime-cli");
+        fs::write(&target, "target").unwrap();
+        fs::write(&command, "upstream").unwrap();
+
+        install_plugin_link(&command, &target).unwrap();
+
+        assert!(plugin_link_valid(&command, &target));
+        assert_eq!(
+            fs::read_to_string(command.with_extension("av-backup")).unwrap(),
+            "upstream"
+        );
+        install_plugin_link(&command, &target).unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3127,6 +3127,13 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
+        case .wakatimeHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
+            let requested = xpc_dictionary_get_uint64(message, "requested_version")
+            guard requested == 1 else {
+                reply(peer, to: message, ok: false, error: "WakaTime helper protocol upgrade is required")
+                return
+            }
+            reply(peer, to: message, ok: true, error: nil, value: "1")
         case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing):
             handleInject(
                 message,
@@ -3138,7 +3145,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 signing: signing
             )
         case .inject, .keys, .authorize, .dockerGet, .goatGet, .ordercliGet, .openhueGet, .plumberGet, .uaaGet, .railwayGet,
-             .oxideGet, .terraformGet:
+             .oxideGet, .terraformGet, .wakatimeGet:
             handleInject(
                 message,
                 on: peer,
@@ -3529,15 +3536,22 @@ private final class ApprovalServer: @unchecked Sendable {
                 helperPath: callerPath,
                 helperSigning: signing
             )
-            let conflicts = Set(oxideRequest.envConflicts)
-            let selectionNames = oxideRequest.keys.filter {
-                oxideRequest.replaceExistingEnv || !conflicts.contains($0)
+            let wakatimeRequest = try wakatimeCredentialRequest(
+                from: message,
+                request: oxideRequest,
+                helperIdentity: identity,
+                helperPath: callerPath,
+                helperSigning: signing
+            )
+            let conflicts = Set(wakatimeRequest.envConflicts)
+            let selectionNames = wakatimeRequest.keys.filter {
+                wakatimeRequest.replaceExistingEnv || !conflicts.contains($0)
             }
             let selected = try secretValueCustody.bind(
                 names: selectionNames,
-                cwd: oxideRequest.cwd
+                cwd: wakatimeRequest.cwd
             )
-            request = approvalRequestWithCredentialContext(oxideRequest.selecting(selected))
+            request = approvalRequestWithCredentialContext(wakatimeRequest.selecting(selected))
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
             return
@@ -6405,6 +6419,71 @@ private final class ApprovalServer: @unchecked Sendable {
         )
     }
 
+    private func wakatimeCredentialRequest(
+        from message: xpc_object_t,
+        request: ApprovalRequest,
+        helperIdentity: AVProcessIdentity,
+        helperPath: String,
+        helperSigning: SigningInfo
+    ) throws -> ApprovalRequest {
+        guard request.op == "wakatime-get" else { return request }
+        guard request.tool == "wakatime-cli",
+              isTrustedAvCaller(path: helperPath, signing: helperSigning),
+              request.target.isEmpty,
+              request.args.isEmpty,
+              request.keys == [wakatimeCredentialSecretName],
+              !request.replaceExistingEnv,
+              !request.allowMissingKeys,
+              request.envConflicts.isEmpty,
+              request.shebangScript == nil,
+              request.scriptData == nil,
+              let urlPointer = xpc_dictionary_get_string(message, "wakatime_api_url"),
+              String(cString: urlPointer) == wakatimeOfficialAPIURL
+        else { throw AppError("invalid WakaTime credential request") }
+        let parent = try wakatimeCredentialParent(for: helperIdentity)
+        return ApprovalRequest(
+            op: request.op,
+            keys: request.keys,
+            target: parent.target,
+            args: Array(parent.arguments.dropFirst()),
+            cwd: request.cwd,
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "wakatime-cli",
+            title: "Use the WakaTime API key?",
+            detail: "The verified WakaTime Target will receive the global API key for WakaTime's official API endpoint.",
+            credentialScope: wakatimeOfficialAPIURL,
+            credentialParent: parent
+        )
+    }
+
+    private func wakatimeCredentialParent(
+        for helperIdentity: AVProcessIdentity
+    ) throws -> CredentialHelperParent {
+        let parentPID = helperIdentity.ppid
+        var parentIdentity = AVProcessIdentity()
+        guard parentPID > 1,
+              av_process_identity(parentPID, &parentIdentity),
+              parentIdentity.euid == helperIdentity.euid,
+              let arguments = processArguments(parentPID),
+              !arguments.isEmpty
+        else { throw AppError("WakaTime credential helper has no live parent") }
+        let target = pathString(parentIdentity)
+        guard wakatimeTargetIdentityValid(pid: parentPID, path: target) else {
+            throw AppError("credential helper parent is not an eligible WakaTime Target")
+        }
+        return CredentialHelperParent(
+            pid: parentPID,
+            startUsec: parentIdentity.start_usec,
+            euid: parentIdentity.euid,
+            target: target,
+            arguments: arguments
+        )
+    }
+
     private func terraformCredentialParent(
         for helperIdentity: AVProcessIdentity
     ) throws -> CredentialHelperParent {
@@ -6441,6 +6520,7 @@ private final class ApprovalServer: @unchecked Sendable {
         case "tofu": "opentofu"
         case "terraform": "terraform"
         case "uaa": "uaa-cli"
+        case "wakatime-cli": "wakatime-cli"
         default: ""
         }
     }
@@ -6482,6 +6562,9 @@ private final class ApprovalServer: @unchecked Sendable {
         case "terraform", "opentofu":
             return credentialHelperTool(parent) == tool
                 && terraformTargetIdentityValid(pid: parent.pid, path: parent.target)
+        case "wakatime-cli":
+            return credentialHelperTool(parent) == tool
+                && wakatimeTargetIdentityValid(pid: parent.pid, path: parent.target)
         default: return false
         }
     }
@@ -6578,6 +6661,18 @@ private final class ApprovalServer: @unchecked Sendable {
             && signing.runtimeProtection.allowsSecretGateAccess
     }
 
+    private func wakatimeTargetIdentityValid(pid: pid_t, path: String) -> Bool {
+        guard configuredSecretGateTarget("wakatime-cli", matches: path),
+              let signing = liveSigningInfo(pid: pid),
+              signing.mainExecutable == path
+        else { return false }
+        return signing.identifier == "wakatime-cli"
+            && signing.teamIdentifier == "ZU76A67LGU"
+            && signing.isDeveloperID
+            && signing.runtimeProtection == .hardened
+            && liveProcessHasNoEntitlements(pid: pid)
+    }
+
     private func configuredSecretGateTarget(_ gateID: String, matches path: String) -> Bool {
         secretGateDescriptors.first(where: { $0.id == gateID })?.routes.contains {
             normalizedExecutablePath($0.targetPath) == normalizedExecutablePath(path)
@@ -6589,7 +6684,7 @@ private final class ApprovalServer: @unchecked Sendable {
         awsRegistration: AWSRegistrationCandidate?
     ) throws -> AuthorizationFulfillmentTransaction<ApprovedFulfillmentMaterial> {
         let credentialParent: CredentialHelperParent?
-        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get"]
+        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get", "wakatime-get"]
             .contains(request.op)
         {
             guard let scope = request.credentialScope,
@@ -6621,6 +6716,11 @@ private final class ApprovalServer: @unchecked Sendable {
                     throw AppError("Oxide credential scope changed before Secret Application")
                 }
                 expected = oxide.secretName
+            case "wakatime-get":
+                guard scope == wakatimeOfficialAPIURL else {
+                    throw AppError("WakaTime API endpoint changed before Secret Application")
+                }
+                expected = wakatimeCredentialSecretName
             default: expected = terraformCredentialSecretName(scope)
             }
             guard request.keys == [expected] else {
@@ -6676,6 +6776,11 @@ private final class ApprovalServer: @unchecked Sendable {
                       let value = secrets[scope.secretName],
                       parseOxideCredential(value) != nil
                 else { throw AppError("Oxide credential changed before Secret Application") }
+            } else if request.op == "wakatime-get" {
+                guard scope == wakatimeOfficialAPIURL,
+                      let value = secrets[wakatimeCredentialSecretName],
+                      validWakaTimeAPIKey(value)
+                else { throw AppError("WakaTime credential changed before Secret Application") }
             } else {
                 guard let value = secrets[terraformCredentialSecretName(scope)],
                       parseTerraformCredential(value) != nil
@@ -7053,7 +7158,7 @@ private final class ApprovalServer: @unchecked Sendable {
         let op = String(cString: opPointer)
         guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign"
             || op == "docker-get" || op == "goat-get" || op == "ordercli-get" || op == "openhue-get" || op == "plumber-get" || op == "uaa-get" || op == "railway-get"
-            || op == "oxide-get" || op == "terraform-get"
+            || op == "oxide-get" || op == "terraform-get" || op == "wakatime-get"
             || op == "proxy-start"
         else { return nil }
         let scriptData: Data?
@@ -7465,6 +7570,8 @@ private func classifySecretGateRequest(
         return oxideRequestClassification(request.args)
     case "terraform", "opentofu":
         return terraformRequestClassification(request.args)
+    case "wakatime-cli":
+        return wakatimeRequestClassification(request.args)
     case "aws":
         if awsRequestMayUseLongLivedCredentials(request) { return .secretDump }
         return awsRequestIsReadOnly(awsCommandWords(request)) ? .readOnly : .mutating
@@ -7476,6 +7583,24 @@ private func classifySecretGateRequest(
             arguments: secretGateCommandWords(request)
         )
     }
+}
+
+private func wakatimeRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
+    let words = args.map { $0.lowercased() }
+    if words.contains(where: {
+        $0 == "--entity" || $0.hasPrefix("--entity=") || $0 == "--extra-heartbeats"
+            || $0 == "--sync-offline-activity" || $0.hasPrefix("--sync-offline-activity=")
+            || $0 == "--sync-ai-activity" || $0 == "--sync-ai-heartbeats"
+    }) {
+        return .mutating
+    }
+    if words.contains(where: {
+        $0 == "--today" || $0 == "--file-experts" || $0 == "--today-goal"
+            || $0.hasPrefix("--today-goal=")
+    }) {
+        return .readOnly
+    }
+    return .unknown
 }
 
 private func goatRequestClassification(_ args: [String]) -> SecretGateRequestClassification {
@@ -8486,6 +8611,23 @@ private func parseTerraformCredential(_ value: String) -> String? {
           !token.unicodeScalars.contains(where: { $0.value == 0 })
     else { return nil }
     return token
+}
+
+private let wakatimeCredentialSecretName = "WAKATIME_API_KEY"
+private let wakatimeOfficialAPIURL = "https://api.wakatime.com/api/v1"
+
+private func validWakaTimeAPIKey(_ value: String) -> Bool {
+    let key = value.hasPrefix("waka_") ? String(value.dropFirst(5)) : value
+    let bytes = Array(key.utf8)
+    let hyphens = Set([8, 13, 18, 23])
+    guard bytes.count == 36, bytes[14] == 52, [56, 57, 97, 98].contains(bytes[19]) else {
+        return false
+    }
+    return bytes.enumerated().allSatisfy { index, byte in
+        hyphens.contains(index)
+            ? byte == 45
+            : (48...57).contains(byte) || (97...102).contains(byte)
+    }
 }
 
 private func isGhTokenKey(_ key: String) -> Bool {
@@ -12532,6 +12674,22 @@ private func runTerraformCredentialSelfCheck() -> Int32 {
     return 0
 }
 
+private func runWakaTimeCredentialSelfCheck() -> Int32 {
+    let valid = ["waka_01234567", "89ab", "4cde", "8fab", "0123456789ab"].joined(separator: "-")
+    let bare = ["01234567", "89ab", "4cde", "bfab", "0123456789ab"].joined(separator: "-")
+    let wrongVersion = ["01234567", "89ab", "3cde", "8fab", "0123456789ab"].joined(separator: "-")
+    guard wakatimeRequestClassification(["--today"]) == .readOnly,
+          wakatimeRequestClassification(["--today-goal=123"]) == .readOnly,
+          wakatimeRequestClassification(["--entity", "/tmp/main.rs"]) == .mutating,
+          wakatimeRequestClassification(["--sync-offline-activity=100"]) == .mutating,
+          wakatimeRequestClassification(["--future-operation"]) == .unknown,
+          validWakaTimeAPIKey(valid),
+          validWakaTimeAPIKey(bare),
+          !validWakaTimeAPIKey(wrongVersion)
+    else { return 1 }
+    return 0
+}
+
 private func runOxideCredentialSelfCheck() -> Int32 {
     let canonical = #"{"host":"https://oxide.example","profile":"prod"}"#
     guard oxideRequestClassification(["auth", "status"]) == .readOnly,
@@ -13633,6 +13791,10 @@ if CommandLine.arguments.contains("--self-check-docker-credentials") {
 
 if CommandLine.arguments.contains("--self-check-terraform-credentials") {
     exit(runTerraformCredentialSelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-wakatime-credentials") {
+    exit(runWakaTimeCredentialSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-oxide-credentials") {

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -9,6 +9,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case railwayHelperVersion = "railway-helper-version"
     case oxideHelperVersion = "oxide-helper-version"
     case terraformHelperVersion = "terraform-helper-version"
+    case wakatimeHelperVersion = "wakatime-helper-version"
     case inject
     case varlock
     case keys
@@ -25,6 +26,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case railwayGet = "railway-get"
     case oxideGet = "oxide-get"
     case terraformGet = "terraform-get"
+    case wakatimeGet = "wakatime-get"
     case dockerSave = "docker-save"
     case dockerDelete = "docker-delete"
     case goatSave = "goat-save"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -25,6 +25,8 @@ import Testing
 
 @Test func goatCredentialsHaveDedicatedWireOperations() {
     #expect(ApprovalServiceOperation.goatGet.rawValue == "goat-get")
+    #expect(ApprovalServiceOperation.wakatimeHelperVersion.rawValue == "wakatime-helper-version")
+    #expect(ApprovalServiceOperation.wakatimeGet.rawValue == "wakatime-get")
     #expect(ApprovalServiceOperation.goatSave.rawValue == "goat-save")
     #expect(ApprovalServiceOperation.goatDelete.rawValue == "goat-delete")
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -10,6 +10,7 @@ const PLUMBER_HELPER_PROTOCOL_VERSION: u64 = 1;
 const RAILWAY_HELPER_PROTOCOL_VERSION: u64 = 1;
 const TERRAFORM_HELPER_PROTOCOL_VERSION: u64 = 1;
 const UAA_HELPER_PROTOCOL_VERSION: u64 = 1;
+const WAKATIME_HELPER_PROTOCOL_VERSION: u64 = 1;
 
 struct XpcReply {
     value: Option<String>,
@@ -236,6 +237,31 @@ pub(crate) fn ensure_terraform_helper_ready() -> Result<(), String> {
             "the running Automic Vault app reported unsupported Terraform helper version {version}"
         )),
         None => Err("the running Automic Vault app returned no Terraform helper version".into()),
+    }
+}
+
+pub(crate) fn ensure_wakatime_helper_ready() -> Result<(), String> {
+    if crate::test_keychain_dir().is_some() {
+        return Ok(());
+    }
+    let reply = xpc_request(
+        "wakatime-helper-version",
+        None,
+        None,
+        None,
+        Some((b"requested_version\0", WAKATIME_HELPER_PROTOCOL_VERSION)),
+    )
+    .map_err(|error| {
+        format!(
+            "WakaTime credential-helper protocol negotiation failed; update and open the Automic Vault app: {error}"
+        )
+    })?;
+    match reply.value.as_deref() {
+        Some("1") => Ok(()),
+        Some(version) => Err(format!(
+            "the running Automic Vault app reported unsupported WakaTime helper version {version}"
+        )),
+        None => Err("the running Automic Vault app returned no WakaTime helper version".into()),
     }
 }
 


### PR DESCRIPTION
## Summary

- install the signed WakaTime CLI Isotope through the AV tap or verified direct fallback
- migrate the global API key into Automic Vault and configure `api_key_vault_cmd`
- bind every key read to the live signed Target and WakaTime official API endpoint
- point editor plugins at the verified Target and add Detector, Doctor, Gate, and ADR coverage

The source patch is published at [automic-vault/wakatime-cli](https://github.com/automic-vault/wakatime-cli), release [v2.24.4](https://github.com/automic-vault/wakatime-cli/releases/tag/v2.24.4), and tap formula [`wakatime-cli-isotope`](https://github.com/automic-vault/homebrew-isotopes/blob/main/Formula/wakatime-cli-isotope.rb).

## Verification

- `go test ./...` in the Isotope fork
- signed release archive verification in the tap publish pipeline
- `cargo test --all-targets`
- `swift test --package-path src/menu-helper`
- `AutomicVaultMenubar --self-check-wakatime-credentials`
- `cargo fmt --all -- --check`
- `git diff --check`

`brew audit --formula automic-vault/isotopes/wakatime-cli-isotope` was attempted twice but the locally installed Brew Authorization Gate denied the audit before Homebrew ran.