### PR TITLE
Fix shell PATH finding mitigation

### DIFF
--- a/src/isotopes/detectors/bash/detector.md
+++ b/src/isotopes/detectors/bash/detector.md
@@ -22,6 +22,8 @@ configuration. Automic Vault cannot rewrite them without changing shell
 behavior or guessing which commands need each secret. Move the reported value
 with `av save KEY`, then inject it only into the command that needs it.
 
+## PATH Mitigation
+
 Version managers commonly prepend user-writable tool directories to `PATH`;
 this is expected, but those directories can still shadow later commands. Remove
 empty, relative, and unexpected entries. If the ordering is intentional, use

--- a/src/isotopes/detectors/bash/detector.md
+++ b/src/isotopes/detectors/bash/detector.md
@@ -20,9 +20,14 @@
 Bash startup files contain arbitrary user programs and shared environment
 configuration. Automic Vault cannot rewrite them without changing shell
 behavior or guessing which commands need each secret. Move the reported value
-with `av save KEY`, then inject it only into the command that needs it. For an
-unsafe `PATH`, move every protected system directory before the reported
-user-writable directories and remove empty or relative entries.
+with `av save KEY`, then inject it only into the command that needs it.
+
+Version managers commonly prepend user-writable tool directories to `PATH`;
+this is expected, but those directories can still shadow later commands. Remove
+empty, relative, and unexpected entries. If the ordering is intentional, use
+absolute paths for security-sensitive commands and keep reusable secrets out of
+the shell environment with `av inject` or `av proxy`; these reduce exposure but
+do not make the `PATH` safe.
 
 ## Why This is not Yet Hardened
 

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -431,7 +431,7 @@ fn merge_duplicate_owned_shell_path_findings(findings: Vec<DetectorResult>) -> V
         // Shell docs cover credential assignments and PATH hazards, but each
         // finding needs only the mitigation for the condition it reports.
         if shell_path_entry(&finding.finding).is_some() {
-            finding.finding.solution = SHELL_PATH_SOLUTION.to_string();
+            finding.finding.solution = shell_path_solution(finding.finding.source);
         }
         let existing = shell_path_entry(&finding.finding).and_then(|entry| {
             merged.iter_mut().find(|candidate| {
@@ -452,7 +452,6 @@ fn merge_duplicate_owned_shell_path_findings(findings: Vec<DetectorResult>) -> V
 
 const SHELL_PATH_FINDING_SOURCES: &[&str] = &["bash", "zsh"];
 const MERGED_SHELL_PATH_SOURCE: &str = "bash+zsh";
-const SHELL_PATH_SOLUTION: &str = "Version managers commonly prepend user-writable tool directories to `PATH`; this is expected, but those directories can still shadow later commands. Remove empty, relative, and unexpected entries. If the ordering is intentional, use absolute paths for security-sensitive commands and keep reusable secrets out of the shell environment with `av inject` or `av proxy`; these reduce exposure but do not make the `PATH` safe.";
 
 /// `bash` and `zsh` each detect the same process-wide `$PATH` independently,
 /// so an insecure directory is reported once per shell. Collapse those
@@ -489,6 +488,18 @@ fn shell_path_entry(finding: &Finding) -> Option<&str> {
         .strip_prefix(": ")
 }
 
+fn shell_path_solution(source: &str) -> String {
+    let documentation = DETECTORS
+        .iter()
+        .find(|detector| detector.module == source)
+        .expect("shell PATH findings have a registered detector")
+        .documentation;
+    documented_section(documentation, "## PATH Mitigation")
+        .map(first_paragraph)
+        .filter(|solution| !solution.is_empty())
+        .expect("shell detector documentation has a PATH mitigation")
+}
+
 fn merge_shell_path_finding(existing: &mut Finding) {
     if let Some(entry) = shell_path_entry(existing) {
         existing.explanation = format!(
@@ -496,15 +507,10 @@ fn merge_shell_path_finding(existing: &mut Finding) {
         );
     }
     existing.source = MERGED_SHELL_PATH_SOURCE;
-    existing.solution = SHELL_PATH_SOLUTION.to_string();
 }
 
 pub(crate) fn documented_solution(documentation: &str) -> Option<String> {
-    if let Some(mitigation) = documentation
-        .split_once("## Mitigation")
-        .map(|(_, section)| section)
-        .and_then(|section| section.split("\n## ").next())
-    {
+    if let Some(mitigation) = documented_section(documentation, "## Mitigation") {
         if let Some(command) = mitigation.lines().find(|line| line.contains("av harden ")) {
             return Some(format!("Run `{}`.", command.trim()));
         }
@@ -519,6 +525,13 @@ pub(crate) fn documented_solution(documentation: &str) -> Option<String> {
         .and_then(|section| section.split("\n## ").next())
         .map(first_paragraph)
         .filter(|solution| !solution.is_empty())
+}
+
+fn documented_section<'a>(documentation: &'a str, heading: &str) -> Option<&'a str> {
+    documentation
+        .split_once(heading)
+        .map(|(_, section)| section)
+        .and_then(|section| section.split("\n## ").next())
 }
 
 fn first_paragraph(section: &str) -> String {
@@ -761,7 +774,12 @@ mod tests {
 
         let merged = merge_duplicate_shell_path_findings(findings);
 
-        assert_eq!(merged[0].solution, SHELL_PATH_SOLUTION);
+        assert_eq!(merged[0].solution, shell_path_solution("bash"));
+    }
+
+    #[test]
+    fn bash_and_zsh_share_the_same_path_mitigation() {
+        assert_eq!(shell_path_solution("bash"), shell_path_solution("zsh"));
     }
 
     #[test]
@@ -775,7 +793,7 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].source, "bash+zsh");
-        assert_eq!(merged[0].solution, SHELL_PATH_SOLUTION);
+        assert_eq!(merged[0].solution, shell_path_solution("bash"));
         assert_eq!(
             merged[0].explanation,
             "Bash and zsh PATH have a user-writable directory before protected system directories: /opt/homebrew/bin"

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -427,7 +427,12 @@ pub(crate) fn findings_for(
 
 fn merge_duplicate_owned_shell_path_findings(findings: Vec<DetectorResult>) -> Vec<DetectorResult> {
     let mut merged: Vec<DetectorResult> = Vec::with_capacity(findings.len());
-    for finding in findings {
+    for mut finding in findings {
+        // Shell docs cover credential assignments and PATH hazards, but each
+        // finding needs only the mitigation for the condition it reports.
+        if shell_path_entry(&finding.finding).is_some() {
+            finding.finding.solution = SHELL_PATH_SOLUTION.to_string();
+        }
         let existing = shell_path_entry(&finding.finding).and_then(|entry| {
             merged.iter_mut().find(|candidate| {
                 candidate.finding.source != finding.finding.source
@@ -447,7 +452,7 @@ fn merge_duplicate_owned_shell_path_findings(findings: Vec<DetectorResult>) -> V
 
 const SHELL_PATH_FINDING_SOURCES: &[&str] = &["bash", "zsh"];
 const MERGED_SHELL_PATH_SOURCE: &str = "bash+zsh";
-const MERGED_SHELL_PATH_SOLUTION: &str = "Shell startup files contain arbitrary user programs and shared environment configuration. Automic Vault cannot rewrite them without changing shell behavior or guessing which commands need each secret. Move the reported value with `av save KEY`, then inject it only into the command that needs it. For an unsafe `PATH`, move every protected system directory before the reported user-writable directories and remove empty or relative entries.";
+const SHELL_PATH_SOLUTION: &str = "Version managers commonly prepend user-writable tool directories to `PATH`; this is expected, but those directories can still shadow later commands. Remove empty, relative, and unexpected entries. If the ordering is intentional, use absolute paths for security-sensitive commands and keep reusable secrets out of the shell environment with `av inject` or `av proxy`; these reduce exposure but do not make the `PATH` safe.";
 
 /// `bash` and `zsh` each detect the same process-wide `$PATH` independently,
 /// so an insecure directory is reported once per shell. Collapse those
@@ -455,19 +460,18 @@ const MERGED_SHELL_PATH_SOLUTION: &str = "Shell startup files contain arbitrary 
 /// of doubling the audit for anyone with both shells configured.
 #[cfg(test)]
 fn merge_duplicate_shell_path_findings(findings: Vec<Finding>) -> Vec<Finding> {
-    let mut merged: Vec<Finding> = Vec::with_capacity(findings.len());
-    for finding in findings {
-        let existing = shell_path_entry(&finding).and_then(|entry| {
-            merged.iter_mut().find(|candidate| {
-                candidate.source != finding.source && shell_path_entry(candidate) == Some(entry)
+    merge_duplicate_owned_shell_path_findings(
+        findings
+            .into_iter()
+            .map(|finding| DetectorResult {
+                detectors: vec![finding.source.to_string()],
+                finding,
             })
-        });
-        match existing {
-            Some(existing) => merge_shell_path_finding(existing),
-            None => merged.push(finding),
-        }
-    }
-    merged
+            .collect(),
+    )
+    .into_iter()
+    .map(|result| result.finding)
+    .collect()
 }
 
 /// The PATH entry a shell PATH finding reports, taken from the explanation
@@ -492,7 +496,7 @@ fn merge_shell_path_finding(existing: &mut Finding) {
         );
     }
     existing.source = MERGED_SHELL_PATH_SOURCE;
-    existing.solution = MERGED_SHELL_PATH_SOLUTION.to_string();
+    existing.solution = SHELL_PATH_SOLUTION.to_string();
 }
 
 pub(crate) fn documented_solution(documentation: &str) -> Option<String> {
@@ -733,6 +737,11 @@ mod tests {
             "{} PATH has a user-writable directory before protected system directories: {path}",
             if shell == "bash" { "Bash" } else { "Zsh" },
         );
+        let documentation = if shell == "bash" {
+            include_str!("bash/detector.md")
+        } else {
+            include_str!("zsh/detector.md")
+        };
         Finding {
             source: shell,
             homepage: "https://example.test/",
@@ -741,9 +750,18 @@ mod tests {
             // empty entries have no affected path here either.
             affected: super::radioisotope::affected(&explanation),
             explanation,
-            solution: format!("{shell} startup files contain arbitrary user programs."),
+            solution: documented_solution(documentation).unwrap(),
             docs_url: "https://example.test/docs.md",
         }
+    }
+
+    #[test]
+    fn gives_a_lone_shell_path_finding_path_specific_mitigation() {
+        let findings = vec![shell_path_finding("bash", "/Users/tester/.local/bin")];
+
+        let merged = merge_duplicate_shell_path_findings(findings);
+
+        assert_eq!(merged[0].solution, SHELL_PATH_SOLUTION);
     }
 
     #[test]
@@ -757,6 +775,7 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].source, "bash+zsh");
+        assert_eq!(merged[0].solution, SHELL_PATH_SOLUTION);
         assert_eq!(
             merged[0].explanation,
             "Bash and zsh PATH have a user-writable directory before protected system directories: /opt/homebrew/bin"

--- a/src/isotopes/detectors/zsh/detector.md
+++ b/src/isotopes/detectors/zsh/detector.md
@@ -27,6 +27,8 @@ configuration. Automic Vault cannot rewrite them without changing shell
 behavior or guessing which commands need each secret. Move the reported value
 with `av save KEY`, then inject it only into the command that needs it.
 
+## PATH Mitigation
+
 Version managers commonly prepend user-writable tool directories to `PATH`;
 this is expected, but those directories can still shadow later commands. Remove
 empty, relative, and unexpected entries. If the ordering is intentional, use

--- a/src/isotopes/detectors/zsh/detector.md
+++ b/src/isotopes/detectors/zsh/detector.md
@@ -25,9 +25,14 @@
 Zsh startup files contain arbitrary user programs and shared environment
 configuration. Automic Vault cannot rewrite them without changing shell
 behavior or guessing which commands need each secret. Move the reported value
-with `av save KEY`, then inject it only into the command that needs it. For an
-unsafe `PATH`, move every protected system directory before the reported
-user-writable directories and remove empty or relative entries.
+with `av save KEY`, then inject it only into the command that needs it.
+
+Version managers commonly prepend user-writable tool directories to `PATH`;
+this is expected, but those directories can still shadow later commands. Remove
+empty, relative, and unexpected entries. If the ordering is intentional, use
+absolute paths for security-sensitive commands and keep reusable secrets out of
+the shell environment with `av inject` or `av proxy`; these reduce exposure but
+do not make the `PATH` safe.
 
 ## Why This is not Yet Hardened
 


### PR DESCRIPTION
## Summary

- give bash and zsh PATH findings mitigation specific to command-shadowing hazards
- preserve the warning for expected version-manager layouts without treating them as safe
- keep credential-assignment findings on the existing `av save KEY` guidance
- cover both single-shell and merged-shell findings at the production post-processing seam

## Security

Detection and severity are unchanged. The new guidance recommends removing empty, relative, and unexpected entries, using absolute paths for security-sensitive commands, and keeping reusable secrets out of the shell environment. It explicitly states that `av inject` and `av proxy` reduce exposure but do not make an unsafe `PATH` safe.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- clean-home PATH-only CLI repro

Fixes #226