### PR TITLE
Render Doctor remediations as Markdown

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2220,7 +2220,11 @@ private struct DashboardDetailView: View {
                     Text(item.subtitle)
                         .font(.system(size: 14))
                         .foregroundStyle(.secondary)
-                    InfoBlock(title: model.selectedSection.title, text: item.detail)
+                    InfoBlock(
+                        title: model.selectedSection.title,
+                        text: item.detail,
+                        rendersMarkdown: model.selectedSection == .doctor
+                    )
                     if let error = model.errorMessage {
                         InfoBlock(title: "Error", text: error)
                     }
@@ -3198,6 +3202,7 @@ private func isMediumDetectorSeverity(_ severity: String) -> Bool {
 private struct InfoBlock: View {
     let title: String
     let text: String
+    var rendersMarkdown = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -3205,7 +3210,13 @@ private struct InfoBlock: View {
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .tracking(0.7)
-            Text(text)
+            Group {
+                if rendersMarkdown {
+                    RenderedMarkdown(markdown: text)
+                } else {
+                    Text(text)
+                }
+            }
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -225,7 +225,7 @@ final class DashboardModel: ObservableObject {
                     kind: issue.command == nil || issue.command == issue.hardener ? nil : issue.hardener,
                     subtitle: issue.message,
                     detail: ([issue.message, "Remediation: \(issue.remediation)"] + paths)
-                        .joined(separator: "\n")
+                        .joined(separator: "\n\n")
                 )
             }
         case .hardenedTools:
@@ -1754,7 +1754,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
     guard model.selectedItem?.title == "aws",
           model.selectedItem?.kind == nil,
           model.selectedItem?.detail.contains("Resolved: /opt/homebrew/bin/aws") == true,
-          model.selectedItem?.detail.contains("Remediation:") == true
+          model.selectedItem?.detail.contains("\n\nRemediation:") == true
     else { return 1 }
     model.showAccessRequest(id: accessRequest.id, records: [accessRequest])
     guard model.selectedSection == .secretUsage,

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -3202,7 +3202,7 @@ private func isMediumDetectorSeverity(_ severity: String) -> Bool {
 private struct InfoBlock: View {
     let title: String
     let text: String
-    var rendersMarkdown = false
+    let rendersMarkdown: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -3202,7 +3202,7 @@ private func isMediumDetectorSeverity(_ severity: String) -> Bool {
 private struct InfoBlock: View {
     let title: String
     let text: String
-    let rendersMarkdown: Bool = false
+    var rendersMarkdown = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## Summary

- render Doctor details with the existing Markdown renderer
- keep every other info block on its current plain-text path
- make inline CLI commands visually distinct and selectable without Markdown backticks

Reported in [Byron Rode's feedback](https://x.com/byronrode/status/2094820844811829427).

## Testing

- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`