### PR TITLE
Add kubectl credential hardener

### DIFF
--- a/docs/adr/0037-kubectl-exec-credential-custody.md
+++ b/docs/adr/0037-kubectl-exec-credential-custody.md
@@ -25,8 +25,8 @@ kubeconfig user, Kubernetes API server, credential kind, live parent kubectl
 Target, and complete parent arguments. Unknown fields, multiple kubeconfig
 paths, basic authentication, credential files, auth-provider plugins,
 pre-existing exec plugins, ambiguous credentials, and unsafe filesystem state
-fail closed. The Authorization Record is persisted before the credential is
-released.
+fail closed. Cluster endpoints must use HTTPS with certificate verification
+enabled. The Authorization Record is persisted before the credential is released.
 
 ## Consequences
 

--- a/docs/adr/0037-kubectl-exec-credential-custody.md
+++ b/docs/adr/0037-kubectl-exec-credential-custody.md
@@ -1,0 +1,38 @@
+# ADR 0037: kubectl ExecCredential Custody
+
+- Status: Accepted
+- Date: 2026-09-01
+
+## Context
+
+kubeconfig can contain bearer tokens, client certificates, and private keys in
+plaintext. Kubernetes supports an `ExecCredential` plugin, but its request
+describes the cluster rather than the kubectl operation. Upstream macOS kubectl
+releases are ad-hoc signed and therefore do not provide the Developer ID,
+Hardened Runtime Target identity required by an Automic Vault Authorization
+Gate.
+
+## Decision
+
+The kubectl hardener installs an unmodified Automic Vault Isotope signed with
+Developer ID, Hardened Runtime, and no entitlements. It migrates supported inline
+bearer tokens and complete inline client certificate/key pairs to Global Values,
+then rewrites one kubeconfig to invoke `/usr/local/bin/av kubectl-credential`
+through Kubernetes' native version-one `ExecCredential` protocol.
+
+The Gate Client and menu helper independently bind each request to the exact
+kubeconfig user, Kubernetes API server, credential kind, live parent kubectl
+Target, and complete parent arguments. Unknown fields, multiple kubeconfig
+paths, basic authentication, credential files, auth-provider plugins,
+pre-existing exec plugins, ambiguous credentials, and unsafe filesystem state
+fail closed. The Authorization Record is persisted before the credential is
+released.
+
+## Consequences
+
+kubectl receives the credential format it natively expects without a source
+patch. The Isotope signature protects Target integrity but does not prove
+operation intent. Every request therefore classifies as Unknown and initially
+requires Approval. `ExecCredential` caching may retain the credential within the
+verified kubectl process until its normal cache invalidation boundary; Automic
+Vault does not claim per-API-operation authorization.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,6 +265,14 @@ menu shows any available Verified Launcher attribution, Target, and Secret
 Names. Process liveness changes display state only: it grants no authority and
 cannot revoke Secret Values already released.
 
+The kubectl credential helper additionally binds Secret Application to the
+exact kubeconfig user and normalized Kubernetes API server supplied through
+Kubernetes' native `ExecCredential` request. The signed kubectl Isotope remains
+unmodified; its Hardened Runtime identity establishes the Target boundary, not
+operation intent. kubectl operations therefore classify as Unknown and require
+Approval unless a later design introduces independently verified operation
+context.
+
 Grants are memory-only and running countdowns use both wall-clock and monotonic
 deadlines. Suspending freezes the lesser remaining duration from those clocks
 and makes the grant ineligible to authorize requests. Resuming creates new

--- a/scripts/test-menu-helper-self-checks.sh
+++ b/scripts/test-menu-helper-self-checks.sh
@@ -45,6 +45,7 @@ checks=(
   --self-check-terraform-credentials
   --self-check-aliyun-credentials
   --self-check-wakatime-credentials
+  --self-check-kubectl-credentials
   --self-check-oxide-credentials
   --self-check-goat-credentials
   --self-check-railway-credentials

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1667,6 +1667,7 @@ mod tests {
                                 | "uaa-cli"
                                 | "railway"
                                 | "rclone"
+                                | "kubectl"
                                 | "oxide-cli"
                                 | "stripe"
                                 | "supabase"

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -51,6 +51,7 @@ struct ApprovalRequest {
     openhue_scope: Option<String>,
     uaa_scope: Option<String>,
     railway_scope: Option<String>,
+    kubectl_scope: Option<String>,
     wakatime_api_url: Option<String>,
 }
 
@@ -367,6 +368,7 @@ fn approval_request(
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     })
 }
@@ -395,6 +397,7 @@ pub(super) fn docker_credential(key: String, server_url: String) -> Result<Strin
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -430,6 +433,7 @@ pub(super) fn terraform_credential(key: String, hostname: String) -> Result<Stri
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -465,6 +469,7 @@ pub(super) fn aliyun_credential(key: String, profile: String) -> Result<String, 
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -500,6 +505,7 @@ pub(super) fn wakatime_credential(key: String, api_url: String) -> Result<String
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: Some(api_url),
     };
     if crate::test_keychain_dir().is_some() {
@@ -535,6 +541,7 @@ pub(super) fn rclone_password(key: String) -> Result<String, String> {
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -569,8 +576,8 @@ pub(super) fn kubectl_credential(key: String, scope: String) -> Result<String, S
         ordercli_scope: None,
         openhue_scope: None,
         uaa_scope: None,
-        // kubectl is the only new scope and reuses this internal slot to keep the wire struct flat.
-        railway_scope: Some(scope),
+        railway_scope: None,
+        kubectl_scope: Some(scope),
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -606,6 +613,7 @@ pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, Str
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -641,6 +649,7 @@ pub(super) fn goat_credential(key: String, scope: String) -> Result<String, Stri
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -676,6 +685,7 @@ pub(super) fn railway_credential(key: String, scope: String) -> Result<String, S
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: Some(scope),
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -711,6 +721,7 @@ pub(super) fn ordercli_credential(key: String, scope: String) -> Result<String, 
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -746,6 +757,7 @@ pub(super) fn uaa_credential(key: String, scope: String) -> Result<String, Strin
         openhue_scope: None,
         uaa_scope: Some(scope),
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -781,6 +793,7 @@ pub(super) fn openhue_credential(key: String, scope: String) -> Result<String, S
         openhue_scope: Some(scope),
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -817,6 +830,7 @@ pub(super) fn plumber_credential(key: String, scope: String) -> Result<String, S
         openhue_scope: None,
         uaa_scope: None,
         railway_scope: None,
+        kubectl_scope: None,
         wakatime_api_url: None,
     };
     if crate::test_keychain_dir().is_some() {
@@ -1076,6 +1090,7 @@ pub(super) fn approve_gpg_signing(
             openhue_scope: None,
             uaa_scope: None,
             railway_scope: None,
+            kubectl_scope: None,
             wakatime_api_url: None,
         },
         response_keys,
@@ -1236,15 +1251,10 @@ fn xpc_approve_request(
             set_string(message, b"uaa_scope\0", scope)?;
         }
         if let Some(scope) = &request.railway_scope {
-            set_string(
-                message,
-                if request.tool == Some("kubectl") {
-                    b"kubectl_scope\0"
-                } else {
-                    b"railway_scope\0"
-                },
-                scope,
-            )?;
+            set_string(message, b"railway_scope\0", scope)?;
+        }
+        if let Some(scope) = &request.kubectl_scope {
+            set_string(message, b"kubectl_scope\0", scope)?;
         }
         if let Some(api_url) = &request.wakatime_api_url {
             set_string(message, b"wakatime_api_url\0", api_url)?;

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -546,6 +546,42 @@ pub(super) fn rclone_password(key: String) -> Result<String, String> {
         .ok_or_else(|| format!("Automic Vault returned no rclone config password for {key}"))
 }
 
+pub(super) fn kubectl_credential(key: String, scope: String) -> Result<String, String> {
+    validate_key_name(&key)?;
+    let request = ApprovalRequest {
+        op: "kubectl-get",
+        keys: vec![key.clone()],
+        target: String::new(),
+        args: Vec::new(),
+        cwd: crate::path_security::current_working_directory_utf8()?,
+        replace_existing_env: false,
+        allow_missing_keys: false,
+        env_conflicts: Vec::new(),
+        shebang_script: None,
+        script_data: None,
+        snapshot_incompatible_interpreter: None,
+        tool: Some("kubectl"),
+        docker_server_url: None,
+        terraform_hostname: None,
+        aliyun_profile: None,
+        oxide_scope: None,
+        goat_scope: None,
+        ordercli_scope: None,
+        openhue_scope: None,
+        uaa_scope: None,
+        // kubectl is the only new scope and reuses this internal slot to keep the wire struct flat.
+        railway_scope: Some(scope),
+        wakatime_api_url: None,
+    };
+    if crate::test_keychain_dir().is_some() {
+        return load_test_secret_if_present(&key)?
+            .ok_or_else(|| format!("failed to load secret {key}: -25300"));
+    }
+    xpc_approve_injection(&request)?
+        .remove(&key)
+        .ok_or_else(|| format!("Automic Vault returned no kubectl credential for {key}"))
+}
+
 pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
@@ -1200,7 +1236,15 @@ fn xpc_approve_request(
             set_string(message, b"uaa_scope\0", scope)?;
         }
         if let Some(scope) = &request.railway_scope {
-            set_string(message, b"railway_scope\0", scope)?;
+            set_string(
+                message,
+                if request.tool == Some("kubectl") {
+                    b"kubectl_scope\0"
+                } else {
+                    b"railway_scope\0"
+                },
+                scope,
+            )?;
         }
         if let Some(api_url) = &request.wakatime_api_url {
             set_string(message, b"wakatime_api_url\0", api_url)?;

--- a/src/cli/kubectl_credential.rs
+++ b/src/cli/kubectl_credential.rs
@@ -1,0 +1,207 @@
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::io::Write;
+
+use ring::digest::{SHA256, digest};
+use serde_json::{Value, json};
+
+const MAX_EXEC_INFO_BYTES: usize = 64 * 1024;
+const MAX_CREDENTIAL_BYTES: usize = 4 * 1024 * 1024;
+
+pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match run_inner(&args, stdout) {
+        Ok(()) => 0,
+        Err(error) => {
+            let _ = writeln!(stderr, "kubectl-credential: {error}");
+            1
+        }
+    }
+}
+
+fn run_inner(args: &[OsString], stdout: &mut dyn Write) -> Result<(), String> {
+    let [version, kind, user] = args else {
+        return Err("usage: av kubectl-credential 1 <token|client-certificate> <user>".into());
+    };
+    if version != "1" {
+        return Err("unsupported kubectl credential request".into());
+    }
+    let kind = kind
+        .to_str()
+        .ok_or_else(|| "kubectl credential kind must be UTF-8".to_string())?;
+    let user = user
+        .to_str()
+        .ok_or_else(|| "kubectl user name must be UTF-8".to_string())?;
+    validate_user(user)?;
+    if !matches!(kind, "token" | "client-certificate") {
+        return Err("unsupported kubectl credential kind".into());
+    }
+    let info = std::env::var("KUBERNETES_EXEC_INFO")
+        .map_err(|_| "KUBERNETES_EXEC_INFO is missing or is not UTF-8".to_string())?;
+    let server = exec_server(&info)?;
+    let scope = credential_scope(kind, &server, user)?;
+    let key = secret_name(user);
+    crate::secrets::ensure_kubectl_helper_ready()?;
+    let stored = super::inject::kubectl_credential(key, scope)?;
+    let status = credential_status(kind, &stored)?;
+    let response = json!({
+        "apiVersion": "client.authentication.k8s.io/v1",
+        "kind": "ExecCredential",
+        "status": status,
+    });
+    serde_json::to_writer(&mut *stdout, &response)
+        .map_err(|error| format!("failed to return kubectl credential: {error}"))?;
+    writeln!(stdout).map_err(|error| format!("failed to return kubectl credential: {error}"))
+}
+
+pub(crate) fn secret_name(user: &str) -> String {
+    let hash = digest(&SHA256, user.as_bytes());
+    let suffix = hash
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<String>();
+    format!("KUBECTL_USER_CREDENTIAL_{suffix}")
+}
+
+pub(crate) fn validate_user(user: &str) -> Result<(), String> {
+    if user.is_empty()
+        || user.len() > 1024
+        || user.trim() != user
+        || user.chars().any(|ch| ch.is_control())
+    {
+        return Err("invalid kubectl user name".into());
+    }
+    Ok(())
+}
+
+pub(crate) fn credential_scope(kind: &str, server: &str, user: &str) -> Result<String, String> {
+    validate_user(user)?;
+    if !matches!(kind, "token" | "client-certificate") {
+        return Err("unsupported kubectl credential kind".into());
+    }
+    let server = normalize_server(server)?;
+    let fields = BTreeMap::from([("kind", kind), ("server", server.as_str()), ("user", user)]);
+    serde_json::to_string(&fields)
+        .map_err(|error| format!("failed to encode kubectl scope: {error}"))
+}
+
+fn normalize_server(server: &str) -> Result<String, String> {
+    if server.is_empty() || server.len() > 4096 || !server.is_ascii() {
+        return Err("invalid Kubernetes API server".into());
+    }
+    let url = url::Url::parse(server).map_err(|_| "invalid Kubernetes API server")?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err("invalid Kubernetes API server".into());
+    }
+    Ok(url.to_string())
+}
+
+fn exec_server(input: &str) -> Result<String, String> {
+    if input.len() > MAX_EXEC_INFO_BYTES {
+        return Err("KUBERNETES_EXEC_INFO exceeds 64 KiB".into());
+    }
+    let value: Value = serde_json::from_str(input)
+        .map_err(|error| format!("invalid KUBERNETES_EXEC_INFO: {error}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "invalid KUBERNETES_EXEC_INFO".to_string())?;
+    if object.get("apiVersion").and_then(Value::as_str) != Some("client.authentication.k8s.io/v1")
+        || object.get("kind").and_then(Value::as_str) != Some("ExecCredential")
+    {
+        return Err("unsupported kubectl ExecCredential request".into());
+    }
+    let spec = object
+        .get("spec")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "kubectl ExecCredential request has no spec".to_string())?;
+    if spec.get("interactive").and_then(Value::as_bool) != Some(false) {
+        return Err("interactive kubectl credential requests are not supported".into());
+    }
+    let server = spec
+        .get("cluster")
+        .and_then(Value::as_object)
+        .and_then(|cluster| cluster.get("server"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| "kubectl ExecCredential request has no API server".to_string())?;
+    normalize_server(server)
+}
+
+pub(crate) fn credential_status(kind: &str, stored: &str) -> Result<Value, String> {
+    if stored.len() > MAX_CREDENTIAL_BYTES {
+        return Err("stored kubectl credential exceeds 4 MiB".into());
+    }
+    let object = serde_json::from_str::<Value>(stored)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .ok_or_else(|| "stored kubectl credential is invalid".to_string())?;
+    match kind {
+        "token" => {
+            if object.len() != 1 {
+                return Err("stored kubectl token is invalid".into());
+            }
+            let token = object
+                .get("token")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if token.is_empty() || token.len() > 1024 * 1024 || token.contains('\0') {
+                return Err("stored kubectl token is invalid".into());
+            }
+            Ok(json!({"token": token}))
+        }
+        "client-certificate" => {
+            if object.len() != 2 {
+                return Err("stored kubectl client certificate is invalid".into());
+            }
+            let certificate = object
+                .get("clientCertificateData")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let key = object
+                .get("clientKeyData")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if !certificate.contains("-----BEGIN CERTIFICATE-----")
+                || !key.contains("-----BEGIN")
+                || !key.contains("PRIVATE KEY-----")
+                || certificate.contains('\0')
+                || key.contains('\0')
+            {
+                return Err("stored kubectl client certificate is invalid".into());
+            }
+            Ok(json!({"clientCertificateData": certificate, "clientKeyData": key}))
+        }
+        _ => Err("unsupported kubectl credential kind".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scopes_are_canonical_and_bound_to_the_user_and_server() {
+        assert_eq!(
+            credential_scope("token", "https://EXAMPLE.com:443", "prod").unwrap(),
+            r#"{"kind":"token","server":"https://example.com/","user":"prod"}"#
+        );
+        assert!(credential_scope("token", "https://user@example.com", "prod").is_err());
+        assert!(credential_scope("token", "file:///tmp/socket", "prod").is_err());
+    }
+
+    #[test]
+    fn validates_exec_info_and_stored_credential_shape() {
+        let info = r#"{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{"interactive":false,"cluster":{"server":"https://example.com"}}}"#;
+        assert_eq!(exec_server(info).unwrap(), "https://example.com/");
+        assert_eq!(
+            credential_status("token", r#"{"token":"secret"}"#).unwrap(),
+            json!({"token": "secret"})
+        );
+        assert!(credential_status("token", r#"{"token":"secret","future":true}"#).is_err());
+    }
+}

--- a/src/cli/kubectl_credential.rs
+++ b/src/cli/kubectl_credential.rs
@@ -90,7 +90,7 @@ fn normalize_server(server: &str) -> Result<String, String> {
         return Err("invalid Kubernetes API server".into());
     }
     let url = url::Url::parse(server).map_err(|_| "invalid Kubernetes API server")?;
-    if !matches!(url.scheme(), "http" | "https")
+    if url.scheme() != "https"
         || url.host_str().is_none()
         || !url.username().is_empty()
         || url.password().is_some()
@@ -191,6 +191,7 @@ mod tests {
             r#"{"kind":"token","server":"https://example.com/","user":"prod"}"#
         );
         assert!(credential_scope("token", "https://user@example.com", "prod").is_err());
+        assert!(credential_scope("token", "http://example.com", "prod").is_err());
         assert!(credential_scope("token", "file:///tmp/socket", "prod").is_err());
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod doctor;
 pub(crate) mod goat_credential;
 mod gpg_sign;
 mod inject;
+pub(crate) mod kubectl_credential;
 mod launcher_bundle;
 mod list;
 mod open;
@@ -56,7 +57,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 41;
+pub(crate) const INSTALL_REVISION: u32 = 42;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -428,6 +429,10 @@ where
                 let result = hardeners::rclone::run(stdout, yes);
                 return finish_hardening(result, "rclone", stdout, stderr);
             }
+            if target == "kubectl" || target == "kubernetes-cli" {
+                let result = hardeners::kubectl::run(stdout, yes);
+                return finish_hardening(result, "kubectl", stdout, stderr);
+            }
             if target == "gh" || target == "gh-cli" {
                 let result = hardeners::gh_cli::run(stdout, yes);
                 return finish_hardening(result, "gh", stdout, stderr);
@@ -486,6 +491,7 @@ where
         Some("aliyun-credential") => aliyun_credential::run(rest, stdout, stderr),
         Some("oxide-credential") => oxide_credential::run(rest, stdout, stderr),
         Some("goat-credential") => goat_credential::run(rest, stdout, stderr),
+        Some("kubectl-credential") => kubectl_credential::run(rest, stdout, stderr),
         Some("ordercli-credential") => ordercli_credential::run(rest, stdout, stderr),
         Some("openhue-credential") => openhue_credential::run(rest, stdout, stderr),
         Some("plumber-credential") => plumber_credential::run(rest, stdout, stderr),

--- a/src/isotopes/detectors/kubernetes_cli/detector.md
+++ b/src/isotopes/detectors/kubernetes_cli/detector.md
@@ -9,11 +9,11 @@
 - `$KUBECONFIG`
 - `~/.kube/config`
 
-## Why This is not Yet Hardened
+## Hardening
 
-The retired hardener moved kubeconfig credentials to the macOS Keychain and
-rewrote supported users to call `av credential-helper kubernetes`. The current
-`av` CLI does not ship that credential-helper route. We need to review its
-approval-token boundary before restoring a hardener that changes kubeconfig.
+Run `av harden kubectl`. The hardener supports one kubeconfig containing inline
+bearer tokens or complete inline client certificate/key pairs. It stores each
+credential as a Global Value and configures Kubernetes' native `ExecCredential`
+protocol to request it from Automic Vault.
 
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+Unsupported, ambiguous, or unsafe kubeconfigs fail closed without being rewritten.

--- a/src/isotopes/hardeners/isotope.rs
+++ b/src/isotopes/hardeners/isotope.rs
@@ -129,6 +129,14 @@ pub(crate) const RCLONE: Spec = Spec {
     binaries: &["rclone"],
     test_path: "AUTOMIC_VAULT_TEST_RCLONE_TARGET",
 };
+pub(crate) const KUBECTL: Spec = Spec {
+    hardener: "kubectl",
+    formula: "kubectl-isotope",
+    repository: "kubectl",
+    primary: "kubectl",
+    binaries: &["kubectl"],
+    test_path: "AUTOMIC_VAULT_TEST_KUBECTL_TARGET",
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Spec {
@@ -361,6 +369,9 @@ pub(crate) fn install_privileged(
         }
         if spec.hardener == RCLONE.hardener {
             super::rclone::verify_target(&stage)?;
+        }
+        if spec.hardener == KUBECTL.hardener {
+            super::kubectl::verify_target(&stage)?;
         }
         staged.push((stage, bin_dir.join(binary)));
     }
@@ -683,16 +694,21 @@ fn conflicting_formula(spec: Spec) -> Option<String> {
         return crate::test_env_string("AUTOMIC_VAULT_TEST_ISOTOPE_CONFLICT")
             .filter(|formula| !formula.is_empty());
     }
+    let conflict = if spec.hardener == KUBECTL.hardener {
+        "kubernetes-cli"
+    } else {
+        spec.hardener
+    };
     ["/opt/homebrew/opt", "/usr/local/opt"]
         .map(|root| {
             Path::new(root)
-                .join(spec.hardener)
+                .join(conflict)
                 .join("bin")
                 .join(spec.primary)
         })
         .into_iter()
         .any(|path| executable(&path))
-        .then(|| spec.hardener.to_string())
+        .then(|| conflict.to_string())
 }
 
 fn direct_target(spec: Spec) -> PathBuf {
@@ -760,6 +776,9 @@ fn installed(spec: Spec, path: &Path) -> bool {
     if spec.hardener == RCLONE.hardener {
         return super::rclone::verify_target(path).is_ok();
     }
+    if spec.hardener == KUBECTL.hardener {
+        return super::kubectl::verify_target(path).is_ok();
+    }
     true
 }
 
@@ -770,7 +789,7 @@ fn formula_url(spec: Spec) -> String {
 fn spec(hardener: &str) -> Option<Spec> {
     [
         GH, STRIPE, SUPABASE, OPENTOFU, OXIDE, GOAT, RAILWAY, ORDERCLI, OPENHUE, UAA, PLUMBER,
-        ALIYUN, WAKATIME, RCLONE,
+        ALIYUN, WAKATIME, RCLONE, KUBECTL,
     ]
     .into_iter()
     .find(|spec| spec.hardener == hardener)

--- a/src/isotopes/hardeners/kubectl.md
+++ b/src/isotopes/hardeners/kubectl.md
@@ -1,0 +1,12 @@
+# kubectl Hardener
+
+The kubectl hardener installs the signed, unmodified kubectl Isotope and rewrites one
+safe kubeconfig to use Kubernetes' native `ExecCredential` protocol. Supported inline
+bearer tokens and client certificate/key pairs move to Automic Vault before the
+kubeconfig is replaced atomically.
+
+The migration fails closed for multiple kubeconfig paths, basic authentication,
+credential files, auth-provider plugins, pre-existing exec plugins, ambiguous
+credentials, unsafe file ownership or permissions, and incomplete certificate pairs.
+Every credential request initially requires approval and is bound to the exact
+kubeconfig user and Kubernetes API server.

--- a/src/isotopes/hardeners/kubectl.md
+++ b/src/isotopes/hardeners/kubectl.md
@@ -8,5 +8,6 @@ kubeconfig is replaced atomically.
 The migration fails closed for multiple kubeconfig paths, basic authentication,
 credential files, auth-provider plugins, pre-existing exec plugins, ambiguous
 credentials, unsafe file ownership or permissions, and incomplete certificate pairs.
-Every credential request initially requires approval and is bound to the exact
-kubeconfig user and Kubernetes API server.
+Clusters must use HTTPS with certificate verification enabled. Every credential
+request initially requires approval and is bound to the exact kubeconfig user and
+Kubernetes API server.

--- a/src/isotopes/hardeners/kubectl.rs
+++ b/src/isotopes/hardeners/kubectl.rs
@@ -1,0 +1,604 @@
+use std::collections::BTreeSet;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use base64::Engine;
+use serde_json::{Map, Value, json};
+
+use super::{
+    HardenerCommand, HardenerDetection, HardenerDiagnostic, RequiredExecutable,
+    SecretGateDescriptor, SecretGateRoute,
+};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const MAX_CONFIG_BYTES: u64 = 16 * 1024 * 1024;
+const TEAM_IDENTIFIER: &str = "ZU76A67LGU";
+
+struct Migration {
+    key: String,
+    value: String,
+}
+
+struct SanitizedConfig {
+    value: Value,
+    migrations: Vec<Migration>,
+    has_helper: bool,
+}
+
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
+    let testing = test_config_path().is_some();
+    super::PrivilegeMode::Mixed.require_user("kubectl", testing)?;
+    reject_competing_config()?;
+    if !testing {
+        crate::secrets::ensure_kubectl_helper_ready()?;
+    }
+    let config = config_path()?;
+    validate_config_file(&config)?;
+    let plan = super::isotope::plan(super::isotope::KUBECTL)?;
+
+    writeln!(stdout, "╭─ harden kubectl").ok();
+    writeln!(stdout, "│").ok();
+    plan.write(stdout, super::isotope::KUBECTL);
+    writeln!(
+        stdout,
+        "├─ migrate supported kubeconfig credentials without printing them"
+    )
+    .ok();
+    writeln!(
+        stdout,
+        "├─ configure kubectl's native ExecCredential protocol"
+    )
+    .ok();
+    writeln!(stdout, "├─ require approval for every credential use").ok();
+    writeln!(stdout, "│").ok();
+    if !super::gh_cli::confirm(stdout, yes)? {
+        writeln!(stdout, "╰─ cancelled").ok();
+        return Ok(());
+    }
+
+    plan.apply(super::isotope::KUBECTL)?;
+    let target = target();
+    verify_target(&target)?;
+    let original = render_config(&target, &config)?;
+    let sanitized = sanitize_config(original)?;
+    if !sanitized.has_helper && sanitized.migrations.is_empty() {
+        return Err("kubeconfig has no supported inline credentials to harden".into());
+    }
+    for migration in &sanitized.migrations {
+        crate::secrets::store_secret_if_absent_or_equal(&migration.key, &migration.value)?;
+    }
+    if !sanitized.migrations.is_empty() {
+        write_config(&config, &sanitized.value)?;
+    }
+    let verified = sanitize_config(render_config(&target, &config)?)?;
+    if !verified.has_helper || !verified.migrations.is_empty() {
+        return Err("kubectl reported success but kubeconfig is not hardened".into());
+    }
+
+    writeln!(stdout, "╰─ hardened kubectl").ok();
+    super::write_secret_gate_notice(stdout, "kubectl");
+    Ok(())
+}
+
+pub(crate) fn detect() -> HardenerDetection {
+    let testing = test_config_path().is_some();
+    let target = target();
+    let target_valid = verify_target(&target).is_ok();
+    let config = config_path().ok();
+    let config_valid = config.as_deref().is_some_and(|path| {
+        validate_config_file(path).is_ok()
+            && target_valid
+            && render_config(&target, path)
+                .and_then(sanitize_config)
+                .is_ok_and(|state| state.has_helper && state.migrations.is_empty())
+    });
+    let hardened = target_valid && config_valid;
+    let isotope = super::isotope::detect(super::isotope::KUBECTL)
+        .commands
+        .into_iter()
+        .next()
+        .and_then(|command| command.isotope);
+    let command = HardenerCommand {
+        name: "kubectl".into(),
+        hardened,
+        stub_valid: true,
+        stub_path: None,
+        target_path: target.display().to_string(),
+        required_paths: if testing {
+            Vec::new()
+        } else {
+            vec![RequiredExecutable {
+                name: "Automic Vault CLI",
+                path: AV_PATH.into(),
+            }]
+        },
+        stub_requirements: None,
+        injected_keys: Vec::new(),
+        assignment_keys: Vec::new(),
+        isotope,
+    };
+    let mut detection = HardenerDetection::commands(hardened, vec![command]);
+    detection.applicable = config.as_deref().is_some_and(Path::exists) || target.exists();
+    if target.exists() && !target_valid && !testing {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "kubectl_target_invalid",
+            message: verify_target(&target).unwrap_err(),
+            remediation: "Rerun `av harden kubectl` to install the signed kubectl Isotope.".into(),
+            path: Some(target.display().to_string()),
+        });
+    }
+    if config.as_deref().is_some_and(Path::exists) && !config_valid {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "kubectl_config_not_hardened",
+            message: "kubeconfig is not in the supported Hardened State.".into(),
+            remediation:
+                "Rerun `av harden kubectl`; unsupported credential routes must be removed manually."
+                    .into(),
+            path: config.map(|path| path.display().to_string()),
+        });
+    }
+    detection
+}
+
+pub(crate) fn secret_gate() -> SecretGateDescriptor {
+    SecretGateDescriptor {
+        id: "kubectl",
+        key_patterns: vec!["KUBECTL_USER_CREDENTIAL_*".into()],
+        routes: vec![SecretGateRoute {
+            operation: "kubectl-get",
+            script_path: None,
+            target_path: target().display().to_string(),
+            caller_identifiers: vec!["com.automicvault.av"],
+            key_patterns: vec!["KUBECTL_USER_CREDENTIAL_*".into()],
+            replace_existing_env: false,
+            allow_missing_keys: false,
+        }],
+    }
+}
+
+fn reject_competing_config() -> Result<(), String> {
+    let Some(value) = std::env::var_os("KUBECONFIG").filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    let paths = std::env::split_paths(&value).collect::<Vec<_>>();
+    if paths.len() != 1 || !paths[0].is_absolute() {
+        return Err("KUBECONFIG must name exactly one absolute kubeconfig before hardening".into());
+    }
+    Ok(())
+}
+
+fn config_path() -> Result<PathBuf, String> {
+    if let Some(path) = test_config_path() {
+        return Ok(path);
+    }
+    if let Some(value) = std::env::var_os("KUBECONFIG").filter(|value| !value.is_empty()) {
+        reject_competing_config()?;
+        return Ok(PathBuf::from(value));
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is not set".to_string())?;
+    Ok(home.join(".kube/config"))
+}
+
+fn test_config_path() -> Option<PathBuf> {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_KUBECTL_CONFIG").map(PathBuf::from)
+}
+
+fn target() -> PathBuf {
+    super::isotope::target(super::isotope::KUBECTL)
+}
+
+fn validate_config_file(path: &Path) -> Result<(), String> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    if !metadata.file_type().is_file()
+        || metadata.len() > MAX_CONFIG_BYTES
+        || metadata.uid() != super::effective_uid()
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(format!("refusing unsafe kubeconfig {}", path.display()));
+    }
+    Ok(())
+}
+
+fn render_config(target: &Path, config: &Path) -> Result<Value, String> {
+    let output = Command::new(target)
+        .arg(format!("--kubeconfig={}", config.display()))
+        .args(["config", "view", "--raw", "-o", "json"])
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("failed to run {}: {error}", target.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "kubectl could not parse {}: {}",
+            config.display(),
+            output.status
+        ));
+    }
+    if output.stdout.len() as u64 > MAX_CONFIG_BYTES {
+        return Err("rendered kubeconfig exceeds 16 MiB".into());
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("kubectl returned invalid kubeconfig JSON: {error}"))
+}
+
+fn sanitize_config(mut root: Value) -> Result<SanitizedConfig, String> {
+    let users = root
+        .as_object_mut()
+        .and_then(|root| root.get_mut("users"))
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| "kubeconfig has no users array".to_string())?;
+    let mut names = BTreeSet::new();
+    let mut migrations = Vec::new();
+    let mut has_helper = false;
+    for entry in users {
+        let entry = entry
+            .as_object_mut()
+            .ok_or_else(|| "kubeconfig contains an invalid user entry".to_string())?;
+        let name = entry
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "kubeconfig contains a user without a name".to_string())?
+            .to_string();
+        crate::cli::kubectl_credential::validate_user(&name)?;
+        if !names.insert(name.clone()) {
+            return Err(format!("kubeconfig contains duplicate user {name:?}"));
+        }
+        let auth = entry
+            .get_mut("user")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| format!("kubeconfig user {name:?} has invalid authentication data"))?;
+        if exact_helper(auth, &name) {
+            has_helper = true;
+            continue;
+        }
+        reject_unsupported_auth(auth, &name)?;
+        let token = auth
+            .get("token")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty());
+        let certificate = auth
+            .get("client-certificate-data")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty());
+        let key = auth
+            .get("client-key-data")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty());
+        if certificate.is_some() != key.is_some() {
+            return Err(format!(
+                "kubeconfig user {name:?} has an incomplete client certificate"
+            ));
+        }
+        if token.is_some() && certificate.is_some() {
+            return Err(format!(
+                "kubeconfig user {name:?} has ambiguous credentials"
+            ));
+        }
+        let (kind, stored) = if let Some(token) = token {
+            if token.len() > 1024 * 1024 || token.contains('\0') {
+                return Err(format!("kubeconfig user {name:?} has an invalid token"));
+            }
+            ("token", json!({"token": token}))
+        } else if let (Some(certificate), Some(key)) = (certificate, key) {
+            let certificate = decode_pem(certificate, "certificate", &name)?;
+            let key = decode_pem(key, "private key", &name)?;
+            if !certificate.contains("-----BEGIN CERTIFICATE-----")
+                || !key.contains("-----BEGIN")
+                || !key.contains("PRIVATE KEY-----")
+            {
+                return Err(format!(
+                    "kubeconfig user {name:?} has invalid PEM credentials"
+                ));
+            }
+            (
+                "client-certificate",
+                json!({"clientCertificateData": certificate, "clientKeyData": key}),
+            )
+        } else {
+            continue;
+        };
+        let stored = serde_json::to_string(&stored)
+            .map_err(|error| format!("failed to encode kubectl credential: {error}"))?;
+        migrations.push(Migration {
+            key: crate::cli::kubectl_credential::secret_name(&name),
+            value: stored,
+        });
+        auth.remove("token");
+        auth.remove("client-certificate-data");
+        auth.remove("client-key-data");
+        auth.insert("exec".into(), helper_config(kind, &name));
+        has_helper = true;
+    }
+    Ok(SanitizedConfig {
+        value: root,
+        migrations,
+        has_helper,
+    })
+}
+
+fn reject_unsupported_auth(auth: &Map<String, Value>, name: &str) -> Result<(), String> {
+    let safe = BTreeSet::from([
+        "token",
+        "client-certificate-data",
+        "client-key-data",
+        "impersonate",
+        "impersonate-uid",
+        "impersonate-groups",
+        "impersonate-user-extra",
+        "extensions",
+    ]);
+    if let Some(field) = auth
+        .iter()
+        .find(|(field, value)| !safe.contains(field.as_str()) && !value.is_null())
+        .map(|(field, _)| field)
+    {
+        return Err(format!(
+            "kubeconfig user {name:?} uses unsupported authentication field {field:?}"
+        ));
+    }
+    Ok(())
+}
+
+fn decode_pem(value: &str, label: &str, user: &str) -> Result<String, String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|_| format!("kubeconfig user {user:?} has invalid base64 {label}"))?;
+    if bytes.is_empty() || bytes.len() > 2 * 1024 * 1024 {
+        return Err(format!("kubeconfig user {user:?} has invalid {label}"));
+    }
+    String::from_utf8(bytes).map_err(|_| format!("kubeconfig user {user:?} has non-UTF-8 {label}"))
+}
+
+fn helper_config(kind: &str, user: &str) -> Value {
+    json!({
+        "apiVersion": "client.authentication.k8s.io/v1",
+        "command": AV_PATH,
+        "args": ["kubectl-credential", "1", kind, user],
+        "provideClusterInfo": true,
+        "interactiveMode": "Never",
+    })
+}
+
+fn exact_helper(auth: &Map<String, Value>, user: &str) -> bool {
+    auth.get("exec")
+        == Some(&helper_config(
+            auth.get("exec")
+                .and_then(Value::as_object)
+                .and_then(|exec| exec.get("args"))
+                .and_then(Value::as_array)
+                .and_then(|args| args.get(2))
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            user,
+        ))
+        && auth
+            .get("exec")
+            .and_then(Value::as_object)
+            .and_then(|exec| exec.get("args"))
+            .and_then(Value::as_array)
+            .and_then(|args| args.get(2))
+            .and_then(Value::as_str)
+            .is_some_and(|kind| matches!(kind, "token" | "client-certificate"))
+        && auth.keys().all(|field| {
+            matches!(
+                field.as_str(),
+                "exec"
+                    | "impersonate"
+                    | "impersonate-uid"
+                    | "impersonate-groups"
+                    | "impersonate-user-extra"
+                    | "extensions"
+            )
+        })
+}
+
+fn write_config(path: &Path, value: &Value) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "kubeconfig has no parent directory".to_string())?;
+    let metadata = fs::symlink_metadata(parent)
+        .map_err(|error| format!("failed to inspect {}: {error}", parent.display()))?;
+    if !metadata.file_type().is_dir()
+        || metadata.uid() != super::effective_uid()
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(format!(
+            "refusing unsafe kubeconfig directory {}",
+            parent.display()
+        ));
+    }
+    let staging = parent.join(format!(".config.av-{}.tmp", super::isotope::now_nanos()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&staging)
+            .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+        serde_json::to_writer_pretty(&mut file, value)
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        file.write_all(b"\n")
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        fs::rename(&staging, path)
+            .map_err(|error| format!("failed to replace {}: {error}", path.display()))?;
+        OpenOptions::new()
+            .read(true)
+            .open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("failed to sync {}: {error}", parent.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(staging);
+    }
+    result
+}
+
+pub(crate) fn verify_target(path: &Path) -> Result<(), String> {
+    if test_config_path().is_some() {
+        return path
+            .exists()
+            .then_some(())
+            .ok_or_else(|| format!("test kubectl Target is missing: {}", path.display()));
+    }
+    let requirement = format!(
+        "=identifier \"kubectl\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{TEAM_IDENTIFIER}\""
+    );
+    let status = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--strict", "-R", &requirement])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to verify {}: {error}", path.display()))?;
+    if !status.success() {
+        return Err(format!(
+            "kubectl Target signature is invalid: {}",
+            path.display()
+        ));
+    }
+    let output = Command::new("/usr/bin/codesign")
+        .args(["-d", "-vvv"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    let details = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success()
+        || !details.contains("flags=0x10000(runtime)")
+        || !details.contains(&format!("TeamIdentifier={TEAM_IDENTIFIER}"))
+        || !details.contains("Timestamp=")
+    {
+        return Err(
+            "kubectl Target lacks the required Developer ID Hardened Runtime identity".into(),
+        );
+    }
+    let entitlements = Command::new("/usr/bin/codesign")
+        .args(["-d", "--entitlements", ":-"])
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .output()
+        .map_err(|error| format!("failed to inspect kubectl entitlements: {error}"))?;
+    if !entitlements.status.success() || !entitlements.stdout.is_empty() {
+        return Err("kubectl Target has unexpected code-signing entitlements".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn migrates_only_supported_unambiguous_credentials() {
+        let input = json!({
+            "apiVersion": "v1",
+            "kind": "Config",
+            "users": [{"name": "prod", "user": {"token": "secret"}}]
+        });
+        let sanitized = sanitize_config(input).unwrap();
+        assert!(sanitized.has_helper);
+        assert_eq!(sanitized.migrations.len(), 1);
+        assert_eq!(
+            sanitized.migrations[0].key,
+            crate::cli::kubectl_credential::secret_name("prod")
+        );
+        assert!(
+            sanitize_config(json!({
+                "users": [{"name": "prod", "user": {"username": "u", "password": "p"}}]
+            }))
+            .is_err()
+        );
+        assert!(
+            sanitize_config(json!({
+                "users": [{"name": "prod", "user": {"exec": {"command": "other"}}}]
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn recognizes_the_exact_generated_helper_only() {
+        let mut auth = Map::new();
+        auth.insert("exec".into(), helper_config("token", "prod"));
+        assert!(exact_helper(&auth, "prod"));
+        auth.get_mut("exec").unwrap()["command"] = json!("av");
+        assert!(!exact_helper(&auth, "prod"));
+    }
+
+    #[test]
+    fn hardener_migrates_a_token_and_installs_the_exact_exec_helper() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "av-kubectl-hardener-test-{}-{}",
+            std::process::id(),
+            super::super::isotope::now_nanos()
+        ));
+        let config = root.join("config");
+        let target = root.join("kubectl");
+        let keychain = root.join("keychain");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            &config,
+            r#"{"apiVersion":"v1","kind":"Config","users":[{"name":"prod","user":{"token":"secret"}}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            &target,
+            "#!/bin/sh\nfile=${1#--kubeconfig=}\n/bin/cat \"$file\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
+        let previous_kubeconfig = std::env::var_os("KUBECONFIG");
+        unsafe {
+            std::env::remove_var("KUBECONFIG");
+            std::env::set_var("AUTOMIC_VAULT_TEST_KUBECTL_CONFIG", &config);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KUBECTL_TARGET", &target);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        }
+
+        run(&mut Vec::new(), true).unwrap();
+
+        let hardened: Value = serde_json::from_slice(&fs::read(&config).unwrap()).unwrap();
+        assert!(hardened.to_string().contains("kubectl-credential"));
+        assert!(!hardened.to_string().contains("secret"));
+        assert_eq!(
+            fs::read_to_string(keychain.join(crate::cli::kubectl_credential::secret_name("prod")))
+                .unwrap(),
+            r#"{"token":"secret"}"#
+        );
+        assert!(detect().hardened);
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KUBECTL_CONFIG");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KUBECTL_TARGET");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+            if let Some(value) = previous_kubeconfig {
+                std::env::set_var("KUBECONFIG", value);
+            }
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/isotopes/hardeners/kubectl.rs
+++ b/src/isotopes/hardeners/kubectl.rs
@@ -236,6 +236,7 @@ fn render_config(target: &Path, config: &Path) -> Result<Value, String> {
 }
 
 fn sanitize_config(mut root: Value) -> Result<SanitizedConfig, String> {
+    validate_clusters(&root)?;
     let users = root
         .as_object_mut()
         .and_then(|root| root.get_mut("users"))
@@ -328,6 +329,47 @@ fn sanitize_config(mut root: Value) -> Result<SanitizedConfig, String> {
         migrations,
         has_helper,
     })
+}
+
+fn validate_clusters(root: &Value) -> Result<(), String> {
+    let clusters = root
+        .as_object()
+        .and_then(|root| root.get("clusters"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| "kubeconfig has no clusters array".to_string())?;
+    for entry in clusters {
+        let cluster = entry
+            .as_object()
+            .and_then(|entry| entry.get("cluster"))
+            .and_then(Value::as_object)
+            .ok_or_else(|| "kubeconfig contains an invalid cluster entry".to_string())?;
+        let server = cluster
+            .get("server")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "kubeconfig contains a cluster without a server".to_string())?;
+        if server.is_empty() || server.len() > 4096 || !server.is_ascii() {
+            return Err("kubeconfig contains an invalid Kubernetes API server".into());
+        }
+        let url = url::Url::parse(server)
+            .map_err(|_| "kubeconfig contains an invalid Kubernetes API server")?;
+        if url.scheme() != "https"
+            || url.host_str().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err("kubeconfig contains an unsafe Kubernetes API server".into());
+        }
+        if cluster
+            .get("insecure-skip-tls-verify")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            return Err("kubeconfig disables Kubernetes API certificate verification".into());
+        }
+    }
+    Ok(())
 }
 
 fn reject_unsupported_auth(auth: &Map<String, Value>, name: &str) -> Result<(), String> {
@@ -516,6 +558,7 @@ mod tests {
         let input = json!({
             "apiVersion": "v1",
             "kind": "Config",
+            "clusters": [{"name": "prod", "cluster": {"server": "https://example.com"}}],
             "users": [{"name": "prod", "user": {"token": "secret"}}]
         });
         let sanitized = sanitize_config(input).unwrap();
@@ -527,13 +570,25 @@ mod tests {
         );
         assert!(
             sanitize_config(json!({
+                "clusters": [{"name": "prod", "cluster": {"server": "https://example.com"}}],
                 "users": [{"name": "prod", "user": {"username": "u", "password": "p"}}]
             }))
             .is_err()
         );
         assert!(
             sanitize_config(json!({
+                "clusters": [{"name": "prod", "cluster": {"server": "https://example.com"}}],
                 "users": [{"name": "prod", "user": {"exec": {"command": "other"}}}]
+            }))
+            .is_err()
+        );
+        assert!(
+            sanitize_config(json!({
+                "clusters": [{"name": "prod", "cluster": {
+                    "server": "https://example.com",
+                    "insecure-skip-tls-verify": true
+                }}],
+                "users": [{"name": "prod", "user": {"token": "secret"}}]
             }))
             .is_err()
         );
@@ -562,7 +617,7 @@ mod tests {
         fs::create_dir_all(&root).unwrap();
         fs::write(
             &config,
-            r#"{"apiVersion":"v1","kind":"Config","users":[{"name":"prod","user":{"token":"secret"}}]}"#,
+            r#"{"apiVersion":"v1","kind":"Config","clusters":[{"name":"prod","cluster":{"server":"https://example.com"}}],"users":[{"name":"prod","user":{"token":"secret"}}]}"#,
         )
         .unwrap();
         fs::write(

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod gh_cli;
 pub(crate) mod goat;
 pub(crate) mod homebrew;
 pub(crate) mod isotope;
+pub(crate) mod kubectl;
 mod migrations;
 pub(crate) mod openhue_cli;
 pub(crate) mod ordercli;
@@ -134,7 +135,9 @@ pub(crate) struct RequiredIdentity {
 }
 
 pub(crate) fn write_secret_gate_notice(stdout: &mut dyn std::io::Write, gate_id: &str) {
-    let protection = if gate_id == "brew" {
+    let protection = if gate_id == "kubectl" {
+        "Approval Required"
+    } else if gate_id == "brew" {
         "Read & Update"
     } else {
         "Read Only"
@@ -309,6 +312,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
         gated_hardener!(uaa_cli, "uaa-cli"),
         gated_hardener!(railway, "railway"),
         gated_hardener!(rclone, "rclone"),
+        gated_hardener!(kubectl, "kubectl"),
         gated_hardener!(oxide_cli, "oxide-cli"),
         gated_hardener!(homebrew, "brew"),
         gated_hardener!(gh_cli, "gh"),

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -350,6 +350,7 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
         uaa_cli::secret_gate(),
         railway::secret_gate(),
         rclone::secret_gate(),
+        kubectl::secret_gate(),
         oxide_cli::secret_gate(),
         homebrew::secret_gate(),
         gh_cli::secret_gate(),
@@ -405,6 +406,13 @@ mod tests {
         assert_eq!(
             String::from_utf8(brew).unwrap(),
             "\n◇ `brew` defaults to Read & Update, adjust this in the app: `av open --secret-gate brew`\n"
+        );
+
+        let mut kubectl = Vec::new();
+        super::write_secret_gate_notice(&mut kubectl, "kubectl");
+        assert_eq!(
+            String::from_utf8(kubectl).unwrap(),
+            "\n◇ `kubectl` defaults to Approval Required, adjust this in the app: `av open --secret-gate kubectl`\n"
         );
     }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3240,6 +3240,13 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
+        case .kubectlHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
+            let requested = xpc_dictionary_get_uint64(message, "requested_version")
+            guard requested == 1 else {
+                reply(peer, to: message, ok: false, error: "kubectl helper protocol upgrade is required")
+                return
+            }
+            reply(peer, to: message, ok: true, error: nil, value: "1")
         case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing):
             handleInject(
                 message,
@@ -3251,7 +3258,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 signing: signing
             )
         case .inject, .keys, .authorize, .dockerGet, .goatGet, .ordercliGet, .openhueGet, .plumberGet, .uaaGet, .railwayGet,
-             .oxideGet, .terraformGet, .aliyunGet, .wakatimeGet, .rcloneGet:
+             .oxideGet, .terraformGet, .aliyunGet, .wakatimeGet, .rcloneGet, .kubectlGet:
             handleInject(
                 message,
                 on: peer,
@@ -3662,15 +3669,22 @@ private final class ApprovalServer: @unchecked Sendable {
                 helperPath: callerPath,
                 helperSigning: signing
             )
-            let conflicts = Set(rcloneRequest.envConflicts)
-            let selectionNames = rcloneRequest.keys.filter {
-                rcloneRequest.replaceExistingEnv || !conflicts.contains($0)
+            let kubectlRequest = try kubectlCredentialRequest(
+                from: message,
+                request: rcloneRequest,
+                helperIdentity: identity,
+                helperPath: callerPath,
+                helperSigning: signing
+            )
+            let conflicts = Set(kubectlRequest.envConflicts)
+            let selectionNames = kubectlRequest.keys.filter {
+                kubectlRequest.replaceExistingEnv || !conflicts.contains($0)
             }
             let selected = try secretValueCustody.bind(
                 names: selectionNames,
-                cwd: rcloneRequest.cwd
+                cwd: kubectlRequest.cwd
             )
-            request = approvalRequestWithCredentialContext(rcloneRequest.selecting(selected))
+            request = approvalRequestWithCredentialContext(kubectlRequest.selecting(selected))
         } catch {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
             return
@@ -6678,6 +6692,72 @@ private final class ApprovalServer: @unchecked Sendable {
         )
     }
 
+    private func kubectlCredentialRequest(
+        from message: xpc_object_t,
+        request: ApprovalRequest,
+        helperIdentity: AVProcessIdentity,
+        helperPath: String,
+        helperSigning: SigningInfo
+    ) throws -> ApprovalRequest {
+        guard request.op == "kubectl-get" else { return request }
+        guard request.tool == "kubectl",
+              isTrustedAvCaller(path: helperPath, signing: helperSigning),
+              request.target.isEmpty,
+              request.args.isEmpty,
+              request.keys.count == 1,
+              !request.replaceExistingEnv,
+              !request.allowMissingKeys,
+              request.envConflicts.isEmpty,
+              request.shebangScript == nil,
+              request.scriptData == nil,
+              let scopePointer = xpc_dictionary_get_string(message, "kubectl_scope"),
+              let scope = parseKubectlCredentialScope(String(cString: scopePointer)),
+              request.keys == [scope.secretName]
+        else { throw AppError("invalid kubectl credential request") }
+        let parent = try kubectlCredentialParent(for: helperIdentity)
+        return ApprovalRequest(
+            op: request.op,
+            keys: request.keys,
+            target: parent.target,
+            args: Array(parent.arguments.dropFirst()),
+            cwd: "/",
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: nil,
+            scriptData: nil,
+            tool: "kubectl",
+            title: "Use Kubernetes credential for \(scope.user)?",
+            detail: "The verified kubectl Target will receive this credential for \(scope.server).",
+            credentialScope: scope.canonical,
+            credentialParent: parent
+        )
+    }
+
+    private func kubectlCredentialParent(
+        for helperIdentity: AVProcessIdentity
+    ) throws -> CredentialHelperParent {
+        let parentPID = helperIdentity.ppid
+        var parentIdentity = AVProcessIdentity()
+        guard parentPID > 1,
+              av_process_identity(parentPID, &parentIdentity),
+              parentIdentity.euid == helperIdentity.euid,
+              let arguments = processArguments(parentPID),
+              !arguments.isEmpty
+        else { throw AppError("kubectl credential helper has no live parent") }
+        let target = pathString(parentIdentity)
+        guard kubectlTargetIdentityValid(pid: parentPID, path: target) else {
+            throw AppError("credential helper parent is not an eligible kubectl Target")
+        }
+        return CredentialHelperParent(
+            pid: parentPID,
+            startUsec: parentIdentity.start_usec,
+            euid: parentIdentity.euid,
+            target: target,
+            arguments: arguments
+        )
+    }
+
     private func terraformCredentialParent(
         for helperIdentity: AVProcessIdentity
     ) throws -> CredentialHelperParent {
@@ -6781,6 +6861,7 @@ private final class ApprovalServer: @unchecked Sendable {
         case "plumber": "plumber"
         case "railway": "railway"
         case "rclone": "rclone"
+        case "kubectl": "kubectl"
         case "tofu": "opentofu"
         case "terraform": "terraform"
         case "uaa": "uaa-cli"
@@ -6835,6 +6916,9 @@ private final class ApprovalServer: @unchecked Sendable {
         case "rclone":
             return credentialHelperTool(parent) == tool
                 && rcloneTargetIdentityValid(pid: parent.pid, path: parent.target)
+        case "kubectl":
+            return credentialHelperTool(parent) == tool
+                && kubectlTargetIdentityValid(pid: parent.pid, path: parent.target)
         default: return false
         }
     }
@@ -6965,6 +7049,18 @@ private final class ApprovalServer: @unchecked Sendable {
             && liveProcessHasNoEntitlements(pid: pid)
     }
 
+    private func kubectlTargetIdentityValid(pid: pid_t, path: String) -> Bool {
+        guard configuredSecretGateTarget("kubectl", matches: path),
+              let signing = liveSigningInfo(pid: pid),
+              signing.mainExecutable == path
+        else { return false }
+        return signing.identifier == "kubectl"
+            && signing.teamIdentifier == "ZU76A67LGU"
+            && signing.isDeveloperID
+            && signing.runtimeProtection == .hardened
+            && liveProcessHasNoEntitlements(pid: pid)
+    }
+
     private func configuredSecretGateTarget(_ gateID: String, matches path: String) -> Bool {
         secretGateDescriptors.first(where: { $0.id == gateID })?.routes.contains {
             normalizedExecutablePath($0.targetPath) == normalizedExecutablePath(path)
@@ -6976,7 +7072,7 @@ private final class ApprovalServer: @unchecked Sendable {
         awsRegistration: AWSRegistrationCandidate?
     ) throws -> AuthorizationFulfillmentTransaction<ApprovedFulfillmentMaterial> {
         let credentialParent: CredentialHelperParent?
-        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get", "aliyun-get", "wakatime-get", "rclone-get"]
+        if ["docker-get", "goat-get", "ordercli-get", "openhue-get", "plumber-get", "uaa-get", "railway-get", "oxide-get", "terraform-get", "aliyun-get", "wakatime-get", "rclone-get", "kubectl-get"]
             .contains(request.op)
         {
             guard let scope = request.credentialScope,
@@ -7019,6 +7115,11 @@ private final class ApprovalServer: @unchecked Sendable {
                     throw AppError("rclone credential scope changed before Secret Application")
                 }
                 expected = rcloneConfigPasswordSecretName
+            case "kubectl-get":
+                guard let kubectl = parseKubectlCredentialScope(scope) else {
+                    throw AppError("kubectl credential scope changed before Secret Application")
+                }
+                expected = kubectl.secretName
             default: expected = terraformCredentialSecretName(scope)
             }
             guard request.keys == [expected] else {
@@ -7088,6 +7189,11 @@ private final class ApprovalServer: @unchecked Sendable {
                       let value = secrets[rcloneConfigPasswordSecretName],
                       validRcloneConfigPassword(value)
                 else { throw AppError("rclone config password changed before Secret Application") }
+            } else if request.op == "kubectl-get" {
+                guard let scope = parseKubectlCredentialScope(scope),
+                      let value = secrets[scope.secretName],
+                      validKubectlCredential(value, kind: scope.kind)
+                else { throw AppError("kubectl credential changed before Secret Application") }
             } else {
                 guard let value = secrets[terraformCredentialSecretName(scope)],
                       parseTerraformCredential(value) != nil
@@ -7466,6 +7572,7 @@ private final class ApprovalServer: @unchecked Sendable {
         guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign"
             || op == "docker-get" || op == "goat-get" || op == "ordercli-get" || op == "openhue-get" || op == "plumber-get" || op == "uaa-get" || op == "railway-get"
             || op == "oxide-get" || op == "terraform-get" || op == "aliyun-get" || op == "wakatime-get"
+            || op == "rclone-get" || op == "kubectl-get"
             || op == "proxy-start"
         else { return nil }
         let scriptData: Data?
@@ -7882,6 +7989,8 @@ private func classifySecretGateRequest(
     case "wakatime-cli":
         return wakatimeRequestClassification(request.args)
     case "rclone":
+        return .unknown
+    case "kubectl":
         return .unknown
     case "aws":
         if awsRequestMayUseLongLivedCredentials(request) { return .secretDump }
@@ -8999,6 +9108,79 @@ private func validRcloneConfigPassword(_ value: String) -> Bool {
         && !value.unicodeScalars.contains(where: { [0, 10, 13].contains($0.value) })
 }
 
+private struct StoredKubectlCredentialScope {
+    let kind: String
+    let server: String
+    let user: String
+    let canonical: String
+
+    var secretName: String {
+        let hash = SHA256.hash(data: Data(user.utf8)).map { String(format: "%02X", $0) }.joined()
+        return "KUBECTL_USER_CREDENTIAL_\(hash)"
+    }
+}
+
+private func parseKubectlCredentialScope(_ value: String) -> StoredKubectlCredentialScope? {
+    guard value.utf8.count <= 8 * 1024,
+          let data = value.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          Set(object.keys) == Set(["kind", "server", "user"]),
+          let kind = object["kind"] as? String,
+          kind == "token" || kind == "client-certificate",
+          let server = object["server"] as? String,
+          server.utf8.count <= 4096,
+          server.unicodeScalars.allSatisfy(\.isASCII),
+          let components = URLComponents(string: server),
+          components.scheme == "http" || components.scheme == "https",
+          components.host?.isEmpty == false,
+          components.user == nil,
+          components.password == nil,
+          components.query == nil,
+          components.fragment == nil,
+          let user = object["user"] as? String,
+          !user.isEmpty,
+          user.utf8.count <= 1024,
+          user == user.trimmingCharacters(in: .whitespacesAndNewlines),
+          !user.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains),
+          let canonicalData = try? JSONSerialization.data(
+              withJSONObject: ["kind": kind, "server": server, "user": user],
+              options: [.sortedKeys, .withoutEscapingSlashes]
+          ),
+          let canonical = String(data: canonicalData, encoding: .utf8),
+          canonical == value
+    else { return nil }
+    return StoredKubectlCredentialScope(
+        kind: kind,
+        server: server,
+        user: user,
+        canonical: canonical
+    )
+}
+
+private func validKubectlCredential(_ value: String, kind: String) -> Bool {
+    guard value.utf8.count <= 4 * 1024 * 1024,
+          let data = value.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return false }
+    if kind == "token" {
+        guard Set(object.keys) == Set(["token"]), let token = object["token"] as? String else {
+            return false
+        }
+        return !token.isEmpty && token.utf8.count <= 1024 * 1024
+            && !token.unicodeScalars.contains(where: { $0.value == 0 })
+    }
+    guard kind == "client-certificate",
+          Set(object.keys) == Set(["clientCertificateData", "clientKeyData"]),
+          let certificate = object["clientCertificateData"] as? String,
+          let key = object["clientKeyData"] as? String
+    else { return false }
+    return certificate.contains("-----BEGIN CERTIFICATE-----")
+        && key.contains("-----BEGIN")
+        && key.contains("PRIVATE KEY-----")
+        && !certificate.unicodeScalars.contains(where: { $0.value == 0 })
+        && !key.unicodeScalars.contains(where: { $0.value == 0 })
+}
+
 private func isGhTokenKey(_ key: String) -> Bool {
     key.hasPrefix("GH_TOKEN_") && validSecretKeyName(key)
 }
@@ -9886,8 +10068,9 @@ private extension ApprovalServiceOperation {
         switch self {
         case .openWindow, .awsHelperVersion, .dockerHelperVersion, .goatHelperVersion,
              .ordercliHelperVersion, .openhueHelperVersion, .plumberHelperVersion, .uaaHelperVersion,
-             .railwayHelperVersion, .oxideHelperVersion,
-             .terraformHelperVersion, .aliyunHelperVersion: false
+             .railwayHelperVersion, .oxideHelperVersion, .terraformHelperVersion,
+             .aliyunHelperVersion, .wakatimeHelperVersion, .rcloneHelperVersion,
+             .kubectlHelperVersion: false
         default: true
         }
     }
@@ -13555,6 +13738,23 @@ private func runWakaTimeCredentialSelfCheck() -> Int32 {
     return 0
 }
 
+private func runKubectlCredentialSelfCheck() -> Int32 {
+    let canonical = #"{"kind":"token","server":"https://example.com/","user":"prod"}"#
+    guard let scope = parseKubectlCredentialScope(canonical),
+          scope.kind == "token",
+          scope.server == "https://example.com/",
+          scope.user == "prod",
+          scope.secretName
+              == "KUBECTL_USER_CREDENTIAL_6754AF9632A2745E85C293E5AAC0863370D9BD3330B9938C00CADFD215227D77",
+          validKubectlCredential(#"{"token":"secret"}"#, kind: "token"),
+          !validKubectlCredential(#"{"token":"secret","future":true}"#, kind: "token"),
+          parseKubectlCredentialScope(
+              #"{"kind":"token","server":"https://user@example.com/","user":"prod"}"#
+          ) == nil
+    else { return 1 }
+    return 0
+}
+
 private func runOxideCredentialSelfCheck() -> Int32 {
     let canonical = #"{"host":"https://oxide.example","profile":"prod"}"#
     guard oxideRequestClassification(["auth", "status"]) == .readOnly,
@@ -14690,6 +14890,10 @@ if CommandLine.arguments.contains("--self-check-aliyun-credentials") {
 
 if CommandLine.arguments.contains("--self-check-wakatime-credentials") {
     exit(runWakaTimeCredentialSelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-kubectl-credentials") {
+    exit(runKubectlCredentialSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-oxide-credentials") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -9131,7 +9131,7 @@ private func parseKubectlCredentialScope(_ value: String) -> StoredKubectlCreden
           server.utf8.count <= 4096,
           server.unicodeScalars.allSatisfy(\.isASCII),
           let components = URLComponents(string: server),
-          components.scheme == "http" || components.scheme == "https",
+          components.scheme == "https",
           components.host?.isEmpty == false,
           components.user == nil,
           components.password == nil,
@@ -13750,6 +13750,9 @@ private func runKubectlCredentialSelfCheck() -> Int32 {
           !validKubectlCredential(#"{"token":"secret","future":true}"#, kind: "token"),
           parseKubectlCredentialScope(
               #"{"kind":"token","server":"https://user@example.com/","user":"prod"}"#
+          ) == nil,
+          parseKubectlCredentialScope(
+              #"{"kind":"token","server":"http://example.com/","user":"prod"}"#
           ) == nil
     else { return 1 }
     return 0

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -12,6 +12,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case aliyunHelperVersion = "aliyun-helper-version"
     case wakatimeHelperVersion = "wakatime-helper-version"
     case rcloneHelperVersion = "rclone-helper-version"
+    case kubectlHelperVersion = "kubectl-helper-version"
     case inject
     case varlock
     case keys
@@ -31,6 +32,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case aliyunGet = "aliyun-get"
     case wakatimeGet = "wakatime-get"
     case rcloneGet = "rclone-get"
+    case kubectlGet = "kubectl-get"
     case dockerSave = "docker-save"
     case dockerDelete = "docker-delete"
     case goatSave = "goat-save"

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -636,7 +636,7 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     }
 
     public var initialProtection: SecretGateProtection {
-        if id == "gpg-signing" { return .noAccess }
+        if id == "gpg-signing" || id == "kubectl" { return .noAccess }
         return id == "brew" ? .readOnlyAndUpdates : .readOnly
     }
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -47,6 +47,11 @@ import Testing
     #expect(ApprovalServiceOperation.rcloneGet.rawValue == "rclone-get")
 }
 
+@Test func kubectlCredentialsHaveDedicatedWireOperations() {
+    #expect(ApprovalServiceOperation.kubectlHelperVersion.rawValue == "kubectl-helper-version")
+    #expect(ApprovalServiceOperation.kubectlGet.rawValue == "kubectl-get")
+}
+
 @Test func ordercliCredentialsHaveDedicatedWireOperations() {
     #expect(ApprovalServiceOperation.ordercliGet.rawValue == "ordercli-get")
     #expect(ApprovalServiceOperation.ordercliSave.rawValue == "ordercli-save")

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -5,6 +5,7 @@ const ALIYUN_HELPER_PROTOCOL_VERSION: u64 = 1;
 const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 2;
 const OXIDE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const GOAT_HELPER_PROTOCOL_VERSION: u64 = 1;
+const KUBECTL_HELPER_PROTOCOL_VERSION: u64 = 1;
 const ORDERCLI_HELPER_PROTOCOL_VERSION: u64 = 1;
 const OPENHUE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const PLUMBER_HELPER_PROTOCOL_VERSION: u64 = 1;
@@ -316,6 +317,31 @@ pub(crate) fn ensure_rclone_helper_ready() -> Result<(), String> {
             "the running Automic Vault app reported unsupported rclone helper version {version}"
         )),
         None => Err("the running Automic Vault app returned no rclone helper version".into()),
+    }
+}
+
+pub(crate) fn ensure_kubectl_helper_ready() -> Result<(), String> {
+    if crate::test_keychain_dir().is_some() {
+        return Ok(());
+    }
+    let reply = xpc_request(
+        "kubectl-helper-version",
+        None,
+        None,
+        None,
+        Some((b"requested_version\0", KUBECTL_HELPER_PROTOCOL_VERSION)),
+    )
+    .map_err(|error| {
+        format!(
+            "kubectl credential-helper protocol negotiation failed; update and open the Automic Vault app: {error}"
+        )
+    })?;
+    match reply.value.as_deref() {
+        Some("1") => Ok(()),
+        Some(version) => Err(format!(
+            "the running Automic Vault app reported unsupported kubectl helper version {version}"
+        )),
+        None => Err("the running Automic Vault app returned no kubectl helper version".into()),
     }
 }
 


### PR DESCRIPTION
## Summary

- install the signed, unmodified kubectl Isotope through the Automic Vault tap when Homebrew is available, with the standard direct-install fallback
- migrate supported inline kubeconfig bearer tokens and client certificate pairs into Global Values, then atomically replace them with the native ExecCredential helper
- add a kubectl Authorization Gate that binds every request to the verified live kubectl Target, exact user, credential kind, API server, and parent arguments
- fail closed on multiple kubeconfigs, unsupported authentication, unsafe config files, plaintext API endpoints, disabled TLS verification, invalid signatures, and unexpected entitlements

Packaging:
- Isotope fork: https://github.com/automic-vault/kubectl
- Signed release: https://github.com/automic-vault/kubectl/releases/tag/v1.37.0
- Formula: automic-vault/av/kubectl-isotope

Roadmap: #186

## Verification

- cargo test --all-targets --all-features --locked
- swift test in src/menu-helper: 241 passed
- scripts/test-menu-helper-self-checks.sh: 27 passed
- brew style Formula/kubectl-isotope.rb in av.tap