### PR TITLE
Add rclone encrypted-config Isotope

### DIFF
--- a/docs/adr/0035-rclone-config-password-custody.md
+++ b/docs/adr/0035-rclone-config-password-custody.md
@@ -1,0 +1,29 @@
+# ADR 0035: rclone Configuration Password Custody
+
+## Decision
+
+rclone's configuration wrapping password is a Global Value applied only through
+the `rclone` Authorization Gate. The Target must be the Automic Vault Isotope,
+signed by the Automic Vault team with Hardened Runtime and no entitlements. The
+Isotope changes only rclone's default password command to
+`/usr/local/bin/av rclone-password 1`.
+
+The Hardener uses rclone's native configuration encryption rather than parsing,
+extracting, or recreating individual remote credentials. Competing password
+environment variables and inherited config-key files fail closed during
+hardening.
+
+## Context
+
+rclone supports many backends and stores their credentials together in one
+configuration. Its native encrypted-config boundary covers those formats without
+temporary plaintext files, but the password command receives no remote or
+operation context. Upstream's macOS release is not code signed, so the Gate
+cannot accept it as a Target.
+
+## Consequences
+
+One approved Secret Application unlocks every remote in the configuration for
+the lifetime of that verified rclone process. Automic Vault does not claim
+per-remote access control. Doctor verifies the signed Target and native encrypted
+configuration; unsupported encryption versions and plaintext state fail closed.

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1666,6 +1666,7 @@ mod tests {
                                 | "plumber"
                                 | "uaa-cli"
                                 | "railway"
+                                | "rclone"
                                 | "oxide-cli"
                                 | "stripe"
                                 | "supabase"

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -511,6 +511,41 @@ pub(super) fn wakatime_credential(key: String, api_url: String) -> Result<String
         .ok_or_else(|| format!("Automic Vault returned no WakaTime credential for {key}"))
 }
 
+pub(super) fn rclone_password(key: String) -> Result<String, String> {
+    validate_key_name(&key)?;
+    let request = ApprovalRequest {
+        op: "rclone-get",
+        keys: vec![key.clone()],
+        target: String::new(),
+        args: Vec::new(),
+        cwd: crate::path_security::current_working_directory_utf8()?,
+        replace_existing_env: false,
+        allow_missing_keys: false,
+        env_conflicts: Vec::new(),
+        shebang_script: None,
+        script_data: None,
+        snapshot_incompatible_interpreter: None,
+        tool: Some("rclone"),
+        docker_server_url: None,
+        terraform_hostname: None,
+        aliyun_profile: None,
+        oxide_scope: None,
+        goat_scope: None,
+        ordercli_scope: None,
+        openhue_scope: None,
+        uaa_scope: None,
+        railway_scope: None,
+        wakatime_api_url: None,
+    };
+    if crate::test_keychain_dir().is_some() {
+        return load_test_secret_if_present(&key)?
+            .ok_or_else(|| format!("failed to load secret {key}: -25300"));
+    }
+    xpc_approve_injection(&request)?
+        .remove(&key)
+        .ok_or_else(|| format!("Automic Vault returned no rclone config password for {key}"))
+}
+
 pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod oxide_credential;
 pub(crate) mod plumber_credential;
 mod proxy;
 pub(crate) mod railway_credential;
+pub(crate) mod rclone_password;
 mod save;
 mod scan;
 mod shell_secrets;
@@ -423,6 +424,10 @@ where
                 let result = hardeners::wakatime_cli::run(stdout, yes);
                 return finish_hardening(result, "wakatime-cli", stdout, stderr);
             }
+            if target == "rclone" {
+                let result = hardeners::rclone::run(stdout, yes);
+                return finish_hardening(result, "rclone", stdout, stderr);
+            }
             if target == "gh" || target == "gh-cli" {
                 let result = hardeners::gh_cli::run(stdout, yes);
                 return finish_hardening(result, "gh", stdout, stderr);
@@ -487,6 +492,7 @@ where
         Some("uaa-credential") => uaa_credential::run(rest, stdout, stderr),
         Some("railway-credential") => railway_credential::run(rest, stdout, stderr),
         Some("wakatime-credential") => wakatime_credential::run(rest, stdout, stderr),
+        Some("rclone-password") => rclone_password::run(rest, stdout, stderr),
         Some("list" | "ls") => list::run(rest, stdout, stderr),
         Some("bless") => bless::run(rest, stderr),
         Some("open") => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,7 +56,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 39;
+pub(crate) const INSTALL_REVISION: u32 = 40;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()

--- a/src/cli/rclone_password.rs
+++ b/src/cli/rclone_password.rs
@@ -1,0 +1,50 @@
+use std::ffi::OsString;
+use std::io::Write;
+
+use super::inject;
+
+pub(crate) const SECRET_NAME: &str = "RCLONE_CONFIG_PASSWORD";
+
+pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match run_inner(&args, stdout) {
+        Ok(()) => 0,
+        Err(error) => {
+            let _ = writeln!(stderr, "rclone-password: {error}");
+            1
+        }
+    }
+}
+
+fn run_inner(args: &[OsString], stdout: &mut dyn Write) -> Result<(), String> {
+    if args != ["1"] {
+        return Err("usage: av rclone-password 1".into());
+    }
+    crate::secrets::ensure_rclone_helper_ready()?;
+    let password = inject::rclone_password(SECRET_NAME.into())?;
+    validate_password(&password)?;
+    writeln!(stdout, "{password}")
+        .map_err(|error| format!("failed to return rclone config password: {error}"))
+}
+
+pub(crate) fn validate_password(value: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > 1024
+        || value.bytes().any(|byte| matches!(byte, 0 | b'\n' | b'\r'))
+    {
+        return Err("invalid rclone config password".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_passwords_that_cannot_be_returned_as_one_line() {
+        assert!(validate_password("correct horse battery staple").is_ok());
+        assert!(validate_password("").is_err());
+        assert!(validate_password("line\nbreak").is_err());
+        assert!(validate_password("nul\0byte").is_err());
+    }
+}

--- a/src/cli/rclone_password.rs
+++ b/src/cli/rclone_password.rs
@@ -16,8 +16,11 @@ pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn 
 }
 
 fn run_inner(args: &[OsString], stdout: &mut dyn Write) -> Result<(), String> {
-    if args != ["1"] {
+    let [version] = args else {
         return Err("usage: av rclone-password 1".into());
+    };
+    if version != "1" {
+        return Err("unsupported rclone password request".into());
     }
     crate::secrets::ensure_rclone_helper_ready()?;
     let password = inject::rclone_password(SECRET_NAME.into())?;

--- a/src/isotopes/detectors/rclone/detector.md
+++ b/src/isotopes/detectors/rclone/detector.md
@@ -11,14 +11,13 @@
 - `~/.config/rclone/rclone.conf`
 - `~/.rclone.conf`
 
-## Why This is not Yet Hardened
+## Hardening
 
-The retired `rclone` hardener moved the detected secret to the macOS Keychain,
-then recreated `$RCLONE_CONFIG` inside a temporary directory for each run. We no
-longer consider a temporary plaintext file a sufficient security boundary, so
-this detector remains report-only.
+`av harden rclone` installs the signed rclone Isotope and uses rclone's native
+configuration encryption. The wrapping password remains a Global Value in
+Automic Vault and the verified rclone Target requests it through rclone's native
+password-command interface.
 
-If a narrow environment-variable or credential-helper interface can cover this
-state without writing the secret back to disk, we can reconsider the hardener.
-
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+Because one encrypted configuration contains every remote, one approved Secret
+Application unlocks all configured remotes for that rclone process. The Gate
+does not claim per-remote access control.

--- a/src/isotopes/hardeners/isotope.rs
+++ b/src/isotopes/hardeners/isotope.rs
@@ -121,6 +121,14 @@ pub(crate) const WAKATIME: Spec = Spec {
     binaries: &["wakatime-cli"],
     test_path: "AUTOMIC_VAULT_TEST_WAKATIME_TARGET",
 };
+pub(crate) const RCLONE: Spec = Spec {
+    hardener: "rclone",
+    formula: "rclone-isotope",
+    repository: "rclone",
+    primary: "rclone",
+    binaries: &["rclone"],
+    test_path: "AUTOMIC_VAULT_TEST_RCLONE_TARGET",
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Spec {
@@ -350,6 +358,9 @@ pub(crate) fn install_privileged(
         }
         if spec.hardener == WAKATIME.hardener {
             super::wakatime_cli::verify_target(&stage)?;
+        }
+        if spec.hardener == RCLONE.hardener {
+            super::rclone::verify_target(&stage)?;
         }
         staged.push((stage, bin_dir.join(binary)));
     }
@@ -746,6 +757,9 @@ fn installed(spec: Spec, path: &Path) -> bool {
     if spec.hardener == WAKATIME.hardener {
         return super::wakatime_cli::verify_target(path).is_ok();
     }
+    if spec.hardener == RCLONE.hardener {
+        return super::rclone::verify_target(path).is_ok();
+    }
     true
 }
 
@@ -756,7 +770,7 @@ fn formula_url(spec: Spec) -> String {
 fn spec(hardener: &str) -> Option<Spec> {
     [
         GH, STRIPE, SUPABASE, OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
-        ALIYUN, WAKATIME,
+        ALIYUN, WAKATIME, RCLONE,
     ]
     .into_iter()
     .find(|spec| spec.hardener == hardener)
@@ -864,7 +878,7 @@ mod tests {
     #[test]
     fn every_executable_isotope_is_registered_for_direct_fallback() {
         for expected in [
-            OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER, WAKATIME,
+            OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER, WAKATIME, RCLONE,
         ] {
             assert_eq!(
                 spec(expected.hardener).map(|value| value.hardener),
@@ -885,6 +899,7 @@ mod tests {
             (OPENHUE, "openhue-cli-isotope", "openhue-cli"),
             (PLUMBER, "plumber-isotope", "plumber"),
             (WAKATIME, "wakatime-cli-isotope", "wakatime-cli"),
+            (RCLONE, "rclone-isotope", "rclone"),
         ] {
             assert_eq!(isotope.formula, formula);
             assert_eq!(isotope.repository, repository);
@@ -903,7 +918,7 @@ mod tests {
         }
         for isotope in [
             GH, STRIPE, SUPABASE, OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
-            WAKATIME,
+            WAKATIME, RCLONE,
         ] {
             let missing =
                 std::env::temp_dir().join(format!("av-test-missing-{}-isotope", isotope.hardener));

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod ordercli;
 pub(crate) mod oxide_cli;
 pub(crate) mod plumber;
 pub(crate) mod railway;
+pub(crate) mod rclone;
 pub(crate) mod stripe_cli;
 pub(crate) mod sudo;
 pub(crate) mod supabase;
@@ -307,6 +308,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
         gated_hardener!(plumber, "plumber"),
         gated_hardener!(uaa_cli, "uaa-cli"),
         gated_hardener!(railway, "railway"),
+        gated_hardener!(rclone, "rclone"),
         gated_hardener!(oxide_cli, "oxide-cli"),
         gated_hardener!(homebrew, "brew"),
         gated_hardener!(gh_cli, "gh"),
@@ -343,6 +345,7 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
         plumber::secret_gate(),
         uaa_cli::secret_gate(),
         railway::secret_gate(),
+        rclone::secret_gate(),
         oxide_cli::secret_gate(),
         homebrew::secret_gate(),
         gh_cli::secret_gate(),

--- a/src/isotopes/hardeners/rclone.md
+++ b/src/isotopes/hardeners/rclone.md
@@ -1,0 +1,10 @@
+# rclone
+
+The hardener installs the signed rclone Isotope and encrypts the complete
+`rclone.conf` with rclone's native configuration encryption. The generated
+wrapping password is a Global Value applied through rclone's native password
+command only to a verified rclone Target.
+
+rclone keeps all remotes in one encrypted configuration. One approved Secret
+Application therefore unlocks every configured remote for that rclone process;
+this Gate cannot provide per-remote access control.

--- a/src/isotopes/hardeners/rclone.rs
+++ b/src/isotopes/hardeners/rclone.rs
@@ -201,7 +201,7 @@ fn target() -> PathBuf {
 }
 
 fn read_config(path: &Path) -> Result<String, String> {
-    let mut file = OpenOptions::new()
+    let file = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open(path)
@@ -220,8 +220,15 @@ fn read_config(path: &Path) -> Result<String, String> {
         ));
     }
     let mut contents = String::new();
-    file.read_to_string(&mut contents)
+    file.take(MAX_CONFIG_BYTES + 1)
+        .read_to_string(&mut contents)
         .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if contents.len() as u64 > MAX_CONFIG_BYTES {
+        return Err(format!(
+            "rclone configuration is too large: {}",
+            path.display()
+        ));
+    }
     Ok(contents)
 }
 

--- a/src/isotopes/hardeners/rclone.rs
+++ b/src/isotopes/hardeners/rclone.rs
@@ -355,6 +355,7 @@ pub(crate) fn verify_target(path: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn recognizes_only_supported_native_encryption() {
@@ -368,5 +369,46 @@ mod tests {
         let password = generate_password().unwrap();
         assert_eq!(password.len(), 64);
         assert!(crate::cli::rclone_password::validate_password(&password).is_ok());
+    }
+
+    #[test]
+    fn hardener_creates_password_only_after_the_target_reports_it_missing() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-rclone-hardener-{}", std::process::id()));
+        let config = root.join("rclone.conf");
+        let target = root.join("rclone");
+        let keychain = root.join("keychain");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&keychain).unwrap();
+        std::fs::write(&config, "[remote]\ntoken = plaintext\n").unwrap();
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::write(
+            &target,
+            "#!/bin/sh\nset -eu\ntest \"$1\" = --config\ntest \"$3 $4 $5\" = 'config encryption set'\nif test -f \"$AUTOMIC_VAULT_TEST_KEYCHAIN_DIR/RCLONE_CONFIG_PASSWORD\"; then\n  printf '# encrypted\\n\\nRCLONE_ENCRYPT_V0:\\ndata\\n' > \"$2\"\nelse\n  echo 'failed to load secret RCLONE_CONFIG_PASSWORD: -25300' >&2\nfi\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_RCLONE_CONFIG", &config);
+            std::env::set_var("AUTOMIC_VAULT_TEST_RCLONE_TARGET", &target);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        }
+
+        let mut output = Vec::new();
+        let result = run(&mut output, true);
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_RCLONE_CONFIG");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_RCLONE_TARGET");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+        }
+        assert!(result.is_ok(), "{result:?}");
+        assert!(encrypted_state(&std::fs::read_to_string(&config).unwrap()).unwrap());
+        assert!(
+            keychain
+                .join(crate::cli::rclone_password::SECRET_NAME)
+                .exists()
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/isotopes/hardeners/rclone.rs
+++ b/src/isotopes/hardeners/rclone.rs
@@ -1,0 +1,372 @@
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use base64::Engine;
+use ring::rand::{SecureRandom, SystemRandom};
+
+use super::{
+    HardenerCommand, HardenerDetection, HardenerDiagnostic, RequiredExecutable,
+    SecretGateDescriptor, SecretGateRoute,
+};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const MAX_CONFIG_BYTES: u64 = 16 * 1024 * 1024;
+const TEAM_IDENTIFIER: &str = "ZU76A67LGU";
+
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
+    let testing = test_config_path().is_some();
+    super::PrivilegeMode::Mixed.require_user("rclone", testing)?;
+    reject_competing_password_sources()?;
+    if !testing {
+        crate::secrets::ensure_rclone_helper_ready()?;
+    }
+    let config = config_path()?;
+    let encrypted = encrypted_state(&read_config(&config)?)?;
+    let target = target();
+    let plan = super::isotope::plan(super::isotope::RCLONE)?;
+
+    writeln!(stdout, "╭─ harden rclone").ok();
+    writeln!(stdout, "│").ok();
+    plan.write(stdout, super::isotope::RCLONE);
+    writeln!(stdout, "├─ encrypt {}", config.display()).ok();
+    writeln!(stdout, "├─ keep its wrapping password in Automic Vault").ok();
+    writeln!(
+        stdout,
+        "├─ authorize one rclone process for every configured remote"
+    )
+    .ok();
+    writeln!(stdout, "│").ok();
+    if !super::gh_cli::confirm(stdout, yes)? {
+        writeln!(stdout, "╰─ cancelled").ok();
+        return Ok(());
+    }
+
+    plan.apply(super::isotope::RCLONE)?;
+    verify_target(&target)?;
+    if encrypted {
+        encryption_set(&target, &config)?.require_success()?;
+    } else {
+        let first = encryption_set(&target, &config)?;
+        if !encrypted_state(&read_config(&config)?)? {
+            if !first.secret_was_missing() {
+                return Err(first.failure("rclone could not encrypt its configuration"));
+            }
+            let password = generate_password()?;
+            crate::secrets::store_secret(crate::cli::rclone_password::SECRET_NAME, &password)?;
+            encryption_set(&target, &config)?.require_success()?;
+        }
+    }
+    if !encrypted_state(&read_config(&config)?)? {
+        return Err("rclone reported success but its configuration remains plaintext".into());
+    }
+
+    writeln!(stdout, "╰─ hardened rclone").ok();
+    super::write_secret_gate_notice(stdout, "rclone");
+    Ok(())
+}
+
+pub(crate) fn detect() -> HardenerDetection {
+    let testing = test_config_path().is_some();
+    let target = target();
+    let target_valid = verify_target(&target).is_ok();
+    let config = config_path().ok();
+    let config_valid = config.as_deref().is_some_and(|path| {
+        read_config(path)
+            .and_then(|contents| encrypted_state(&contents))
+            .unwrap_or(false)
+    });
+    let hardened = target_valid && config_valid;
+    let isotope = super::isotope::detect(super::isotope::RCLONE)
+        .commands
+        .into_iter()
+        .next()
+        .and_then(|command| command.isotope);
+    let command = HardenerCommand {
+        name: "rclone".into(),
+        hardened,
+        stub_valid: true,
+        stub_path: None,
+        target_path: target.display().to_string(),
+        required_paths: if testing {
+            Vec::new()
+        } else {
+            vec![RequiredExecutable {
+                name: "Automic Vault CLI",
+                path: AV_PATH.into(),
+            }]
+        },
+        stub_requirements: None,
+        injected_keys: Vec::new(),
+        assignment_keys: Vec::new(),
+        isotope,
+    };
+    let mut detection = HardenerDetection::commands(hardened, vec![command]);
+    detection.applicable = config.as_deref().is_some_and(Path::exists) || target.exists();
+    if target.exists() && !target_valid && !testing {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "rclone_target_invalid",
+            message: verify_target(&target).unwrap_err(),
+            remediation: "Rerun `av harden rclone` to install the signed rclone Isotope.".into(),
+            path: Some(target.display().to_string()),
+        });
+    }
+    if config.as_deref().is_some_and(Path::exists) && !config_valid {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "rclone_config_not_encrypted",
+            message: "rclone configuration is not encrypted with its native config encryption."
+                .into(),
+            remediation: "Rerun `av harden rclone`.".into(),
+            path: config.map(|path| path.display().to_string()),
+        });
+    }
+    detection
+}
+
+pub(crate) fn secret_gate() -> SecretGateDescriptor {
+    SecretGateDescriptor {
+        id: "rclone",
+        key_patterns: vec![crate::cli::rclone_password::SECRET_NAME.into()],
+        routes: vec![SecretGateRoute {
+            operation: "rclone-get",
+            script_path: None,
+            target_path: target().display().to_string(),
+            caller_identifiers: vec!["com.automicvault.av"],
+            key_patterns: vec![crate::cli::rclone_password::SECRET_NAME.into()],
+            replace_existing_env: false,
+            allow_missing_keys: false,
+        }],
+    }
+}
+
+fn reject_competing_password_sources() -> Result<(), String> {
+    for name in [
+        "RCLONE_CONFIG_PASS",
+        "RCLONE_PASSWORD_COMMAND",
+        "_RCLONE_CONFIG_KEY_FILE",
+    ] {
+        if std::env::var_os(name).is_some_and(|value| !value.is_empty()) {
+            return Err(format!("unset {name} before hardening rclone"));
+        }
+    }
+    Ok(())
+}
+
+fn config_path() -> Result<PathBuf, String> {
+    if let Some(path) = test_config_path() {
+        return Ok(path);
+    }
+    if let Some(path) = std::env::var_os("RCLONE_CONFIG").filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            return Err("RCLONE_CONFIG must be an absolute path".into());
+        }
+        return Ok(path);
+    }
+    if let Some(parent) = target().parent() {
+        let local = parent.join("rclone.conf");
+        if local.exists() {
+            return Ok(local);
+        }
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is not set".to_string())?;
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(xdg).join("rclone/rclone.conf");
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+    for path in [
+        home.join(".config/rclone/rclone.conf"),
+        home.join(".rclone.conf"),
+    ] {
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+    Err("configure rclone before hardening it; no rclone.conf was found".into())
+}
+
+fn test_config_path() -> Option<PathBuf> {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_RCLONE_CONFIG").map(PathBuf::from)
+}
+
+fn target() -> PathBuf {
+    super::isotope::target(super::isotope::RCLONE)
+}
+
+fn read_config(path: &Path) -> Result<String, String> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    if !metadata.file_type().is_file()
+        || metadata.len() > MAX_CONFIG_BYTES
+        || metadata.uid() != super::effective_uid()
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(format!(
+            "refusing unsafe rclone configuration: {}",
+            path.display()
+        ));
+    }
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    Ok(contents)
+}
+
+fn encrypted_state(contents: &str) -> Result<bool, String> {
+    let Some(first) = contents
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#') && !line.starts_with(';'))
+    else {
+        return Ok(false);
+    };
+    if first == "RCLONE_ENCRYPT_V0:" {
+        return Ok(true);
+    }
+    if first.starts_with("RCLONE_ENCRYPT_V") {
+        return Err("unsupported rclone configuration encryption version".into());
+    }
+    Ok(false)
+}
+
+struct EncryptionResult {
+    status: std::process::ExitStatus,
+    output: String,
+}
+
+impl EncryptionResult {
+    fn secret_was_missing(&self) -> bool {
+        self.output.contains("RCLONE_CONFIG_PASSWORD") && self.output.contains("-25300")
+    }
+
+    fn failure(&self, prefix: &str) -> String {
+        format!("{prefix}: {}", self.status)
+    }
+
+    fn require_success(self) -> Result<(), String> {
+        self.status
+            .success()
+            .then_some(())
+            .ok_or_else(|| self.failure("rclone config encryption failed"))
+    }
+}
+
+fn encryption_set(target: &Path, config: &Path) -> Result<EncryptionResult, String> {
+    let output = Command::new(target)
+        .arg("--config")
+        .arg(config)
+        .args(["config", "encryption", "set"])
+        .env_remove("RCLONE_CONFIG")
+        .env_remove("RCLONE_CONFIG_PASS")
+        .env_remove("RCLONE_PASSWORD_COMMAND")
+        .env_remove("_RCLONE_CONFIG_KEY_FILE")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("failed to run {}: {error}", target.display()))?;
+    Ok(EncryptionResult {
+        status: output.status,
+        output: format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    })
+}
+
+fn generate_password() -> Result<String, String> {
+    let mut bytes = [0_u8; 48];
+    SystemRandom::new()
+        .fill(&mut bytes)
+        .map_err(|_| "failed to generate rclone config password".to_string())?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+pub(crate) fn verify_target(path: &Path) -> Result<(), String> {
+    if test_config_path().is_some() {
+        return path
+            .exists()
+            .then_some(())
+            .ok_or_else(|| format!("test rclone Target is missing: {}", path.display()));
+    }
+    let requirement = format!(
+        "=identifier \"rclone\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{TEAM_IDENTIFIER}\""
+    );
+    let status = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--strict", "-R", &requirement])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to verify {}: {error}", path.display()))?;
+    if !status.success() {
+        return Err(format!(
+            "rclone Target signature is invalid: {}",
+            path.display()
+        ));
+    }
+    let output = Command::new("/usr/bin/codesign")
+        .args(["-d", "-vvv"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    let details = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success()
+        || !details.contains("flags=0x10000(runtime)")
+        || !details.contains(&format!("TeamIdentifier={TEAM_IDENTIFIER}"))
+        || !details.contains("Timestamp=")
+    {
+        return Err(
+            "rclone Target lacks the required Developer ID Hardened Runtime identity".into(),
+        );
+    }
+    let entitlements = Command::new("/usr/bin/codesign")
+        .args(["-d", "--entitlements", ":-"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect rclone entitlements: {error}"))?;
+    if !entitlements.status.success() || !entitlements.stdout.is_empty() {
+        return Err("rclone Target has unexpected code-signing entitlements".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_only_supported_native_encryption() {
+        assert!(encrypted_state("# rclone\n\nRCLONE_ENCRYPT_V0:\ndata").unwrap());
+        assert!(!encrypted_state("[remote]\ntoken = secret\n").unwrap());
+        assert!(encrypted_state("RCLONE_ENCRYPT_V1:\ndata").is_err());
+    }
+
+    #[test]
+    fn generated_password_is_a_single_high_entropy_line() {
+        let password = generate_password().unwrap();
+        assert_eq!(password.len(), 64);
+        assert!(crate::cli::rclone_password::validate_password(&password).is_ok());
+    }
+}

--- a/src/isotopes/hardeners/rclone.rs
+++ b/src/isotopes/hardeners/rclone.rs
@@ -249,7 +249,7 @@ struct EncryptionResult {
 
 impl EncryptionResult {
     fn secret_was_missing(&self) -> bool {
-        self.output.contains("RCLONE_CONFIG_PASSWORD") && self.output.contains("-25300")
+        output_reports_missing_secret(&self.output)
     }
 
     fn failure(&self, prefix: &str) -> String {
@@ -262,6 +262,10 @@ impl EncryptionResult {
             .then_some(())
             .ok_or_else(|| self.failure("rclone config encryption failed"))
     }
+}
+
+fn output_reports_missing_secret(output: &str) -> bool {
+    output.contains("failed to load secret RCLONE_CONFIG_PASSWORD: -25300")
 }
 
 fn encryption_set(target: &Path, config: &Path) -> Result<EncryptionResult, String> {
@@ -369,6 +373,16 @@ mod tests {
         let password = generate_password().unwrap();
         assert_eq!(password.len(), 64);
         assert!(crate::cli::rclone_password::validate_password(&password).is_ok());
+    }
+
+    #[test]
+    fn only_the_exact_missing_secret_error_allows_password_creation() {
+        assert!(output_reports_missing_secret(
+            "rclone-password: failed to load secret RCLONE_CONFIG_PASSWORD: -25300"
+        ));
+        assert!(!output_reports_missing_secret(
+            "another failure for RCLONE_CONFIG_PASSWORD also mentioned -25300"
+        ));
     }
 
     #[test]

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -6548,7 +6548,7 @@ private final class ApprovalServer: @unchecked Sendable {
             keys: request.keys,
             target: parent.target,
             args: Array(parent.arguments.dropFirst()),
-            cwd: "",
+            cwd: "/",
             replaceExistingEnv: false,
             allowMissingKeys: false,
             envConflicts: [],

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3154,6 +3154,13 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
+        case .rcloneHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
+            let requested = xpc_dictionary_get_uint64(message, "requested_version")
+            guard requested == 1 else {
+                reply(peer, to: message, ok: false, error: "rclone helper protocol upgrade is required")
+                return
+            }
+            reply(peer, to: message, ok: true, error: nil, value: "1")
         case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing):
             handleInject(
                 message,
@@ -3165,7 +3172,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 signing: signing
             )
         case .inject, .keys, .authorize, .dockerGet, .goatGet, .ordercliGet, .openhueGet, .plumberGet, .uaaGet, .railwayGet,
-             .oxideGet, .terraformGet, .aliyunGet, .wakatimeGet:
+             .oxideGet, .terraformGet, .aliyunGet, .wakatimeGet, .rcloneGet:
             handleInject(
                 message,
                 on: peer,
@@ -3570,15 +3577,21 @@ private final class ApprovalServer: @unchecked Sendable {
                 helperPath: callerPath,
                 helperSigning: signing
             )
-            let conflicts = Set(wakatimeRequest.envConflicts)
-            let selectionNames = wakatimeRequest.keys.filter {
-                wakatimeRequest.replaceExistingEnv || !conflicts.contains($0)
+            let rcloneRequest = try rclonePasswordRequest(
+                request: wakatimeRequest,
+                helperIdentity: identity,
+                helperPath: callerPath,
+                helperSigning: signing
+            )
+            let conflicts = Set(rcloneRequest.envConflicts)
+            let selectionNames = rcloneRequest.keys.filter {
+                rcloneRequest.replaceExistingEnv || !conflicts.contains($0)
             }
             let selected = try secretValueCustody.bind(
                 names: selectionNames,
-                cwd: wakatimeRequest.cwd
+                cwd: rcloneRequest.cwd
             )
-            request = approvalRequestWithCredentialContext(wakatimeRequest.selecting(selected))
+            request = approvalRequestWithCredentialContext(rcloneRequest.selecting(selected))
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
             return
@@ -6511,6 +6524,68 @@ private final class ApprovalServer: @unchecked Sendable {
         )
     }
 
+    private func rclonePasswordRequest(
+        request: ApprovalRequest,
+        helperIdentity: AVProcessIdentity,
+        helperPath: String,
+        helperSigning: SigningInfo
+    ) throws -> ApprovalRequest {
+        guard request.op == "rclone-get" else { return request }
+        guard request.tool == "rclone",
+              isTrustedAvCaller(path: helperPath, signing: helperSigning),
+              request.target.isEmpty,
+              request.args.isEmpty,
+              request.keys == [rcloneConfigPasswordSecretName],
+              !request.replaceExistingEnv,
+              !request.allowMissingKeys,
+              request.envConflicts.isEmpty,
+              request.shebangScript == nil,
+              request.scriptData == nil
+        else { throw AppError("invalid rclone password request") }
+        let parent = try rcloneCredentialParent(for: helperIdentity)
+        return ApprovalRequest(
+            op: request.op,
+            keys: request.keys,
+            target: parent.target,
+            args: Array(parent.arguments.dropFirst()),
+            cwd: "",
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "rclone",
+            title: "Unlock the rclone configuration?",
+            detail: "The verified rclone Target will receive one wrapping password that unlocks every configured remote for this process.",
+            credentialScope: rcloneAllRemotesScope,
+            credentialParent: parent
+        )
+    }
+
+    private func rcloneCredentialParent(
+        for helperIdentity: AVProcessIdentity
+    ) throws -> CredentialHelperParent {
+        let parentPID = helperIdentity.ppid
+        var parentIdentity = AVProcessIdentity()
+        guard parentPID > 1,
+              av_process_identity(parentPID, &parentIdentity),
+              parentIdentity.euid == helperIdentity.euid,
+              let arguments = processArguments(parentPID),
+              !arguments.isEmpty
+        else { throw AppError("rclone password helper has no live parent") }
+        let target = pathString(parentIdentity)
+        guard rcloneTargetIdentityValid(pid: parentPID, path: target) else {
+            throw AppError("credential helper parent is not an eligible rclone Target")
+        }
+        return CredentialHelperParent(
+            pid: parentPID,
+            startUsec: parentIdentity.start_usec,
+            euid: parentIdentity.euid,
+            target: target,
+            arguments: arguments
+        )
+    }
+
     private func terraformCredentialParent(
         for helperIdentity: AVProcessIdentity
     ) throws -> CredentialHelperParent {
@@ -6613,6 +6688,7 @@ private final class ApprovalServer: @unchecked Sendable {
         case "oxide": "oxide-cli"
         case "plumber": "plumber"
         case "railway": "railway"
+        case "rclone": "rclone"
         case "tofu": "opentofu"
         case "terraform": "terraform"
         case "uaa": "uaa-cli"
@@ -6664,6 +6740,9 @@ private final class ApprovalServer: @unchecked Sendable {
         case "wakatime-cli":
             return credentialHelperTool(parent) == tool
                 && wakatimeTargetIdentityValid(pid: parent.pid, path: parent.target)
+        case "rclone":
+            return credentialHelperTool(parent) == tool
+                && rcloneTargetIdentityValid(pid: parent.pid, path: parent.target)
         default: return false
         }
     }
@@ -6782,6 +6861,18 @@ private final class ApprovalServer: @unchecked Sendable {
             && liveProcessHasNoEntitlements(pid: pid)
     }
 
+    private func rcloneTargetIdentityValid(pid: pid_t, path: String) -> Bool {
+        guard configuredSecretGateTarget("rclone", matches: path),
+              let signing = liveSigningInfo(pid: pid),
+              signing.mainExecutable == path
+        else { return false }
+        return signing.identifier == "rclone"
+            && signing.teamIdentifier == "ZU76A67LGU"
+            && signing.isDeveloperID
+            && signing.runtimeProtection == .hardened
+            && liveProcessHasNoEntitlements(pid: pid)
+    }
+
     private func configuredSecretGateTarget(_ gateID: String, matches path: String) -> Bool {
         secretGateDescriptors.first(where: { $0.id == gateID })?.routes.contains {
             normalizedExecutablePath($0.targetPath) == normalizedExecutablePath(path)
@@ -6793,7 +6884,7 @@ private final class ApprovalServer: @unchecked Sendable {
         awsRegistration: AWSRegistrationCandidate?
     ) throws -> AuthorizationFulfillmentTransaction<ApprovedFulfillmentMaterial> {
         let credentialParent: CredentialHelperParent?
-        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get", "aliyun-get", "wakatime-get"]
+        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get", "aliyun-get", "wakatime-get", "rclone-get"]
             .contains(request.op)
         {
             guard let scope = request.credentialScope,
@@ -6831,6 +6922,11 @@ private final class ApprovalServer: @unchecked Sendable {
                     throw AppError("WakaTime API endpoint changed before Secret Application")
                 }
                 expected = wakatimeCredentialSecretName
+            case "rclone-get":
+                guard scope == rcloneAllRemotesScope else {
+                    throw AppError("rclone credential scope changed before Secret Application")
+                }
+                expected = rcloneConfigPasswordSecretName
             default: expected = terraformCredentialSecretName(scope)
             }
             guard request.keys == [expected] else {
@@ -6895,6 +6991,11 @@ private final class ApprovalServer: @unchecked Sendable {
                       let value = secrets[wakatimeCredentialSecretName],
                       validWakaTimeAPIKey(value)
                 else { throw AppError("WakaTime credential changed before Secret Application") }
+            } else if request.op == "rclone-get" {
+                guard scope == rcloneAllRemotesScope,
+                      let value = secrets[rcloneConfigPasswordSecretName],
+                      validRcloneConfigPassword(value)
+                else { throw AppError("rclone config password changed before Secret Application") }
             } else {
                 guard let value = secrets[terraformCredentialSecretName(scope)],
                       parseTerraformCredential(value) != nil
@@ -7688,6 +7789,8 @@ private func classifySecretGateRequest(
         return aliyunRequestClassification(request.args)
     case "wakatime-cli":
         return wakatimeRequestClassification(request.args)
+    case "rclone":
+        return .unknown
     case "aws":
         if awsRequestMayUseLongLivedCredentials(request) { return .secretDump }
         return awsRequestIsReadOnly(awsCommandWords(request)) ? .readOnly : .mutating
@@ -8794,6 +8897,14 @@ private func validWakaTimeAPIKey(_ value: String) -> Bool {
             ? byte == 45
             : (48...57).contains(byte) || (97...102).contains(byte)
     }
+}
+
+private let rcloneConfigPasswordSecretName = "RCLONE_CONFIG_PASSWORD"
+private let rcloneAllRemotesScope = "all-remotes"
+
+private func validRcloneConfigPassword(_ value: String) -> Bool {
+    !value.isEmpty && value.utf8.count <= 1024
+        && !value.unicodeScalars.contains(where: { [0, 10, 13].contains($0.value) })
 }
 
 private func isGhTokenKey(_ key: String) -> Bool {

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -11,6 +11,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case terraformHelperVersion = "terraform-helper-version"
     case aliyunHelperVersion = "aliyun-helper-version"
     case wakatimeHelperVersion = "wakatime-helper-version"
+    case rcloneHelperVersion = "rclone-helper-version"
     case inject
     case varlock
     case keys
@@ -29,6 +30,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case terraformGet = "terraform-get"
     case aliyunGet = "aliyun-get"
     case wakatimeGet = "wakatime-get"
+    case rcloneGet = "rclone-get"
     case dockerSave = "docker-save"
     case dockerDelete = "docker-delete"
     case goatSave = "goat-save"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -42,6 +42,11 @@ import Testing
     #expect(ApprovalServiceOperation.railwayDelete.rawValue == "railway-delete")
 }
 
+@Test func rclonePasswordHasDedicatedWireOperations() {
+    #expect(ApprovalServiceOperation.rcloneHelperVersion.rawValue == "rclone-helper-version")
+    #expect(ApprovalServiceOperation.rcloneGet.rawValue == "rclone-get")
+}
+
 @Test func ordercliCredentialsHaveDedicatedWireOperations() {
     #expect(ApprovalServiceOperation.ordercliGet.rawValue == "ordercli-get")
     #expect(ApprovalServiceOperation.ordercliSave.rawValue == "ordercli-save")

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -1135,6 +1135,27 @@ func protectionPolicyMatrix(
     #expect(selected["MISSING"] == nil)
 }
 
+@Test func filesystemRootSelectionCannotResolveAProjectValue() throws {
+    let global = StoredSecretValue(
+        source: .global,
+        keychainAccount: "GLOBAL",
+        accessibility: .whenUnlocked,
+        keychainProperties: []
+    )
+    let project = StoredSecretValue(
+        source: .projectDirectory(FileManager.default.temporaryDirectory.path),
+        keychainAccount: "PROJECT",
+        accessibility: .whenUnlocked,
+        keychainProperties: []
+    )
+    let selected = try resolveStoredSecretValues(
+        names: ["TOKEN"],
+        cwd: "/",
+        secrets: [StoredSecret(account: "TOKEN", values: [project, global])]
+    )
+    #expect(selected["TOKEN"] == global)
+}
+
 @Test func projectDirectoryValidationUsesPhysicalCanonicalPathsAndRejectsRoots() throws {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent("av-project-path-\(UUID().uuidString)", isDirectory: true)

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -9,6 +9,7 @@ const ORDERCLI_HELPER_PROTOCOL_VERSION: u64 = 1;
 const OPENHUE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const PLUMBER_HELPER_PROTOCOL_VERSION: u64 = 1;
 const RAILWAY_HELPER_PROTOCOL_VERSION: u64 = 1;
+const RCLONE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const TERRAFORM_HELPER_PROTOCOL_VERSION: u64 = 1;
 const UAA_HELPER_PROTOCOL_VERSION: u64 = 1;
 const WAKATIME_HELPER_PROTOCOL_VERSION: u64 = 1;
@@ -290,6 +291,31 @@ pub(crate) fn ensure_wakatime_helper_ready() -> Result<(), String> {
             "the running Automic Vault app reported unsupported WakaTime helper version {version}"
         )),
         None => Err("the running Automic Vault app returned no WakaTime helper version".into()),
+    }
+}
+
+pub(crate) fn ensure_rclone_helper_ready() -> Result<(), String> {
+    if crate::test_keychain_dir().is_some() {
+        return Ok(());
+    }
+    let reply = xpc_request(
+        "rclone-helper-version",
+        None,
+        None,
+        None,
+        Some((b"requested_version\0", RCLONE_HELPER_PROTOCOL_VERSION)),
+    )
+    .map_err(|error| {
+        format!(
+            "rclone password-command protocol negotiation failed; update and open the Automic Vault app: {error}"
+        )
+    })?;
+    match reply.value.as_deref() {
+        Some("1") => Ok(()),
+        Some(version) => Err(format!(
+            "the running Automic Vault app reported unsupported rclone helper version {version}"
+        )),
+        None => Err("the running Automic Vault app returned no rclone helper version".into()),
     }
 }
 


### PR DESCRIPTION
## Summary

- install the signed rclone Isotope and use rclone's native encrypted configuration
- keep the configuration wrapping password as a Global Value behind a Target-bound Authorization Gate
- make the all-remotes authority explicit and fail closed on competing password sources

The fork and signed v1.75.0 release are published at https://github.com/automic-vault/rclone/releases/tag/v1.75.0, and `rclone-isotope` is published in the tap. Tracks #186.

## Verification

- hosted Rust and Swift checks
- focused rclone migration and Global Value selection tests
- `./scripts/build.sh`
- fork `go test -mod=readonly ./fs`
- release signature and Hardened Runtime verification
- release SHA-256 matches the tap formula