### PR TITLE
Validate targeted app code-signing SPI

### DIFF
--- a/docs/adr/0033-targeted-app-launcher-validation.md
+++ b/docs/adr/0033-targeted-app-launcher-validation.md
@@ -41,3 +41,6 @@ sealed resource no longer invalidates Launcher Identity because that resource
 does not contribute authority. Removal of the private API degrades performance
 by selecting the strict complete-bundle fallback rather than weakening
 validation.
+
+Validation evidence and known integration limits are recorded in
+[Targeted App Resource Validation](../targeted-app-resource-validation.md).

--- a/docs/targeted-app-resource-validation.md
+++ b/docs/targeted-app-resource-validation.md
@@ -66,7 +66,7 @@ The harness launches signed app A, replaces A's bundle path with independently v
 2. static inspection at the original path now reports B's identity;
 3. targeted main-executable validation succeeds for B.
 
-This is correct SPI behavior because `SecStaticCodeValidateResourceWithErrors` accepts static code. The ordinary app-Launcher path in `launcherIdentities` currently combines live runtime posture from A with `staticSigningInfo` from B and does not compare the live code identifier with the current main executable's code identifier. If B has an existing Launcher-specific rule, A can be attributed B's Launcher Identity after same-user bundle-path substitution.
+This is correct SPI behavior because `SecStaticCodeValidateResourceWithErrors` accepts static code. The ordinary app Launcher path in `launcherIdentities` currently combines live runtime posture from A with `staticSigningInfo` from B and does not compare the live code identifier with the current main executable's code identifier. If B has an existing Launcher-specific rule, A can be attributed B's Launcher Identity after same-user bundle-path substitution.
 
 Verified Launcher Helpers already make the required live-to-disk code-identifier comparison before accepting app attribution. Ordinary app Launchers should apply the same fail-closed invariant. A mismatch should deny app attribution until the updated app is relaunched. This issue predates targeted validation; complete static bundle validation also validates B rather than the already-running A.
 

--- a/docs/targeted-app-resource-validation.md
+++ b/docs/targeted-app-resource-validation.md
@@ -1,0 +1,75 @@
+# Targeted App Resource Validation
+
+Date: 2026-08-31
+
+This report validates the private API selected by [ADR 0033](adr/0033-targeted-app-launcher-validation.md). It records evidence, not a new security boundary.
+
+## Conclusion
+
+`SecStaticCodeValidateResourceWithErrors` behaves as ADR 0033 expects when it is combined with the existing strict, all-architecture `SecStaticCodeCheckValidity` precheck and the expected `SecRequirement`:
+
+- the app's main executable and one exact sealed resource can be validated without traversing unrelated resources;
+- changed, missing, added, unsealed, or out-of-bundle targets fail;
+- a changed or forged `CodeResources` file cannot bless modified target bytes;
+- a valid update signed by the same Developer ID remains the same code-signing identity;
+- ad-hoc re-signing does not satisfy a Developer ID requirement or a nested-code seal;
+- the public precheck rejects damage in a non-native architecture that the targeted SPI alone does not inspect on the current architecture.
+
+The SPI is suitable for the targeted static validation role. It is not sufficient to bind a live process to the code currently stored at its bundle path.
+
+## Contract evidence
+
+Apple's open-source Security header declares the exact ABI as:
+
+```c
+OSStatus SecStaticCodeValidateResourceWithErrors(
+    SecStaticCodeRef code,
+    CFURLRef resourcePath,
+    SecCSFlags flags,
+    CFErrorRef *errors
+);
+```
+
+The header marks the SPI available from macOS 11.3 and documents these relevant results: `errSecParam` for a path outside the code object, `errSecCSResourcesNotFound` or `errSecCSResourcesNotSealed` for unusable seals, and `errSecCSBadResource` or `errSecCSSignatureFailed` for changed targets. The implementation first validates the static code's core signature, then validates only the selected main executable, `Info.plist`, plain resource, symlink, or nested code. See Apple's [private header](https://github.com/apple-oss-distributions/Security/blob/db15acbe6a7f257a859ad9a3bb86097bfe0679d9/OSX/libsecurity_codesigning/lib/SecStaticCodePriv.h#L103-L130) and [implementation](https://github.com/apple-oss-distributions/Security/blob/db15acbe6a7f257a859ad9a3bb86097bfe0679d9/OSX/libsecurity_codesigning/lib/SecStaticCode.cpp#L162-L187).
+
+The symbol is exported by every SDK locally available during validation: macOS 13.3, 14.4, 15.4, 26.5, and Xcode 26.6's current macOS SDK. Dynamic resolution and the strict complete-bundle fallback remain necessary because this is SPI, not a compatibility guarantee.
+
+## Reproduction
+
+The independent harness builds disposable universal `x86_64`/`arm64e` app bundles and never invokes Automic Vault:
+
+```sh
+scripts/validate-targeted-app-resource.swift
+scripts/validate-targeted-app-resource.swift \
+  --identity "Developer ID Application: Example (TEAMID)"
+```
+
+The first command uses ad-hoc signatures. The second additionally verifies Developer ID update and identity-mismatch behavior.
+
+Observed environment:
+
+- macOS 26.6.2 (25G83), Apple silicon
+- Xcode 26.6 (17F113)
+- 19 ad-hoc checks passed
+- 23 Developer ID checks passed
+- the existing `MenubarHelperCore` targeted-validation test passed with a macOS 14 deployment target
+
+The matrix covers baseline agreement with `codesign --verify --strict --all-architectures`, correct and incorrect requirements, unrelated and selected resource mutations, deletion, addition, containment, main executable replacement, `Info.plist`, resource-seal corruption and substitution, nested signed code, symlinks, `CFError`, non-native architecture damage, same-identity updates, and ad-hoc re-signing.
+
+## Integration finding: live-to-disk substitution
+
+Priority: high.
+
+The harness launches signed app A, replaces A's bundle path with independently valid signed app B, and confirms all three facts simultaneously:
+
+1. the live PID still has A's code-signing identity;
+2. static inspection at the original path now reports B's identity;
+3. targeted main-executable validation succeeds for B.
+
+This is correct SPI behavior because `SecStaticCodeValidateResourceWithErrors` accepts static code. The ordinary app-Launcher path in `launcherIdentities` currently combines live runtime posture from A with `staticSigningInfo` from B and does not compare the live code identifier with the current main executable's code identifier. If B has an existing Launcher-specific rule, A can be attributed B's Launcher Identity after same-user bundle-path substitution.
+
+Verified Launcher Helpers already make the required live-to-disk code-identifier comparison before accepting app attribution. Ordinary app Launchers should apply the same fail-closed invariant. A mismatch should deny app attribution until the updated app is relaunched. This issue predates targeted validation; complete static bundle validation also validates B rather than the already-running A.
+
+## Limits
+
+This run does not establish future SPI availability or behavior. It did not execute on Intel hardware or older macOS releases, exercise certificate expiry or revocation, or validate root-volume resource exemptions. The dynamically resolved fallback and focused regression tests remain required.

--- a/scripts/validate-targeted-app-resource.swift
+++ b/scripts/validate-targeted-app-resource.swift
@@ -181,9 +181,32 @@ private func overwriteFirstByte(_ url: URL) throws {
     try handle.write(contentsOf: Data([0]))
 }
 
+private func flipByte(_ url: URL, offset: UInt64) throws {
+    let handle = try FileHandle(forUpdating: url)
+    defer { try? handle.close() }
+    try handle.seek(toOffset: offset)
+    guard let byte = try handle.read(upToCount: 1)?.first else {
+        throw CommandError(command: "flip byte", output: "\(url.path) is too short")
+    }
+    try handle.seek(toOffset: offset)
+    try handle.write(contentsOf: Data([byte ^ 0xff]))
+}
+
 private func replaceExecutable(_ url: URL) throws {
     try FileManager.default.removeItem(at: url)
     try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/false"), to: url)
+}
+
+private func tamperX86Slice(_ fixture: Fixture) throws {
+    let x86 = fixture.root.appendingPathComponent("x86_64")
+    let arm = fixture.root.appendingPathComponent("arm64e")
+    let replacement = fixture.root.appendingPathComponent("tampered-universal")
+    _ = try run("/usr/bin/lipo", [fixture.executable.path, "-thin", "x86_64", "-output", x86.path])
+    _ = try run("/usr/bin/lipo", [fixture.executable.path, "-thin", "arm64e", "-output", arm.path])
+    try flipByte(x86, offset: 4_096)
+    _ = try run("/usr/bin/lipo", ["-create", x86.path, arm.path, "-output", replacement.path])
+    try FileManager.default.removeItem(at: fixture.executable)
+    try FileManager.default.moveItem(at: replacement, to: fixture.executable)
 }
 
 private func codesignAccepts(_ app: URL, reportFailure: Bool = false) -> Bool {
@@ -279,6 +302,14 @@ harness.check("mismatched requirement fails closed") {
     }
 }
 
+harness.check("successful validation leaves the CFError pointer empty") {
+    try withFixture(identity: identity) {
+        var unmanagedError: Unmanaged<CFError>?
+        let status = try directStatus(app: $0.app, resource: $0.target, error: &unmanagedError)
+        return status == errSecSuccess && unmanagedError == nil
+    }
+}
+
 harness.check("unrelated sealed-resource damage is ignored only by targeted validation") {
     try withFixture(identity: identity) {
         try Data("changed".utf8).write(to: $0.unrelated)
@@ -341,6 +372,25 @@ harness.check("resource seal modification fails selected-resource validation") {
     }
 }
 
+harness.check("a forged matching CodeResources file cannot bless modified resource bytes") {
+    try withFixture(identity: identity) { original in
+        let resigned = try makeFixture(identity: identity)
+        defer { try? FileManager.default.removeItem(at: resigned.root) }
+        try Data("attacker-selected".utf8).write(to: original.target)
+        try Data("attacker-selected".utf8).write(to: resigned.target)
+        try sign(
+            resigned.app,
+            identity: identity,
+            identifier: "com.automicvault.targeted-validation"
+        )
+        let originalSeal = original.app.appendingPathComponent("Contents/_CodeSignature/CodeResources")
+        let forgedSeal = resigned.app.appendingPathComponent("Contents/_CodeSignature/CodeResources")
+        try FileManager.default.removeItem(at: originalSeal)
+        try FileManager.default.copyItem(at: forgedSeal, to: originalSeal)
+        return try directStatus(app: original.app, resource: original.target) != errSecSuccess
+    }
+}
+
 harness.check("signed nested helper validates") {
     try withFixture(identity: identity) {
         try directStatus(app: $0.app, resource: $0.helper) == errSecSuccess
@@ -373,7 +423,46 @@ harness.check("failure returns a retained CFError matching the OSStatus") {
     }
 }
 
+#if arch(arm64)
+harness.check("production flags reject a damaged non-native architecture") {
+    try withFixture(identity: identity) {
+        try tamperX86Slice($0)
+        return try directStatus(app: $0.app, resource: $0.executable) == errSecSuccess
+            && targetedStatus(app: $0.app, resource: $0.executable) != errSecSuccess
+    }
+}
+#endif
+
 if identity != "-" {
+    harness.check("an app update signed by the same Developer ID satisfies the stored requirement") {
+        try withFixture(identity: identity) {
+            let original = try designatedRequirement($0.app)
+            try replaceExecutable($0.executable)
+            try sign(
+                $0.app,
+                identity: identity,
+                identifier: "com.automicvault.targeted-validation"
+            )
+            return try targetedStatus(
+                app: $0.app,
+                resource: $0.executable,
+                requirement: original
+            ) == errSecSuccess
+        }
+    }
+
+    harness.check("a helper update signed by the same Developer ID satisfies its sealed requirement") {
+        try withFixture(identity: identity) {
+            try replaceExecutable($0.helper)
+            try sign(
+                $0.helper,
+                identity: identity,
+                identifier: "com.automicvault.targeted-validation.helper"
+            )
+            return try directStatus(app: $0.app, resource: $0.helper) == errSecSuccess
+        }
+    }
+
     harness.check("re-signing the app ad hoc no longer satisfies its Developer ID requirement") {
         try withFixture(identity: identity) {
             let original = try designatedRequirement($0.app)

--- a/scripts/validate-targeted-app-resource.swift
+++ b/scripts/validate-targeted-app-resource.swift
@@ -1,0 +1,396 @@
+#!/usr/bin/env swift
+
+import Darwin
+import Foundation
+import Security
+
+private typealias ValidateResource = @convention(c) (
+    SecStaticCode,
+    CFURL,
+    UInt32,
+    UnsafeMutablePointer<Unmanaged<CFError>?>?
+) -> OSStatus
+
+private struct CommandError: Error, CustomStringConvertible {
+    let command: String
+    let output: String
+
+    var description: String { "\(command) failed: \(output)" }
+}
+
+private struct Fixture {
+    let root: URL
+    let app: URL
+    let executable: URL
+    let helper: URL
+    let target: URL
+    let unrelated: URL
+    let link: URL
+}
+
+private let validateResource: ValidateResource = {
+    guard let handle = dlopen(nil, RTLD_LAZY),
+          let symbol = dlsym(handle, "SecStaticCodeValidateResourceWithErrors")
+    else {
+        fputs("SecStaticCodeValidateResourceWithErrors is unavailable\n", stderr)
+        exit(2)
+    }
+    return unsafeBitCast(symbol, to: ValidateResource.self)
+}()
+
+private func run(_ executable: String, _ arguments: [String]) throws -> String {
+    let process = Process()
+    let pipe = Pipe()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    process.waitUntilExit()
+    let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    guard process.terminationStatus == 0 else {
+        throw CommandError(command: ([executable] + arguments).joined(separator: " "), output: output)
+    }
+    return output
+}
+
+private func sign(_ url: URL, identity: String, identifier: String) throws {
+    var arguments = [
+        "--force", "--sign", identity, "--options", "runtime",
+        "--identifier", identifier,
+    ]
+    if identity != "-" { arguments.append("--timestamp=none") }
+    arguments.append(url.path)
+    _ = try run("/usr/bin/codesign", arguments)
+}
+
+private func makeFixture(identity: String) throws -> Fixture {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("av-targeted-validation-\(UUID().uuidString)", isDirectory: true)
+    let app = root.appendingPathComponent("Example.app", isDirectory: true)
+    let contents = app.appendingPathComponent("Contents", isDirectory: true)
+    let macOS = contents.appendingPathComponent("MacOS", isDirectory: true)
+    let helpers = contents.appendingPathComponent("Helpers", isDirectory: true)
+    let resources = contents.appendingPathComponent("Resources", isDirectory: true)
+    let executable = macOS.appendingPathComponent("Example")
+    let helper = helpers.appendingPathComponent("helper")
+    let target = resources.appendingPathComponent("target")
+    let unrelated = resources.appendingPathComponent("unrelated")
+    let link = resources.appendingPathComponent("link")
+
+    try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: helpers, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+    try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/true"), to: executable)
+    try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/true"), to: helper)
+    try Data("target".utf8).write(to: target)
+    try Data("unrelated".utf8).write(to: unrelated)
+    try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: "target")
+    try Data("""
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0"><dict>
+    <key>CFBundleExecutable</key><string>Example</string>
+    <key>CFBundleIdentifier</key><string>com.automicvault.targeted-validation</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    </dict></plist>
+    """.utf8).write(to: contents.appendingPathComponent("Info.plist"))
+    try sign(helper, identity: identity, identifier: "com.automicvault.targeted-validation.helper")
+    try sign(app, identity: identity, identifier: "com.automicvault.targeted-validation")
+    return Fixture(
+        root: root,
+        app: app,
+        executable: executable,
+        helper: helper,
+        target: target,
+        unrelated: unrelated,
+        link: link
+    )
+}
+
+private func staticCode(_ url: URL) throws -> SecStaticCode {
+    var code: SecStaticCode?
+    let status = SecStaticCodeCreateWithPath(url as CFURL, [], &code)
+    guard status == errSecSuccess, let code else {
+        throw CommandError(command: "SecStaticCodeCreateWithPath \(url.path)", output: "OSStatus \(status)")
+    }
+    return code
+}
+
+private func directStatus(
+    app: URL,
+    resource: URL,
+    error: UnsafeMutablePointer<Unmanaged<CFError>?>? = nil
+) throws -> OSStatus {
+    validateResource(try staticCode(app), resource as CFURL, kSecCSStrictValidate, error)
+}
+
+private func targetedStatus(
+    app: URL,
+    resource: URL,
+    requirement: SecRequirement? = nil
+) throws -> OSStatus {
+    let code = try staticCode(app)
+    let flags = SecCSFlags(
+        rawValue: kSecCSCheckAllArchitectures
+            | kSecCSDoNotValidateResources
+            | kSecCSStrictValidate
+    )
+    let status = SecStaticCodeCheckValidity(code, flags, requirement)
+    guard status == errSecSuccess else { return status }
+    return validateResource(code, resource as CFURL, kSecCSStrictValidate, nil)
+}
+
+private func fullStatus(_ app: URL) throws -> OSStatus {
+    SecStaticCodeCheckValidity(
+        try staticCode(app),
+        SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate),
+        nil
+    )
+}
+
+private func designatedRequirement(_ app: URL) throws -> SecRequirement {
+    var requirement: SecRequirement?
+    let status = SecCodeCopyDesignatedRequirement(try staticCode(app), [], &requirement)
+    guard status == errSecSuccess, let requirement else {
+        throw CommandError(command: "SecCodeCopyDesignatedRequirement", output: "OSStatus \(status)")
+    }
+    return requirement
+}
+
+private func requirement(_ source: String) throws -> SecRequirement {
+    var requirement: SecRequirement?
+    let status = SecRequirementCreateWithString(source as CFString, [], &requirement)
+    guard status == errSecSuccess, let requirement else {
+        throw CommandError(command: "SecRequirementCreateWithString", output: "OSStatus \(status)")
+    }
+    return requirement
+}
+
+private func mutate(_ url: URL) throws {
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: Data([0]))
+}
+
+private func overwriteFirstByte(_ url: URL) throws {
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seek(toOffset: 0)
+    try handle.write(contentsOf: Data([0]))
+}
+
+private func replaceExecutable(_ url: URL) throws {
+    try FileManager.default.removeItem(at: url)
+    try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/false"), to: url)
+}
+
+private func codesignAccepts(_ app: URL, reportFailure: Bool = false) -> Bool {
+    do {
+        _ = try run("/usr/bin/codesign", ["--verify", "--strict", "--all-architectures", app.path])
+        return true
+    } catch {
+        if reportFailure { print("      \(error)") }
+        return false
+    }
+}
+
+private func withFixture(
+    identity: String,
+    _ body: (Fixture) throws -> Bool
+) throws -> Bool {
+    let fixture = try makeFixture(identity: identity)
+    defer { try? FileManager.default.removeItem(at: fixture.root) }
+    return try body(fixture)
+}
+
+private struct Harness {
+    var passed = 0
+    var failed = 0
+
+    mutating func check(_ name: String, _ body: () throws -> Bool) {
+        do {
+            if try body() {
+                passed += 1
+                print("PASS  \(name)")
+            } else {
+                failed += 1
+                print("FAIL  \(name)")
+            }
+        } catch {
+            failed += 1
+            print("FAIL  \(name): \(error)")
+        }
+    }
+}
+
+private let arguments = Array(CommandLine.arguments.dropFirst())
+private let identity: String = {
+    guard let index = arguments.firstIndex(of: "--identity"), arguments.indices.contains(index + 1)
+    else { return "-" }
+    return arguments[index + 1]
+}()
+
+print("macOS: \(ProcessInfo.processInfo.operatingSystemVersionString)")
+#if arch(arm64)
+print("architecture: arm64")
+#elseif arch(x86_64)
+print("architecture: x86_64")
+#else
+print("architecture: unknown")
+#endif
+print("signing identity: \(identity == "-" ? "ad hoc" : identity)")
+
+private var harness = Harness()
+
+harness.check("baseline: SPI, production flags, full validation, and codesign agree") {
+    try withFixture(identity: identity) {
+        let main = try directStatus(app: $0.app, resource: $0.executable)
+        let target = try directStatus(app: $0.app, resource: $0.target)
+        let targeted = try targetedStatus(app: $0.app, resource: $0.executable)
+        let full = try fullStatus($0.app)
+        let codesign = codesignAccepts($0.app, reportFailure: true)
+        let passed = main == errSecSuccess
+            && target == errSecSuccess
+            && targeted == errSecSuccess
+            && full == errSecSuccess
+            && codesign
+        if !passed {
+            print("      main=\(main) target=\(target) targeted=\(targeted) full=\(full) codesign=\(codesign)")
+        }
+        return passed
+    }
+}
+
+harness.check("stored requirement accepts the original app identity") {
+    try withFixture(identity: identity) {
+        let requirement = try designatedRequirement($0.app)
+        return try targetedStatus(app: $0.app, resource: $0.executable, requirement: requirement)
+            == errSecSuccess
+    }
+}
+
+harness.check("mismatched requirement fails closed") {
+    try withFixture(identity: identity) {
+        let wrong = try requirement("identifier \"com.automicvault.wrong\"")
+        return try targetedStatus(app: $0.app, resource: $0.executable, requirement: wrong)
+            != errSecSuccess
+    }
+}
+
+harness.check("unrelated sealed-resource damage is ignored only by targeted validation") {
+    try withFixture(identity: identity) {
+        try Data("changed".utf8).write(to: $0.unrelated)
+        return try directStatus(app: $0.app, resource: $0.executable) == errSecSuccess
+            && directStatus(app: $0.app, resource: $0.target) == errSecSuccess
+            && fullStatus($0.app) != errSecSuccess
+            && !codesignAccepts($0.app)
+    }
+}
+
+harness.check("selected resource modification fails") {
+    try withFixture(identity: identity) {
+        try Data("changed".utf8).write(to: $0.target)
+        return try directStatus(app: $0.app, resource: $0.target) != errSecSuccess
+    }
+}
+
+harness.check("selected resource deletion fails") {
+    try withFixture(identity: identity) {
+        try FileManager.default.removeItem(at: $0.target)
+        return try directStatus(app: $0.app, resource: $0.target) != errSecSuccess
+    }
+}
+
+harness.check("new unsealed resource fails") {
+    try withFixture(identity: identity) {
+        let added = $0.target.deletingLastPathComponent().appendingPathComponent("added")
+        try Data("added".utf8).write(to: added)
+        return try directStatus(app: $0.app, resource: added) != errSecSuccess
+    }
+}
+
+harness.check("path outside the bundle returns errSecParam") {
+    try withFixture(identity: identity) {
+        try directStatus(app: $0.app, resource: URL(fileURLWithPath: "/usr/bin/true")) == errSecParam
+    }
+}
+
+harness.check("a valid main-executable replacement is rejected by the stored identity requirement") {
+    try withFixture(identity: identity) {
+        let original = try designatedRequirement($0.app)
+        try replaceExecutable($0.executable)
+        return try directStatus(app: $0.app, resource: $0.executable) == errSecSuccess
+            && targetedStatus(app: $0.app, resource: $0.executable, requirement: original)
+                != errSecSuccess
+    }
+}
+
+harness.check("Info.plist modification fails main-executable validation") {
+    try withFixture(identity: identity) {
+        try mutate($0.app.appendingPathComponent("Contents/Info.plist"))
+        return try directStatus(app: $0.app, resource: $0.executable) != errSecSuccess
+    }
+}
+
+harness.check("resource seal modification fails selected-resource validation") {
+    try withFixture(identity: identity) {
+        try overwriteFirstByte($0.app.appendingPathComponent("Contents/_CodeSignature/CodeResources"))
+        return try directStatus(app: $0.app, resource: $0.target) != errSecSuccess
+    }
+}
+
+harness.check("signed nested helper validates") {
+    try withFixture(identity: identity) {
+        try directStatus(app: $0.app, resource: $0.helper) == errSecSuccess
+    }
+}
+
+harness.check("unsigned nested-helper modification fails") {
+    try withFixture(identity: identity) {
+        try replaceExecutable($0.helper)
+        return try directStatus(app: $0.app, resource: $0.helper) != errSecSuccess
+    }
+}
+
+harness.check("sealed symlink validates, but retargeting it fails") {
+    try withFixture(identity: identity) {
+        guard try directStatus(app: $0.app, resource: $0.link) == errSecSuccess else { return false }
+        try FileManager.default.removeItem(at: $0.link)
+        try FileManager.default.createSymbolicLink(atPath: $0.link.path, withDestinationPath: "unrelated")
+        return try directStatus(app: $0.app, resource: $0.link) != errSecSuccess
+    }
+}
+
+harness.check("failure returns a retained CFError matching the OSStatus") {
+    try withFixture(identity: identity) {
+        try Data("changed".utf8).write(to: $0.target)
+        var unmanagedError: Unmanaged<CFError>?
+        let status = try directStatus(app: $0.app, resource: $0.target, error: &unmanagedError)
+        guard let error = unmanagedError?.takeRetainedValue() else { return false }
+        return status != errSecSuccess && CFErrorGetCode(error) == status
+    }
+}
+
+if identity != "-" {
+    harness.check("re-signing the app ad hoc no longer satisfies its Developer ID requirement") {
+        try withFixture(identity: identity) {
+            let original = try designatedRequirement($0.app)
+            try sign($0.helper, identity: "-", identifier: "com.automicvault.targeted-validation.helper")
+            try sign($0.app, identity: "-", identifier: "com.automicvault.targeted-validation")
+            return try targetedStatus(app: $0.app, resource: $0.executable, requirement: original)
+                != errSecSuccess
+        }
+    }
+
+    harness.check("helper re-signed ad hoc no longer satisfies its sealed Developer ID requirement") {
+        try withFixture(identity: identity) {
+            try sign($0.helper, identity: "-", identifier: "com.automicvault.targeted-validation.helper")
+            return try directStatus(app: $0.app, resource: $0.helper) != errSecSuccess
+        }
+    }
+}
+
+print("RESULT \(harness.passed) passed, \(harness.failed) failed")
+exit(harness.failed == 0 ? 0 : 1)

--- a/scripts/validate-targeted-app-resource.swift
+++ b/scripts/validate-targeted-app-resource.swift
@@ -64,7 +64,11 @@ private func sign(_ url: URL, identity: String, identifier: String) throws {
     _ = try run("/usr/bin/codesign", arguments)
 }
 
-private func makeFixture(identity: String) throws -> Fixture {
+private func makeFixture(
+    identity: String,
+    appIdentifier: String = "com.automicvault.targeted-validation",
+    executableSource: String = "/usr/bin/true"
+) throws -> Fixture {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent("av-targeted-validation-\(UUID().uuidString)", isDirectory: true)
     let app = root.appendingPathComponent("Example.app", isDirectory: true)
@@ -81,7 +85,7 @@ private func makeFixture(identity: String) throws -> Fixture {
     try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
     try FileManager.default.createDirectory(at: helpers, withIntermediateDirectories: true)
     try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
-    try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/true"), to: executable)
+    try FileManager.default.copyItem(at: URL(fileURLWithPath: executableSource), to: executable)
     try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/true"), to: helper)
     try Data("target".utf8).write(to: target)
     try Data("unrelated".utf8).write(to: unrelated)
@@ -91,12 +95,12 @@ private func makeFixture(identity: String) throws -> Fixture {
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0"><dict>
     <key>CFBundleExecutable</key><string>Example</string>
-    <key>CFBundleIdentifier</key><string>com.automicvault.targeted-validation</string>
+    <key>CFBundleIdentifier</key><string>\(appIdentifier)</string>
     <key>CFBundlePackageType</key><string>APPL</string>
     </dict></plist>
     """.utf8).write(to: contents.appendingPathComponent("Info.plist"))
-    try sign(helper, identity: identity, identifier: "com.automicvault.targeted-validation.helper")
-    try sign(app, identity: identity, identifier: "com.automicvault.targeted-validation")
+    try sign(helper, identity: identity, identifier: "\(appIdentifier).helper")
+    try sign(app, identity: identity, identifier: appIdentifier)
     return Fixture(
         root: root,
         app: app,
@@ -156,6 +160,28 @@ private func designatedRequirement(_ app: URL) throws -> SecRequirement {
         throw CommandError(command: "SecCodeCopyDesignatedRequirement", output: "OSStatus \(status)")
     }
     return requirement
+}
+
+private func signingIdentifier(_ code: SecStaticCode) throws -> String {
+    var information: CFDictionary?
+    let status = SecCodeCopySigningInformation(code, [], &information)
+    guard status == errSecSuccess,
+          let dictionary = information as? [CFString: Any],
+          let identifier = dictionary[kSecCodeInfoIdentifier] as? String
+    else {
+        throw CommandError(command: "SecCodeCopySigningInformation", output: "OSStatus \(status)")
+    }
+    return identifier
+}
+
+private func liveSigningIdentifier(_ pid: pid_t) throws -> String {
+    var code: SecCode?
+    let attributes = [kSecGuestAttributePid as String: NSNumber(value: pid)] as CFDictionary
+    let status = SecCodeCopyGuestWithAttributes(nil, attributes, [], &code)
+    guard status == errSecSuccess, let code else {
+        throw CommandError(command: "SecCodeCopyGuestWithAttributes", output: "OSStatus \(status)")
+    }
+    return try signingIdentifier(unsafeBitCast(code, to: SecStaticCode.self))
 }
 
 private func requirement(_ source: String) throws -> SecRequirement {
@@ -356,6 +382,38 @@ harness.check("a valid main-executable replacement is rejected by the stored ide
             && targetedStatus(app: $0.app, resource: $0.executable, requirement: original)
                 != errSecSuccess
     }
+}
+
+harness.check("SPI validation is static and does not bind a live process to its current bundle path") {
+    let runningIdentifier = "com.automicvault.targeted-validation.running"
+    let replacementIdentifier = "com.automicvault.targeted-validation.replacement"
+    let running = try makeFixture(
+        identity: identity,
+        appIdentifier: runningIdentifier,
+        executableSource: "/bin/sleep"
+    )
+    let replacement = try makeFixture(identity: identity, appIdentifier: replacementIdentifier)
+    defer {
+        try? FileManager.default.removeItem(at: running.root)
+        try? FileManager.default.removeItem(at: replacement.root)
+    }
+    let process = Process()
+    process.executableURL = running.executable
+    process.arguments = ["30"]
+    try process.run()
+    defer {
+        if process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+        }
+    }
+    let originalApp = running.root.appendingPathComponent("Running.app")
+    try FileManager.default.moveItem(at: running.app, to: originalApp)
+    try FileManager.default.moveItem(at: replacement.app, to: running.app)
+    let currentExecutable = running.app.appendingPathComponent("Contents/MacOS/Example")
+    return try liveSigningIdentifier(process.processIdentifier) == runningIdentifier
+        && signingIdentifier(staticCode(running.app)) == replacementIdentifier
+        && directStatus(app: running.app, resource: currentExecutable) == errSecSuccess
 }
 
 harness.check("Info.plist modification fails main-executable validation") {

--- a/scripts/validate-targeted-app-resource.swift
+++ b/scripts/validate-targeted-app-resource.swift
@@ -181,7 +181,12 @@ private func liveSigningIdentifier(_ pid: pid_t) throws -> String {
     guard status == errSecSuccess, let code else {
         throw CommandError(command: "SecCodeCopyGuestWithAttributes", output: "OSStatus \(status)")
     }
-    return try signingIdentifier(unsafeBitCast(code, to: SecStaticCode.self))
+    var staticCode: SecStaticCode?
+    let staticStatus = SecCodeCopyStaticCode(code, [], &staticCode)
+    guard staticStatus == errSecSuccess, let staticCode else {
+        throw CommandError(command: "SecCodeCopyStaticCode", output: "OSStatus \(staticStatus)")
+    }
+    return try signingIdentifier(staticCode)
 }
 
 private func requirement(_ source: String) throws -> SecRequirement {

--- a/src/menu-helper/Sources/MenubarHelperCore/AppBundleValidation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AppBundleValidation.swift
@@ -6,7 +6,7 @@ private typealias ValidateSealedResource = @convention(c) (
     SecStaticCode,
     CFURL,
     UInt32,
-    UnsafeMutableRawPointer?
+    UnsafeMutablePointer<Unmanaged<CFError>?>?
 ) -> OSStatus
 
 // Resolve the private SPI dynamically and retain strict complete-bundle validation as fallback.


### PR DESCRIPTION
## Summary

- add an independent disposable-app harness for SecStaticCodeValidateResourceWithErrors
- validate ad-hoc and Developer ID behavior across mutations, re-signing, requirements, resource seals, nested code, symlinks, CFError, and non-native architecture damage
- record Apple SPI contract evidence, observed results, limitations, and the live-to-disk substitution finding
- match the dynamically resolved function pointer to the exact CFError ABI

## Result

The SPI behaves as ADR 0033 expects when combined with the strict all-architecture precheck and expected SecRequirement. The harness passes 19 ad-hoc checks and 23 Developer ID checks on macOS 26.6.2.

The validation also confirms a high-priority integration gap that predates this SPI: ordinary app Launchers do not bind the live process code identifier to the current on-disk main executable before adopting the app identity. Verified Launcher Helpers already perform this comparison. This PR documents and reproduces the gap but does not change the authority model or implement that separate fix.

## Verification

- ./scripts/validate-targeted-app-resource.swift
- ./scripts/validate-targeted-app-resource.swift --identity <Developer ID identity>
- swift test --package-path src/menu-helper (236 tests passed)