### PR TITLE
Allow patch releases from maintenance branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "Release runs must be dispatched from main." >&2
+          release_branch="${GITHUB_REF#refs/heads/}"
+          if [[ "$GITHUB_REF" != refs/heads/* ]] ||
+            [[ "$release_branch" != "main" && ! "$release_branch" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            echo "Release runs must be dispatched from main or a vMAJOR.MINOR maintenance branch." >&2
             exit 64
           fi
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Version must use MAJOR.MINOR.PATCH." >&2
+            exit 64
+          fi
+          maintenance_prefix="${release_branch#v}."
+          if [[ "$release_branch" != "main" && "$VERSION" != "$maintenance_prefix"* ]]; then
+            echo "Version $VERSION does not belong to maintenance branch $release_branch." >&2
             exit 64
           fi
           if [[ -z "$RELEASE_NOTES" ]]; then
@@ -69,7 +76,7 @@ jobs:
             exit 64
           fi
           if [[ ! "$COMMIT" =~ ^[0-9a-f]{40}$ || "$COMMIT" != "$GITHUB_SHA" ]]; then
-            echo "The requested commit must be the dispatched main commit." >&2
+            echo "The requested commit must be the dispatched release-branch commit." >&2
             exit 64
           fi
           manifest_version="$(

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,8 +11,8 @@ It also reviews installed-artifact, persistence, protocol, and schema revisions,
 including the CLI install and Homebrew stub revisions, and applies any missing
 numeric increments before creating the release commit.
 The script updates `Cargo.toml` and `Cargo.lock`, commits and pushes that exact
-release commit to `main`, then dispatches the workflow. The workflow signs and
-notarizes the app, staples the notarization ticket, creates SHA-256 checksums
+release commit to the current release branch, then dispatches the workflow. The
+workflow signs and notarizes the app, staples the notarization ticket, creates SHA-256 checksums
 and an SPDX SBOM, attests the final DMG, and creates a draft GitHub release.
 After a human approves publication in `publish.sh`, the script publishes the
 draft and updates the local Homebrew tap. The website resolves its download
@@ -28,8 +28,8 @@ blocked, and the clone is deleted after the check.
 ## One-time GitHub setup
 
 Create a GitHub Actions environment named `release`. Protect it with required
-reviewers. If deployment branch rules are available, allow `main`; the draft
-build runs from `main`.
+reviewers. If deployment branch rules are available, allow `main` and any active
+`vMAJOR.MINOR` maintenance branches.
 
 Enable immutable releases:
 
@@ -114,7 +114,7 @@ gh variable set POSTHOG_API_KEY \
 
 ## Publish a release
 
-Run from a clean `main` checkout matching `origin/main`:
+Run from a clean `main` or `vMAJOR.MINOR` checkout matching its remote branch:
 
 ```sh
 scripts/publish.sh
@@ -122,12 +122,12 @@ scripts/publish.sh
 
 Pass `--version X.Y.Z` to require a particular version while still using Codex
 to write and validate the release notes. If a workflow fails after its release
-commit was pushed, fix and push `main`, then pass that same version to retry
+commit was pushed, fix and push the release branch, then pass that same version to retry
 without creating another version bump.
 
 The script prints Codex's selected version and release notes, updates the Cargo
 version metadata and any required internal revisions, pushes the resulting
-release commit, then dispatches that exact `main` commit. It waits for the
+release commit, then dispatches that exact release-branch commit. It waits for the
 workflow, verifies that the result is a draft targeting that commit, checks the
 updater against the draft, and launches the draft app in macOS 14. Only then
 does it print the draft URL and ask `release y/n?`. Answering `y` publishes the
@@ -136,7 +136,8 @@ Homebrew tap. Answering anything else leaves the draft unpublished. Draft
 creation never updates Homebrew. The website download redirects to GitHub's
 latest published release independently of this script.
 
-The run fails if local `main` differs from `origin/main`, Codex returns an
+The run fails if the local release branch differs from its remote, a maintenance
+branch does not match the version's major and minor components, Codex returns an
 invalid or non-increasing version, the tag or release already exists, required
 configuration is missing, or immutable releases are disabled.
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -52,9 +52,15 @@ RECOVERED_RELEASE=0
 RESUMED_DRAFT=0
 DRAFT_HEAD=""
 DRAFT_URL=""
+RELEASE_BRANCH="$(git -C "$ROOT" branch --show-current)"
 if [[ -n "$REQUESTED_VERSION" && "$REQUESTED_VERSION" == "$CURRENT_VERSION" ]]; then
   RESUME_RELEASE=1
 fi
+
+version_matches_release_branch() {
+  local version="$1"
+  [[ "$RELEASE_BRANCH" == "main" || "$version" == "${RELEASE_BRANCH#v}."* ]]
+}
 
 cleanup_release_notes() {
   if [[ -n "$RELEASE_NOTES" ]]; then
@@ -503,11 +509,11 @@ resume_published_release() {
     echo "error: recovery requires an unmodified publish script" >&2
     exit 64
   fi
-  git -C "$ROOT" fetch --quiet origin main
+  git -C "$ROOT" fetch --quiet origin "$RELEASE_BRANCH"
   if [[ ! "$head" =~ ^[0-9a-f]{40}$ ]] ||
     ! git -C "$ROOT" cat-file -e "$head^{commit}" 2>/dev/null ||
-    ! git -C "$ROOT" merge-base --is-ancestor "$head" origin/main; then
-    echo "error: release $REQUESTED_VERSION does not target a commit on main" >&2
+    ! git -C "$ROOT" merge-base --is-ancestor "$head" "origin/$RELEASE_BRANCH"; then
+    echo "error: release $REQUESTED_VERSION does not target a commit on $RELEASE_BRANCH" >&2
     exit 1
   fi
 
@@ -742,6 +748,14 @@ case "$(git -C "$ROOT" remote get-url origin)" in
     exit 64
     ;;
 esac
+if [[ "$RELEASE_BRANCH" != "main" && ! "$RELEASE_BRANCH" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+  echo "error: publish requires main or a vMAJOR.MINOR maintenance branch" >&2
+  exit 64
+fi
+if [[ -n "$REQUESTED_VERSION" ]] && ! version_matches_release_branch "$REQUESTED_VERSION"; then
+  echo "error: version $REQUESTED_VERSION does not belong to branch $RELEASE_BRANCH" >&2
+  exit 64
+fi
 resume_published_release
 if [[ "$RECOVERED_RELEASE" -eq 1 ]]; then
   exit 0
@@ -758,23 +772,19 @@ if [[ -n "$(git -C "$ROOT" status --porcelain --untracked-files=all)" ]]; then
   echo "error: publish requires a clean checkout" >&2
   exit 64
 fi
-if [[ "$(git -C "$ROOT" branch --show-current)" != "main" ]]; then
-  echo "error: publish requires the main branch" >&2
-  exit 64
-fi
 prepare_cask_publish
 prepare_website_publish
-git -C "$ROOT" fetch --quiet origin main
+git -C "$ROOT" fetch --quiet origin "$RELEASE_BRANCH"
 source_head="$(git -C "$ROOT" rev-parse HEAD)"
 if [[ "$RESUMED_DRAFT" -eq 1 ]]; then
   if [[ ! "$DRAFT_HEAD" =~ ^[0-9a-f]{40}$ ]] ||
     ! git -C "$ROOT" cat-file -e "$DRAFT_HEAD^{commit}" 2>/dev/null ||
-    ! git -C "$ROOT" merge-base --is-ancestor "$DRAFT_HEAD" origin/main; then
-    echo "error: draft release $VERSION does not target a commit on main" >&2
+    ! git -C "$ROOT" merge-base --is-ancestor "$DRAFT_HEAD" "origin/$RELEASE_BRANCH"; then
+    echo "error: draft release $VERSION does not target a commit on $RELEASE_BRANCH" >&2
     exit 1
   fi
-elif [[ "$source_head" != "$(git -C "$ROOT" rev-parse origin/main)" ]]; then
-  echo "error: publish requires main to match origin/main" >&2
+elif [[ "$source_head" != "$(git -C "$ROOT" rev-parse "origin/$RELEASE_BRANCH")" ]]; then
+  echo "error: publish requires $RELEASE_BRANCH to match origin/$RELEASE_BRANCH" >&2
   exit 64
 fi
 if [[ "$RESUMED_DRAFT" -eq 1 ]]; then
@@ -783,6 +793,10 @@ if [[ "$RESUMED_DRAFT" -eq 1 ]]; then
   echo "Resuming draft release $VERSION."
 else
   generate_release_metadata "$source_head"
+  if ! version_matches_release_branch "$VERSION"; then
+    echo "error: version $VERSION does not belong to branch $RELEASE_BRANCH" >&2
+    exit 64
+  fi
   if [[ "$RESUME_RELEASE" -eq 0 ]] && ! version_is_greater "$VERSION" "$CURRENT_VERSION"; then
     echo "error: release version $VERSION must be newer than $CURRENT_VERSION" >&2
     exit 64
@@ -807,13 +821,13 @@ else
   if [[ "$RESUME_RELEASE" -eq 0 || "${#INTERNAL_VERSION_FILES[@]}" -gt 0 ]]; then
     git -C "$ROOT" diff --cached --check
     git -C "$ROOT" commit -m "Release $VERSION"
-    git -C "$ROOT" push origin HEAD:main
+    git -C "$ROOT" push origin "HEAD:$RELEASE_BRANCH"
   fi
   head="$(git -C "$ROOT" rev-parse HEAD)"
   run_url="$(
     gh workflow run release.yml \
       --repo "$REPOSITORY" \
-      --ref main \
+      --ref "$RELEASE_BRANCH" \
       -f version="$VERSION" \
       -f commit="$head" \
       -f notes="$(<"$RELEASE_NOTES")"
@@ -826,7 +840,7 @@ else
   run_id="${BASH_REMATCH[1]}"
   echo "Release workflow: $run_url"
   if ! gh run watch "$run_id" --repo "$REPOSITORY" --compact --exit-status; then
-    echo "Release workflow failed; after fixing main, retry with: $0 --version $VERSION" >&2
+    echo "Release workflow failed; after fixing $RELEASE_BRANCH, retry with: $0 --version $VERSION" >&2
     exit 1
   fi
   read -r is_draft target_commitish release_url < <(

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -20,7 +20,10 @@ fn release_workflow_binds_the_dmg_to_reviewed_source() {
     assert!(RELEASE_WORKFLOW.contains("commit:"));
     assert!(RELEASE_WORKFLOW.contains("notes:"));
     assert!(RELEASE_WORKFLOW.contains("Release notes must not be empty."));
-    assert!(RELEASE_WORKFLOW.contains("refs/heads/main"));
+    assert!(RELEASE_WORKFLOW.contains("refs/heads/*"));
+    assert!(RELEASE_WORKFLOW.contains("release_branch\" != \"main"));
+    assert!(RELEASE_WORKFLOW.contains("^v[0-9]+\\.[0-9]+$"));
+    assert!(RELEASE_WORKFLOW.contains("does not belong to maintenance branch"));
     assert!(RELEASE_WORKFLOW.contains("IMMUTABLE_RELEASES_ENABLED"));
     assert!(RELEASE_WORKFLOW.contains("--target \"$GITHUB_SHA\""));
     assert!(RELEASE_WORKFLOW.contains("targetCommitish"));
@@ -292,11 +295,15 @@ fn release_actions_delegate_website_publication_to_the_local_script() {
     assert!(PUBLISH_SCRIPT.contains(r#"select(.tag_name == \"$REQUESTED_VERSION\")"#));
     assert!(PUBLISH_SCRIPT.contains("multiple GitHub releases exist for $REQUESTED_VERSION"));
     assert!(PUBLISH_SCRIPT.contains("Resuming draft release $VERSION."));
-    assert!(PUBLISH_SCRIPT.contains("draft release $VERSION does not target a commit on main"));
     assert!(
         PUBLISH_SCRIPT
-            .contains("git -C \"$ROOT\" merge-base --is-ancestor \"$DRAFT_HEAD\" origin/main")
+            .contains("draft release $VERSION does not target a commit on $RELEASE_BRANCH")
     );
+    assert!(PUBLISH_SCRIPT.contains(
+        "git -C \"$ROOT\" merge-base --is-ancestor \"$DRAFT_HEAD\" \"origin/$RELEASE_BRANCH\""
+    ));
+    assert!(PUBLISH_SCRIPT.contains("version_matches_release_branch"));
+    assert!(PUBLISH_SCRIPT.contains("--ref \"$RELEASE_BRANCH\""));
     assert!(PUBLISH_SCRIPT.contains("if [[ \"$RESUMED_DRAFT\" -eq 0 ]] && ! command -v codex"));
     assert!(!PUBLISH_SCRIPT.contains("if resume_published_release; then"));
     let resume = PUBLISH_SCRIPT


### PR DESCRIPTION
## Summary
- allow release dispatches from guarded `vMAJOR.MINOR` branches
- require maintenance releases to match the branch major/minor
- keep exact-commit, signing, notarization, attestation, and immutable-release checks unchanged

## Checks
- `cargo test --locked --test release_workflow` (14 passed)
- `bash -n scripts/publish.sh`
- `shellcheck --exclude=SC2329 scripts/publish.sh`
- `actionlint .github/workflows/release.yml`

Needed to publish 3.18.1 from `v3.18` after #211.