### PR TITLE
Stop project ancestry at filesystem root

### DIFF
--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1689,6 +1689,9 @@ public func canonicalProjectDirectory(_ path: String) throws -> String {
 
 func physicalDirectoryAncestors(
     _ path: String,
+    parentPath: (String) -> String = {
+        URL(fileURLWithPath: $0, isDirectory: true).deletingLastPathComponent().path
+    },
     canonicalize: (String) throws -> (path: String, device: UInt64)
 ) throws -> [String] {
     let start = try canonicalize(path)
@@ -1699,8 +1702,8 @@ func physicalDirectoryAncestors(
     var seen = Set(result)
     var current = start.path
     while true {
-        let parent = URL(fileURLWithPath: current, isDirectory: true)
-            .deletingLastPathComponent().path
+        guard current != "/" else { break }
+        let parent = parentPath(current)
         guard parent != current else { break }
         let parentDirectory = try canonicalize(parent)
         guard parentDirectory.device == start.device else { break }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1671,6 +1671,7 @@ public func validateCanonicalProjectDirectory(_ path: String) throws -> String {
     guard directory.path == path else {
         throw ProjectDirectoryValidationError.notCanonical(directory.path)
     }
+    guard path != "/" else { throw ProjectDirectoryValidationError.filesystemRoot }
     let parent = URL(fileURLWithPath: path, isDirectory: true)
         .deletingLastPathComponent().path
     guard parent != path else { throw ProjectDirectoryValidationError.filesystemRoot }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -1097,6 +1097,20 @@ func protectionPolicyMatrix(
     }
 }
 
+@Test func physicalDirectoryAncestorsStopsAtCanonicalRoot() throws {
+    let ancestors = try physicalDirectoryAncestors(
+        "/project",
+        parentPath: { $0 == "/project" ? "/" : "/.." }
+    ) { path in
+        switch path {
+        case "/project", "/": (path, 1)
+        case "/..": ("/", 1)
+        default: throw ProjectDirectoryValidationError.unavailable
+        }
+    }
+    #expect(ancestors == ["/project", "/"])
+}
+
 @Test func multiValueAvailabilityAndRenameCompleteAsForwardOperations() throws {
     guard dataProtectionKeychainAvailable() else { return }
     let service = "com.automicvault.tests.project-mutation.\(UUID().uuidString)"


### PR DESCRIPTION
Fixes #204.

`physicalDirectoryAncestors` now stops at canonical `/` before asking Foundation for its parent. This prevents macOS 15's `/` → `/..` → `/` behavior from being mistaken for a filesystem cycle while retaining fail-closed detection for genuine repeated canonical directories.

`validateCanonicalProjectDirectory` also rejects canonical `/` before asking Foundation for its parent, preserving the invariant that a filesystem root cannot become a Project Directory on affected macOS versions.

The regression injects the macOS 15 parent behavior so it remains deterministic on newer macOS releases.

Security impact: Project Value selection still examines only physical canonical ancestors on the starting filesystem. The filesystem root remains ineligible as a Project Directory, filesystem boundaries remain enforced, and genuine ancestry cycles still deny selection.

Verification on the rebased `v3.18` history:

- `swift test --package-path src/menu-helper --disable-automatic-resolution --filter 'projectDirectoryValidationUsesPhysicalCanonicalPathsAndRejectsRoots|physicalDirectoryAncestors'`
- `swift test --package-path src/menu-helper --disable-automatic-resolution` (197 tests)
