### PR TITLE
Recognize live Apple platform status

### DIFF
--- a/docs/adr/0030-apple-platform-launcher-runtime.md
+++ b/docs/adr/0030-apple-platform-launcher-runtime.md
@@ -4,23 +4,25 @@ Status: accepted
 
 ## Context
 
-Apple apps signed as part of a macOS release carry a platform identifier but
-may omit the CodeDirectory Hardened Runtime flag. macOS intrinsically applies
-the corresponding runtime protections to these platform binaries. Requiring
-the flag alone incorrectly made Apple Launchers such as Chess ineligible for
-Authorization Gate policy.
+Apple platform code may omit the CodeDirectory Hardened Runtime flag. Static
+signing information can carry a platform identifier, while live code reports
+the platform status applied by macOS. macOS intrinsically applies the
+corresponding runtime protections to these platform binaries. Requiring the
+Hardened Runtime flag alone incorrectly made Apple Launchers such as Chess
+ineligible for Authorization Gate policy.
 
 ## Decision
 
 Launcher runtime classification treats a valid signing-information platform
-identifier as equivalent to the Hardened Runtime flag. The same blocked-runtime
-entitlement checks still apply. Static app selection, live process inspection,
-and Launcher Bundle inspection use this shared classification.
+identifier or live platform status as equivalent to the Hardened Runtime flag.
+The same blocked-runtime entitlement checks still apply. Static app selection,
+live process inspection, and Launcher Bundle inspection use this shared
+classification.
 
 ## Consequences
 
 Apple platform apps can become Verified Launchers without a CodeDirectory
 Hardened Runtime flag. A merely Apple-issued Developer ID signature is not
-enough: the code must be identified by macOS as part of an operating-system
-release, and normal signature, designated-requirement, entitlement, and live
-process checks continue to fail closed.
+enough: macOS must identify the code as platform code, and normal signature,
+designated-requirement, entitlement, and live process checks continue to fail
+closed.

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -566,16 +566,18 @@ public func launcherRuntimeProtection(
 public func launcherRuntimeProtection(
     signingInformation: [CFString: Any]
 ) -> LauncherRuntimeProtection {
-    let signatureFlags = (
-        signingInformation[kSecCodeInfoStatus] ?? signingInformation[kSecCodeInfoFlags]
-    ) as? NSNumber
+    let liveStatus = signingInformation[kSecCodeInfoStatus] as? NSNumber
+    let signatureFlags = liveStatus
+        ?? (signingInformation[kSecCodeInfoFlags] as? NSNumber)
+    let isPlatformCode = signingInformation[kSecCodeInfoPlatformIdentifier] is NSNumber
+        || (liveStatus?.uint32Value ?? 0) & SecCodeStatus.platform.rawValue != 0
     let entitlements = signingInformation[kSecCodeInfoEntitlementsDict] as? [String: Any] ?? [:]
     let enabledEntitlements = Set(entitlements.compactMap { key, value in
         (value as? NSNumber)?.boolValue == true ? key : nil
     })
     return launcherRuntimeProtection(
         signatureFlags: (signatureFlags?.uint32Value ?? 0) |
-            (signingInformation[kSecCodeInfoPlatformIdentifier] is NSNumber
+            (isPlatformCode
                 ? SecCodeSignatureFlags.runtime.rawValue
                 : 0),
         enabledEntitlements: enabledEntitlements

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/LauncherRuntimeProtectionTests.swift
@@ -36,6 +36,16 @@ import Testing
     ]) == .unsafeEntitlements(["com.apple.security.get-task-allow"]))
 }
 
+@Test func liveApplePlatformCodeIsIntrinsicallyRuntimeProtected() {
+    #expect(launcherRuntimeProtection(signingInformation: [
+        kSecCodeInfoFlags: 0,
+        kSecCodeInfoStatus: SecCodeStatus.platform.rawValue,
+    ]) == .hardened)
+    #expect(launcherRuntimeProtection(signingInformation: [
+        kSecCodeInfoFlags: SecCodeStatus.platform.rawValue,
+    ]) == .hardenedRuntimeMissing)
+}
+
 @Test func injectionAndDebuggingExceptionsPreventSecretGateAdmission() {
     let unsafe: Set<String> = [
         "com.apple.security.cs.allow-dyld-environment-variables",


### PR DESCRIPTION
## Summary
- treat the public live platform-code status as intrinsic Hardened Runtime protection
- keep static signing flags fail-closed and preserve blocked-entitlement checks
- document the static and live platform evidence in ADR 0030

## Root cause
Live inspection preferred kSecCodeInfoStatus, but platform equivalence only checked kSecCodeInfoPlatformIdentifier. Xcode Git has the live platform status without that static identifier, so it appeared unhardened.

## Tests
- swift test --package-path src/menu-helper --disable-automatic-resolution (219 tests passed)