### PR TITLE
Explain sandbox-blocked Isotope approval access

### DIFF
--- a/src/approval_service.rs
+++ b/src/approval_service.rs
@@ -1,0 +1,50 @@
+use std::ffi::CStr;
+
+pub(crate) fn unavailable_message(service: &CStr) -> &'static str {
+    unavailable_message_for_sandbox(sandbox_denies_mach_lookup(service))
+}
+
+#[cfg(target_os = "macos")]
+fn sandbox_denies_mach_lookup(service: &CStr) -> bool {
+    use std::os::raw::{c_char, c_int};
+
+    #[link(name = "sandbox")]
+    unsafe extern "C" {
+        fn sandbox_check(pid: libc::pid_t, operation: *const c_char, filter: c_int, ...) -> c_int;
+    }
+
+    const SANDBOX_FILTER_GLOBAL_NAME: c_int = 2;
+    unsafe {
+        sandbox_check(
+            libc::getpid(),
+            c"mach-lookup".as_ptr(),
+            SANDBOX_FILTER_GLOBAL_NAME,
+            service.as_ptr(),
+        ) != 0
+    }
+}
+
+fn unavailable_message_for_sandbox(sandbox_denied: bool) -> &'static str {
+    if sandbox_denied {
+        "Automic Vault approval service is blocked by this process's sandbox; retry with elevated permissions"
+    } else {
+        "Automic Vault approval service is not running; open the menu bar app"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_message_distinguishes_sandbox_denial() {
+        assert_eq!(
+            unavailable_message_for_sandbox(true),
+            "Automic Vault approval service is blocked by this process's sandbox; retry with elevated permissions"
+        );
+        assert_eq!(
+            unavailable_message_for_sandbox(false),
+            "Automic Vault approval service is not running; open the menu bar app"
+        );
+    }
+}

--- a/src/approval_service.rs
+++ b/src/approval_service.rs
@@ -1,5 +1,23 @@
 use std::ffi::CStr;
 
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    static _xpc_error_connection_invalid: u8;
+    fn xpc_equal(object1: *mut std::ffi::c_void, object2: *mut std::ffi::c_void) -> bool;
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) unsafe fn connection_invalid(reply: *mut std::ffi::c_void) -> bool {
+    unsafe {
+        xpc_equal(
+            reply,
+            std::ptr::addr_of!(_xpc_error_connection_invalid)
+                .cast_mut()
+                .cast(),
+        )
+    }
+}
+
 pub(crate) fn unavailable_message(service: &CStr) -> &'static str {
     unavailable_message_for_sandbox(sandbox_denies_mach_lookup(service))
 }
@@ -35,6 +53,15 @@ fn unavailable_message_for_sandbox(sandbox_denied: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn recognizes_connection_invalid_xpc_object() {
+        let error = std::ptr::addr_of!(_xpc_error_connection_invalid)
+            .cast_mut()
+            .cast();
+        assert!(unsafe { connection_invalid(error) });
+    }
 
     #[test]
     fn unavailable_message_distinguishes_sandbox_denial() {

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -512,7 +512,7 @@ fn xpc_authorize(request: &AuthorizationRequest) -> Result<(), String> {
                     .into_owned()
             };
             if error == "Connection invalid" {
-                Err("Automic Vault approval service is not running; open the menu bar app".into())
+                Err(av::approval_service_unavailable_message(&service).into())
             } else {
                 Err(error)
             }

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -503,17 +503,17 @@ fn xpc_authorize(request: &AuthorizationRequest) -> Result<(), String> {
 
     let result = unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
-            let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-            let error = if error.is_null() {
-                "approval XPC connection failed".into()
-            } else {
-                std::ffi::CStr::from_ptr(error)
-                    .to_string_lossy()
-                    .into_owned()
-            };
-            if error == "Connection invalid" {
+            if av::approval_service_connection_invalid(reply) {
                 Err(av::approval_service_unavailable_message(&service).into())
             } else {
+                let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
+                let error = if error.is_null() {
+                    "approval XPC connection failed".into()
+                } else {
+                    std::ffi::CStr::from_ptr(error)
+                        .to_string_lossy()
+                        .into_owned()
+                };
                 Err(error)
             }
         } else if xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {

--- a/src/cli/aws.rs
+++ b/src/cli/aws.rs
@@ -361,15 +361,15 @@ fn xpc_request(
     }
     let result = unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
-            let value = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-            let error = if value.is_null() {
-                "approval XPC connection failed".into()
-            } else {
-                CStr::from_ptr(value).to_string_lossy().into_owned()
-            };
-            if error == "Connection invalid" {
+            if crate::approval_service_connection_invalid(reply) {
                 Err(crate::approval_service_unavailable_message(service).into())
             } else {
+                let value = xpc_dictionary_get_string(reply, _xpc_error_key_description);
+                let error = if value.is_null() {
+                    "approval XPC connection failed".into()
+                } else {
+                    CStr::from_ptr(value).to_string_lossy().into_owned()
+                };
                 Err(error)
             }
         } else if !xpc_dictionary_get_bool(reply, c"ok".as_ptr()) {

--- a/src/cli/aws.rs
+++ b/src/cli/aws.rs
@@ -362,11 +362,16 @@ fn xpc_request(
     let result = unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
             let value = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-            Err(if value.is_null() {
+            let error = if value.is_null() {
                 "approval XPC connection failed".into()
             } else {
                 CStr::from_ptr(value).to_string_lossy().into_owned()
-            })
+            };
+            if error == "Connection invalid" {
+                Err(crate::approval_service_unavailable_message(service).into())
+            } else {
+                Err(error)
+            }
         } else if !xpc_dictionary_get_bool(reply, c"ok".as_ptr()) {
             let value = xpc_dictionary_get_string(reply, c"error".as_ptr());
             Err(if value.is_null() {

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -1241,17 +1241,17 @@ fn xpc_approve_request(
 
     let result = unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
-            let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-            let error = if error.is_null() {
-                "approval XPC connection failed".into()
-            } else {
-                std::ffi::CStr::from_ptr(error)
-                    .to_string_lossy()
-                    .into_owned()
-            };
-            if error == "Connection invalid" {
+            if crate::approval_service_connection_invalid(reply) {
                 Err(crate::approval_service_unavailable_message(&service).into())
             } else {
+                let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
+                let error = if error.is_null() {
+                    "approval XPC connection failed".into()
+                } else {
+                    std::ffi::CStr::from_ptr(error)
+                        .to_string_lossy()
+                        .into_owned()
+                };
                 Err(error)
             }
         } else {

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -1250,10 +1250,7 @@ fn xpc_approve_request(
                     .into_owned()
             };
             if error == "Connection invalid" {
-                Err(
-                    approval_service_unavailable_message(sandbox_denies_mach_lookup(&service))
-                        .into(),
-                )
+                Err(crate::approval_service_unavailable_message(&service).into())
             } else {
                 Err(error)
             }
@@ -1302,34 +1299,6 @@ fn xpc_approve_request(
     result
 }
 
-#[cfg(target_os = "macos")]
-fn sandbox_denies_mach_lookup(service: &std::ffi::CStr) -> bool {
-    use std::os::raw::{c_char, c_int};
-
-    #[link(name = "sandbox")]
-    unsafe extern "C" {
-        fn sandbox_check(pid: libc::pid_t, operation: *const c_char, filter: c_int, ...) -> c_int;
-    }
-
-    const SANDBOX_FILTER_GLOBAL_NAME: c_int = 2;
-    unsafe {
-        sandbox_check(
-            libc::getpid(),
-            c"mach-lookup".as_ptr(),
-            SANDBOX_FILTER_GLOBAL_NAME,
-            service.as_ptr(),
-        ) != 0
-    }
-}
-
-fn approval_service_unavailable_message(sandbox_denied: bool) -> &'static str {
-    if sandbox_denied {
-        "Automic Vault approval service is blocked by this process's sandbox; retry with elevated permissions"
-    } else {
-        "Automic Vault approval service is not running; open the menu bar app"
-    }
-}
-
 fn human_approval_message(decision: &[u8]) -> Option<&'static str> {
     match decision {
         b"approved" => Some("approved"),
@@ -1347,14 +1316,6 @@ mod tests {
         assert_eq!(human_approval_message(b"approved"), Some("approved"));
         assert_eq!(human_approval_message(b"denied"), Some("denied"));
         assert_eq!(human_approval_message(b"unexpected"), None);
-    }
-
-    #[test]
-    fn connection_error_explains_sandbox_denial() {
-        assert_eq!(
-            approval_service_unavailable_message(true),
-            "Automic Vault approval service is blocked by this process's sandbox; retry with elevated permissions"
-        );
     }
 
     fn os(values: &[&str]) -> Vec<OsString> {

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -427,15 +427,15 @@ fn start_session(request: &StartRequest) -> Result<SessionEnvironment, String> {
     let result = (|| -> Result<SessionEnvironment, String> {
         unsafe {
             if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
-                let value = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-                let error = if value.is_null() {
-                    "Proxy Session XPC connection failed".into()
-                } else {
-                    CStr::from_ptr(value).to_string_lossy().into_owned()
-                };
-                if error == "Connection invalid" {
+                if crate::approval_service_connection_invalid(reply) {
                     Err(crate::approval_service_unavailable_message(service).into())
                 } else {
+                    let value = xpc_dictionary_get_string(reply, _xpc_error_key_description);
+                    let error = if value.is_null() {
+                        "Proxy Session XPC connection failed".into()
+                    } else {
+                        CStr::from_ptr(value).to_string_lossy().into_owned()
+                    };
                     Err(error)
                 }
             } else if !xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -428,11 +428,16 @@ fn start_session(request: &StartRequest) -> Result<SessionEnvironment, String> {
         unsafe {
             if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
                 let value = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-                Err(if value.is_null() {
+                let error = if value.is_null() {
                     "Proxy Session XPC connection failed".into()
                 } else {
                     CStr::from_ptr(value).to_string_lossy().into_owned()
-                })
+                };
+                if error == "Connection invalid" {
+                    Err(crate::approval_service_unavailable_message(service).into())
+                } else {
+                    Err(error)
+                }
             } else if !xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {
                 Err(get_string(reply, b"error\0").unwrap_or_else(|| "Proxy Session denied".into()))
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(target_os = "macos")]
 
+mod approval_service;
 pub mod brew_cask_policy;
 mod cli;
 mod gpg;
@@ -9,6 +10,11 @@ mod secrets;
 
 pub use cli::{run, run_scanner_terminal, run_terminal};
 pub use gpg::run_git_program;
+
+#[doc(hidden)]
+pub fn approval_service_unavailable_message(service: &std::ffi::CStr) -> &'static str {
+    approval_service::unavailable_message(service)
+}
 
 pub const MENU_HELPER_CODE_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = ZU76A67LGU and identifier "com.automicvault""#;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,14 @@ pub fn approval_service_unavailable_message(service: &std::ffi::CStr) -> &'stati
     approval_service::unavailable_message(service)
 }
 
+/// # Safety
+///
+/// `reply` must be a valid XPC object.
+#[doc(hidden)]
+pub unsafe fn approval_service_connection_invalid(reply: *mut std::ffi::c_void) -> bool {
+    unsafe { approval_service::connection_invalid(reply) }
+}
+
 pub const MENU_HELPER_CODE_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = ZU76A67LGU and identifier "com.automicvault""#;
 
 fn test_env_var(name: &str) -> Option<std::ffi::OsString> {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -855,17 +855,17 @@ fn xpc_request_with_project_directory(
 
     let result = unsafe {
         if reply_is_error {
-            let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
-            let error = if error.is_null() {
-                "approval XPC connection failed".into()
-            } else {
-                std::ffi::CStr::from_ptr(error)
-                    .to_string_lossy()
-                    .into_owned()
-            };
-            if error == "Connection invalid" {
+            if crate::approval_service_connection_invalid(reply) {
                 Err(crate::approval_service_unavailable_message(&service).into())
             } else {
+                let error = xpc_dictionary_get_string(reply, _xpc_error_key_description);
+                let error = if error.is_null() {
+                    "approval XPC connection failed".into()
+                } else {
+                    std::ffi::CStr::from_ptr(error)
+                        .to_string_lossy()
+                        .into_owned()
+                };
                 Err(error)
             }
         } else if xpc_dictionary_get_bool(reply, b"ok\0".as_ptr().cast()) {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -864,7 +864,7 @@ fn xpc_request_with_project_directory(
                     .into_owned()
             };
             if error == "Connection invalid" {
-                Err("Automic Vault approval service is not running; open the menu bar app".into())
+                Err(crate::approval_service_unavailable_message(&service).into())
             } else {
                 Err(error)
             }


### PR DESCRIPTION
## Summary

- Centralize approval-service failure classification and preserve the existing fail-closed behavior.
- Apply sandbox-denial guidance to every AV-owned XPC path: delegated credential helpers, `av inject`, AWS, Proxy Sessions, and the Homebrew stub.
- WakaTime and the other AV-delegating Isotopes inherit the behavior without fork changes.

Direct-XPC companion PRs:

- automic-vault/gh-cli#5
- automic-vault/stripe-cli#2
- automic-vault/supabase-cli#1

Addresses #225.

## Security

This does not add authority or bypass the sandbox. It only distinguishes a local Mach-service denial after the XPC connection has already failed, so agents can retry through their existing escalation mechanism.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- A denied `sandbox-exec` WakaTime credential request reports that the sandbox blocked the approval service and asks the caller to retry with elevated permissions.