### PR TITLE
Fail closed on Supabase Keychain migration errors

### DIFF
--- a/src/isotopes/hardeners/gh_cli.rs
+++ b/src/isotopes/hardeners/gh_cli.rs
@@ -319,7 +319,7 @@ pub(super) fn security_find_generic_password(
         .flatten()
 }
 
-fn security_find_generic_password_result(
+pub(super) fn security_find_generic_password_result(
     service: &str,
     account: Option<&str>,
 ) -> Result<Option<String>, String> {
@@ -333,20 +333,22 @@ fn security_find_generic_password_result(
         .output()
         .map_err(|err| format!("failed to run security: {err}"))?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("could not be found")
-            || stderr.contains("The specified item could not be found")
-        {
+        if output.status.code() == Some(44) {
             return Ok(None);
         }
+        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!(
             "failed to read legacy keychain item (service {service:?}, account {account:?}): {}",
             stderr.trim()
         ));
     }
-    Ok(decode_legacy_keychain_password(
-        String::from_utf8_lossy(&output.stdout).trim(),
-    ))
+    decode_legacy_keychain_password(String::from_utf8_lossy(&output.stdout).trim())
+        .map(Some)
+        .ok_or_else(|| {
+            format!(
+                "legacy keychain item (service {service:?}, account {account:?}) contained an unsupported or malformed value"
+            )
+        })
 }
 
 fn decode_legacy_keychain_password(value: &str) -> Option<String> {

--- a/src/isotopes/hardeners/gh_cli.rs
+++ b/src/isotopes/hardeners/gh_cli.rs
@@ -313,10 +313,8 @@ fn configured_hosts(hosts_paths: &[PathBuf]) -> BTreeMap<String, Option<String>>
 pub(super) fn security_find_generic_password(
     service: &str,
     account: Option<&str>,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     security_find_generic_password_result(service, account)
-        .ok()
-        .flatten()
 }
 
 pub(super) fn security_find_generic_password_result(

--- a/src/isotopes/hardeners/stripe_cli.rs
+++ b/src/isotopes/hardeners/stripe_cli.rs
@@ -41,12 +41,12 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
             {
                 add_credential(&mut credentials, key.clone(), value, None)?;
             }
-            if let Some(value) = legacy_keychain_value(&legacy_key) {
+            if let Some(value) = legacy_keychain_value(&legacy_key)? {
                 add_credential(&mut credentials, key, value, Some(legacy_key))?;
             }
         }
         let session_key = format!("{profile}.stripe_cli_session");
-        if let Some(value) = legacy_keychain_value(&session_key) {
+        if let Some(value) = legacy_keychain_value(&session_key)? {
             add_credential(
                 &mut credentials,
                 vault_key(&session_key),
@@ -55,7 +55,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
             )?;
         }
     }
-    if let Some(value) = legacy_keychain_value("uat") {
+    if let Some(value) = legacy_keychain_value("uat")? {
         add_credential(
             &mut credentials,
             vault_key("uat"),
@@ -284,11 +284,11 @@ fn add_credential(
     Ok(())
 }
 
-fn legacy_keychain_value(account: &str) -> Option<String> {
+fn legacy_keychain_value(account: &str) -> Result<Option<String>, String> {
     if let Some(json) = crate::test_env_string("AUTOMIC_VAULT_TEST_STRIPE_LEGACY_KEYS") {
         return serde_json::from_str::<BTreeMap<String, String>>(&json)
-            .ok()?
-            .remove(account);
+            .map(|mut values| values.remove(account))
+            .map_err(|err| format!("failed to parse test Stripe Keychain values: {err}"));
     }
     super::gh_cli::security_find_generic_password(KEYCHAIN_SERVICE, Some(account))
 }
@@ -362,6 +362,7 @@ fn redact(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -455,6 +456,29 @@ mod tests {
         assert_eq!(gate.key_patterns, ["STRIPE_CLI_*"]);
         assert_eq!(gate.routes[0].caller_identifiers, ["stripe"]);
         assert_eq!(gate.routes[0].key_patterns, ["STRIPE_CLI_*"]);
+    }
+
+    #[test]
+    fn keychain_read_errors_fail_closed() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let security = temp_path("denied-stripe-keychain");
+        fs::write(
+            &security,
+            "#!/bin/sh\nprintf '%s\\n' 'user interaction is not allowed' >&2\nexit 1\n",
+        )
+        .unwrap();
+        fs::set_permissions(&security, fs::Permissions::from_mode(0o700)).unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_SECURITY_PATH", &security);
+        }
+
+        let error = legacy_keychain_value("uat").unwrap_err();
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_SECURITY_PATH");
+        }
+        assert!(error.contains("failed to read legacy keychain item"));
+        let _ = fs::remove_file(security);
     }
 
     fn temp_path(name: &str) -> PathBuf {

--- a/src/isotopes/hardeners/supabase.rs
+++ b/src/isotopes/hardeners/supabase.rs
@@ -32,9 +32,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     .and_then(|()| stdout.flush())
     .map_err(|err| format!("failed to show Keychain notice: {err}"))?;
 
-    if tokens.is_empty() {
-        tokens.extend(read_legacy_keychain_tokens());
-    }
+    tokens.extend(read_legacy_keychain_tokens()?);
     tokens.sort();
     tokens.dedup();
 
@@ -156,26 +154,32 @@ fn read_plaintext_tokens(paths: &[PathBuf]) -> Result<Vec<String>, String> {
     Ok(tokens)
 }
 
-fn read_legacy_keychain_tokens() -> Vec<String> {
+fn read_legacy_keychain_tokens() -> Result<Vec<String>, String> {
     if let Some(token) = crate::test_env_string("AUTOMIC_VAULT_TEST_SUPABASE_LEGACY_TOKEN") {
-        return vec![token];
+        return validate_legacy_keychain_token("test", token).map(|token| vec![token]);
     }
-    KEYCHAIN_ACCOUNTS
-        .iter()
-        .filter_map(|account| security_find_generic_password(KEYCHAIN_SERVICE, account))
-        .collect()
+    if crate::test_keychain_dir().is_some() {
+        return Ok(Vec::new());
+    }
+    let mut tokens = Vec::new();
+    for account in KEYCHAIN_ACCOUNTS {
+        if let Some(token) = security_find_generic_password(KEYCHAIN_SERVICE, account)? {
+            tokens.push(token);
+        }
+    }
+    Ok(tokens)
 }
 
-fn security_find_generic_password(service: &str, account: &str) -> Option<String> {
-    let output = Command::new("/usr/bin/security")
-        .args(["find-generic-password", "-s", service, "-a", account, "-w"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    is_supabase_access_token(&token).then_some(token)
+fn security_find_generic_password(service: &str, account: &str) -> Result<Option<String>, String> {
+    super::gh_cli::security_find_generic_password_result(service, Some(account))?
+        .map(|token| validate_legacy_keychain_token(account, token))
+        .transpose()
+}
+
+fn validate_legacy_keychain_token(account: &str, token: String) -> Result<String, String> {
+    is_supabase_access_token(&token).then_some(token).ok_or_else(|| {
+        format!("legacy Supabase Keychain item for account {account:?} is not a supported access token")
+    })
 }
 
 fn remove_plaintext_token(path: &Path) -> Result<(), String> {
@@ -225,6 +229,7 @@ fn is_supabase_access_token(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -293,6 +298,115 @@ mod tests {
         ));
         assert!(!is_supabase_access_token("sbp_short"));
         assert!(!is_supabase_access_token("not-a-token"));
+    }
+
+    #[test]
+    fn normalizes_go_keyring_wrapped_keychain_tokens() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let security = fake_security(
+            "wrapped-supabase-keychain",
+            "printf '%s\\n' 'go-keyring-base64:c2JwXzAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc='\n",
+        );
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_SECURITY_PATH", &security);
+        }
+
+        let token = security_find_generic_password(KEYCHAIN_SERVICE, "supabase").unwrap();
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_SECURITY_PATH");
+        }
+        assert_eq!(
+            token.as_deref(),
+            Some("sbp_0123456789abcdef0123456789abcdef01234567")
+        );
+        let _ = fs::remove_file(security);
+    }
+
+    #[test]
+    fn treats_only_item_not_found_as_keychain_absence() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let security = fake_security(
+            "missing-supabase-keychain",
+            "printf '%s\\n' 'The specified item could not be found in the keychain.' >&2\nexit 44\n",
+        );
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_SECURITY_PATH", &security);
+        }
+
+        let token = security_find_generic_password(KEYCHAIN_SERVICE, "supabase").unwrap();
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_SECURITY_PATH");
+        }
+        assert_eq!(token, None);
+        let _ = fs::remove_file(security);
+    }
+
+    #[test]
+    fn keychain_read_errors_fail_closed() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_path("denied-supabase-migration");
+        let home = dir.join("home");
+        let supabase = dir.join("supabase");
+        let token_path = home.join(".supabase/access-token");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        fs::write(&supabase, "original").unwrap();
+        fs::write(
+            &token_path,
+            "sbp_0123456789abcdef0123456789abcdef01234567\n",
+        )
+        .unwrap();
+        let security = fake_security(
+            "denied-supabase-keychain",
+            "printf '%s\\n' 'user interaction is not allowed' >&2\nexit 1\n",
+        );
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AUTOMIC_VAULT_TEST_SUPABASE_CLI_PATH", &supabase);
+            std::env::set_var("AUTOMIC_VAULT_TEST_SECURITY_PATH", &security);
+        }
+
+        let error = run(&mut Vec::new(), true).unwrap_err();
+
+        unsafe {
+            std::env::remove_var("HOME");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_SUPABASE_CLI_PATH");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_SECURITY_PATH");
+        }
+        assert!(error.contains("failed to read legacy keychain item"));
+        assert!(error.contains("user interaction is not allowed"));
+        assert!(token_path.exists());
+        assert_eq!(fs::read_to_string(supabase).unwrap(), "original");
+        let _ = fs::remove_file(security);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn malformed_keychain_values_fail_closed() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let security = fake_security(
+            "malformed-supabase-keychain",
+            "printf '%s\\n' 'go-keyring-base64:not-base64'\n",
+        );
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_SECURITY_PATH", &security);
+        }
+
+        let error = security_find_generic_password(KEYCHAIN_SERVICE, "supabase").unwrap_err();
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_SECURITY_PATH");
+        }
+        assert!(error.contains("unsupported or malformed value"));
+        let _ = fs::remove_file(security);
+    }
+
+    fn fake_security(label: &str, body: &str) -> PathBuf {
+        let path = temp_path(label);
+        fs::write(&path, format!("#!/bin/sh\n{body}")).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        path
     }
 
     fn temp_path(label: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- normalize native and legacy go-keyring-wrapped Supabase access tokens before migration
- treat only `/usr/bin/security` exit 44 (`errSecItemNotFound`) as absence and fail closed on every other read or malformed value
- inspect every legacy Supabase Keychain source even when a plaintext fallback exists, so migration cannot delete an unread or conflicting credential
- propagate the same shared Keychain read failures through Stripe instead of treating them as missing credentials
- preserve legacy sources and installed executables when Keychain inspection fails

## Security boundary

This changes migration diagnostics only. It does not broaden either Secret Gate, Target set, or Authorization Policy.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked` (943 library tests plus all integration targets)
- targeted Supabase, Stripe, and GH suites after the review follow-up
- verified the real macOS `security find-generic-password` item-not-found exit is 44

Roadmap: #186
