### PR TITLE
Reduce first dashboard load latency

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -70,36 +70,7 @@ pub(crate) fn run<W: Write>(
     json: bool,
     style: Style,
 ) -> Result<i32, String> {
-    let path = std::env::var_os("PATH").unwrap_or_default();
-    let launcher_bundles = launcher_bundles();
-    let selected_launcher = selector.and_then(|selector| {
-        launcher_bundles
-            .iter()
-            .find(|launcher| launcher.command == selector)
-    });
-    let mut results = if let Some(launcher) = selected_launcher {
-        vec![diagnose_launcher_bundle(
-            launcher,
-            Path::new(LAUNCHER_BUNDLE_COMMAND_ROOT),
-            &path,
-            0,
-        )]
-    } else if let Some(agent) = select_agent_cli(selector) {
-        vec![diagnose_agent_cli(agent, &path, vendor_signature_valid)]
-    } else {
-        diagnose(hardeners::metadata(), selector, &path)?
-    };
-    if selector.is_none() {
-        results.extend(launcher_bundles.iter().map(|launcher| {
-            diagnose_launcher_bundle(launcher, Path::new(LAUNCHER_BUNDLE_COMMAND_ROOT), &path, 0)
-        }));
-        results.extend(
-            AGENT_CLIS
-                .iter()
-                .filter(|agent| resolve(agent.command, &path).is_some())
-                .map(|agent| diagnose_agent_cli(agent, &path, vendor_signature_valid)),
-        );
-    }
+    let results = results(selector, None)?;
     let issue_count = results
         .iter()
         .map(|result| result.issues.len())
@@ -110,6 +81,88 @@ pub(crate) fn run<W: Write>(
         print_human(stdout, &results, issue_count, style);
     }
     Ok(if issue_count == 0 { 0 } else { 1 })
+}
+
+pub(crate) fn dashboard_results_json<T>(
+    load_hardeners: impl FnOnce() -> (Vec<HardenerMetadata>, T),
+) -> Result<(T, Vec<serde_json::Value>), String> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let launcher_bundles = launcher_bundles();
+    std::thread::scope(|scope| {
+        let agent_results = scope.spawn(|| agent_cli_results(&path, vendor_signature_valid));
+        let (hardeners, hardener_report) = load_hardeners();
+        let mut results = diagnose(hardeners, None, &path)?;
+        results.extend(launcher_bundles.iter().map(|launcher| {
+            diagnose_launcher_bundle(launcher, Path::new(LAUNCHER_BUNDLE_COMMAND_ROOT), &path, 0)
+        }));
+        results.extend(
+            agent_results
+                .join()
+                .expect("agent CLI Doctor worker panicked"),
+        );
+        Ok((hardener_report, json_results(&results)))
+    })
+}
+
+fn results(
+    selector: Option<&str>,
+    hardeners: Option<Vec<HardenerMetadata>>,
+) -> Result<Vec<DoctorResult>, String> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let launcher_bundles = launcher_bundles();
+    if selector.is_none() {
+        return std::thread::scope(|scope| {
+            let agent_results = scope.spawn(|| agent_cli_results(&path, vendor_signature_valid));
+            let mut results = diagnose(hardeners.unwrap_or_else(hardeners::metadata), None, &path)?;
+            results.extend(launcher_bundles.iter().map(|launcher| {
+                diagnose_launcher_bundle(
+                    launcher,
+                    Path::new(LAUNCHER_BUNDLE_COMMAND_ROOT),
+                    &path,
+                    0,
+                )
+            }));
+            results.extend(
+                agent_results
+                    .join()
+                    .expect("agent CLI Doctor worker panicked"),
+            );
+            Ok(results)
+        });
+    }
+    let selected_launcher = selector.and_then(|selector| {
+        launcher_bundles
+            .iter()
+            .find(|launcher| launcher.command == selector)
+    });
+    let results = if let Some(launcher) = selected_launcher {
+        vec![diagnose_launcher_bundle(
+            launcher,
+            Path::new(LAUNCHER_BUNDLE_COMMAND_ROOT),
+            &path,
+            0,
+        )]
+    } else if let Some(agent) = select_agent_cli(selector) {
+        vec![diagnose_agent_cli(agent, &path, vendor_signature_valid)]
+    } else {
+        diagnose(
+            hardeners.unwrap_or_else(hardeners::metadata),
+            selector,
+            &path,
+        )?
+    };
+    Ok(results)
+}
+
+fn agent_cli_results(
+    path: &OsStr,
+    signature_valid: fn(&Path, &str, &str) -> bool,
+) -> Vec<DoctorResult> {
+    AGENT_CLIS
+        .iter()
+        .filter(|agent| resolve(agent.command, path).is_some())
+        .map(|agent| diagnose_agent_cli(agent, path, signature_valid))
+        .collect()
 }
 
 fn select_agent_cli(selector: Option<&str>) -> Option<&'static AgentCliDoctor> {
@@ -956,21 +1009,30 @@ fn same_path(left: &Path, right: &Path) -> bool {
 
 fn print_json(stdout: &mut dyn Write, results: &[DoctorResult]) {
     let report = serde_json::json!({
-        "results": results.iter().map(|result| serde_json::json!({
-            "name": result.name,
-            "commands": result.commands,
-            "issues": result.issues.iter().map(|issue| serde_json::json!({
-                "kind": issue.kind,
-                "command": issue.command,
-                "message": issue.message,
-                "remediation": issue.remediation,
-                "stub_path": issue.stub_path,
-                "target_path": issue.target_path,
-                "resolved_path": issue.resolved_path,
-            })).collect::<Vec<_>>(),
-        })).collect::<Vec<_>>(),
+        "results": json_results(results),
     });
     let _ = writeln!(stdout, "{report}");
+}
+
+fn json_results(results: &[DoctorResult]) -> Vec<serde_json::Value> {
+    results
+        .iter()
+        .map(|result| {
+            serde_json::json!({
+                "name": result.name,
+                "commands": result.commands,
+                "issues": result.issues.iter().map(|issue| serde_json::json!({
+                    "kind": issue.kind,
+                    "command": issue.command,
+                    "message": issue.message,
+                    "remediation": issue.remediation,
+                    "stub_path": issue.stub_path,
+                    "target_path": issue.target_path,
+                    "resolved_path": issue.resolved_path,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect()
 }
 
 fn print_human(stdout: &mut dyn Write, results: &[DoctorResult], issue_count: usize, style: Style) {
@@ -1127,6 +1189,27 @@ mod tests {
                 .remediation
                 .contains("Anthropic's native installer or the Homebrew cask")
         );
+    }
+
+    #[test]
+    fn aggregate_agent_cli_results_preserve_catalog_order() {
+        let dir = temp_dir("agent-order");
+        executable_file(&dir.join("claude"));
+        executable_file(&dir.join("codex"));
+
+        let results = agent_cli_results(dir.as_os_str(), |_, _, _| false);
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.name.as_str())
+                .collect::<Vec<_>>(),
+            ["claude", "codex"]
+        );
+        assert!(results.iter().all(|result| {
+            result.issues.len() == 1 && result.issues[0].kind == "agent_cli_signature_invalid"
+        }));
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,7 +53,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 38;
+pub(crate) const INSTALL_REVISION: u32 = 39;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -313,6 +313,15 @@ where
         }
         Some("detectors") if rest == [OsString::from("--json")] => scan::run_detectors_json(stdout),
         Some("hardeners") if rest == [OsString::from("--json")] => scan::run_hardeners_json(stdout),
+        Some("__dashboard-hardening-json") if rest.is_empty() => {
+            match scan::run_dashboard_hardening_json(stdout) {
+                Ok(code) => code,
+                Err(err) => {
+                    let _ = writeln!(stderr, "av: {err}");
+                    1
+                }
+            }
+        }
         Some("__secret-gates-json") if rest.is_empty() => scan::run_secret_gates_json(stdout),
         Some("gpg-sign") => gpg_sign::run(rest, stdout, stderr),
         Some("__gpg-public-key") if rest.is_empty() => gpg_sign::validate(stdout, stderr),
@@ -676,6 +685,33 @@ mod tests {
 
         assert_eq!(code, 0);
         assert_eq!(stderr, "");
+    }
+
+    #[test]
+    fn private_dashboard_hardening_report_combines_hardeners_and_doctor() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_AWS_STUB_PATH", "/nonexistent");
+        }
+
+        let (code, stdout, stderr) = run_args(&["av", "__dashboard-hardening-json"]);
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_AWS_STUB_PATH") };
+        let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(stderr, "");
+        assert!(
+            report["hardeners"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+        );
+        assert!(
+            report["detectors"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+        );
+        assert!(report["secret_gates"].is_array());
+        assert!(report["results"].is_array());
     }
 
     #[test]

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -59,7 +59,16 @@ pub(crate) fn run_json<W: Write, E: Write>(
 pub(crate) fn run_detectors_json<W: Write>(stdout: &mut W) -> i32 {
     let home = home();
     let report = serde_json::json!({
-        "detectors": isotopes::detector_metadata(Path::new(&home)).into_iter().map(|detector| {
+        "detectors": json_detectors(Path::new(&home)),
+    });
+    let _ = writeln!(stdout, "{report}");
+    0
+}
+
+fn json_detectors(home: &Path) -> Vec<serde_json::Value> {
+    isotopes::detector_metadata(home)
+        .into_iter()
+        .map(|detector| {
             serde_json::json!({
                 "name": detector.name,
                 "homepage": detector.homepage,
@@ -70,16 +79,43 @@ pub(crate) fn run_detectors_json<W: Write>(stdout: &mut W) -> i32 {
                     "recursive": scope.recursive,
                 })).collect::<Vec<_>>(),
             })
-        }).collect::<Vec<_>>(),
+        })
+        .collect()
+}
+
+pub(crate) fn run_hardeners_json<W: Write>(stdout: &mut W) -> i32 {
+    let hardeners = isotopes::hardener_metadata();
+    let report = serde_json::json!({
+        "hardeners": json_hardeners(&hardeners),
     });
     let _ = writeln!(stdout, "{report}");
     0
 }
 
-pub(crate) fn run_hardeners_json<W: Write>(stdout: &mut W) -> i32 {
+pub(crate) fn run_dashboard_hardening_json<W: Write>(stdout: &mut W) -> Result<i32, String> {
+    let home = home();
+    let (hardener_report, doctor_report) = super::doctor::dashboard_results_json(|| {
+        let hardeners = isotopes::hardener_metadata();
+        let report = json_hardeners(&hardeners);
+        (hardeners, report)
+    })?;
     let report = serde_json::json!({
-        "hardeners": isotopes::hardener_metadata().into_iter().map(|hardener| {
-            let secret_gate = hardener.secret_gate.map(json_secret_gate);
+        "hardeners": hardener_report,
+        "detectors": json_detectors(Path::new(&home)),
+        "secret_gates": json_secret_gates(),
+        "results": doctor_report,
+    });
+    let _ = writeln!(stdout, "{report}");
+    Ok(0)
+}
+
+fn json_hardeners(
+    hardeners: &[crate::isotopes::hardeners::HardenerMetadata],
+) -> Vec<serde_json::Value> {
+    hardeners
+        .iter()
+        .map(|hardener| {
+            let secret_gate = hardener.secret_gate.as_ref().map(json_secret_gate);
             serde_json::json!({
                 "name": hardener.name,
                 "documentation": hardener.documentation,
@@ -87,7 +123,7 @@ pub(crate) fn run_hardeners_json<W: Write>(stdout: &mut W) -> i32 {
                 "applicable": hardener.detection.applicable,
                 "stub_path": hardener.detection.stub_path,
                 "target_path": hardener.detection.target_path,
-                "commands": hardener.detection.commands.into_iter().map(|command| serde_json::json!({
+                "commands": hardener.detection.commands.iter().map(|command| serde_json::json!({
                     "name": command.name,
                     "hardened": command.hardened,
                     "stub_path": command.stub_path,
@@ -96,28 +132,30 @@ pub(crate) fn run_hardeners_json<W: Write>(stdout: &mut W) -> i32 {
                 })).collect::<Vec<_>>(),
                 "secret_gate": secret_gate,
             })
-        }).collect::<Vec<_>>(),
-    });
-    let _ = writeln!(stdout, "{report}");
-    0
+        })
+        .collect()
 }
 
 pub(crate) fn run_secret_gates_json<W: Write>(stdout: &mut W) -> i32 {
     let report = serde_json::json!({
-        "secret_gates": isotopes::secret_gate_metadata()
-            .into_iter()
-            .map(json_secret_gate)
-            .collect::<Vec<_>>(),
+        "secret_gates": json_secret_gates(),
     });
     let _ = writeln!(stdout, "{report}");
     0
 }
 
-fn json_secret_gate(gate: crate::isotopes::hardeners::SecretGateDescriptor) -> serde_json::Value {
+fn json_secret_gates() -> Vec<serde_json::Value> {
+    isotopes::secret_gate_metadata()
+        .iter()
+        .map(json_secret_gate)
+        .collect()
+}
+
+fn json_secret_gate(gate: &crate::isotopes::hardeners::SecretGateDescriptor) -> serde_json::Value {
     serde_json::json!({
         "id": gate.id,
         "key_patterns": gate.key_patterns,
-        "routes": gate.routes.into_iter().map(|route| serde_json::json!({
+        "routes": gate.routes.iter().map(|route| serde_json::json!({
             "operation": route.operation,
             "script_path": route.script_path,
             "target_path": route.target_path,

--- a/src/isotopes/hardeners/aws_release.rs
+++ b/src/isotopes/hardeners/aws_release.rs
@@ -124,8 +124,7 @@ pub(crate) fn current_release_valid() -> Result<(), String> {
             target.display()
         ));
     }
-    validate_protected_tree(&release_root, true)?;
-    verify_manifest(&release_root)?;
+    verify_protected_manifest(&release_root)?;
     verify_aws_executable(&target)
 }
 
@@ -424,8 +423,7 @@ fn install_payload(root: &Path, payload: &Path, version: &str, sha256: &str) -> 
         manifest.as_bytes(),
         0o444,
     )?;
-    validate_protected_tree(&replacement, true)?;
-    verify_manifest(&replacement)?;
+    verify_protected_manifest(&replacement)?;
 
     fs::rename(&replacement, &destination)
         .map_err(|err| format!("failed to install official AWS CLI: {err}"))?;
@@ -574,8 +572,16 @@ fn parse_latest_version(changelog: &str) -> Result<String, String> {
 }
 
 fn build_manifest(root: &Path) -> Result<String, String> {
+    build_manifest_with(root, &mut |_, _| Ok(()))
+}
+
+fn build_manifest_with(
+    root: &Path,
+    visit: &mut impl FnMut(&Path, &fs::Metadata) -> Result<(), String>,
+) -> Result<String, String> {
     let mut entries = Vec::new();
     walk(root, &mut |path, metadata| {
+        visit(path, metadata)?;
         let relative = path
             .strip_prefix(root)
             .map_err(|_| "AWS manifest path escaped its root".to_string())?
@@ -604,10 +610,14 @@ fn build_manifest(root: &Path) -> Result<String, String> {
     Ok(entries.join("\n") + "\n")
 }
 
-fn verify_manifest(root: &Path) -> Result<(), String> {
+fn verify_protected_manifest(root: &Path) -> Result<(), String> {
+    validate_protected_entry(
+        root,
+        &fs::symlink_metadata(root).map_err(|err| err.to_string())?,
+    )?;
+    let actual = build_manifest_with(root, &mut validate_protected_entry)?;
     let expected = fs::read_to_string(root.join(".av-manifest"))
         .map_err(|err| format!("official AWS CLI integrity manifest is unavailable: {err}"))?;
-    let actual = build_manifest(root)?;
     if actual == expected {
         Ok(())
     } else {
@@ -637,16 +647,6 @@ fn protect_tree(root: &Path) -> Result<(), String> {
             .map_err(|err| format!("failed to inspect {}: {err}", root.display()))?,
     )?;
     walk(root, protect)
-}
-
-fn validate_protected_tree(root: &Path, include_root: bool) -> Result<(), String> {
-    if include_root {
-        validate_protected_entry(
-            root,
-            &fs::symlink_metadata(root).map_err(|err| err.to_string())?,
-        )?;
-    }
-    walk(root, &mut validate_protected_entry)
 }
 
 fn validate_protected_entry(path: &Path, metadata: &fs::Metadata) -> Result<(), String> {
@@ -1002,6 +1002,28 @@ mod tests {
             "2.36.22"
         );
         assert!(parse_latest_version("CHANGELOG\nlatest\n======\n").is_err());
+    }
+
+    #[test]
+    fn protected_manifest_verification_rejects_unsafe_modes_and_content_changes() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = temp_path("protected-manifest");
+        let release = root.join("release");
+        fs::create_dir_all(&release).unwrap();
+        fs::write(release.join("aws"), "original").unwrap();
+        let manifest = build_manifest(&release).unwrap();
+        fs::write(release.join(".av-manifest"), manifest).unwrap();
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_AWS_INSTALL_ROOT", &root) };
+
+        assert!(verify_protected_manifest(&release).is_ok());
+        fs::set_permissions(release.join("aws"), fs::Permissions::from_mode(0o666)).unwrap();
+        assert!(verify_protected_manifest(&release).is_err());
+        fs::set_permissions(release.join("aws"), fs::Permissions::from_mode(0o644)).unwrap();
+        fs::write(release.join("aws"), "changed").unwrap();
+        assert!(verify_protected_manifest(&release).is_err());
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_AWS_INSTALL_ROOT") };
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -84,11 +84,12 @@ public struct DashboardSnapshot: Equatable, Sendable {
         policyService: String = secretGatePoliciesKeychainService
     ) -> DashboardSnapshot {
         _ = resumePendingSecretMutation()
-        let hardenerMetadata = loadHardenerMetadata(avExecutableURL: avExecutableURL)
+        let hardening = loadDashboardHardening(avExecutableURL: avExecutableURL)
+        let hardenerMetadata = hardening.hardeners
         let secrets = loadStoredSecrets(directAccessRules: loadDirectAccessRules())
         let gateDescriptors = dashboardSecretGateDescriptors(
             hardeners: hardenerMetadata,
-            catalog: (try? loadSecretGateDescriptors(avExecutableURL: avExecutableURL)) ?? [],
+            catalog: hardening.secretGates,
             storedSecretNames: Set(secrets.map(\.account))
         )
         _ = initializeSecretGatePolicies(descriptors: gateDescriptors, service: policyService)
@@ -98,7 +99,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             metadata: hardenerMetadata
         )
         return DashboardSnapshot(
-            detectors: loadDetectorMetadata(avExecutableURL: avExecutableURL),
+            detectors: hardening.detectors,
             detectorFindings: [],
             hardenedTools: hardenedTools,
             hardeners: hardenerMetadata,
@@ -107,7 +108,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             secretNameAccessApps: loadSecretNameAccessApps(),
             secrets: secrets,
             accessRequests: loadAccessRequestRecords(),
-            doctorIssues: loadDoctorIssues(avExecutableURL: avExecutableURL)
+            doctorIssues: hardening.doctorIssues
         )
     }
 }
@@ -871,6 +872,27 @@ struct HardenerReport: Codable {
     let hardeners: [HardenerMetadata]
 }
 
+struct DashboardHardening: Sendable {
+    let hardeners: [HardenerMetadata]
+    let detectors: [DetectorMetadata]
+    let secretGates: [SecretGateDescriptor]
+    let doctorIssues: [DoctorIssue]
+}
+
+private struct DashboardHardeningReport: Codable {
+    let hardeners: [HardenerMetadata]
+    let detectors: [DetectorMetadata]
+    let secretGates: [SecretGateDescriptor]
+    let results: [DoctorResult]
+
+    private enum CodingKeys: String, CodingKey {
+        case hardeners
+        case detectors
+        case secretGates = "secret_gates"
+        case results
+    }
+}
+
 private struct SecretGateReport: Codable {
     let secretGates: [SecretGateDescriptor]
 
@@ -920,8 +942,30 @@ public func hardenerMetadata(from hardenersJSON: Data) throws -> [HardenerMetada
     try JSONDecoder().decode(HardenerReport.self, from: hardenersJSON).hardeners
 }
 
+func dashboardHardening(
+    from dashboardJSON: Data,
+    loginShellPATHAvailable: Bool = true
+) throws -> DashboardHardening {
+    let report = try JSONDecoder().decode(DashboardHardeningReport.self, from: dashboardJSON)
+    return DashboardHardening(
+        hardeners: report.hardeners,
+        detectors: report.detectors,
+        secretGates: try validatedSecretGateDescriptors(report.secretGates),
+        doctorIssues: doctorIssues(
+            from: report.results,
+            loginShellPATHAvailable: loginShellPATHAvailable
+        )
+    )
+}
+
 public func secretGateDescriptors(from secretGatesJSON: Data) throws -> [SecretGateDescriptor] {
     let gates = try JSONDecoder().decode(SecretGateReport.self, from: secretGatesJSON).secretGates
+    return try validatedSecretGateDescriptors(gates)
+}
+
+private func validatedSecretGateDescriptors(
+    _ gates: [SecretGateDescriptor]
+) throws -> [SecretGateDescriptor] {
     guard !gates.isEmpty,
           Set(gates.map(\.id)).count == gates.count,
           gates.allSatisfy({ gate in
@@ -941,7 +985,15 @@ public func secretGateDescriptors(from secretGatesJSON: Data) throws -> [SecretG
 }
 
 public func doctorIssues(from doctorJSON: Data, loginShellPATHAvailable: Bool = true) throws -> [DoctorIssue] {
-    var issues = try JSONDecoder().decode(DoctorReport.self, from: doctorJSON).results.flatMap { result in
+    let results = try JSONDecoder().decode(DoctorReport.self, from: doctorJSON).results
+    return doctorIssues(from: results, loginShellPATHAvailable: loginShellPATHAvailable)
+}
+
+private func doctorIssues(
+    from results: [DoctorResult],
+    loginShellPATHAvailable: Bool
+) -> [DoctorIssue] {
+    var issues = results.flatMap { result in
         result.issues.map {
             DoctorIssue(
                 hardener: result.name,
@@ -2593,6 +2645,25 @@ public func loadDetectorMetadata(avExecutableURL: URL) -> [DetectorMetadata] {
 public func loadHardenerMetadata(avExecutableURL: URL) -> [HardenerMetadata] {
     loadJSON(avExecutableURL: avExecutableURL, arguments: ["hardeners", "--json"])
         .flatMap { try? hardenerMetadata(from: $0) } ?? []
+}
+
+func loadDashboardHardening(avExecutableURL: URL) -> DashboardHardening {
+    if let data = loadJSON(
+        avExecutableURL: avExecutableURL,
+        arguments: ["__dashboard-hardening-json"]
+    ), let report = try? dashboardHardening(from: data, loginShellPATHAvailable: false) {
+        return report
+    }
+    let hardeners = loadHardenerMetadata(avExecutableURL: avExecutableURL)
+    let secretGates = (try? loadSecretGateDescriptors(avExecutableURL: avExecutableURL)) ?? []
+    let detectors = loadDetectorMetadata(avExecutableURL: avExecutableURL)
+    let doctorIssues = loadDoctorIssues(avExecutableURL: avExecutableURL)
+    return DashboardHardening(
+        hardeners: hardeners,
+        detectors: detectors,
+        secretGates: secretGates,
+        doctorIssues: doctorIssues
+    )
 }
 
 public func loadSecretGateDescriptors(avExecutableURL: URL) throws -> [SecretGateDescriptor] {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -133,6 +133,76 @@ import Testing
     #expect(hardener.secretGate?.routes.first?.callerIdentifiers == ["gh", "com.github.cli"])
 }
 
+@Test func dashboardHardeningJSONDecodesHardenerAndDoctorFromOneReport() throws {
+    let data = Data(#"""
+    {
+      "hardeners":[{"name":"aws","documentation":"AWS docs","hardened":true,"stub_path":"/usr/local/bin/aws","target_path":"/opt/av/aws/current/aws"}],
+      "detectors":[{"name":"aws-cli","homepage":"https://example.com","docs_url":"https://example.com/docs","documentation":"AWS detector","watch_scopes":[]}],
+      "secret_gates":[{"id":"aws","key_patterns":["AWS_ACCESS_KEY_ID"],"routes":[{"operation":"inject","script_path":null,"target_path":"/usr/local/bin/aws","caller_identifiers":["com.automicvault.av"],"key_patterns":["AWS_ACCESS_KEY_ID"],"replace_existing_env":false,"allow_missing_keys":false}]}],
+      "results":[{"name":"aws","commands":["aws"],"issues":[{"kind":"aws_update_available","command":"aws","message":"Update available","remediation":"Run `av harden aws`.","stub_path":"/usr/local/bin/aws","target_path":"/opt/av/aws/current/aws","resolved_path":null}]}]
+    }
+    """#.utf8)
+
+    let report = try dashboardHardening(from: data, loginShellPATHAvailable: false)
+
+    #expect(report.hardeners.map(\.name) == ["aws"])
+    #expect(report.detectors.map(\.name) == ["aws-cli"])
+    #expect(report.secretGates.map(\.id) == ["aws"])
+    #expect(report.doctorIssues.map(\.kind) == ["aws_update_available"])
+}
+
+@Test func dashboardHardeningLoadsThroughOneExecutableInvocation() throws {
+    let directory = temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let executable = directory.appendingPathComponent("av")
+    let invocations = directory.appendingPathComponent("invocations")
+    try #"""
+#!/bin/sh
+printf '%s\n' "$*" >> "$(dirname "$0")/invocations"
+test "$1" = '__dashboard-hardening-json' || exit 2
+printf '%s\n' '{"hardeners":[{"name":"aws","documentation":"AWS docs","hardened":true}],"detectors":[],"secret_gates":[{"id":"aws","key_patterns":["AWS_ACCESS_KEY_ID"],"routes":[{"operation":"inject","script_path":null,"target_path":"/usr/local/bin/aws","caller_identifiers":["com.automicvault.av"],"key_patterns":["AWS_ACCESS_KEY_ID"],"replace_existing_env":false,"allow_missing_keys":false}]}],"results":[]}'
+"""#.write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+
+    let report = loadDashboardHardening(avExecutableURL: executable)
+
+    #expect(report.hardeners.map(\.name) == ["aws"])
+    #expect(report.detectors.isEmpty)
+    #expect(report.secretGates.map(\.id) == ["aws"])
+    #expect(report.doctorIssues.isEmpty)
+    #expect(try String(contentsOf: invocations, encoding: .utf8) == "__dashboard-hardening-json\n")
+}
+
+@Test func dashboardHardeningFallsBackForOlderExecutable() throws {
+    let directory = temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let executable = directory.appendingPathComponent("av")
+    let invocations = directory.appendingPathComponent("invocations")
+    try #"""
+#!/bin/sh
+printf '%s\n' "$*" >> "$(dirname "$0")/invocations"
+case "$*" in
+  'hardeners --json') printf '%s\n' '{"hardeners":[{"name":"aws","documentation":"AWS docs","hardened":true}]}' ;;
+  'detectors --json') printf '%s\n' '{"detectors":[]}' ;;
+  '__secret-gates-json') printf '%s\n' '{"secret_gates":[{"id":"aws","key_patterns":["AWS_ACCESS_KEY_ID"],"routes":[{"operation":"inject","script_path":null,"target_path":"/usr/local/bin/aws","caller_identifiers":["com.automicvault.av"],"key_patterns":["AWS_ACCESS_KEY_ID"],"replace_existing_env":false,"allow_missing_keys":false}]}]}' ;;
+  'doctor --json') printf '%s\n' '{"results":[]}' ;;
+  *) exit 2 ;;
+esac
+"""#.write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+
+    let report = loadDashboardHardening(avExecutableURL: executable)
+
+    #expect(report.hardeners.map(\.name) == ["aws"])
+    #expect(report.detectors.isEmpty)
+    #expect(report.secretGates.map(\.id) == ["aws"])
+    #expect(report.doctorIssues.isEmpty)
+    #expect(
+        try String(contentsOf: invocations, encoding: .utf8)
+            == "__dashboard-hardening-json\nhardeners --json\n__secret-gates-json\ndetectors --json\ndoctor --json\n"
+    )
+}
+
 @Test func secretGateCatalogRequiresUniqueDefinitions() throws {
     let data = Data(#"{"secret_gates":[{"id":"aws","key_patterns":["AWS_ACCESS_KEY_ID"],"routes":[{"operation":"inject","script_path":null,"target_path":"/usr/local/libexec/av/aws","caller_identifiers":["com.automicvault.av"],"key_patterns":["AWS_ACCESS_KEY_ID"],"replace_existing_env":false,"allow_missing_keys":false}]}]}"#.utf8)
 


### PR DESCRIPTION
## Summary

- load dashboard hardener, Doctor, detector, and Secret Gate data through one private CLI report
- reuse one fresh hardener evaluation and overlap independent agent signature checks
- validate AWS protected-tree metadata during manifest hashing instead of performing a second filesystem walk
- retain the established multi-command fallback for older or mismatched app/CLI installations

## Security

No security checks are cached, skipped, or deferred. AWS ownership, type, mode, manifest, signature, and content checks remain fresh and fail closed. The combined Secret Gate catalog retains the existing nonempty and uniqueness validation.

## Performance

- previous four-process dashboard CLI path: 1.09-1.13s warm
- combined path: 0.65-0.67s warm (about 40% faster)
- observed cold probe: 3.08s to 2.06s (cold-cache timing is noisier)

## Validation

- `cargo test`
- `swift test` (201 tests)
- `cargo fmt --check`
- `git diff --check`
- semantic comparison of all four established JSON payloads against the combined report
- strict Clippy reports existing repository-wide warnings, with none in the touched Rust files