### PR TITLE
Detect Wrangler keyring credential exposure

### DIFF
--- a/src/isotopes/detectors/cloudflare_wrangler/detector.md
+++ b/src/isotopes/detectors/cloudflare_wrangler/detector.md
@@ -3,17 +3,31 @@
 ## Trigger Conditions
 
 - Wrangler auth config contains plaintext Cloudflare tokens.
+- Wrangler encrypted auth config uses a Keychain encryption key that
+  `/usr/bin/security` can retrieve non-interactively.
+- Access to that Keychain encryption key cannot be inspected.
 
 ## Sensitive Files
 
-- `~/Library/Preferences/.wrangler/config/default.toml`
-- `~/.wrangler/config/default.toml`
-- `~/.config/.wrangler/config/default.toml`
+- `~/Library/Preferences/.wrangler/config/*.toml`
+- `~/Library/Preferences/.wrangler/config/*.enc`
+- `~/.wrangler/config/*.toml`
+- `~/.wrangler/config/*.enc`
+- `~/.config/.wrangler/config/*.toml`
+- `~/.config/.wrangler/config/*.enc`
 
 ## Why This is not Yet Hardened
 
-Wrangler can persist OAuth access and refresh tokens in its global config
-directory. Because the CLI refreshes those tokens, this detector reports the
-plaintext state without attempting migration.
+Wrangler 4.107.0 added `wrangler login --use-keyring`, which encrypts OAuth
+credentials on disk and stores the encryption key in the macOS Keychain. Its
+macOS backend creates and reads that key through `/usr/bin/security`. When the
+Keychain item authorizes that tool, other software running as the user can ask
+the same tool for the key and decrypt the credentials without crossing an
+Authorization Gate.
+
+This mode reduces plaintext-at-rest exposure, but it does not establish the
+Secret custody and authorization boundary required for Hardened State. The
+detector inspects the Keychain access-control list without retrieving the key or
+credentials and reports inspection uncertainty as a Hazard.
 
 [Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).

--- a/src/isotopes/detectors/cloudflare_wrangler/detector.md
+++ b/src/isotopes/detectors/cloudflare_wrangler/detector.md
@@ -15,6 +15,8 @@
 - `~/.wrangler/config/*.enc`
 - `~/.config/.wrangler/config/*.toml`
 - `~/.config/.wrangler/config/*.enc`
+- `$XDG_CONFIG_HOME/.wrangler/config/*.toml`
+- `$XDG_CONFIG_HOME/.wrangler/config/*.enc`
 
 ## Why This is not Yet Hardened
 
@@ -26,7 +28,7 @@ the same tool for the key and decrypt the credentials without crossing an
 Authorization Gate.
 
 This mode reduces plaintext-at-rest exposure, but it does not establish the
-Secret custody and authorization boundary required for Hardened State. The
+Secret Custody and authorization boundary required for Hardened State. The
 detector inspects the Keychain access-control list without retrieving the key or
 credentials and reports inspection uncertainty as a Hazard.
 

--- a/src/isotopes/detectors/cloudflare_wrangler/mod.rs
+++ b/src/isotopes/detectors/cloudflare_wrangler/mod.rs
@@ -8,7 +8,7 @@ pub fn install_is_insecure() -> Result<bool, String> {
 
 pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
     let mut reasons = Vec::new();
-    for path in candidate_auth_files()? {
+    for path in candidate_auth_files("toml")? {
         if path.exists() && wrangler_auth_file_contains_secret(&read_to_string(&path)?) {
             reasons.push(format!(
                 "Wrangler auth config contains plaintext Cloudflare tokens: {}",
@@ -16,12 +16,26 @@ pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
             ));
         }
     }
+    for path in candidate_auth_files("enc")? {
+        if !path.exists() {
+            continue;
+        }
+        let Some(account) = path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if let Some(reason) = encrypted_auth_file_reason(
+            &path,
+            super::gh_cli::keychain_item_allows_security_tool("wrangler", account),
+        ) {
+            reasons.push(reason);
+        }
+    }
     reasons.sort();
     reasons.dedup();
     Ok(reasons)
 }
 
-fn candidate_auth_files() -> Result<Vec<PathBuf>, String> {
+fn candidate_auth_files(extension: &str) -> Result<Vec<PathBuf>, String> {
     let home = home_dir()?;
     let mut roots = vec![
         home.join(".wrangler"),
@@ -34,14 +48,14 @@ fn candidate_auth_files() -> Result<Vec<PathBuf>, String> {
 
     let mut paths = Vec::new();
     for root in roots {
-        paths.push(root.join("config/default.toml"));
+        paths.push(root.join(format!("config/default.{extension}")));
         if let Ok(entries) = std::fs::read_dir(root.join("config")) {
             for entry in entries.flatten() {
                 if entry
                     .file_type()
                     .map(|kind| kind.is_file())
                     .unwrap_or(false)
-                    && entry.path().extension().and_then(|value| value.to_str()) == Some("toml")
+                    && entry.path().extension().and_then(|value| value.to_str()) == Some(extension)
                 {
                     paths.push(entry.path());
                 }
@@ -49,6 +63,20 @@ fn candidate_auth_files() -> Result<Vec<PathBuf>, String> {
         }
     }
     Ok(paths)
+}
+
+fn encrypted_auth_file_reason(path: &Path, key_access: Result<bool, String>) -> Option<String> {
+    match key_access {
+        Ok(true) => Some(format!(
+            "Wrangler encrypted auth config uses a Keychain encryption key retrievable non-interactively through /usr/bin/security: {}",
+            path.display()
+        )),
+        Ok(false) => None,
+        Err(error) => Some(format!(
+            "Wrangler encrypted auth config Keychain access could not be inspected ({error}): {}",
+            path.display()
+        )),
+    }
 }
 
 fn home_dir() -> Result<PathBuf, String> {
@@ -107,6 +135,30 @@ mod tests {
         assert!(!wrangler_auth_file_contains_secret(
             "scopes = [\"user:read\"]\n"
         ));
+    }
+
+    #[test]
+    fn reports_encrypted_auth_only_when_key_access_is_exposed_or_unknown() {
+        let path = Path::new("/tmp/default.enc");
+        assert!(encrypted_auth_file_reason(path, Ok(false)).is_none());
+        assert!(
+            encrypted_auth_file_reason(path, Ok(true))
+                .unwrap()
+                .contains("retrievable non-interactively")
+        );
+        assert!(
+            encrypted_auth_file_reason(path, Err("inspection failed".to_string()))
+                .unwrap()
+                .contains("could not be inspected")
+        );
+    }
+
+    #[test]
+    fn documentation_explains_why_wrangler_keyring_is_not_hardened() {
+        let documentation = include_str!("detector.md");
+        assert!(documentation.contains("wrangler login --use-keyring"));
+        assert!(documentation.contains("`/usr/bin/security`"));
+        assert!(documentation.contains("Authorization Gate"));
     }
 }
 

--- a/src/isotopes/detectors/gh_cli/mod.rs
+++ b/src/isotopes/detectors/gh_cli/mod.rs
@@ -110,8 +110,24 @@ pub(crate) fn keychain_services_allow_security_tool(services: &[String]) -> Resu
     macos_keychain::keychain_allows_security_tool(services)
 }
 
+#[cfg(target_os = "macos")]
+pub(crate) fn keychain_item_allows_security_tool(
+    service: &str,
+    account: &str,
+) -> Result<bool, String> {
+    macos_keychain::keychain_item_allows_security_tool(service, account)
+}
+
 #[cfg(not(target_os = "macos"))]
 pub(crate) fn keychain_services_allow_security_tool(_services: &[String]) -> Result<bool, String> {
+    Ok(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn keychain_item_allows_security_tool(
+    _service: &str,
+    _account: &str,
+) -> Result<bool, String> {
     Ok(false)
 }
 
@@ -361,6 +377,18 @@ mod macos_keychain {
     pub(super) fn keychain_allows_security_tool(services: &[String]) -> Result<bool, String> {
         for service in services {
             if service_allows_security_tool(service)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub(super) fn keychain_item_allows_security_tool(
+        service: &str,
+        account: &str,
+    ) -> Result<bool, String> {
+        for item in service_items(service)? {
+            if item_account(item.0)? == account && item_allows_security_tool(item.0)? {
                 return Ok(true);
             }
         }


### PR DESCRIPTION
## Summary

- keep Wrangler encrypted auth profiles visible when the matching Keychain key permits non-interactive retrieval through /usr/bin/security
- reuse the passive Keychain ACL inspection and report inspection failures as a Hazard
- explain that keyring mode reduces plaintext-at-rest exposure without establishing an Authorization Gate or Hardened State

## Security

The Detector never reads the encryption key or credentials. It inspects legacy Keychain ACL metadata and matches each encrypted profile filename to the corresponding service=wrangler Keychain account.

Closes #222.

## Tests

- cargo test --all-targets
- cargo test -q cloudflare_wrangler
- cargo test -q gh_cli::macos_keychain::tests