### PR TITLE
Show Verified Launcher inspection progress in the gate

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -4688,7 +4688,6 @@ private struct SecretGateDetailView: View {
                         .controlSize(.small)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .accessibilityLabel("Inspecting the selected app for Verified Launcher Helpers")
                         .accessibilityIdentifier("verified-launcher-helper-inspection-progress")
                 }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1862,13 +1862,15 @@ struct DashboardRootView: View {
                         if model.isDiscoveringLauncherHelpers {
                             ProgressView()
                                 .controlSize(.small)
-                                .help("Inspecting the selected app for signed helpers")
+                                .help("Inspecting the selected app for Verified Launcher Helpers")
+                                .accessibilityLabel("Inspecting the selected app for Verified Launcher Helpers")
                             Button {
                                 model.cancelLauncherHelperDiscovery()
                             } label: {
                                 Image(systemName: "xmark")
                             }
                             .help("Cancel App Inspection")
+                            .accessibilityLabel("Cancel App Inspection")
                         } else {
                             Button {
                                 model.addApp(to: gate)
@@ -4680,6 +4682,15 @@ private struct SecretGateDetailView: View {
                 Text("App Access")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.primary)
+
+                if model.isDiscoveringLauncherHelpers {
+                    ProgressView("Inspecting the selected app for Verified Launcher Helpers…")
+                        .controlSize(.small)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Inspecting the selected app for Verified Launcher Helpers")
+                        .accessibilityIdentifier("verified-launcher-helper-inspection-progress")
+                }
 
                 VStack(spacing: 0) {
                     DefaultAppPolicyRow(gate: gate, protection: gate.defaultProtection) {


### PR DESCRIPTION
## Summary

- show a labeled spinner beside App Access while the selected app is inspected
- keep the existing toolbar cancel action available
- make the progress and cancel states explicit to VoiceOver
- leave signature and resource-seal verification unchanged

## Security

This is presentation-only. Verified Launcher Helper discovery, validation, review, and approval behavior are unchanged.

## Tests

- `swift test --package-path src/menu-helper --disable-automatic-resolution` (235 tests)
- `scripts/test-menu-helper-self-checks.sh` (26 checks)
- `swift build --package-path src/menu-helper --disable-automatic-resolution`