### PR TITLE
Clarify GitHub CLI credential exposure

### DIFF
--- a/src/isotopes/detectors/gh_cli/keychain_access.md
+++ b/src/isotopes/detectors/gh_cli/keychain_access.md
@@ -2,18 +2,28 @@
 
 ## Trigger Conditions
 
-Any process that can run `/usr/bin/security` can trivially retrieve your GitHub
-token:
+- A `gh:<host>` Keychain item authorizes `/usr/bin/security` to read its
+  secret non-interactively.
+
+The official macOS `gh` executable is Developer ID signed, but its upstream
+Keychain integration delegates credential reads to `/usr/bin/security`. The
+signature does not restrict retrieval to `gh` when that tool is in the item's
+access list.
+
+Confirm the finding in a private terminal:
 
 ```sh
-security find-generic-password -s gh:<host> -w
+/usr/bin/security find-generic-password -s gh:<host> -w
 ```
 
-Or, more simply:
+`gh` also provides an independent Secret Disclosure command:
 
 ```sh
 gh auth token
 ```
+
+Both commands print a live token to standard output. Do not paste their output
+into an issue report.
 
 ## Mitigation
 

--- a/src/isotopes/detectors/gh_cli/keychain_access.md
+++ b/src/isotopes/detectors/gh_cli/keychain_access.md
@@ -2,13 +2,13 @@
 
 ## Trigger Conditions
 
-- A `gh:<host>` Keychain item authorizes `/usr/bin/security` to read its
-  secret non-interactively.
+- The access-control list for a `gh:<host>` Keychain item authorizes
+  `/usr/bin/security` to read its secret non-interactively.
 
 The official macOS `gh` executable is Developer ID signed, but its upstream
 Keychain integration delegates credential reads to `/usr/bin/security`. The
-signature does not restrict retrieval to `gh` when that tool is in the item's
-access list.
+signature does not restrict retrieval to `gh` when `/usr/bin/security` is in
+the item's access list.
 
 Confirm the finding in a private terminal:
 

--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -11,7 +11,7 @@ We provide a [patched version] of `gh`. `av harden gh` installs it from our
 [tap] when Homebrew is available, or installs the same signed release directly
 at `/usr/local/bin/gh`. The Isotope:
 
-1. Uses its Automic Vault signature to bind the Gate Client and Target.
+1. Is Automic Vault-signed so the gate can bind the Gate Client and Target.
 2. Keeps the credential in Automic Vault custody instead of an upstream
    `gh:<host>` Keychain item accessible through `/usr/bin/security`.
 3. Routes authenticated operations through the `gh` Secret Gate.

--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -2,14 +2,19 @@
 
 ## How Automic Vault Hardens `gh`
 
+The official macOS `gh` executable is Developer ID signed. Upstream still
+delegates Keychain reads to `/usr/bin/security` and provides `gh auth token`,
+which prints the credential to standard output. Code signing establishes the
+executable's identity and integrity; it does not authorize credential use.
+
 We provide a [patched version] of `gh`. `av harden gh` installs it from our
 [tap] when Homebrew is available, or installs the same signed release directly
-at `/usr/local/bin/gh`. The patches are concerned with:
+at `/usr/local/bin/gh`. The Isotope:
 
-1. Is codesigned such that `gh` (and only `gh`) can access its
-   secure credentials.
-2. Ensures that authenticated `gh` usage goes via the Automic Vault Secret Gate
-   system.
+1. Uses its Automic Vault signature to bind the Gate Client and Target.
+2. Keeps the credential in Automic Vault custody instead of an upstream
+   `gh:<host>` Keychain item accessible through `/usr/bin/security`.
+3. Routes authenticated operations through the `gh` Secret Gate.
 
 [patched version]: https://github.com/automic-vault/gh-cli
 [tap]: https://github.com/automic-vault/homebrew-isotopes


### PR DESCRIPTION
## Summary

- document that the official macOS `gh` executable is Developer ID signed
- explain why an upstream Keychain item that trusts `/usr/bin/security` remains exposed
- identify `gh auth token` as a separate Secret Disclosure and correct the Isotope security-boundary description

## Verification

- `cargo test isotopes::detectors::gh_cli`
- `cargo test documentation_supplies_hardening_or_deferred_solution`