### PR TITLE
Fix undismissable Direct Access confirmation sheet

### DIFF
--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -24,7 +24,7 @@ const BREW_USER_UID_FILE: &str = "var/automic/user-uid";
 const LEGACY_CASK_USER_UID_FILE: &str = "var/automic/cask-user-uid";
 const STUB_MARKER_PREFIX: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V";
 #[cfg(test)]
-const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V19";
+const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V20";
 const STUB_VERSION: u32 = 20;
 const ID_RANGE: std::ops::RangeInclusive<u32> = 550..=599;
 
@@ -1539,7 +1539,7 @@ mod tests {
         assert!(is_managed_stub_file(&path));
         assert!(!stub_is_current(&path));
 
-        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V20 future").unwrap();
+        fs::write(&path, b"AUTOMIC_VAULT_BREW_STUB_V21 future").unwrap();
         assert!(stub_is_current(&path));
 
         for invalid in [

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2680,7 +2680,6 @@ private struct StoredSecretDetailView: View {
     let secret: StoredSecret
     @State private var isAvailableWhileLocked: Bool
     @State private var isConfirmingDelete = false
-    @State private var isConfirmingDirectAccess = false
     @State private var pendingDirectAccessLauncher: DirectAccessLauncherSelection?
     @State private var replacingValue: StoredSecretValue?
     @State private var deletingValue: StoredSecretValue?
@@ -2774,7 +2773,6 @@ private struct StoredSecretDetailView: View {
                     model.chooseDirectAccessLauncher { launcher in
                         guard let launcher else { return }
                         pendingDirectAccessLauncher = launcher
-                        isConfirmingDirectAccess = true
                     }
                 } label: {
                     Label("Allow Launcher…", systemImage: "app.badge.checkmark")
@@ -2856,18 +2854,14 @@ private struct StoredSecretDetailView: View {
         .sheet(item: $replacingValue) { value in
             ReplaceSecretValueView(model: model, secret: secret, storedValue: value)
         }
-        .sheet(isPresented: $isConfirmingDirectAccess, onDismiss: {
-            pendingDirectAccessLauncher = nil
-        }) {
-            if let selection = pendingDirectAccessLauncher {
-                DirectAccessConfirmationView(
-                    secretName: secret.account,
-                    launcherName: selection.launcher.bundleIdentifier,
-                    runtimeWarning: launcherRuntimeWarning(selection.runtimeRequirement)
-                ) {
-                    isConfirmingDirectAccess = false
-                    model.addDirectAccessLauncher(selection, to: secret)
-                }
+        .sheet(item: $pendingDirectAccessLauncher) { selection in
+            DirectAccessConfirmationView(
+                secretName: secret.account,
+                launcherName: selection.launcher.bundleIdentifier,
+                runtimeWarning: launcherRuntimeWarning(selection.runtimeRequirement)
+            ) {
+                pendingDirectAccessLauncher = nil
+                model.addDirectAccessLauncher(selection, to: secret)
             }
         }
     }
@@ -4982,9 +4976,11 @@ struct LauncherHelperReview: Identifiable, Sendable {
     let helpers: [VerifiedLauncherHelper]
 }
 
-struct DirectAccessLauncherSelection {
+struct DirectAccessLauncherSelection: Identifiable {
     let launcher: BlessedScriptLauncher
     let runtimeRequirement: LauncherRuntimeRequirement
+
+    var id: String { launcher.requirement }
 }
 
 private let libraryValidationWarning = "This Launcher permits third-party libraries and plug-ins to run inside its process. That code can inherit the Launcher’s Secret Gate authority."


### PR DESCRIPTION
## Summary

- drive the Direct Access confirmation sheet from the selected Launcher
- remove the independent Boolean presentation state
- identify the ephemeral selection by its existing designated requirement

## Root cause

Commit `4f2fe168` split presentation across `isConfirmingDirectAccess` and `pendingDirectAccessLauncher`. SwiftUI could present from the Boolean while the optional item still rendered nil, producing an empty sheet with no dismiss control.

Using `.sheet(item:)` makes presentation and content share one state, so the empty-sheet state is unrepresentable.

## Security

This changes presentation state only. Launcher eligibility, runtime-protection checks, the Direct Access warning, Approval, Direct Access Rule persistence, and fail-closed behavior are unchanged.

## Verification

- deterministic source invariant: red before, green after
- `swift test --package-path src/menu-helper --disable-automatic-resolution` — 240 runnable tests passed; entitlement-dependent Keychain tests skipped as expected
- `scripts/test-menu-helper-self-checks.sh` — 26 passed
- `scripts/test-launcher-bundle-runner.sh` — passed
- `scripts/test-varlock-plugin-helper.sh` — passed

Closes #235
