### PR TITLE
Use targeted validation for app launchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av"
-version = "3.18.0"
+version = "4.0.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av"
-version = "3.18.0"
+version = "4.0.0"
 edition = "2024"
 
 [profile.release]

--- a/docs/adr/0020-app-launcher-main-executable.md
+++ b/docs/adr/0020-app-launcher-main-executable.md
@@ -2,6 +2,9 @@
 
 Status: accepted
 
+App validation scope was refined by
+[ADR 0033](0033-targeted-app-launcher-validation.md).
+
 ## Context
 
 A signed executable may live inside an app bundle without being that app's
@@ -18,8 +21,9 @@ the app or executable at the root of the operation's verified launch chain.
 
 An ordinary app bundle is a Launcher candidate only when the live process path
 or its code-signing main executable matches the bundle's declared main
-executable. Automic Vault then performs the existing full static code-signature
-and resource validation before accepting that app as a Verified Launcher.
+executable. Automic Vault then performs static code-signature and exact
+executable resource validation before accepting that app as a Verified
+Launcher.
 
 Bundle-contained intermediary executables remain visible in the process chain
 and retain their live code-signature and runtime-posture checks, but they do not
@@ -30,22 +34,24 @@ must be the exact live executable and a required, unaltered member of the app's
 resource seal. Disabled associations are persisted in the Data Protection
 Keychain so same-user preference writes cannot enable them.
 
-Helper validation checks the app's signed executable without scanning unrelated
-resources, then validates only the helper against the app's resource seal. If
-the targeted macOS validation facility is unavailable, validation falls back to
-the complete bundle seal. Existing explicit rules for Automic Vault Launcher
-Bundle payloads and the Vaultty session bridge remain unchanged. Eligible
-standalone Developer ID executables retain their existing fallback identity.
+App and helper validation checks the app's signed executable without scanning
+unrelated resources, then validates only the exact representing executable
+against the app's resource seal. If the targeted macOS validation facility is
+unavailable, validation falls back to the complete bundle seal. Existing
+explicit rules for Automic Vault Launcher Bundle payloads and the Vaultty
+session bridge remain unchanged. Eligible standalone Developer ID executables
+retain their existing fallback identity.
 
 ## Consequences
 
 Terminal, Portal, and other app main processes keep their existing app Launcher
-identity and full bundle validation. ChatGPT's signed, sealed Codex helper can
-represent ChatGPT when its built-in association is enabled. The built-in Claude
-Code association remains dormant unless Anthropic seals its signed Claude Code
-executable inside the exact Claude app identity. Xcode's Git does not match an
-association, so it neither claims Xcode Launcher authority nor causes Xcode's
-complete resource seal to be scanned while authorizing a Git signature. A
-helper without its app's main process in the live ancestry must qualify under
-an enabled helper association, Launcher Bundle enrollment, or standalone
-Launcher rules instead of inheriting ambient authority from its containing app.
+identity with targeted executable validation. ChatGPT's signed, sealed Codex
+helper can represent ChatGPT when its built-in association is enabled. The
+built-in Claude Code association remains dormant unless Anthropic seals its
+signed Claude Code executable inside the exact Claude app identity. Xcode's Git
+does not match an association, so it neither claims Xcode Launcher authority nor
+causes Xcode's complete resource seal to be scanned while authorizing a Git
+signature. A helper without its app's main process in the live ancestry must
+qualify under an enabled helper association, Launcher Bundle enrollment, or
+standalone Launcher rules instead of inheriting ambient authority from its
+containing app.

--- a/docs/adr/0033-targeted-app-launcher-validation.md
+++ b/docs/adr/0033-targeted-app-launcher-validation.md
@@ -1,0 +1,43 @@
+# ADR 0033: Validate only authority-bearing app resources
+
+Status: accepted
+
+## Context
+
+Complete static validation traverses every sealed resource in an app bundle.
+That work can take several seconds for large development apps even though
+Launcher Identity depends on one live executable. Unrelated documentation,
+SDKs, plug-ins, and tools neither establish nor inherit that identity.
+
+macOS provides a targeted code-signing operation that validates one exact file
+against an app's resource seal. It is private API, so relying on it changes the
+product's compatibility boundary and warrants a major version transition.
+
+## Decision
+
+For ordinary app Launchers, Automic Vault validates the app's signed main
+executable with strict all-architecture code-signature checks while excluding
+unrelated resources, then uses `SecStaticCodeValidateResourceWithErrors` to
+validate the exact executable representing the Launcher against the app's
+resource seal. The symbol is resolved dynamically. If it is unavailable,
+Automic Vault falls back to strict complete-bundle validation.
+
+The same primitive applies to an app's declared main executable and to an
+enabled Verified Launcher Helper. Live process identity, designated
+requirements, Team IDs, runtime posture, and helper catalog matching remain
+separate mandatory checks.
+
+This does not replace strict standalone executable verification, release-time
+distribution verification, or Launcher Bundle enrollment. Launcher Bundles are
+small security artifacts whose complete bundle, nested payload, digest, and
+enrollment remain one invariant.
+
+## Consequences
+
+Launcher verification time depends on the authority-bearing executable rather
+than total app size. Modifying that executable, its signature, the app's signed
+main executable, or the seal entry fails verification. Modifying an unrelated
+sealed resource no longer invalidates Launcher Identity because that resource
+does not contribute authority. Removal of the private API degrades performance
+by selecting the strict complete-bundle fallback rather than weakening
+validation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,18 +282,21 @@ Authorization Record.
 
 The policy identity is the Launcher's designated requirement, checked against the live process and its launch chain. Paths, process identifiers, names, and icons help the user recognize software but do not establish identity. Hardened Runtime requirements and rejected entitlements form part of launcher eligibility.
 
-An app's declared main executable may represent the app after complete static
-bundle validation. A non-main executable may represent the app only as an
-enabled Verified Launcher Helper whose exact app and helper signing identities
-appear in the built-in positive catalog. Disabled catalog entries are stored in
-the Data Protection Keychain; missing or malformed stored configuration fails
-closed except that a genuinely absent record uses the built-in defaults.
-Runtime verification binds the live helper to the on-disk executable, validates
-the app executable without scanning unrelated resources, and validates that
-exact executable as a required, unaltered member of the app's resource seal. If
-targeted resource validation is unavailable, Automic Vault falls back to
+An app's declared main executable may represent the app after its code signature
+and exact membership in the app's resource seal are validated. A non-main
+executable may represent the app only as an enabled Verified Launcher Helper
+whose exact app and helper signing identities appear in the built-in positive
+catalog. Disabled catalog entries are stored in the Data Protection Keychain;
+missing or malformed stored configuration fails closed except that a genuinely
+absent record uses the built-in defaults. Runtime verification binds the live
+helper to the on-disk executable, validates the app executable, and validates
+the exact helper as a required, unaltered member of the app's resource seal.
+Unrelated app resources are not Launcher Identity evidence and are not scanned.
+If targeted resource validation is unavailable, Automic Vault falls back to
 complete bundle validation. Other bundle-contained executables do not inherit
-the app identity. See [ADR 0020](adr/0020-app-launcher-main-executable.md).
+the app identity. Launcher Bundles retain their complete enrolled-bundle and
+payload verification. See [ADR 0020](adr/0020-app-launcher-main-executable.md)
+and [ADR 0033](adr/0033-targeted-app-launcher-validation.md).
 
 Eligible Launchers must enable Hardened Runtime or be Apple platform binaries
 signed as part of a macOS release, for which macOS applies the runtime

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -197,6 +197,13 @@ History or telemetry.
 
 The designated requirement stored when the user establishes trust and revalidated for each request. A path, display name, process identifier, or icon is metadata, not identity.
 
+For an ordinary app Launcher, integrity validation covers the app's signed main
+executable and the exact executable representing the Launcher. Other resources
+in the app bundle are outside the Launcher Identity and are not evidence for or
+against it. If targeted resource validation is unavailable, Automic Vault
+validates the complete bundle. Launcher Bundles retain their separately defined
+complete enrollment and integrity checks.
+
 ### Verified Launcher Helper
 
 A vendor-signed executable that may represent one exact containing app as its

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -56,6 +56,8 @@ Automic Vault decides whether a complete operation may use it.
 User-facing copy must preserve these limits:
 
 - Code signing establishes software identity and integrity, not intent.
+- App Launcher verification covers the exact executable that represents the
+  Launcher, not every unrelated resource shipped in the containing app.
 - After Secret Application, the Target controls the Secret in its memory,
   helpers, child processes, and output.
 - Automic Vault does not contain root or kernel compromise, prevent arbitrary

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -4797,15 +4797,18 @@ private func launcherSigning(_ url: URL) -> LauncherSigning? {
     }
     var staticCode: SecStaticCode?
     guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
-          let staticCode,
-          SecStaticCodeCheckValidity(
-              staticCode,
-              SecCSFlags(rawValue: kSecCSStrictValidate | kSecCSCheckNestedCode),
-              nil
-          ) == errSecSuccess
+          let staticCode
     else {
         return nil
     }
+    let validationStatus = isApp
+        ? validateAppBundleMainExecutable(staticCode)
+        : SecStaticCodeCheckValidity(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSStrictValidate | kSecCSCheckNestedCode),
+            nil
+        )
+    guard validationStatus == errSecSuccess else { return nil }
 
     var info: CFDictionary?
     let flags = SecCSFlags(rawValue: kSecCSSigningInformation | kSecCSRequirementInformation)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -9466,7 +9466,7 @@ private func staticSigningInfo(url: URL) -> StaticSigningInfo? {
     var staticCode: SecStaticCode?
     guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
           let staticCode,
-          SecStaticCodeCheckValidity(staticCode, [], nil) == errSecSuccess
+          validateAppBundleMainExecutable(staticCode) == errSecSuccess
     else {
         return nil
     }
@@ -9549,7 +9549,7 @@ private func appBundleVerificationFailure(_ url: URL) -> LauncherAppVerification
     else {
         return nil
     }
-    let status = SecStaticCodeCheckValidity(staticCode, [], nil)
+    let status = validateAppBundleMainExecutable(staticCode)
     guard status != errSecSuccess else { return nil }
     let name = url.deletingPathExtension().lastPathComponent
     let executableOnly = SecCSFlags(
@@ -9667,23 +9667,6 @@ private func verifiedLauncherHelperAssociation(
     )
 }
 
-// Apple ships this targeted resource-seal validator on every supported macOS release.
-// Resolve the SPI dynamically so absence falls back to strict full-bundle validation.
-private typealias ValidateSealedResource = @convention(c) (
-    SecStaticCode,
-    CFURL,
-    UInt32,
-    UnsafeMutableRawPointer?
-) -> OSStatus
-
-private let validateSealedResource: ValidateSealedResource? = {
-    guard let handle = dlopen(nil, RTLD_LAZY),
-          let symbol = dlsym(handle, "SecStaticCodeValidateResourceWithErrors") else {
-        return nil
-    }
-    return unsafeBitCast(symbol, to: ValidateSealedResource.self)
-}()
-
 private func verifiedLauncherHelperSigningInfo(
     _ association: VerifiedLauncherHelperAssociation,
     pid: pid_t
@@ -9709,30 +9692,11 @@ private func verifiedLauncherHelperAppSigningInfo(
         let requirement = verifiedLauncherHelperAppRequirement(association.helper)
     else { return nil }
 
-    guard let validateSealedResource else {
-        let fullFlags = SecCSFlags(
-            rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate
-        )
-        guard SecStaticCodeCheckValidity(staticCode, fullFlags, requirement) == errSecSuccess,
-              let app = staticSigningInfo(staticCode),
-              app.identifier == association.helper.appBundleIdentifier,
-              app.teamIdentifier == association.helper.appTeamIdentifier
-        else { return nil }
-        return app
-    }
-
-    let appFlags = SecCSFlags(
-        rawValue: kSecCSCheckAllArchitectures
-            | kSecCSDoNotValidateResources
-            | kSecCSStrictValidate
-    )
-    guard SecStaticCodeCheckValidity(staticCode, appFlags, requirement) == errSecSuccess,
-          validateSealedResource(
-              staticCode,
-              association.executableURL as CFURL,
-              kSecCSStrictValidate,
-              nil
-          ) == errSecSuccess,
+    guard validateAppBundleResource(
+        staticCode,
+        resourceURL: association.executableURL,
+        requirement: requirement
+    ) == errSecSuccess,
           let app = staticSigningInfo(staticCode),
           app.identifier == association.helper.appBundleIdentifier,
           app.teamIdentifier == association.helper.appTeamIdentifier
@@ -12322,6 +12286,12 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         )
         return verifiedLauncherHelperAppSigningInfo(outsideResource) == nil
     }()
+    let installedMainAppValidation = [
+        URL(fileURLWithPath: "/Applications/ChatGPT.app"),
+        URL(fileURLWithPath: "/Applications/Xcode.app"),
+    ].allSatisfy {
+        !FileManager.default.fileExists(atPath: $0.path) || staticSigningInfo(url: $0) != nil
+    }
     let liveBundleFallback = launcherIdentities(
         pid: 44,
         path: bundledDeveloperID.mainExecutable,
@@ -12344,12 +12314,13 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
           ),
           launcher.isStandalone,
           launcher.designatedRequirement == requirement,
-          validateSealedResource != nil,
+          targetedAppResourceValidationAvailable,
           codexAssociation?.helper == codexVerifiedLauncherHelper,
           codexAssociation?.appURL == chatGPTURL,
           disabledCodexAssociation == nil,
           xcodeHelperAssociation == nil,
           installedCodexValidation,
+          installedMainAppValidation,
           let liveBundleFallback,
           liveBundleFallback.isStandalone,
           liveBundleFallback.identifier == bundledDeveloperID.identifier,

--- a/src/menu-helper/Sources/MenubarHelperCore/AppBundleValidation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AppBundleValidation.swift
@@ -1,0 +1,70 @@
+import Darwin
+import Foundation
+import Security
+
+private typealias ValidateSealedResource = @convention(c) (
+    SecStaticCode,
+    CFURL,
+    UInt32,
+    UnsafeMutableRawPointer?
+) -> OSStatus
+
+// Resolve the private SPI dynamically and retain strict complete-bundle validation as fallback.
+private let validateSealedResource: ValidateSealedResource? = {
+    guard let handle = dlopen(nil, RTLD_LAZY),
+          let symbol = dlsym(handle, "SecStaticCodeValidateResourceWithErrors")
+    else { return nil }
+    return unsafeBitCast(symbol, to: ValidateSealedResource.self)
+}()
+
+public var targetedAppResourceValidationAvailable: Bool {
+    validateSealedResource != nil
+}
+
+public func validateAppBundleMainExecutable(
+    _ staticCode: SecStaticCode,
+    requirement: SecRequirement? = nil
+) -> OSStatus {
+    var information: CFDictionary?
+    guard SecCodeCopySigningInformation(staticCode, [], &information) == errSecSuccess,
+          let dictionary = information as? [CFString: Any],
+          let executableURL = dictionary[kSecCodeInfoMainExecutable] as? URL
+    else { return errSecCSInvalidObjectRef }
+    return validateAppBundleResource(
+        staticCode,
+        resourceURL: executableURL,
+        requirement: requirement
+    )
+}
+
+public func validateAppBundleResource(
+    _ staticCode: SecStaticCode,
+    resourceURL: URL,
+    requirement: SecRequirement? = nil
+) -> OSStatus {
+    let executableFlags = SecCSFlags(
+        rawValue: kSecCSCheckAllArchitectures
+            | kSecCSDoNotValidateResources
+            | kSecCSStrictValidate
+    )
+    let executableStatus = SecStaticCodeCheckValidity(
+        staticCode,
+        executableFlags,
+        requirement
+    )
+    guard executableStatus == errSecSuccess else { return executableStatus }
+
+    guard let validateSealedResource else {
+        return SecStaticCodeCheckValidity(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate),
+            requirement
+        )
+    }
+    return validateSealedResource(
+        staticCode,
+        resourceURL as CFURL,
+        kSecCSStrictValidate,
+        nil
+    )
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/AppBundleValidation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AppBundleValidation.swift
@@ -26,8 +26,9 @@ public func validateAppBundleMainExecutable(
     requirement: SecRequirement? = nil
 ) -> OSStatus {
     var information: CFDictionary?
-    guard SecCodeCopySigningInformation(staticCode, [], &information) == errSecSuccess,
-          let dictionary = information as? [CFString: Any],
+    let informationStatus = SecCodeCopySigningInformation(staticCode, [], &information)
+    guard informationStatus == errSecSuccess else { return informationStatus }
+    guard let dictionary = information as? [CFString: Any],
           let executableURL = dictionary[kSecCodeInfoMainExecutable] as? URL
     else { return errSecCSInvalidObjectRef }
     return validateAppBundleResource(

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AppBundleValidationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AppBundleValidationTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Security
+import Testing
+@testable import MenubarHelperCore
+
+@Test func targetedAppValidationIgnoresUnrelatedResourcesAndRejectsTargetChanges() throws {
+    #expect(targetedAppResourceValidationAvailable)
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let app = root.appendingPathComponent("Example.app", isDirectory: true)
+    let contents = app.appendingPathComponent("Contents", isDirectory: true)
+    let macOS = contents.appendingPathComponent("MacOS", isDirectory: true)
+    let resources = contents.appendingPathComponent("Resources", isDirectory: true)
+    let executable = macOS.appendingPathComponent("Example")
+    let trustedResource = resources.appendingPathComponent("trusted")
+    let unrelatedResource = resources.appendingPathComponent("unrelated")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+    try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/true"), to: executable)
+    try Data("trusted".utf8).write(to: trustedResource)
+    try Data("unrelated".utf8).write(to: unrelatedResource)
+    try Data("""
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0"><dict>
+    <key>CFBundleExecutable</key><string>Example</string>
+    <key>CFBundleIdentifier</key><string>com.example.targeted-validation</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    </dict></plist>
+    """.utf8).write(to: contents.appendingPathComponent("Info.plist"))
+    try signValidationTestApp(app)
+
+    #expect(appValidationStatus(app) == errSecSuccess)
+    #expect(appValidationStatus(app, resource: trustedResource) == errSecSuccess)
+    try Data("changed".utf8).write(to: unrelatedResource)
+    #expect(appValidationStatus(app) == errSecSuccess)
+    #expect(appValidationStatus(app, resource: trustedResource) == errSecSuccess)
+    #expect(fullAppValidationStatus(app) != errSecSuccess)
+    try Data("changed".utf8).write(to: trustedResource)
+    #expect(appValidationStatus(app, resource: trustedResource) != errSecSuccess)
+}
+
+private func appValidationStatus(_ app: URL, resource: URL? = nil) -> OSStatus {
+    var code: SecStaticCode?
+    let creation = SecStaticCodeCreateWithPath(app as CFURL, [], &code)
+    guard creation == errSecSuccess, let code else { return creation }
+    if let resource {
+        return validateAppBundleResource(code, resourceURL: resource)
+    }
+    return validateAppBundleMainExecutable(code)
+}
+
+private func fullAppValidationStatus(_ app: URL) -> OSStatus {
+    var code: SecStaticCode?
+    let creation = SecStaticCodeCreateWithPath(app as CFURL, [], &code)
+    guard creation == errSecSuccess, let code else { return creation }
+    return SecStaticCodeCheckValidity(
+        code,
+        SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate),
+        nil
+    )
+}
+
+private func signValidationTestApp(_ app: URL) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+    process.arguments = [
+        "--force", "--sign", "-", "--options", "runtime",
+        "--identifier", "com.example.targeted-validation", app.path,
+    ]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        throw CocoaError(.executableRuntimeMismatch)
+    }
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AppBundleValidationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AppBundleValidationTests.swift
@@ -3,8 +3,8 @@ import Security
 import Testing
 @testable import MenubarHelperCore
 
-@Test func targetedAppValidationIgnoresUnrelatedResourcesAndRejectsTargetChanges() throws {
-    #expect(targetedAppResourceValidationAvailable)
+@Test(.enabled(if: targetedAppResourceValidationAvailable))
+func targetedAppValidationIgnoresUnrelatedResourcesAndRejectsTargetChanges() throws {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
     let app = root.appendingPathComponent("Example.app", isDirectory: true)


### PR DESCRIPTION
## Summary

- validate ordinary app launchers with the targeted macOS sealed-resource API
- retain strict complete-bundle validation when the private symbol is unavailable
- keep standalone executable, distribution, and Launcher Bundle verification unchanged
- document the security boundary in ADR 0033 and bump the release line to 4.0.0

## Security

The app code signature is checked strictly across all architectures without traversing unrelated resources. The exact executable representing the Launcher is then validated against the app resource seal. Live identity, designated requirements, Team IDs, runtime posture, and Verified Launcher Helper catalog matching remain mandatory.

## Verification

- 199 Swift tests passed
- 926 Rust unit tests plus all integration suites passed
- standalone-launcher and dashboard self-checks passed
- installed ChatGPT, Codex, and Xcode validation self-check completed in 0.66 seconds
- targeted mutation test proves unrelated resources are ignored while changes to the authority-bearing resource fail validation