### PR TITLE
Fix stale scans for unattributed detector findings

### DIFF
--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -69,6 +69,7 @@ pub(crate) fn run_detectors_json<W: Write>(stdout: &mut W) -> i32 {
                     "path": scope.path,
                     "recursive": scope.recursive,
                 })).collect::<Vec<_>>(),
+                "can_produce_unattributed_findings": detector.can_produce_unattributed_findings,
             })
         }).collect::<Vec<_>>(),
     });
@@ -544,6 +545,7 @@ mod tests {
         assert!(output.contains(r#""name":"git-credentials-file""#));
         assert!(output.contains(r##""documentation":"# git-credential-fill Detector"##));
         assert!(output.contains(r#""watch_scopes":[{"path":"#));
+        assert!(output.contains(r#""can_produce_unattributed_findings":true"#));
     }
 
     #[test]

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -161,6 +161,7 @@ pub(crate) struct DetectorMetadata {
     pub(crate) docs_url: String,
     pub(crate) documentation: &'static str,
     pub(crate) watch_scopes: Vec<DetectorWatchScope>,
+    pub(crate) can_produce_unattributed_findings: bool,
 }
 
 pub(crate) struct DetectorWatchScope {
@@ -178,6 +179,7 @@ struct Detector {
     findings: fn(&Path) -> Vec<Finding>,
     docs_url: &'static str,
     documentation: &'static str,
+    can_produce_unattributed_findings: bool,
 }
 
 #[cfg(test)]
@@ -195,6 +197,7 @@ macro_rules! detector {
                 "/detector.md"
             ),
             documentation: include_str!(concat!(stringify!($module), "/detector.md")),
+            can_produce_unattributed_findings: false,
         }
     };
     ($package:ident::$module:ident, $name:literal) => {
@@ -214,6 +217,27 @@ macro_rules! detector {
                 stringify!($module),
                 ".md"
             )),
+            can_produce_unattributed_findings: false,
+        }
+    };
+    ($package:ident::$module:ident, $name:literal, unattributed) => {
+        Detector {
+            module: $name,
+            findings: $package::$module::findings,
+            docs_url: concat!(
+                "https://github.com/automic-vault/automic-vault/blob/main/src/isotopes/detectors/",
+                stringify!($package),
+                "/",
+                stringify!($module),
+                ".md"
+            ),
+            documentation: include_str!(concat!(
+                stringify!($package),
+                "/",
+                stringify!($module),
+                ".md"
+            )),
+            can_produce_unattributed_findings: true,
         }
     };
 }
@@ -269,7 +293,7 @@ const DETECTORS: &[Detector] = &[
     detector!(gcli),
     detector!(gh_cli::hosts_token, "gh-cli-hosts-token"),
     detector!(gh_cli::keychain_access, "gh-cli-keychain-access"),
-    detector!(git::credential_fill, "git-credential-fill"),
+    detector!(git::credential_fill, "git-credential-fill", unattributed),
     detector!(git::credential_oauth, "git-credential-oauth"),
     detector!(git::credentials_file, "git-credentials-file"),
     detector!(glab),
@@ -343,7 +367,13 @@ const DETECTORS: &[Detector] = &[
     detector!(secretlint::shell_history, "secretlint-shell-history"),
     detector!(sentry_cli),
     detector!(shodan),
-    detector!(sip),
+    Detector {
+        module: "sip",
+        findings: sip::findings,
+        docs_url: "https://github.com/automic-vault/automic-vault/blob/main/src/isotopes/detectors/sip/detector.md",
+        documentation: include_str!("sip/detector.md"),
+        can_produce_unattributed_findings: true,
+    },
     detector!(skopeo),
     detector!(snowflake_cli),
     detector!(snyk),
@@ -538,6 +568,7 @@ pub(crate) fn metadata(home: &Path) -> Vec<DetectorMetadata> {
                 docs_url: detector.docs_url.to_string(),
                 name,
                 watch_scopes: sensitive_file_scopes(detector.documentation, home),
+                can_produce_unattributed_findings: detector.can_produce_unattributed_findings,
             }
         })
         .collect()
@@ -652,6 +683,9 @@ mod tests {
         assert!(names.contains(&"mysql@8.0".to_string()));
         assert!(names.contains(&"sudo".to_string()));
         assert!(names.contains(&"terraform-core".to_string()));
+        assert!(metadata.iter().find(|detector| detector.name == "git-credential-fill").unwrap().can_produce_unattributed_findings);
+        assert!(!metadata.iter().find(|detector| detector.name == "git-credential-oauth").unwrap().can_produce_unattributed_findings);
+        assert!(metadata.iter().find(|detector| detector.name == "sip").unwrap().can_produce_unattributed_findings);
         assert_eq!(
             metadata
                 .iter()

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -18,6 +18,7 @@ private let pendingSecretGateKey = "pendingSecretGate"
 let secCodeSignatureAdHoc: UInt32 = 0x2
 private let transientApprovalTTL: TimeInterval = 5 * 60
 private let scanMaximumDelay: TimeInterval = 5
+private let unattributedDetectorScanInterval: TimeInterval = 5 * 60
 private let scanQueue = DispatchQueue(label: "com.automicvault.av2.scan")
 private let updateCheckInterval: Duration = .seconds(24 * 60 * 60)
 private var toastWindows: [NSWindow] = []
@@ -91,6 +92,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var fileWatchSources: [DispatchSourceFileSystemObject] = []
     private var missingFileWatchDetectors: [String: Set<String>] = [:]
     private var missingFilePoller: DispatchSourceTimer?
+    private var unattributedDetectorPoller: DispatchSourceTimer?
     private var mainWindow: NSWindow?
     private var isUserSessionActive = true
     private var areScreensAwake = true
@@ -331,6 +333,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         scanWorkItem = nil
         scanBurstStartedAt = nil
         stopDetectorWatchers()
+        stopUnattributedDetectorPoller()
         approval?.stop()
         approval = nil
     }
@@ -642,6 +645,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         recursiveWatchDetectors = recursive
         startRecursiveWatcher(paths: Array(recursive.keys))
         startMissingFilePoller()
+        startUnattributedDetectorPoller()
     }
 
     private func startRecursiveWatcher(paths: [String]) {
@@ -712,6 +716,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         missingFilePoller = poller
     }
 
+    private func startUnattributedDetectorPoller() {
+        guard unattributedDetectorPoller == nil else { return }
+        let detectors = unattributedDetectorNames(detectorMetadata)
+        guard !detectors.isEmpty else { return }
+        let poller = DispatchSource.makeTimerSource(queue: .main)
+        poller.schedule(
+            deadline: .now() + unattributedDetectorScanInterval,
+            repeating: unattributedDetectorScanInterval
+        )
+        poller.setEventHandler { [weak self] in
+            self?.scheduleScan(detectors: detectors, after: 0)
+        }
+        poller.resume()
+        unattributedDetectorPoller = poller
+    }
+
     private func stopDetectorWatchers() {
         fileWatchSources.forEach { $0.cancel() }
         fileWatchSources.removeAll()
@@ -725,6 +745,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             FSEventStreamRelease(eventStream)
             self.eventStream = nil
         }
+    }
+
+    private func stopUnattributedDetectorPoller() {
+        unattributedDetectorPoller?.cancel()
+        unattributedDetectorPoller = nil
     }
 
     private func scheduleScan(detectors: Set<String>? = nil, after delay: TimeInterval) {
@@ -1046,6 +1071,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 private func scanDetectorGroup(_ detectors: Set<String>) -> Set<String> {
     guard !detectors.isDisjoint(with: ["bash", "zsh"]) else { return detectors }
     return detectors.union(["bash", "zsh"])
+}
+
+private func unattributedDetectorNames(_ metadata: [DetectorMetadata]) -> Set<String> {
+    Set(metadata.lazy.filter(\.canProduceUnattributedFindings).map(\.name))
 }
 
 extension AppDelegate: NSMenuDelegate {
@@ -7718,7 +7747,12 @@ private func runScanSchedulingSelfCheck() -> Int32 {
         maximumDelay: 5
     ) == 0,
     scanDetectorGroup(["npm"]) == ["npm"],
-    scanDetectorGroup(["bash"]) == ["bash", "zsh"]
+    scanDetectorGroup(["bash"]) == ["bash", "zsh"],
+    unattributedDetectorNames([
+        DetectorMetadata(name: "git-credential-fill", homepage: "", docsURL: "", canProduceUnattributedFindings: true),
+        DetectorMetadata(name: "git-credential-oauth", homepage: "", docsURL: ""),
+        DetectorMetadata(name: "sip", homepage: "", docsURL: "", canProduceUnattributedFindings: true),
+    ]) == ["git-credential-fill", "sip"]
     else {
         return 1
     }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -143,6 +143,7 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
     public let docsURL: String
     public let documentation: String
     public let watchScopes: [DetectorWatchScope]
+    public let canProduceUnattributedFindings: Bool
 
     public var displayName: DetectorDisplayName {
         detectorDisplayName(name)
@@ -153,13 +154,15 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
         homepage: String,
         docsURL: String,
         documentation: String = "",
-        watchScopes: [DetectorWatchScope] = []
+        watchScopes: [DetectorWatchScope] = [],
+        canProduceUnattributedFindings: Bool = false
     ) {
         self.name = name
         self.homepage = homepage
         self.docsURL = docsURL
         self.documentation = documentation
         self.watchScopes = watchScopes
+        self.canProduceUnattributedFindings = canProduceUnattributedFindings
     }
 
     public init(from decoder: Decoder) throws {
@@ -169,6 +172,7 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
         self.docsURL = try container.decode(String.self, forKey: .docsURL)
         self.documentation = try container.decodeIfPresent(String.self, forKey: .documentation) ?? ""
         self.watchScopes = try container.decodeIfPresent([DetectorWatchScope].self, forKey: .watchScopes) ?? []
+        self.canProduceUnattributedFindings = try container.decodeIfPresent(Bool.self, forKey: .canProduceUnattributedFindings) ?? false
     }
 
     enum CodingKeys: String, CodingKey {
@@ -177,6 +181,7 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
         case docsURL = "docs_url"
         case documentation
         case watchScopes = "watch_scopes"
+        case canProduceUnattributedFindings = "can_produce_unattributed_findings"
     }
 }
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -51,7 +51,7 @@ import Testing
 
 @Test func detectorMetadataDecodesAllDetectors() throws {
     let data = Data("""
-    {"detectors":[{"name":"git","homepage":"https://git-scm.com/","docs_url":"https://example.test/git","documentation":"# git Detector","watch_scopes":[{"path":"/Users/tester/.gitconfig","recursive":false}]}]}
+    {"detectors":[{"name":"git","homepage":"https://git-scm.com/","docs_url":"https://example.test/git","documentation":"# git Detector","watch_scopes":[{"path":"/Users/tester/.gitconfig","recursive":false}],"can_produce_unattributed_findings":true}]}
     """.utf8)
 
     #expect(try detectorMetadata(from: data) == [
@@ -60,7 +60,8 @@ import Testing
             homepage: "https://git-scm.com/",
             docsURL: "https://example.test/git",
             documentation: "# git Detector",
-            watchScopes: [DetectorWatchScope(path: "/Users/tester/.gitconfig", recursive: false)]
+            watchScopes: [DetectorWatchScope(path: "/Users/tester/.gitconfig", recursive: false)],
+            canProduceUnattributedFindings: true
         )
     ])
 }


### PR DESCRIPTION
Fixes #231

## Cause and fix

The menu helper only scheduled detector rescans from declared watch scopes and affected finding paths. `git-credential-fill` can return a live finding without an affected path, so its state could remain stale when Keychain-backed credentials changed. SIP also reports unattributed live state.

Detector metadata now explicitly identifies detectors that can emit unattributed findings. The menu helper keeps its scoped file watchers and adds one five-minute timer that re-scans only that metadata-defined set. The timer is not reset by normal watcher rebuilds, preventing unrelated filesystem activity from indefinitely delaying the fallback scan.

## Security reasoning

This only adds detection refreshes; it does not alter authorization, findings, remediation, or fail-closed behavior. The detector set is explicit and defaults to false for older CLI metadata.

## Tests

- `swift test --package-path src/menu-helper`
- `swift run --package-path src/menu-helper AutomicVaultMenubar --self-check-scan-scheduling`
- Rust tests were not runnable locally because Cargo is not installed in this environment.

## Rollback

Revert this PR to remove the metadata field and fallback timer; existing file-watch scheduling remains unchanged.