### PR TITLE
Review app helpers when adding Verified Launchers

### DIFF
--- a/docs/adr/0034-user-approved-launcher-helpers.md
+++ b/docs/adr/0034-user-approved-launcher-helpers.md
@@ -1,0 +1,54 @@
+# ADR 0034: Require explicit approval for discovered Launcher helpers
+
+Status: accepted
+
+## Context
+
+Applications often ship separately signed command-line helpers or login-item
+apps that perform the same operations as the containing product. These helpers
+may run without the app's main executable in their live ancestry, so the rule
+established for the app does not match them. Requiring a separate rule for each
+implementation component exposes packaging details and often conflicts with the
+user's intent.
+
+Automatically attributing every bundle-contained executable to the app is not
+acceptable. Development apps may contain unrelated tools, plug-ins, runtimes,
+and utilities. A shared Team ID or bundle location establishes neither intent
+nor the scope the user meant to authorize.
+
+## Decision
+
+When the user adds an app as a Verified Launcher at an Authorization Gate,
+Automic Vault may inspect the app for separately signed executable helpers. The
+inspection is discovery only and runs outside the main actor. It excludes the
+app's declared main executable and offers only helpers whose exact signing
+identity can be read and whose executable is a required, unmodified member of
+the app's resource seal.
+
+Automic Vault presents the discovered helpers unselected. The user may select
+individual helpers and must see a warning that each enabled association makes
+that helper represent the app at every Authorization Gate where the app has a
+current or future Launcher-specific rule. Adding an association is an authority
+change and uses the configured human Approval surface.
+
+The positive catalog combines reviewed built-in associations with exact
+user-approved associations stored in the Data Protection Keychain. Each
+association binds the app bundle identifier and Team ID to the helper signing
+identifier and Team ID. Runtime authorization continues to verify the live
+helper, bind it to the on-disk executable, validate the app's signed executable,
+and validate the helper against the app's resource seal. Discovery results,
+paths, containment, and Team IDs alone never grant authority.
+
+A malformed stored configuration disables every helper association. A user may
+disable an association without deleting any Launcher-specific policy rule.
+
+## Consequences
+
+Apps with intentional background or CLI components can share one reviewed
+Launcher Identity without restoring blanket bundle inheritance. The user sees
+the authority expansion at the moment it is relevant and can decline it.
+
+Large apps may contain many signed executables, so discovery can add latency and
+must remain cancelable and off the main actor. Associations are global rather
+than gate-specific; the warning must not imply that the helper is limited to the
+gate where it was discovered.

--- a/docs/adr/0034-user-approved-launcher-helpers.md
+++ b/docs/adr/0034-user-approved-launcher-helpers.md
@@ -34,10 +34,11 @@ change and uses the configured human Approval surface.
 The positive catalog combines reviewed built-in associations with exact
 user-approved associations stored in the Data Protection Keychain. Each
 association binds the app bundle identifier and Team ID to the helper signing
-identifier and Team ID. Runtime authorization continues to verify the live
-helper, bind it to the on-disk executable, validate the app's signed executable,
-and validate the helper against the app's resource seal. Discovery results,
-paths, containment, and Team IDs alone never grant authority.
+identifier, Team ID, and exact relative path inside the app. Runtime
+authorization continues to verify the live helper, bind it to that on-disk
+executable, validate the app's signed executable, and validate the helper
+against the app's resource seal. Discovery results, paths, containment, and
+Team IDs alone never grant authority.
 
 A malformed stored configuration disables every helper association. A user may
 disable an association without deleting any Launcher-specific policy rule.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,8 +289,9 @@ whose exact app and helper signing identities appear in the positive catalog.
 The catalog combines reviewed built-in associations with associations the user
 explicitly approves after signed, sealed helpers are discovered while adding an
 app as a Verified Launcher. Discovery grants no authority. The approval UI lists
-each exact helper identity and warns that enabling one makes it represent the
-app at every Authorization Gate where that app has a current or future rule.
+each exact helper identity and relative path. User-approved associations bind
+both, and the UI warns that enabling one makes it represent the app at every
+Authorization Gate where that app has a current or future rule.
 User-approved associations and disabled catalog entries are stored in the Data
 Protection Keychain; missing or malformed stored configuration fails closed
 except that a genuinely absent record uses the built-in defaults. Runtime

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,18 +285,26 @@ The policy identity is the Launcher's designated requirement, checked against th
 An app's declared main executable may represent the app after its code signature
 and exact membership in the app's resource seal are validated. A non-main
 executable may represent the app only as an enabled Verified Launcher Helper
-whose exact app and helper signing identities appear in the built-in positive
-catalog. Disabled catalog entries are stored in the Data Protection Keychain;
-missing or malformed stored configuration fails closed except that a genuinely
-absent record uses the built-in defaults. Runtime verification binds the live
-helper to the on-disk executable, validates the app executable, and validates
-the exact helper as a required, unaltered member of the app's resource seal.
+whose exact app and helper signing identities appear in the positive catalog.
+The catalog combines reviewed built-in associations with associations the user
+explicitly approves after signed, sealed helpers are discovered while adding an
+app as a Verified Launcher. Discovery grants no authority. The approval UI lists
+each exact helper identity and warns that enabling one makes it represent the
+app at every Authorization Gate where that app has a current or future rule.
+User-approved associations and disabled catalog entries are stored in the Data
+Protection Keychain; missing or malformed stored configuration fails closed
+except that a genuinely absent record uses the built-in defaults. Runtime
+verification binds the live helper to the on-disk executable, validates the app
+executable, and validates the exact helper as a required, unaltered member of
+the app's resource seal.
 Unrelated app resources are not Launcher Identity evidence and are not scanned.
 If targeted resource validation is unavailable, Automic Vault falls back to
 complete bundle validation. Other bundle-contained executables do not inherit
 the app identity. Launcher Bundles retain their complete enrolled-bundle and
 payload verification. See [ADR 0020](adr/0020-app-launcher-main-executable.md)
 and [ADR 0033](adr/0033-targeted-app-launcher-validation.md).
+User-approved associations are defined by
+[ADR 0034](adr/0034-user-approved-launcher-helpers.md).
 
 Eligible Launchers must enable Hardened Runtime or be Apple platform binaries
 signed as part of a macOS release, for which macOS applies the runtime

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -209,15 +209,22 @@ complete enrollment and integrity checks.
 A vendor-signed executable that may represent one exact containing app as its
 Launcher even though it is not that app's declared main executable. The
 association binds the helper and app signing identities and is enabled through
-an explicit positive catalog whose disabled entries are stored in the Data
-Protection Keychain. Bundle containment, a filename, a path, or a shared Team
-ID alone never creates the association.
+an explicit positive catalog. The catalog contains reviewed built-in
+associations and associations the user explicitly approves after Automic Vault
+discovers signed helpers sealed inside an app. User-approved associations and
+disabled entries are stored in the Data Protection Keychain. Discovery,
+bundle containment, a filename, a path, or a shared Team ID alone never creates
+an association.
 
 Automic Vault verifies the live helper, the app's signed executable, and that
 the exact helper file is a required unmodified resource in the app's resource
 seal before attributing the app's Launcher Identity. If any check fails, the
 helper does not receive the app identity; an independently eligible Developer
 ID executable may still qualify under its own standalone Launcher Identity.
+An enabled association applies wherever policy names the containing app's
+Launcher Identity, across every current and future Authorization Gate. The user
+must be warned about that authority expansion before approving an association
+and may disable it without changing the app's Launcher-specific rules.
 
 ### Retained Launcher Provenance
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -211,8 +211,9 @@ Launcher even though it is not that app's declared main executable. The
 association binds the helper and app signing identities and is enabled through
 an explicit positive catalog. The catalog contains reviewed built-in
 associations and associations the user explicitly approves after Automic Vault
-discovers signed helpers sealed inside an app. User-approved associations and
-disabled entries are stored in the Data Protection Keychain. Discovery,
+discovers signed helpers sealed inside an app. A user-approved association also
+binds the helper's relative path inside that app. User-approved associations
+and disabled entries are stored in the Data Protection Keychain. Discovery,
 bundle containment, a filename, a path, or a shared Team ID alone never creates
 an association.
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -47,6 +47,9 @@ Automic Vault decides whether a complete operation may use it.
 - An explicitly recognized, vendor-signed CLI sealed inside its vendor's app
   may represent that app as a Verified Launcher; unrelated bundled executables
   do not inherit the app's authority.
+- When Automic Vault discovers signed helpers while adding an app as a Verified
+  Launcher, the user may explicitly associate selected helpers with that app
+  after reviewing the cross-gate authority warning.
 - Git can keep its ordinary commit workflow while the GPG Signing Gate
   authorizes private-key use and may select an alternate credential for exact
   Verified Launchers.

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -187,8 +187,11 @@ final class DashboardModel: ObservableObject {
     @Published private(set) var pendingBlessingLaunchers: [BlessedScriptLauncher] = []
     @Published private(set) var launcherBundles: [LauncherBundleEnrollment] = []
     @Published private(set) var pendingLauncherBundle: LauncherBundleCandidate?
+    @Published private(set) var isDiscoveringLauncherHelpers = false
+    @Published private(set) var pendingLauncherHelperReview: LauncherHelperReview?
 
     private var reloadTask: Task<Void, Never>?
+    private var launcherHelperDiscoveryTask: Task<Void, Never>?
     private var blessingCompletion: ((BlessedScriptReviewOutcome) -> Void)?
 
     init(snapshot: DashboardSnapshot = .empty, cliInstallState: CLIInstallState? = nil) {
@@ -955,6 +958,7 @@ final class DashboardModel: ObservableObject {
     }
 
     func addApp(to gate: SecretGate) {
+        guard !isDiscoveringLauncherHelpers, pendingLauncherHelperReview == nil else { return }
         chooseLauncher { [weak self] signing in
             guard let self, let signing else { return }
             guard let runtimeRequirement = signing.runtimeProtection.secretGateAdmissionRequirement else {
@@ -964,23 +968,121 @@ final class DashboardModel: ObservableObject {
                 ))
                 return
             }
-            self.approveAuthorityChange(
-                "Add \(signing.identifier) to \(gate.displayName)",
-                detail: "Recognized read-only operations will be automically authorized."
-            ) {
-                let status = setSecretGateAppProtection(
+            guard URL(fileURLWithPath: signing.path).pathExtension
+                .caseInsensitiveCompare("app") == .orderedSame
+            else {
+                self.finishAddingLauncher(
+                    signing,
+                    to: gate,
+                    runtimeRequirement: runtimeRequirement,
+                    helpers: []
+                )
+                return
+            }
+            self.isDiscoveringLauncherHelpers = true
+            self.launcherHelperDiscoveryTask = Task { [weak self] in
+                let discovered = await discoverVerifiedLauncherHelpers(
+                    in: URL(fileURLWithPath: signing.path, isDirectory: true)
+                )
+                guard let self else { return }
+                self.isDiscoveringLauncherHelpers = false
+                self.launcherHelperDiscoveryTask = nil
+                guard !Task.isCancelled else { return }
+                let configuration = loadVerifiedLauncherHelperConfiguration()
+                var seen = Set<String>()
+                let helpers = discovered.compactMap { discovered -> VerifiedLauncherHelper? in
+                    let helper = configuration.catalogHelper(matching: discovered) ?? discovered
+                    guard !configuration.isEnabled(helper), seen.insert(helper.id).inserted else {
+                        return nil
+                    }
+                    return helper
+                }
+                guard !helpers.isEmpty else {
+                    self.finishAddingLauncher(
+                        signing,
+                        to: gate,
+                        runtimeRequirement: runtimeRequirement,
+                        helpers: []
+                    )
+                    return
+                }
+                self.pendingLauncherHelperReview = LauncherHelperReview(
+                    signing: signing,
+                    gate: gate,
+                    runtimeRequirement: runtimeRequirement,
+                    helpers: helpers
+                )
+            }
+        }
+    }
+
+    func confirmLauncherHelperReview(selectedHelperIDs: Set<String>) {
+        guard let review = pendingLauncherHelperReview else { return }
+        pendingLauncherHelperReview = nil
+        finishAddingLauncher(
+            review.signing,
+            to: review.gate,
+            runtimeRequirement: review.runtimeRequirement,
+            helpers: review.helpers.filter { selectedHelperIDs.contains($0.id) }
+        )
+    }
+
+    func cancelLauncherHelperReview() {
+        pendingLauncherHelperReview = nil
+    }
+
+    private func finishAddingLauncher(
+        _ signing: LauncherSigning,
+        to gate: SecretGate,
+        runtimeRequirement: LauncherRuntimeRequirement,
+        helpers: [VerifiedLauncherHelper]
+    ) {
+        let existingPolicy = gate.appPolicies.contains { $0.requirement == signing.requirement }
+        guard !existingPolicy || !helpers.isEmpty else { return }
+        let helperList = helpers.map {
+            let path = $0.relativePath.map { " at \($0)" } ?? ""
+            return "Verified Launcher Helper: \($0.helperSigningIdentifier), "
+                + "Team \($0.helperTeamIdentifier)\(path)"
+        }.joined(separator: "\n")
+        let helperDetail = helpers.isEmpty ? nil : """
+        \(helperList)
+        Each selected helper will represent \(signing.identifier) at every Authorization Gate where that app has a current or future Launcher-specific rule.
+        """
+        let detail = [
+            existingPolicy ? nil : gate.protectionSubtitle(gate.initialProtection),
+            helperDetail,
+        ].compactMap(\.self).joined(separator: "\n\n")
+        approveAuthorityChange(
+            existingPolicy
+                ? "Add Launcher Helpers for \(signing.identifier)"
+                : "Add \(signing.identifier) to \(gate.displayName)",
+            detail: detail
+        ) { [weak self] in
+            guard let self else { return }
+            if !existingPolicy {
+                let policyStatus = setSecretGateAppProtection(
                     requirement: signing.requirement,
-                    protection: .readOnly,
+                    protection: gate.initialProtection,
                     for: gate,
                     runtimeRequirement: runtimeRequirement
                 )
-                if status == errSecSuccess {
-                    self.errorMessage = nil
-                    self.reload()
-                } else {
-                    self.errorMessage = "Could not allow \(signing.identifier): \(status)"
+                guard policyStatus == errSecSuccess else {
+                    self.errorMessage = "Could not allow \(signing.identifier): \(policyStatus)"
+                    return
                 }
             }
+            guard !helpers.isEmpty else {
+                self.errorMessage = nil
+                self.reload()
+                return
+            }
+            var configuration = loadVerifiedLauncherHelperConfiguration()
+            configuration.enable(helpers)
+            let helperStatus = saveVerifiedLauncherHelperConfiguration(configuration)
+            self.errorMessage = helperStatus == errSecSuccess
+                ? nil
+                : "The Launcher was added, but its helper associations could not be saved: \(helperStatus)"
+            self.reload()
         }
     }
 
@@ -1418,6 +1520,30 @@ func runDashboardSearchSelfCheck() -> Int32 {
     let verifiedLauncherHelpersHeight = NSHostingView(
         rootView: VerifiedLauncherHelpersSettingsView()
     ).fittingSize.height
+    let launcherHelperReviewSize = NSHostingView(rootView: LauncherHelperReviewView(
+        model: model,
+        review: LauncherHelperReview(
+            signing: LauncherSigning(
+                identifier: "com.example.app",
+                teamIdentifier: "EXAMPLETEAM",
+                path: "/Applications/Example.app",
+                requirement: #"identifier "com.example.app""#,
+                runtimeProtection: .hardened
+            ),
+            gate: gate,
+            runtimeRequirement: .hardened,
+            helpers: [VerifiedLauncherHelper(
+                id: "example-helper",
+                name: "Example Helper",
+                appName: "Example",
+                appBundleIdentifier: "com.example.app",
+                appTeamIdentifier: "EXAMPLETEAM",
+                helperSigningIdentifier: "com.example.helper",
+                helperTeamIdentifier: "EXAMPLETEAM",
+                relativePath: "Contents/Helpers/example-helper"
+            )]
+        )
+    )).fittingSize
     let previousScriptData = Data("#!/usr/local/bin/av inject +TOKEN /bin/sh\necho old\n".utf8)
     let currentScriptData = Data("#!/usr/local/bin/av inject +TOKEN /bin/sh\necho current\n".utf8)
     guard let currentDeclaration = try? blessedScriptDeclaration(data: currentScriptData) else { return 1 }
@@ -1493,6 +1619,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
           aboutHeight > 0,
           detachedProcessAccessHeight > 0,
           verifiedLauncherHelpersHeight > 0,
+          launcherHelperReviewSize == CGSize(width: 680, height: 520),
           appRowHeight < 140,
           launcherBundleDisplay.name == "herdr",
           launcherBundleDisplay.bundleIdentifier == launcherBundle.bundleIdentifier,
@@ -1728,12 +1855,18 @@ struct DashboardRootView: View {
                         .help("\(cliActionTitle) at /usr/local/bin/av")
                     }
                     if model.selectedSection == .secretGates, let gate = model.selectedSecretGate {
+                        if model.isDiscoveringLauncherHelpers {
+                            ProgressView()
+                                .controlSize(.small)
+                                .help("Inspecting the selected app for signed helpers")
+                        }
                         Button {
                             model.addApp(to: gate)
                         } label: {
                             Image(systemName: "plus")
                         }
                         .help("Add Calling App")
+                        .disabled(model.isDiscoveringLauncherHelpers)
                     }
                     if model.selectedSection == .blessedScripts {
                         Button {
@@ -1774,6 +1907,12 @@ struct DashboardRootView: View {
             if let request = model.pendingBlessing {
                 BlessedScriptReviewView(model: model, request: request)
             }
+        }
+        .sheet(item: Binding(
+            get: { model.pendingLauncherHelperReview },
+            set: { if $0 == nil { model.cancelLauncherHelperReview() } }
+        )) { review in
+            LauncherHelperReviewView(model: model, review: review)
         }
     }
 }
@@ -3401,6 +3540,101 @@ private struct BlessedScriptReviewView: View {
     }
 }
 
+private struct LauncherHelperReviewView: View {
+    @ObservedObject var model: DashboardModel
+    let review: LauncherHelperReview
+    @State private var selectedHelperIDs: Set<String> = []
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        Text("Automic Vault found signed helpers sealed inside \(appName). "
+                            + "Select only helpers that should share the app’s Launcher Identity.")
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        VStack(spacing: 0) {
+                            ForEach(review.helpers) { helper in
+                                helperRow(helper)
+                                if helper.id != review.helpers.last?.id { hairline }
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color(nsColor: .separatorColor))
+                        }
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("This may widen Secret access", systemImage: "exclamationmark.triangle.fill")
+                                .font(.headline)
+                                .foregroundStyle(.orange)
+                            Text("Each selected helper will represent \(appName) at every Authorization Gate "
+                                + "where that app has a current or future Launcher-specific rule. It may apply "
+                                + "protected Secrets or perform controlled operations up to that rule’s Access "
+                                + "Level. Select it only if you trust the helper to act as the app.")
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(14)
+                        .background(.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+                    }
+                    .padding(22)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .navigationTitle("Include App Helpers?")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { model.cancelLauncherHelperReview() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(selectedHelperIDs.isEmpty ? "Add Launcher Only" : "Add Launcher and Helpers") {
+                        model.confirmLauncherHelperReview(selectedHelperIDs: selectedHelperIDs)
+                    }
+                }
+            }
+        }
+        .frame(width: 680, height: 520)
+    }
+
+    private var appName: String {
+        review.helpers.first?.appName ?? review.signing.identifier
+    }
+
+    private func helperRow(_ helper: VerifiedLauncherHelper) -> some View {
+        Toggle(isOn: Binding(
+            get: { selectedHelperIDs.contains(helper.id) },
+            set: { selected in
+                if selected {
+                    selectedHelperIDs.insert(helper.id)
+                } else {
+                    selectedHelperIDs.remove(helper.id)
+                }
+            }
+        )) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(helper.name)
+                    .font(.system(size: 13, weight: .medium))
+                Text("\(helper.helperSigningIdentifier) · Team \(helper.helperTeamIdentifier)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                if let relativePath = helper.relativePath {
+                    Text(relativePath)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(.vertical, 10)
+        }
+        .toggleStyle(.checkbox)
+    }
+}
+
 private struct BlessedScriptDiffView: View {
     let rows: [String]
 
@@ -3823,13 +4057,14 @@ private struct VerifiedLauncherHelpersSettingsView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Verified Launcher Helpers")
                     .font(.system(size: 24, weight: .semibold))
-                Text("Allow exact vendor-signed CLIs sealed inside their vendor's app to represent that app as the Verified Launcher.")
+                Text("Allow exact vendor-signed helpers sealed inside their vendor's app to represent that app as the Verified Launcher.")
                     .font(.system(size: 13))
                     .foregroundStyle(.secondary)
             }
-            helperRow(codexVerifiedLauncherHelper)
-            Divider()
-            helperRow(claudeCodeVerifiedLauncherHelper)
+            ForEach(configuration.helpers) { helper in
+                helperRow(helper)
+                if helper.id != configuration.helpers.last?.id { Divider() }
+            }
             InfoBlock(
                 title: "Exact identities only",
                 text: "Each association verifies both signing identities, binds the live helper to its on-disk executable, and confirms that exact executable is unmodified in the app's resource seal. Other bundled executables do not inherit the app's authority."
@@ -3855,7 +4090,7 @@ private struct VerifiedLauncherHelpersSettingsView: View {
                         }
                         requestAuthorityChangeApproval(
                             title: "Enable \(helper.name) Launcher Helper",
-                            detail: "Allow the exact signed \(helper.name) helper sealed inside \(helper.appName) to represent \(helper.appName) as the Verified Launcher."
+                            detail: "Allow the exact signed \(helper.name) helper sealed inside \(helper.appName) to represent \(helper.appName) at every Authorization Gate where that app has a current or future Launcher-specific rule. This may widen Secret access and controlled operations up to each rule’s Access Level."
                         ) { approved in
                             if approved { persist(helper, enabled: true) }
                         }
@@ -3866,6 +4101,14 @@ private struct VerifiedLauncherHelpersSettingsView: View {
                 .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)
+            if let relativePath = helper.relativePath {
+                Text(relativePath)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
         }
     }
 
@@ -4665,12 +4908,20 @@ private struct ApprovedAppDisplay {
     }
 }
 
-private struct LauncherSigning {
+struct LauncherSigning: Sendable {
     let identifier: String
     let teamIdentifier: String
     let path: String
     let requirement: String
     let runtimeProtection: LauncherRuntimeProtection
+}
+
+struct LauncherHelperReview: Identifiable, Sendable {
+    let id = UUID()
+    let signing: LauncherSigning
+    let gate: SecretGate
+    let runtimeRequirement: LauncherRuntimeRequirement
+    let helpers: [VerifiedLauncherHelper]
 }
 
 struct DirectAccessLauncherSelection {

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1016,6 +1016,10 @@ final class DashboardModel: ObservableObject {
         }
     }
 
+    func cancelLauncherHelperDiscovery() {
+        launcherHelperDiscoveryTask?.cancel()
+    }
+
     func confirmLauncherHelperReview(selectedHelperIDs: Set<String>) {
         guard let review = pendingLauncherHelperReview else { return }
         pendingLauncherHelperReview = nil
@@ -1859,14 +1863,20 @@ struct DashboardRootView: View {
                             ProgressView()
                                 .controlSize(.small)
                                 .help("Inspecting the selected app for signed helpers")
+                            Button {
+                                model.cancelLauncherHelperDiscovery()
+                            } label: {
+                                Image(systemName: "xmark")
+                            }
+                            .help("Cancel App Inspection")
+                        } else {
+                            Button {
+                                model.addApp(to: gate)
+                            } label: {
+                                Image(systemName: "plus")
+                            }
+                            .help("Add Calling App")
                         }
-                        Button {
-                            model.addApp(to: gate)
-                        } label: {
-                            Image(systemName: "plus")
-                        }
-                        .help("Add Calling App")
-                        .disabled(model.isDiscoveringLauncherHelpers)
                     }
                     if model.selectedSection == .blessedScripts {
                         Button {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -9953,32 +9953,32 @@ private func verifiedLauncherHelperAssociation(
 ) -> VerifiedLauncherHelperAssociation? {
     let configuration = configuration ?? loadVerifiedLauncherHelperConfiguration()
     let helpers = helpers ?? configuration.helpers
-    guard signing.isDeveloperID,
-          let helper = helpers.first(where: {
-              $0.helperSigningIdentifier == signing.identifier
-                  && $0.helperTeamIdentifier == signing.teamIdentifier
-          }),
-          configuration.isEnabled(helper)
-    else { return nil }
+    guard signing.isDeveloperID else { return nil }
     let executablePath = signing.mainExecutable.isEmpty ? path : signing.mainExecutable
     let executableURL = URL(fileURLWithPath: executablePath)
         .standardizedFileURL
         .resolvingSymlinksInPath()
     let appURLs = containingAppURLs ?? appBundleURLs(containing: executableURL.path)
-    guard let appURL = appURLs.first(where: {
-        bundleIdentifier($0) == helper.appBundleIdentifier
-    }) else { return nil }
-    if let relativePath = helper.relativePath {
-        let expectedURL = appURL.appendingPathComponent(relativePath)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-        guard expectedURL == executableURL else { return nil }
+    for helper in helpers where configuration.isEnabled(helper)
+        && helper.helperSigningIdentifier == signing.identifier
+        && helper.helperTeamIdentifier == signing.teamIdentifier
+    {
+        guard let appURL = appURLs.first(where: {
+            bundleIdentifier($0) == helper.appBundleIdentifier
+        }) else { continue }
+        if let relativePath = helper.relativePath {
+            let expectedURL = appURL.appendingPathComponent(relativePath)
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+            guard expectedURL == executableURL else { continue }
+        }
+        return VerifiedLauncherHelperAssociation(
+            helper: helper,
+            appURL: appURL,
+            executableURL: executableURL
+        )
     }
-    return VerifiedLauncherHelperAssociation(
-        helper: helper,
-        appURL: appURL,
-        executableURL: executableURL
-    )
+    return nil
 }
 
 private func verifiedLauncherHelperSigningInfo(
@@ -12563,6 +12563,34 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
         ),
         bundleIdentifier: { _ in codexVerifiedLauncherHelper.appBundleIdentifier }
     )
+    let wrongPathCodexHelper = VerifiedLauncherHelper(
+        id: "wrong-path-codex",
+        name: "Wrong Codex",
+        appName: "ChatGPT",
+        appBundleIdentifier: codexVerifiedLauncherHelper.appBundleIdentifier,
+        appTeamIdentifier: codexVerifiedLauncherHelper.appTeamIdentifier,
+        helperSigningIdentifier: codexVerifiedLauncherHelper.helperSigningIdentifier,
+        helperTeamIdentifier: codexVerifiedLauncherHelper.helperTeamIdentifier,
+        relativePath: "Contents/Resources/not-codex"
+    )
+    let pathBoundCodexHelper = VerifiedLauncherHelper(
+        id: "path-bound-codex",
+        name: "Codex CLI",
+        appName: "ChatGPT",
+        appBundleIdentifier: codexVerifiedLauncherHelper.appBundleIdentifier,
+        appTeamIdentifier: codexVerifiedLauncherHelper.appTeamIdentifier,
+        helperSigningIdentifier: codexVerifiedLauncherHelper.helperSigningIdentifier,
+        helperTeamIdentifier: codexVerifiedLauncherHelper.helperTeamIdentifier,
+        relativePath: "Contents/Resources/codex"
+    )
+    let pathBoundCodexAssociation = verifiedLauncherHelperAssociation(
+        path: bundledCodex.mainExecutable,
+        signing: bundledCodex,
+        containingAppURLs: [chatGPTURL],
+        helpers: [wrongPathCodexHelper, pathBoundCodexHelper],
+        configuration: VerifiedLauncherHelperConfiguration(),
+        bundleIdentifier: { _ in codexVerifiedLauncherHelper.appBundleIdentifier }
+    )
     let xcodeGit = LiveSigningInfo(
         identifier: "com.apple.git",
         teamIdentifier: "Software Signing",
@@ -12631,6 +12659,7 @@ private func runStandaloneLauncherSelfCheck() -> Int32 {
           targetedAppResourceValidationAvailable,
           codexAssociation?.helper == codexVerifiedLauncherHelper,
           codexAssociation?.appURL == chatGPTURL,
+          pathBoundCodexAssociation?.helper == pathBoundCodexHelper,
           disabledCodexAssociation == nil,
           xcodeHelperAssociation == nil,
           installedCodexValidation,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -9947,16 +9947,18 @@ private func verifiedLauncherHelperAssociation(
     path: String,
     signing: LiveSigningInfo,
     containingAppURLs: [URL]? = nil,
-    helpers: [VerifiedLauncherHelper] = verifiedLauncherHelpers,
+    helpers: [VerifiedLauncherHelper]? = nil,
     configuration: VerifiedLauncherHelperConfiguration? = nil,
     bundleIdentifier: (URL) -> String? = { Bundle(url: $0)?.bundleIdentifier }
 ) -> VerifiedLauncherHelperAssociation? {
+    let configuration = configuration ?? loadVerifiedLauncherHelperConfiguration()
+    let helpers = helpers ?? configuration.helpers
     guard signing.isDeveloperID,
           let helper = helpers.first(where: {
               $0.helperSigningIdentifier == signing.identifier
                   && $0.helperTeamIdentifier == signing.teamIdentifier
           }),
-          (configuration ?? loadVerifiedLauncherHelperConfiguration()).isEnabled(helper)
+          configuration.isEnabled(helper)
     else { return nil }
     let executablePath = signing.mainExecutable.isEmpty ? path : signing.mainExecutable
     let executableURL = URL(fileURLWithPath: executablePath)
@@ -9966,6 +9968,12 @@ private func verifiedLauncherHelperAssociation(
     guard let appURL = appURLs.first(where: {
         bundleIdentifier($0) == helper.appBundleIdentifier
     }) else { return nil }
+    if let relativePath = helper.relativePath {
+        let expectedURL = appURL.appendingPathComponent(relativePath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard expectedURL == executableURL else { return nil }
+    }
     return VerifiedLauncherHelperAssociation(
         helper: helper,
         appURL: appURL,

--- a/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
@@ -253,7 +253,7 @@ private func isValidVerifiedLauncherHelperConfiguration(
         == configuration.userApprovedHelpers.count
         && configuration.userApprovedHelpers.allSatisfy(isValidUserApprovedHelper)
         && configuration.userApprovedHelpers.allSatisfy { helper in
-            !verifiedLauncherHelpers.contains { $0.id == helper.id }
+            !verifiedLauncherHelpers.contains { $0.hasSameSigningAssociation(as: helper) }
         }
 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
@@ -4,7 +4,7 @@ import Security
 private let verifiedLauncherHelpersKeychainService = "com.automicvault.verified-launcher-helpers"
 private let verifiedLauncherHelpersKeychainAccount = "VerifiedLauncherHelpersV1"
 
-public struct VerifiedLauncherHelper: Identifiable, Equatable, Sendable {
+public struct VerifiedLauncherHelper: Identifiable, Codable, Equatable, Sendable {
     public let id: String
     public let name: String
     public let appName: String
@@ -12,6 +12,7 @@ public struct VerifiedLauncherHelper: Identifiable, Equatable, Sendable {
     public let appTeamIdentifier: String
     public let helperSigningIdentifier: String
     public let helperTeamIdentifier: String
+    public let relativePath: String?
 
     public init(
         id: String,
@@ -20,7 +21,8 @@ public struct VerifiedLauncherHelper: Identifiable, Equatable, Sendable {
         appBundleIdentifier: String,
         appTeamIdentifier: String,
         helperSigningIdentifier: String,
-        helperTeamIdentifier: String
+        helperTeamIdentifier: String,
+        relativePath: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -29,6 +31,15 @@ public struct VerifiedLauncherHelper: Identifiable, Equatable, Sendable {
         self.appTeamIdentifier = appTeamIdentifier
         self.helperSigningIdentifier = helperSigningIdentifier
         self.helperTeamIdentifier = helperTeamIdentifier
+        self.relativePath = relativePath
+    }
+
+    public func hasSameSigningAssociation(as other: Self) -> Bool {
+        appBundleIdentifier == other.appBundleIdentifier
+            && appTeamIdentifier == other.appTeamIdentifier
+            && helperSigningIdentifier == other.helperSigningIdentifier
+            && helperTeamIdentifier == other.helperTeamIdentifier
+            && (relativePath == nil || other.relativePath == nil || relativePath == other.relativePath)
     }
 }
 
@@ -59,14 +70,230 @@ public let verifiedLauncherHelpers = [
 
 public struct VerifiedLauncherHelperConfiguration: Codable, Equatable, Sendable {
     public var disabledHelperIDs: Set<String>
+    public var userApprovedHelpers: [VerifiedLauncherHelper]
 
-    public init(disabledHelperIDs: Set<String> = []) {
+    public init(
+        disabledHelperIDs: Set<String> = [],
+        userApprovedHelpers: [VerifiedLauncherHelper] = []
+    ) {
         self.disabledHelperIDs = disabledHelperIDs
+        self.userApprovedHelpers = userApprovedHelpers
     }
 
     public func isEnabled(_ helper: VerifiedLauncherHelper) -> Bool {
         !disabledHelperIDs.contains(helper.id)
     }
+
+    public var helpers: [VerifiedLauncherHelper] {
+        verifiedLauncherHelpers + userApprovedHelpers
+    }
+
+    public func catalogHelper(matching discovered: VerifiedLauncherHelper) -> VerifiedLauncherHelper? {
+        helpers.first { $0.hasSameSigningAssociation(as: discovered) }
+    }
+
+    public mutating func enable(_ helpers: [VerifiedLauncherHelper]) {
+        for helper in helpers {
+            let helper = catalogHelper(matching: helper) ?? helper
+            if !verifiedLauncherHelpers.contains(where: { $0.id == helper.id }),
+               !userApprovedHelpers.contains(where: { $0.id == helper.id })
+            {
+                userApprovedHelpers.append(helper)
+            }
+            disabledHelperIDs.remove(helper.id)
+        }
+        userApprovedHelpers.sort { $0.id < $1.id }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case disabledHelperIDs
+        case userApprovedHelpers
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        disabledHelperIDs = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .disabledHelperIDs
+        ) ?? []
+        userApprovedHelpers = try container.decodeIfPresent(
+            [VerifiedLauncherHelper].self,
+            forKey: .userApprovedHelpers
+        ) ?? []
+        guard Set(userApprovedHelpers.map(\.id)).count == userApprovedHelpers.count,
+              userApprovedHelpers.allSatisfy(isValidUserApprovedHelper),
+              userApprovedHelpers.allSatisfy({ helper in
+                  !verifiedLauncherHelpers.contains { $0.id == helper.id }
+              })
+        else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: decoder.codingPath, debugDescription: "Invalid user-approved Launcher helper catalog")
+            )
+        }
+    }
+}
+
+public func userApprovedVerifiedLauncherHelperID(_ helper: VerifiedLauncherHelper) -> String {
+    [
+        "user",
+        helper.appTeamIdentifier,
+        helper.appBundleIdentifier,
+        helper.helperTeamIdentifier,
+        helper.helperSigningIdentifier,
+        helper.relativePath ?? "",
+    ].joined(separator: ":")
+}
+
+@concurrent
+public func discoverVerifiedLauncherHelpers(in appURL: URL) async -> [VerifiedLauncherHelper] {
+    let appURL = appURL.standardizedFileURL.resolvingSymlinksInPath()
+    guard appURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame,
+          let appBundle = Bundle(url: appURL),
+          let appBundleIdentifier = appBundle.bundleIdentifier,
+          let appExecutableURL = appBundle.executableURL?.standardizedFileURL.resolvingSymlinksInPath(),
+          let appCode = staticCode(at: appURL),
+          validateAppBundleMainExecutable(appCode) == errSecSuccess,
+          let appSigning = signingIdentity(appCode),
+          let appTeamIdentifier = appSigning.teamIdentifier,
+          let developerIDRequirement = developerIDRequirement()
+    else { return [] }
+
+    let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+    guard let enumerator = FileManager.default.enumerator(
+        at: contentsURL,
+        includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+        options: [],
+        errorHandler: { _, _ in true }
+    ) else { return [] }
+
+    var helpers: [VerifiedLauncherHelper] = []
+    while let candidate = enumerator.nextObject() as? URL {
+        guard !Task.isCancelled else { return [] }
+        guard let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              FileManager.default.isExecutableFile(atPath: candidate.path)
+        else { continue }
+
+        let executableURL = candidate.standardizedFileURL.resolvingSymlinksInPath()
+        guard executableURL != appExecutableURL,
+              let helperCode = staticCode(at: executableURL),
+              SecStaticCodeCheckValidity(
+                  helperCode,
+                  SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate),
+                  developerIDRequirement
+              ) == errSecSuccess,
+              validateAppBundleResource(appCode, resourceURL: executableURL) == errSecSuccess,
+              let helperSigning = signingIdentity(helperCode),
+              let helperTeamIdentifier = helperSigning.teamIdentifier,
+              launcherRuntimeProtection(signingInformation: helperSigning.information)
+                  .allowsSecretGateAccess
+        else { continue }
+
+        let relativePath = String(executableURL.path.dropFirst(appURL.path.count + 1))
+        var helper = VerifiedLauncherHelper(
+            id: "",
+            name: helperDisplayName(executableURL, inside: appURL),
+            appName: appDisplayName(appBundle, url: appURL),
+            appBundleIdentifier: appBundleIdentifier,
+            appTeamIdentifier: appTeamIdentifier,
+            helperSigningIdentifier: helperSigning.identifier,
+            helperTeamIdentifier: helperTeamIdentifier,
+            relativePath: relativePath
+        )
+        helper = VerifiedLauncherHelper(
+            id: userApprovedVerifiedLauncherHelperID(helper),
+            name: helper.name,
+            appName: helper.appName,
+            appBundleIdentifier: helper.appBundleIdentifier,
+            appTeamIdentifier: helper.appTeamIdentifier,
+            helperSigningIdentifier: helper.helperSigningIdentifier,
+            helperTeamIdentifier: helper.helperTeamIdentifier,
+            relativePath: helper.relativePath
+        )
+        if !helpers.contains(where: { $0.id == helper.id }) { helpers.append(helper) }
+    }
+    return helpers.sorted {
+        let order = $0.name.localizedCaseInsensitiveCompare($1.name)
+        return order == .orderedSame
+            ? ($0.relativePath ?? "") < ($1.relativePath ?? "")
+            : order == .orderedAscending
+    }
+}
+
+private func isValidUserApprovedHelper(_ helper: VerifiedLauncherHelper) -> Bool {
+    guard helper.id == userApprovedVerifiedLauncherHelperID(helper),
+          !helper.name.isEmpty,
+          !helper.appName.isEmpty,
+          !helper.appBundleIdentifier.isEmpty,
+          !helper.appTeamIdentifier.isEmpty,
+          !helper.helperSigningIdentifier.isEmpty,
+          !helper.helperTeamIdentifier.isEmpty,
+          let relativePath = helper.relativePath,
+          !relativePath.isEmpty,
+          !relativePath.hasPrefix("/")
+    else { return false }
+    return !relativePath.split(separator: "/", omittingEmptySubsequences: false).contains {
+        $0.isEmpty || $0 == "." || $0 == ".."
+    }
+}
+
+private struct HelperSigningIdentity {
+    let identifier: String
+    let teamIdentifier: String?
+    let information: [CFString: Any]
+}
+
+private func staticCode(at url: URL) -> SecStaticCode? {
+    var code: SecStaticCode?
+    guard SecStaticCodeCreateWithPath(url as CFURL, [], &code) == errSecSuccess else { return nil }
+    return code
+}
+
+private func signingIdentity(_ code: SecStaticCode) -> HelperSigningIdentity? {
+    var rawInformation: CFDictionary?
+    let flags = SecCSFlags(rawValue: kSecCSSigningInformation | kSecCSRequirementInformation)
+    guard SecCodeCopySigningInformation(code, flags, &rawInformation) == errSecSuccess,
+          let information = rawInformation as? [CFString: Any],
+          let identifier = information[kSecCodeInfoIdentifier] as? String
+    else { return nil }
+    return HelperSigningIdentity(
+        identifier: identifier,
+        teamIdentifier: information[kSecCodeInfoTeamIdentifier] as? String,
+        information: information
+    )
+}
+
+private func developerIDRequirement() -> SecRequirement? {
+    var requirement: SecRequirement?
+    let source = """
+    anchor apple generic and \
+    certificate 1[field.1.2.840.113635.100.6.2.6] exists and \
+    certificate leaf[field.1.2.840.113635.100.6.1.13] exists
+    """
+    guard SecRequirementCreateWithString(source as CFString, [], &requirement) == errSecSuccess
+    else { return nil }
+    return requirement
+}
+
+private func appDisplayName(_ bundle: Bundle, url: URL) -> String {
+    bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+        ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
+        ?? url.deletingPathExtension().lastPathComponent
+}
+
+private func helperDisplayName(_ executableURL: URL, inside appURL: URL) -> String {
+    var container = executableURL.deletingLastPathComponent()
+    while container.path.count > appURL.path.count {
+        if container.pathExtension.caseInsensitiveCompare("app") == .orderedSame,
+           let bundle = Bundle(url: container),
+           bundle.executableURL?.standardizedFileURL.resolvingSymlinksInPath() == executableURL
+        {
+            return appDisplayName(bundle, url: container)
+        }
+        container.deleteLastPathComponent()
+    }
+    return executableURL.lastPathComponent
 }
 
 public func loadVerifiedLauncherHelperConfiguration() -> VerifiedLauncherHelperConfiguration {

--- a/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
@@ -94,14 +94,16 @@ public struct VerifiedLauncherHelperConfiguration: Codable, Equatable, Sendable 
     }
 
     public mutating func enable(_ helpers: [VerifiedLauncherHelper]) {
-        for helper in helpers {
-            let helper = catalogHelper(matching: helper) ?? helper
-            if !verifiedLauncherHelpers.contains(where: { $0.id == helper.id }),
-               !userApprovedHelpers.contains(where: { $0.id == helper.id })
-            {
-                userApprovedHelpers.append(helper)
+        for discovered in helpers {
+            let isValid = verifiedLauncherHelpers.contains(discovered)
+                || isValidUserApprovedHelper(discovered)
+            guard isValid else { continue }
+            if let helper = catalogHelper(matching: discovered) {
+                disabledHelperIDs.remove(helper.id)
+            } else {
+                userApprovedHelpers.append(discovered)
+                disabledHelperIDs.remove(discovered.id)
             }
-            disabledHelperIDs.remove(helper.id)
         }
         userApprovedHelpers.sort { $0.id < $1.id }
     }
@@ -121,12 +123,7 @@ public struct VerifiedLauncherHelperConfiguration: Codable, Equatable, Sendable 
             [VerifiedLauncherHelper].self,
             forKey: .userApprovedHelpers
         ) ?? []
-        guard Set(userApprovedHelpers.map(\.id)).count == userApprovedHelpers.count,
-              userApprovedHelpers.allSatisfy(isValidUserApprovedHelper),
-              userApprovedHelpers.allSatisfy({ helper in
-                  !verifiedLauncherHelpers.contains { $0.id == helper.id }
-              })
-        else {
+        guard isValidVerifiedLauncherHelperConfiguration(self) else {
             throw DecodingError.dataCorrupted(
                 .init(codingPath: decoder.codingPath, debugDescription: "Invalid user-approved Launcher helper catalog")
             )
@@ -190,7 +187,10 @@ public func discoverVerifiedLauncherHelpers(in appURL: URL) async -> [VerifiedLa
                   .allowsSecretGateAccess
         else { continue }
 
-        let relativePath = String(executableURL.path.dropFirst(appURL.path.count + 1))
+        guard let relativePath = verifiedLauncherHelperRelativePath(
+            for: executableURL,
+            inside: appURL
+        ) else { continue }
         var helper = VerifiedLauncherHelper(
             id: "",
             name: helperDisplayName(executableURL, inside: appURL),
@@ -221,6 +221,14 @@ public func discoverVerifiedLauncherHelpers(in appURL: URL) async -> [VerifiedLa
     }
 }
 
+func verifiedLauncherHelperRelativePath(for executableURL: URL, inside appURL: URL) -> String? {
+    let appURL = appURL.standardizedFileURL.resolvingSymlinksInPath()
+    let executableURL = executableURL.standardizedFileURL.resolvingSymlinksInPath()
+    let prefix = appURL.path + "/"
+    guard executableURL.path.hasPrefix(prefix) else { return nil }
+    return String(executableURL.path.dropFirst(prefix.count))
+}
+
 private func isValidUserApprovedHelper(_ helper: VerifiedLauncherHelper) -> Bool {
     guard helper.id == userApprovedVerifiedLauncherHelperID(helper),
           !helper.name.isEmpty,
@@ -236,6 +244,17 @@ private func isValidUserApprovedHelper(_ helper: VerifiedLauncherHelper) -> Bool
     return !relativePath.split(separator: "/", omittingEmptySubsequences: false).contains {
         $0.isEmpty || $0 == "." || $0 == ".."
     }
+}
+
+private func isValidVerifiedLauncherHelperConfiguration(
+    _ configuration: VerifiedLauncherHelperConfiguration
+) -> Bool {
+    Set(configuration.userApprovedHelpers.map(\.id)).count
+        == configuration.userApprovedHelpers.count
+        && configuration.userApprovedHelpers.allSatisfy(isValidUserApprovedHelper)
+        && configuration.userApprovedHelpers.allSatisfy { helper in
+            !verifiedLauncherHelpers.contains { $0.id == helper.id }
+        }
 }
 
 private struct HelperSigningIdentity {
@@ -343,7 +362,9 @@ func saveVerifiedLauncherHelperConfiguration(
     service: String,
     account: String
 ) -> OSStatus {
-    guard let data = try? JSONEncoder().encode(configuration) else { return errSecParam }
+    guard isValidVerifiedLauncherHelperConfiguration(configuration),
+          let data = try? JSONEncoder().encode(configuration)
+    else { return errSecParam }
     return saveKeychainData(
         data,
         service: service,

--- a/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
@@ -81,7 +81,8 @@ public struct VerifiedLauncherHelperConfiguration: Codable, Equatable, Sendable 
     }
 
     public func isEnabled(_ helper: VerifiedLauncherHelper) -> Bool {
-        !disabledHelperIDs.contains(helper.id)
+        guard let helper = catalogHelper(matching: helper) else { return false }
+        return !disabledHelperIDs.contains(helper.id)
     }
 
     public var helpers: [VerifiedLauncherHelper] {

--- a/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/VerifiedLauncherHelpers.swift
@@ -134,14 +134,13 @@ public struct VerifiedLauncherHelperConfiguration: Codable, Equatable, Sendable 
 }
 
 public func userApprovedVerifiedLauncherHelperID(_ helper: VerifiedLauncherHelper) -> String {
-    [
-        "user",
+    "user:" + [
         helper.appTeamIdentifier,
         helper.appBundleIdentifier,
         helper.helperTeamIdentifier,
         helper.helperSigningIdentifier,
         helper.relativePath ?? "",
-    ].joined(separator: ":")
+    ].map { "\($0.utf8.count):\($0)" }.joined()
 }
 
 @concurrent

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
@@ -12,6 +12,10 @@ import Testing
     )
     let data = try JSONEncoder().encode(configured)
     #expect(decodeVerifiedLauncherHelperConfiguration(data) == configured)
+
+    var enabled = configured
+    enabled.enable([codexVerifiedLauncherHelper])
+    #expect(enabled.isEnabled(codexVerifiedLauncherHelper))
 }
 
 @Test func malformedVerifiedLauncherHelperConfigurationFailsClosed() {
@@ -34,6 +38,68 @@ import Testing
 
 @Test func discoveredHelperRequiresUserApprovalBeforeItIsEnabled() {
     #expect(!VerifiedLauncherHelperConfiguration().isEnabled(userApprovedHelper()))
+}
+
+@Test func enablingInvalidDiscoveredHelperDoesNotCorruptTheCatalog() throws {
+    let valid = userApprovedHelper()
+    let invalid = VerifiedLauncherHelper(
+        id: "forged",
+        name: valid.name,
+        appName: valid.appName,
+        appBundleIdentifier: valid.appBundleIdentifier,
+        appTeamIdentifier: valid.appTeamIdentifier,
+        helperSigningIdentifier: valid.helperSigningIdentifier,
+        helperTeamIdentifier: valid.helperTeamIdentifier,
+        relativePath: valid.relativePath
+    )
+    var configuration = VerifiedLauncherHelperConfiguration(disabledHelperIDs: [invalid.id])
+    configuration.enable([invalid])
+
+    #expect(configuration.userApprovedHelpers.isEmpty)
+    #expect(configuration.disabledHelperIDs.contains(invalid.id))
+    let data = try JSONEncoder().encode(configuration)
+    #expect(decodeVerifiedLauncherHelperConfiguration(data) == configuration)
+}
+
+@Test func invalidHelperCannotEnableAMatchingBuiltInAssociation() {
+    let invalid = VerifiedLauncherHelper(
+        id: codexVerifiedLauncherHelper.id,
+        name: codexVerifiedLauncherHelper.name,
+        appName: codexVerifiedLauncherHelper.appName,
+        appBundleIdentifier: codexVerifiedLauncherHelper.appBundleIdentifier,
+        appTeamIdentifier: codexVerifiedLauncherHelper.appTeamIdentifier,
+        helperSigningIdentifier: codexVerifiedLauncherHelper.helperSigningIdentifier,
+        helperTeamIdentifier: codexVerifiedLauncherHelper.helperTeamIdentifier,
+        relativePath: "../codex"
+    )
+    var configuration = VerifiedLauncherHelperConfiguration(
+        disabledHelperIDs: [codexVerifiedLauncherHelper.id]
+    )
+    configuration.enable([invalid])
+
+    #expect(!configuration.isEnabled(codexVerifiedLauncherHelper))
+}
+
+@Test func helperRelativePathRejectsResolvedSymlinkEscape() throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("av-helper-path-\(UUID().uuidString)", isDirectory: true)
+    let app = root.appendingPathComponent("Example.app", isDirectory: true)
+    let contents = app.appendingPathComponent("Contents", isDirectory: true)
+    let outside = root.appendingPathComponent("Outside", isDirectory: true)
+    let helper = outside.appendingPathComponent("helper")
+    try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+    try Data().write(to: helper)
+    try FileManager.default.createSymbolicLink(
+        at: contents.appendingPathComponent("Helpers", isDirectory: true),
+        withDestinationURL: outside
+    )
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    #expect(verifiedLauncherHelperRelativePath(
+        for: contents.appendingPathComponent("Helpers/helper"),
+        inside: app
+    ) == nil)
 }
 
 @Test func legacyConfigurationDecodesWithoutUserApprovedHelpers() {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
@@ -80,6 +80,37 @@ import Testing
     #expect(!configuration.isEnabled(codexVerifiedLauncherHelper))
 }
 
+@Test func storedUserApprovedHelperCannotShadowABuiltInAssociation() throws {
+    let shadow = VerifiedLauncherHelper(
+        id: "",
+        name: codexVerifiedLauncherHelper.name,
+        appName: codexVerifiedLauncherHelper.appName,
+        appBundleIdentifier: codexVerifiedLauncherHelper.appBundleIdentifier,
+        appTeamIdentifier: codexVerifiedLauncherHelper.appTeamIdentifier,
+        helperSigningIdentifier: codexVerifiedLauncherHelper.helperSigningIdentifier,
+        helperTeamIdentifier: codexVerifiedLauncherHelper.helperTeamIdentifier,
+        relativePath: "Contents/Resources/codex"
+    )
+    let stored = VerifiedLauncherHelper(
+        id: userApprovedVerifiedLauncherHelperID(shadow),
+        name: shadow.name,
+        appName: shadow.appName,
+        appBundleIdentifier: shadow.appBundleIdentifier,
+        appTeamIdentifier: shadow.appTeamIdentifier,
+        helperSigningIdentifier: shadow.helperSigningIdentifier,
+        helperTeamIdentifier: shadow.helperTeamIdentifier,
+        relativePath: shadow.relativePath
+    )
+    let data = try JSONEncoder().encode(VerifiedLauncherHelperConfiguration(
+        userApprovedHelpers: [stored]
+    ))
+    let configuration = decodeVerifiedLauncherHelperConfiguration(data)
+
+    #expect(configuration.userApprovedHelpers.isEmpty)
+    #expect(!configuration.isEnabled(codexVerifiedLauncherHelper))
+    #expect(!configuration.isEnabled(claudeCodeVerifiedLauncherHelper))
+}
+
 @Test func helperRelativePathRejectsResolvedSymlinkEscape() throws {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent("av-helper-path-\(UUID().uuidString)", isDirectory: true)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
@@ -19,3 +19,76 @@ import Testing
     #expect(!configuration.isEnabled(codexVerifiedLauncherHelper))
     #expect(!configuration.isEnabled(claudeCodeVerifiedLauncherHelper))
 }
+
+@Test func enablesAndRoundTripsAnExactUserApprovedHelper() throws {
+    let helper = userApprovedHelper()
+    var configuration = VerifiedLauncherHelperConfiguration(disabledHelperIDs: [helper.id])
+    configuration.enable([helper])
+
+    #expect(configuration.userApprovedHelpers == [helper])
+    #expect(configuration.isEnabled(helper))
+    #expect(configuration.catalogHelper(matching: helper) == helper)
+    let data = try JSONEncoder().encode(configuration)
+    #expect(decodeVerifiedLauncherHelperConfiguration(data) == configuration)
+}
+
+@Test func legacyConfigurationDecodesWithoutUserApprovedHelpers() {
+    let configuration = decodeVerifiedLauncherHelperConfiguration(
+        Data(#"{"disabledHelperIDs":["codex"]}"#.utf8)
+    )
+    #expect(configuration.disabledHelperIDs == ["codex"])
+    #expect(configuration.userApprovedHelpers.isEmpty)
+}
+
+@Test func invalidUserApprovedHelperPathFailsClosed() throws {
+    let valid = userApprovedHelper()
+    let invalid = VerifiedLauncherHelper(
+        id: "",
+        name: valid.name,
+        appName: valid.appName,
+        appBundleIdentifier: valid.appBundleIdentifier,
+        appTeamIdentifier: valid.appTeamIdentifier,
+        helperSigningIdentifier: valid.helperSigningIdentifier,
+        helperTeamIdentifier: valid.helperTeamIdentifier,
+        relativePath: "../Other.app/Contents/MacOS/Other"
+    )
+    let encodedInvalid = VerifiedLauncherHelper(
+        id: userApprovedVerifiedLauncherHelperID(invalid),
+        name: invalid.name,
+        appName: invalid.appName,
+        appBundleIdentifier: invalid.appBundleIdentifier,
+        appTeamIdentifier: invalid.appTeamIdentifier,
+        helperSigningIdentifier: invalid.helperSigningIdentifier,
+        helperTeamIdentifier: invalid.helperTeamIdentifier,
+        relativePath: invalid.relativePath
+    )
+    let data = try JSONEncoder().encode(VerifiedLauncherHelperConfiguration(
+        userApprovedHelpers: [encodedInvalid]
+    ))
+    let configuration = decodeVerifiedLauncherHelperConfiguration(data)
+    #expect(!configuration.isEnabled(codexVerifiedLauncherHelper))
+    #expect(configuration.userApprovedHelpers.isEmpty)
+}
+
+private func userApprovedHelper() -> VerifiedLauncherHelper {
+    let helper = VerifiedLauncherHelper(
+        id: "",
+        name: "Package Manager Manager Menu",
+        appName: "Package Manager Manager",
+        appBundleIdentifier: "dev.mxcl.pmm",
+        appTeamIdentifier: "ZU76A67LGU",
+        helperSigningIdentifier: "dev.mxcl.pmm.menu",
+        helperTeamIdentifier: "ZU76A67LGU",
+        relativePath: "Contents/Library/LoginItems/Package Manager Manager Menu.app/Contents/MacOS/PMMMenuBar"
+    )
+    return VerifiedLauncherHelper(
+        id: userApprovedVerifiedLauncherHelperID(helper),
+        name: helper.name,
+        appName: helper.appName,
+        appBundleIdentifier: helper.appBundleIdentifier,
+        appTeamIdentifier: helper.appTeamIdentifier,
+        helperSigningIdentifier: helper.helperSigningIdentifier,
+        helperTeamIdentifier: helper.helperTeamIdentifier,
+        relativePath: helper.relativePath
+    )
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
@@ -92,3 +92,14 @@ private func userApprovedHelper() -> VerifiedLauncherHelper {
         relativePath: helper.relativePath
     )
 }
+
+@Test(.enabled(if: FileManager.default.fileExists(
+    atPath: "/Applications/Package Manager Manager.app"
+)))
+func discoversInstalledPackageManagerManagerHelpers() async {
+    let helpers = await discoverVerifiedLauncherHelpers(
+        in: URL(fileURLWithPath: "/Applications/Package Manager Manager.app", isDirectory: true)
+    )
+    #expect(helpers.contains { $0.helperSigningIdentifier == "dev.mxcl.pmm.menu" })
+    #expect(helpers.contains { $0.helperSigningIdentifier == "pmmctl" })
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/VerifiedLauncherHelpersTests.swift
@@ -32,6 +32,10 @@ import Testing
     #expect(decodeVerifiedLauncherHelperConfiguration(data) == configuration)
 }
 
+@Test func discoveredHelperRequiresUserApprovalBeforeItIsEnabled() {
+    #expect(!VerifiedLauncherHelperConfiguration().isEnabled(userApprovedHelper()))
+}
+
 @Test func legacyConfigurationDecodesWithoutUserApprovedHelpers() {
     let configuration = decodeVerifiedLauncherHelperConfiguration(
         Data(#"{"disabledHelperIDs":["codex"]}"#.utf8)


### PR DESCRIPTION
## Summary

- discover separately signed Hardened Runtime helper CLIs and nested helper apps when adding an app as a Verified Launcher
- show an explicit, opt-in warning modal; helpers begin unchecked and approval widens access across every current and future Authorization Gate for that app
- persist exact app/team + helper/team + relative-path associations in the Data Protection Keychain and expose them in Settings
- keep the built-in Codex and Claude associations, while supporting user-approved helpers without restoring blanket nested-code trust
- document the security boundary in ADR 0034 and the canonical domain language

The save path remains fail-safe: the app policy is written first and helper associations second, so an association failure leaves only the narrower app rule. Unknown discovered helpers are also fail-closed until explicitly approved.

## Verification

- `swift test --package-path src/menu-helper` (209 tests)
- `src/menu-helper/.build/arm64-apple-macosx/debug/AutomicVaultMenubar --self-check-dashboard-search`
- `src/menu-helper/.build/arm64-apple-macosx/debug/AutomicVaultMenubar --self-check-standalone-launchers`
- installed Package Manager Manager discovery test finds its menu app and `pmmctl` helpers
- regression test verifies a discovered helper is not enabled before user approval