### PR TITLE
Document gh credential-resolution failure semantics

### DIFF
--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -5,8 +5,9 @@
 We provide a [patched version] of `gh`. `av harden gh` installs it from our
 [tap] when Homebrew is available, or installs the same signed release directly
 at `/usr/local/bin/gh`. The supported hardened path is designed so that only
-the verified `gh` Isotope can apply its GitHub Secret through the Automic Vault
-Secret Gate.
+the verified `gh` Isotope submits authenticated operations through the `gh`
+Secret Gate; Automic Vault applies the GitHub Secret only to the authorized
+Target.
 
 The statements below describe the intended hardened-state contract. They do
 not establish that this checkout, or a particular installed `gh`, is already
@@ -25,11 +26,11 @@ into Automic Vault. Direct installs are updated by running the same command when
 ## Credential-resolution failure contract
 
 Authenticated operations use the error-aware Automic Vault credential path.
-If Secret retrieval is denied, times out, or the approval service or XPC
-broker is unavailable, `gh` returns a local Vault-retrieval error before it
-makes a GitHub request. An operational retrieval failure never falls back to a
-legacy credential, sends an anonymous request, or turns into a misleading
-HTTP 401.
+If the Secret Application required for credential resolution is denied or
+unavailable, including a timeout or approval-service/XPC unavailability, `gh`
+returns a local Automic Vault credential-resolution error before it makes a
+GitHub request. A credential-resolution failure never falls back to a legacy
+credential, sends an anonymous request, or turns into a misleading HTTP 401.
 
 An account-specific lookup may use the legacy host-wide credential only when
 the account-specific lookup returns the exact `ErrNotFound` condition. If both
@@ -37,12 +38,17 @@ credential locations are genuinely absent, an endpoint that explicitly allows
 anonymous access may remain anonymous. Absence and operational unavailability
 are different outcomes.
 
-`gh auth status` reports Vault retrieval unavailability separately from an
-invalid GitHub credential. It must not describe an operational Vault failure
-as logged out or invalid, or direct the user to log in or authenticate again.
-Long-running authenticated operations resolve through the error-aware path for
-each request or refresh decision, so a transient local Vault failure does not
-poison a later fresh invocation; a subsequent invocation may recover normally.
+`gh auth status` reports a credential-resolution failure caused by a denied or
+unavailable Secret Application separately from an invalid GitHub credential.
+Its operational diagnostic is `Vault retrieval unavailable.` It must not
+describe that failure as logged out or invalid, or direct the user to log in or
+authenticate again.
+
+At the tested request boundaries, API transport and watchers re-resolve
+through the error-aware path before each request. Refresh uses the
+authenticated-flow token directly for credential setup and performs no
+post-login Vault reread. A fresh invocation may recover after a transient
+local Vault failure.
 
 ## Release and installation boundary
 
@@ -73,9 +79,10 @@ Write Access authorizes recognized remote writes, but Secret Disclosure through
 
 ## Upstream context
 
-The upstream discussion in [GitHub CLI issue #13317] and [pull request #13318]
-tracks misleading authentication behavior when credential retrieval fails.
-Both remain open as of 2026-08-27. The Automic Vault Isotope extends the
+On 2026-08-27, the official public GitHub REST state listed [GitHub CLI issue
+#13317] as open. The official [pull request #13318] was open and non-draft.
+These separate upstream records track misleading authentication behavior when
+credential resolution fails. The Automic Vault Isotope extends the
 error-aware contract across the remaining authentication-sensitive callers,
 including API transport, Git credential resolution, token and refresh flows,
 logout, status, and long-running operations.

--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -4,12 +4,14 @@
 
 We provide a [patched version] of `gh`. `av harden gh` installs it from our
 [tap] when Homebrew is available, or installs the same signed release directly
-at `/usr/local/bin/gh`. The patches are concerned with:
+at `/usr/local/bin/gh`. The supported hardened path is designed so that only
+the verified `gh` Isotope can apply its GitHub Secret through the Automic Vault
+Secret Gate.
 
-1. Is codesigned such that `gh` (and only `gh`) can access its
-   secure credentials.
-2. Ensures that authenticated `gh` usage goes via the Automic Vault Secret Gate
-   system.
+The statements below describe the intended hardened-state contract. They do
+not establish that this checkout, or a particular installed `gh`, is already
+in Hardened State. That state is established only after the Hardener has
+verified and activated the supported release.
 
 [patched version]: https://github.com/automic-vault/gh-cli
 [tap]: https://github.com/automic-vault/homebrew-isotopes
@@ -19,6 +21,36 @@ at `/usr/local/bin/gh`. The patches are concerned with:
 Use `av harden gh` to install the Isotope and migrate existing `gh` credentials
 into Automic Vault. Direct installs are updated by running the same command when
 `av doctor gh` reports a new release.
+
+## Credential-resolution failure contract
+
+Authenticated operations use the error-aware Automic Vault credential path.
+If Secret retrieval is denied, times out, or the approval service or XPC
+broker is unavailable, `gh` returns a local Vault-retrieval error before it
+makes a GitHub request. An operational retrieval failure never falls back to a
+legacy credential, sends an anonymous request, or turns into a misleading
+HTTP 401.
+
+An account-specific lookup may use the legacy host-wide credential only when
+the account-specific lookup returns the exact `ErrNotFound` condition. If both
+credential locations are genuinely absent, an endpoint that explicitly allows
+anonymous access may remain anonymous. Absence and operational unavailability
+are different outcomes.
+
+`gh auth status` reports Vault retrieval unavailability separately from an
+invalid GitHub credential. It must not describe an operational Vault failure
+as logged out or invalid, or direct the user to log in or authenticate again.
+Long-running authenticated operations resolve through the error-aware path for
+each request or refresh decision, so a transient local Vault failure does not
+poison a later fresh invocation; a subsequent invocation may recover normally.
+
+## Release and installation boundary
+
+Only a verified official signed Automic Vault `gh` Isotope release installed by
+`av harden gh` is permitted to operate against real credentials. A local source
+build or checkout-local executable is not release evidence and must never
+receive real credentials. Environment tokens, plaintext credential files, and
+direct-binary Git workarounds are not equivalent hardened routes.
 
 ## Secret Gate
 
@@ -38,3 +70,15 @@ Write Access authorizes recognized remote writes, but Secret Disclosure through
   git-credential`; the hardened `gh` helper path requests the token through
   Automic Vault.
 - `av harden gh-cli` remains accepted as a compatibility alias.
+
+## Upstream context
+
+The upstream discussion in [GitHub CLI issue #13317] and [pull request #13318]
+tracks misleading authentication behavior when credential retrieval fails.
+Both remain open as of 2026-08-27. The Automic Vault Isotope extends the
+error-aware contract across the remaining authentication-sensitive callers,
+including API transport, Git credential resolution, token and refresh flows,
+logout, status, and long-running operations.
+
+[GitHub CLI issue #13317]: https://github.com/cli/cli/issues/13317
+[pull request #13318]: https://github.com/cli/cli/pull/13318


### PR DESCRIPTION
Depends on automic-vault/gh-cli#3

## Summary

Document the fail-closed credential-resolution contract for the hardened `gh` Isotope.

The updated hardener guide distinguishes exact credential absence from denial, timeout, and approval-service or XPC unavailability. Operational failures must stop before a GitHub request. `gh auth status` must report `Vault retrieval unavailable.` instead of describing a valid account as logged out or invalid.

The guide also records the tested API, watcher, and refresh boundaries. It links the public upstream issue and pull request without repeating their stale timeout claim.

## Release boundary

The text describes the intended Hardened State. It does not claim that a checkout or currently installed binary already has the fix.

Only a verified official signed Automic Vault `gh` Isotope installed through `av harden gh` may use real credentials. Local source builds remain test-only. Environment tokens, plaintext credential files, and direct-binary workarounds are not equivalent hardened routes.

## Validation

- `git diff --check`
- `cargo +1.96.0 fmt --all -- --check`
- Independent review against the canonical domain language, architecture, and positioning documents

The branch changes one Markdown file. It does not change product code, credentials, policy, or deployment state.

## Authorship and follow-up

An agent wrote this under close human direction. An agent may draft review replies, but `@saltedzucchini` will review them before posting.
