### PR TITLE
Show AV badge for signed isotopes

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -10697,12 +10697,11 @@ private struct ApprovalPromptProcessNodeView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                 if node.isAutomicVaultSigned {
-                    Text("AV")
-                        .font(.system(.caption2, design: .rounded).weight(.black))
-                        .foregroundStyle(.black)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 2)
-                        .background(.green, in: RoundedRectangle(cornerRadius: 4))
+                    Image("NSMenuItem", bundle: .main)
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 10, height: 12)
                         .help("Signed by Automic Vault")
                         .accessibilityHidden(true)
                 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -10696,8 +10696,11 @@ private struct ApprovalPromptProcessNodeView: View {
                     .font(.system(.headline, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                if node.isAutomicVaultSigned {
-                    Image("NSMenuItem", bundle: .main)
+                if node.isAutomicVaultSigned,
+                   let imageURL = Bundle.main.url(forResource: "NSMenuItem", withExtension: "png"),
+                   let image = NSImage(contentsOf: imageURL)
+                {
+                    Image(nsImage: image)
                         .renderingMode(.template)
                         .resizable()
                         .scaledToFit()

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -9195,6 +9195,7 @@ private struct ApprovalProcessSecurityNode: Identifiable {
     let roles: [String]
     let posture: ApprovalProcessPosture
     let explanation: String
+    let isAutomicVaultSigned: Bool
 
     var id: String { "\(pid ?? -1):\(path)" }
     var name: String { URL(fileURLWithPath: path).lastPathComponent }
@@ -9202,6 +9203,13 @@ private struct ApprovalProcessSecurityNode: Identifiable {
 
 private struct ApprovalProcessSecurity {
     let nodes: [ApprovalProcessSecurityNode]
+}
+
+private func isAutomicVaultSigned(
+    _ signing: LiveSigningInfo?,
+    teamIdentifier: String?
+) -> Bool {
+    signing?.isDeveloperID == true && signing?.teamIdentifier == teamIdentifier
 }
 
 private func approvalProcessIdentities(
@@ -9321,6 +9329,7 @@ private func approvalProcessSecurity(
     targetPID: pid_t? = nil,
     launcher: LauncherIdentity?
 ) -> ApprovalProcessSecurity {
+    let automicVaultTeamIdentifier = selfTeamIdentifier()
     var identities = approvalProcessIdentities(
         gateClientPID: gateClientPID,
         launcherPID: launcher?.pid
@@ -9379,7 +9388,11 @@ private func approvalProcessSecurity(
             path: identity.path,
             roles: roles,
             posture: result.0,
-            explanation: result.1
+            explanation: result.1,
+            isAutomicVaultSigned: isAutomicVaultSigned(
+                signing,
+                teamIdentifier: automicVaultTeamIdentifier
+            )
         )
     }
 
@@ -9394,7 +9407,11 @@ private func approvalProcessSecurity(
             path: request.target,
             roles: [request.keys.isEmpty ? "Target (not started)" : "Secret recipient (not started)"],
             posture: result.0,
-            explanation: result.1
+            explanation: result.1,
+            isAutomicVaultSigned: isAutomicVaultSigned(
+                signing,
+                teamIdentifier: automicVaultTeamIdentifier
+            )
         ), at: 0)
     }
     return ApprovalProcessSecurity(nodes: nodes)
@@ -10679,6 +10696,16 @@ private struct ApprovalPromptProcessNodeView: View {
                     .font(.system(.headline, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
+                if node.isAutomicVaultSigned {
+                    Text("AV")
+                        .font(.system(.caption2, design: .rounded).weight(.black))
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 2)
+                        .background(.green, in: RoundedRectangle(cornerRadius: 4))
+                        .help("Signed by Automic Vault")
+                        .accessibilityHidden(true)
+                }
                 if node.posture != .meetsRequirements {
                     Image(systemName: presentation.image)
                         .font(.body)
@@ -10700,7 +10727,9 @@ private struct ApprovalPromptProcessNodeView: View {
         }
         .frame(width: 150)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(node.displayRoles), \(node.name), \(presentation.title)")
+        .accessibilityLabel(
+            "\(node.displayRoles), \(node.name), \(presentation.title)\(node.isAutomicVaultSigned ? ", signed by Automic Vault" : "")"
+        )
     }
 }
 
@@ -11807,14 +11836,16 @@ private func runApprovalSelfCheck() -> Int32 {
             path: "/Applications/Example.app/Contents/MacOS/Example",
             roles: ["Verified Launcher"],
             posture: .meetsRequirements,
-            explanation: "Valid code signature; Hardened Runtime"
+            explanation: "Valid code signature; Hardened Runtime",
+            isAutomicVaultSigned: false
         ),
         ApprovalProcessSecurityNode(
             pid: 41,
             path: "/opt/homebrew/bin/gh",
             roles: ["Secret recipient", "Verified Gate Client"],
             posture: .meetsRequirements,
-            explanation: "Valid code signature; Hardened Runtime"
+            explanation: "Valid code signature; Hardened Runtime",
+            isAutomicVaultSigned: true
         ),
     ])
     let promptContent = ApprovalPromptContent(
@@ -12015,6 +12046,9 @@ private func runApprovalSelfCheck() -> Int32 {
           nestedLaunchers.map(\.identifier) == ["dev.mxcl.pmm.menu", "dev.mxcl.pmm"],
           launcherAncestorStartPIDs(detachedCaller) == [43],
           hardenedPosture.0 == .meetsRequirements,
+          isAutomicVaultSigned(unbundledSigning, teamIdentifier: "TEAM"),
+          !isAutomicVaultSigned(unbundledSigning, teamIdentifier: "OTHER"),
+          !isAutomicVaultSigned(pythonSigning, teamIdentifier: "unknown"),
           nodePosture.0 == .needsAttention,
           nodePosture.1.contains("mutable JavaScript"),
           unsafePosture.0 == .doesNotMeetRequirements,


### PR DESCRIPTION
## Summary
- show the existing monochrome Automic Vault menubar icon beside approval execution-chain nodes signed by Automic Vault
- require a valid Developer ID signature whose Team ID matches the running Automic Vault app
- expose the same trust cue through the node VoiceOver label

## Verification
- `swift test` (203 tests)
- `AutomicVaultMenubar --self-check-approvals`
- verified the installed Stripe Isotope has a valid Developer ID signature from Team ID `ZU76A67LGU`