### PR TITLE
Fix Doctor launcher path collision guidance

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -565,6 +565,8 @@ fn diagnose_command(hardener: &str, command: &HardenerCommand, path: &OsStr) -> 
 }
 
 fn executable_at_reserved_launcher_path(command: &HardenerCommand) -> Option<&str> {
+    // Environment wrappers retain the bare Command name only when they could
+    // not resolve a separate Target outside the reserved Launcher path.
     (Path::new(&command.target_path) == Path::new(&command.name))
         .then(|| command.stub_path.as_deref())
         .flatten()

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -528,8 +528,13 @@ fn aws_update_issue(
 
 fn diagnose_command(hardener: &str, command: &HardenerCommand, path: &OsStr) -> Vec<DoctorIssue> {
     let mut issues = Vec::new();
+    let launcher_collision = executable_at_reserved_launcher_path(command);
     if !executable(Path::new(&command.target_path)) {
-        issues.push(target_issue(hardener, command));
+        issues.push(if let Some(stub) = launcher_collision {
+            target_at_launcher_path_issue(hardener, command, stub)
+        } else {
+            target_issue(hardener, command)
+        });
     }
     issues.extend(
         command
@@ -538,7 +543,7 @@ fn diagnose_command(hardener: &str, command: &HardenerCommand, path: &OsStr) -> 
             .filter(|required| !executable(Path::new(&required.path)))
             .map(|required| dependency_issue(hardener, command, required)),
     );
-    if has_stub_checks(command) {
+    if has_stub_checks(command) && launcher_collision.is_none() {
         let stub_issues = stub_issues(hardener, command);
         let stub_is_healthy = stub_issues.is_empty();
         issues.extend(stub_issues);
@@ -557,6 +562,34 @@ fn diagnose_command(hardener: &str, command: &HardenerCommand, path: &OsStr) -> 
         }
     }
     issues
+}
+
+fn executable_at_reserved_launcher_path(command: &HardenerCommand) -> Option<&str> {
+    (Path::new(&command.target_path) == Path::new(&command.name))
+        .then(|| command.stub_path.as_deref())
+        .flatten()
+        .filter(|stub| executable(Path::new(stub)))
+}
+
+fn target_at_launcher_path_issue(
+    hardener: &str,
+    command: &HardenerCommand,
+    stub: &str,
+) -> DoctorIssue {
+    DoctorIssue {
+        kind: "target_at_launcher_path",
+        command: Some(command.name.clone()),
+        message: format!(
+            "{} has an executable at its reserved Automic Vault Launcher path {stub}, but no separate Target is available",
+            command.name
+        ),
+        remediation: format!(
+            "Review and preserve the executable at {stub}. Move or reinstall the Target under a different directory on PATH, leaving {stub} absent, then run `av harden {hardener}`. The Hardener will show the exact Target path before installing the Launcher and will not overwrite the existing executable."
+        ),
+        stub_path: command.stub_path.clone(),
+        target_path: None,
+        resolved_path: Some(stub.to_string()),
+    }
 }
 
 fn isotope_path_issue(

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -63,6 +63,35 @@ fn av_doctor_omits_unhardened_tools_and_reports_hardened_stubs() {
 }
 
 #[test]
+fn av_doctor_reports_a_target_occupying_its_reserved_launcher_path() {
+    let root = temp_dir();
+    let stubs = root.join("stubs");
+    fs::create_dir_all(&stubs).unwrap();
+    let sentry_cli = stubs.join("sentry-cli");
+    executable(&sentry_cli);
+
+    let output = av(&root)
+        .args(["doctor", "sentry-cli", "--json"])
+        .env("PATH", &stubs)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let issues = report["results"][0]["issues"].as_array().unwrap();
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0]["kind"], "target_at_launcher_path");
+    assert_eq!(issues[0]["stub_path"], sentry_cli.display().to_string());
+    assert_eq!(issues[0]["resolved_path"], sentry_cli.display().to_string());
+    let remediation = issues[0]["remediation"].as_str().unwrap();
+    assert!(remediation.contains("Review and preserve the executable"));
+    assert!(remediation.contains("leaving"));
+    assert!(!remediation.contains("exec sentry-cli"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn av_doctor_rejects_unknown_commands() {
     let output = Command::new(env!("CARGO_BIN_EXE_av"))
         .args(["doctor", "definitely-not-a-hardener"])


### PR DESCRIPTION
## Summary
- detect when an executable occupies an environment wrapper’s reserved Launcher path but no separate Target exists
- report one precise `target_at_launcher_path` issue instead of contradictory missing-target and invalid-stub repairs
- preserve the fail-closed hardener behavior by directing the executable to be reviewed and preserved before the Launcher is installed
- add an end-to-end Doctor regression test for the `sentry-cli` layout

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked` (1,036 tests passed)
- `git diff --check`