### PR TITLE
Make authorization gate access-level edits immediate

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1093,8 +1093,9 @@ final class DashboardModel: ObservableObject {
     func setDefaultProtection(_ protection: SecretGateProtection, for gate: SecretGate) {
         let update = { [weak self] in
             guard let self else { return }
-            self.finishPolicyUpdate(
+            self.finishSecretGatePolicyUpdate(
                 setSecretGateDefaultProtection(protection, for: gate),
+                gate: gate,
                 error: "Could not update the default protection"
             )
         }
@@ -1109,13 +1110,15 @@ final class DashboardModel: ObservableObject {
     func setProtection(_ protection: SecretGateProtection, for app: SecretGatePolicy, in gate: SecretGate) {
         let update = { [weak self] in
             guard let self else { return }
-            self.finishPolicyUpdate(setSecretGateAppProtection(
-                requirement: app.requirement,
-                protection: protection,
-                for: gate,
-                runtimeRequirement: app.runtimeRequirement
-            ),
-            error: "Could not update \(app.bundleIdentifier)"
+            self.finishSecretGatePolicyUpdate(
+                setSecretGateAppProtection(
+                    requirement: app.requirement,
+                    protection: protection,
+                    for: gate,
+                    runtimeRequirement: app.runtimeRequirement
+                ),
+                gate: gate,
+                error: "Could not update \(app.bundleIdentifier)"
             )
         }
         guard protection.addsAuthority(over: app.protection) else { update(); return }
@@ -1127,10 +1130,30 @@ final class DashboardModel: ObservableObject {
     }
 
     func removeAppPolicy(_ app: SecretGatePolicy, from gate: SecretGate) {
-        finishPolicyUpdate(
+        finishSecretGatePolicyUpdate(
             removeSecretGateAppPolicy(app, from: gate),
+            gate: gate,
             error: "Could not delete the Launcher-specific rule for \(app.bundleIdentifier)"
         )
+    }
+
+    private func finishSecretGatePolicyUpdate(_ status: OSStatus, gate: SecretGate, error: String) {
+        guard status == errSecSuccess else {
+            errorMessage = "\(error): \(status)"
+            return
+        }
+        reloadTask?.cancel()
+        reloadTask = nil
+        isReloading = false
+        guard let index = snapshot.secretGates.firstIndex(where: { $0.id == gate.id }) else {
+            errorMessage = "The policy was saved, but the Authorization Gate is no longer available"
+            return
+        }
+        errorMessage = nil
+        var updatedSnapshot = snapshot
+        updatedSnapshot.secretGates[index] = reloadSecretGatePolicy(for: gate)
+        snapshot = updatedSnapshot
+        normalizeSelection()
     }
 
     private func finishPolicyUpdate(_ status: OSStatus, error: String) {

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1151,7 +1151,7 @@ final class DashboardModel: ObservableObject {
         }
         errorMessage = nil
         var updatedSnapshot = snapshot
-        updatedSnapshot.secretGates[index] = reloadSecretGatePolicy(for: gate)
+        updatedSnapshot.secretGates[index] = reloadSecretGatePolicy(for: snapshot.secretGates[index])
         snapshot = updatedSnapshot
         normalizeSelection()
     }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1128,6 +1128,29 @@ public func loadSecretGates(
     .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
 }
 
+public func reloadSecretGatePolicy(
+    for gate: SecretGate,
+    service: String = secretGatePoliciesKeychainService,
+    account: String = secretGatePoliciesKeychainAccount
+) -> SecretGate {
+    let descriptor = SecretGateDescriptor(
+        id: gate.id,
+        keyPatterns: gate.keyPatterns,
+        routes: gate.routes
+    )
+    return loadSecretGates(
+        descriptors: [descriptor],
+        service: service,
+        account: account
+    ).first ?? SecretGate(
+        id: gate.id,
+        keyPatterns: gate.keyPatterns,
+        routes: gate.routes,
+        defaultProtection: .noAccess,
+        appPolicies: []
+    )
+}
+
 public func normalizedExecutablePath(_ path: String) -> String {
     normalizedExecutablePath(path) {
         try? FileManager.default.destinationOfSymbolicLink(atPath: $0)

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1091,41 +1091,48 @@ public func loadSecretGates(
     account: String = secretGatePoliciesKeychainAccount
 ) -> [SecretGate] {
     let loadedRecords = loadSecretGatePolicyRecords(service: service, account: account)
+    return descriptors.map {
+        loadedSecretGate(from: $0, policyRecords: loadedRecords)
+    }
+    .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+}
+
+private func loadedSecretGate(
+    from descriptor: SecretGateDescriptor,
+    policyRecords loadedRecords: SecretGatePolicyRecordsLoad
+) -> SecretGate {
     let records: [SecretGatePolicyRecord] = switch loadedRecords {
     case .success(let records): records
     case .failure: []
     }
     let policiesAreReadable = if case .success = loadedRecords { true } else { false }
-    return descriptors.map { descriptor in
-        let gateRecords = records.filter { $0.gateID == descriptor.id }
-        let prototype = SecretGate(
-            id: descriptor.id,
-            keyPatterns: descriptor.keyPatterns.uniqueSorted(),
-            routes: descriptor.routes,
-            defaultProtection: .noAccess,
-            appPolicies: []
-        )
-        return SecretGate(
-            id: prototype.id,
-            keyPatterns: prototype.keyPatterns,
-            routes: prototype.routes,
-            defaultProtection: prototype.normalizedProtection(
-                gateRecords.last(where: { $0.requirement == nil })?.protection
-                    ?? (policiesAreReadable ? prototype.initialProtection : .noAccess)
-            ),
-            appPolicies: gateRecords.compactMap { record in
-                record.requirement.map {
-                    SecretGatePolicy(
-                        bundleIdentifier: appIdentifier(from: $0) ?? "unknown",
-                        requirement: $0,
-                        protection: prototype.normalizedProtection(record.protection),
-                        runtimeRequirement: record.resolvedRuntimeRequirement
-                    )
-                }
-            }.uniqueSorted()
-        )
-    }
-    .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+    let gateRecords = records.filter { $0.gateID == descriptor.id }
+    let prototype = SecretGate(
+        id: descriptor.id,
+        keyPatterns: descriptor.keyPatterns.uniqueSorted(),
+        routes: descriptor.routes,
+        defaultProtection: .noAccess,
+        appPolicies: []
+    )
+    return SecretGate(
+        id: prototype.id,
+        keyPatterns: prototype.keyPatterns,
+        routes: prototype.routes,
+        defaultProtection: prototype.normalizedProtection(
+            gateRecords.last(where: { $0.requirement == nil })?.protection
+                ?? (policiesAreReadable ? prototype.initialProtection : .noAccess)
+        ),
+        appPolicies: gateRecords.compactMap { record in
+            record.requirement.map {
+                SecretGatePolicy(
+                    bundleIdentifier: appIdentifier(from: $0) ?? "unknown",
+                    requirement: $0,
+                    protection: prototype.normalizedProtection(record.protection),
+                    runtimeRequirement: record.resolvedRuntimeRequirement
+                )
+            }
+        }.uniqueSorted()
+    )
 }
 
 public func reloadSecretGatePolicy(
@@ -1138,16 +1145,9 @@ public func reloadSecretGatePolicy(
         keyPatterns: gate.keyPatterns,
         routes: gate.routes
     )
-    return loadSecretGates(
-        descriptors: [descriptor],
-        service: service,
-        account: account
-    ).first ?? SecretGate(
-        id: gate.id,
-        keyPatterns: gate.keyPatterns,
-        routes: gate.routes,
-        defaultProtection: .noAccess,
-        appPolicies: []
+    return loadedSecretGate(
+        from: descriptor,
+        policyRecords: loadSecretGatePolicyRecords(service: service, account: account)
     )
 }
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -498,6 +498,31 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(secretGate.protectionTitle(.fullExceptSecretDumps) == "Write Access")
 }
 
+@Test func targetedSecretGatePolicyReloadPreservesTheGateDefinition() throws {
+    let gate = SecretGate(
+        id: "gh",
+        keyPatterns: ["GH_TOKEN_*"],
+        routes: try #require(testGateMetadata().secretGate).routes,
+        defaultProtection: .fullIncludingSecretDumps,
+        appPolicies: [SecretGatePolicy(
+            bundleIdentifier: "com.example.app",
+            requirement: #"identifier "com.example.app""#,
+            protection: .fullIncludingSecretDumps,
+            runtimeRequirement: .hardened
+        )]
+    )
+    let refreshed = reloadSecretGatePolicy(
+        for: gate,
+        service: "com.automicvault.tests.\(UUID().uuidString)"
+    )
+
+    #expect(refreshed.id == gate.id)
+    #expect(refreshed.keyPatterns == gate.keyPatterns)
+    #expect(refreshed.routes == gate.routes)
+    #expect(refreshed.defaultProtection == .readOnly)
+    #expect(refreshed.appPolicies.isEmpty)
+}
+
 @Test(.enabled(if: dataProtectionKeychainAvailable(), "requires an entitled Keychain test host"))
 func brewGateBroadensPersistedReadOnlyPoliciesToReadAndUpdate() throws {
     let service = "com.automicvault.tests.\(UUID().uuidString)"


### PR DESCRIPTION
## Summary

- refresh only the affected Authorization Gate after a policy edit
- re-read the persisted Keychain policy and preserve fail-closed behavior
- cancel an in-flight dashboard reload so stale state cannot overwrite the edit
- avoid rerunning hardening and Doctor checks for access-level changes

## Security

The UI updates only after a successful Keychain write. Policy read failures continue to render Approval Required with no launcher-specific overrides.

## Tests

- `swift test --package-path src/menu-helper --disable-automatic-resolution` (236 tests)
- `scripts/test-menu-helper-self-checks.sh` (26 checks)