### PR TITLE
Harden Podman registry credentials

### DIFF
--- a/docs/adr/0038-podman-registry-credential-custody.md
+++ b/docs/adr/0038-podman-registry-credential-custody.md
@@ -1,0 +1,53 @@
+# ADR 0038: Podman registry credential custody
+
+- Status: Accepted
+- Date: 2026-09-01
+
+## Context
+
+On macOS, Podman is a remote client for a Linux service. Upstream's remote
+client reads the local containers/image authentication configuration and
+constructs the registry-auth request header before contacting that service.
+containers/image supports the Docker credential-helper protocol through the
+global `credential-helpers` setting in `registries.conf`.
+
+The official Podman package installs `/opt/podman/bin/podman` with Red Hat's
+Developer ID Application identity, Hardened Runtime, and no entitlements. A
+Podman Isotope would replace that upstream identity without narrowing the
+credential-helper protocol.
+
+## Decision
+
+The Podman Hardener preserves the official client and requires its canonical
+path, Red Hat team `HYSCB8KRL2`, identifier `podman`, Developer ID signature,
+Hardened Runtime, timestamp, and safe entitlements. Automic Vault does not
+install or relocate the upstream multi-file Podman package.
+
+The Hardener migrates supported registry-level credentials from Podman's
+primary macOS `auth.json` into Secret Custody, installs the existing root-owned
+`docker-credential-av` Gate Client, writes a final user
+`registries.conf.d` drop-in selecting helper `av`, and removes migrated inline
+credentials. Namespaced credentials and competing credential helpers fail
+closed because external helpers cannot preserve their semantics.
+
+Docker and Podman intentionally share the registry-address-bound Secret format
+and helper executable. For every `get`, `store`, and `erase`, the menu helper
+derives the Tool from the helper's live parent rather than trusting a client
+claim. It accepts Podman only at `/opt/podman/bin/podman` with the expected live
+code identity and runtime posture, binds the Authorization Request to the
+parent's complete arguments and registry, revalidates the process before Secret
+Application, and routes Podman through a distinct Authorization Gate.
+
+## Consequences
+
+No Podman source fork or Automic Vault Isotope is required while Red Hat ships
+an eligible client. Podman login, logout, pull, push, search, build, and other
+containers/image users can use the native helper without plaintext credential
+files. The verified Podman Target necessarily receives a usable credential in
+memory and the remote service necessarily receives it in the registry-auth
+header; neither boundary is controlled by Automic Vault after Secret
+Application.
+
+The optional helper `list` operation remains unsupported because it would
+disclose registry and account metadata. Podman operations whose intent cannot
+be classified safely remain Unknown and require Approval.

--- a/docs/adr/0038-podman-registry-credential-custody.md
+++ b/docs/adr/0038-podman-registry-credential-custody.md
@@ -23,20 +23,29 @@ path, Red Hat team `HYSCB8KRL2`, identifier `podman`, Developer ID signature,
 Hardened Runtime, timestamp, and safe entitlements. Automic Vault does not
 install or relocate the upstream multi-file Podman package.
 
-The Hardener migrates supported registry-level credentials from Podman's
-primary macOS `auth.json` into Secret Custody, installs the existing root-owned
-`docker-credential-av` Gate Client, writes a final user
-`registries.conf.d` drop-in selecting helper `av`, and removes migrated inline
-credentials. Namespaced credentials and competing credential helpers fail
-closed because external helpers cannot preserve their semantics.
+The Hardener migrates supported registry-level credentials from Podman's macOS
+auth files into Secret Custody, installs an exact root-owned
+`docker-credential-av-podman` launcher, writes a final user
+`registries.conf.d` drop-in selecting helper `av-podman`, and replaces migrated
+inline credentials with registry-only helper markers. Namespaced credentials
+and competing credential helpers fail closed because external helpers cannot
+preserve their semantics.
 
 Docker and Podman intentionally share the registry-address-bound Secret format
-and helper executable. For every `get`, `store`, and `erase`, the menu helper
-derives the Tool from the helper's live parent rather than trusting a client
-claim. It accepts Podman only at `/opt/podman/bin/podman` with the expected live
-code identity and runtime posture, binds the Authorization Request to the
-parent's complete arguments and registry, revalidates the process before Secret
-Application, and routes Podman through a distinct Authorization Gate.
+but use distinct exact helper launchers. For every `get`, `store`, and `erase`,
+the menu helper also verifies the helper's live parent rather than trusting the
+client claim. It accepts Podman only at `/opt/podman/bin/podman` with the
+expected live code identity and runtime posture, binds the Authorization
+Request to the parent's complete arguments and registry, revalidates the
+process before Secret Application, and routes Podman through a distinct
+Authorization Gate.
+
+The Podman helper implements `list` by reading only the registry markers already
+present in the user-readable auth file and returns empty usernames. It does not
+enumerate Secret Names or load Secret Values. Upstream Podman then requests each
+marked credential and sends the resulting multi-auth header to its Linux
+service. Every Podman credential read therefore classifies as a Secret Dump,
+regardless of the apparent command operation.
 
 ## Consequences
 
@@ -48,6 +57,8 @@ memory and the remote service necessarily receives it in the registry-auth
 header; neither boundary is controlled by Automic Vault after Secret
 Application.
 
-The optional helper `list` operation remains unsupported because it would
-disclose registry and account metadata. Podman operations whose intent cannot
-be classified safely remain Unknown and require Approval.
+Registry locations remain visible in Podman's auth file by necessity; account
+names and Secret Values do not. Adding a new registry through `podman login`
+stores the credential first and then atomically adds its marker. A failed marker
+write leaves the Secret safely stored but undiscoverable until login or
+hardening is retried.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,6 +273,15 @@ operation intent. kubectl operations therefore classify as Unknown and require
 Approval unless a later design introduces independently verified operation
 context.
 
+Podman uses the same registry credential-helper protocol as Docker, but its
+macOS remote client resolves credentials locally before sending an
+`X-Registry-Auth` header to the Linux service. The Podman Hardener keeps Red
+Hat's Developer ID-signed, Hardened Runtime client at `/opt/podman/bin/podman`,
+selects Automic Vault as the user's global containers/image credential helper,
+and removes migrated plaintext registry credentials. The shared helper derives
+whether Docker or Podman is requesting a credential from the live parent
+Target; each remains governed by its own Authorization Gate.
+
 Grants are memory-only and running countdowns use both wall-clock and monotonic
 deadlines. Suspending freezes the lesser remaining duration from those clocks
 and makes the grant ineligible to authorize requests. Resuming creates new

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,10 +277,12 @@ Podman uses the same registry credential-helper protocol as Docker, but its
 macOS remote client resolves credentials locally before sending an
 `X-Registry-Auth` header to the Linux service. The Podman Hardener keeps Red
 Hat's Developer ID-signed, Hardened Runtime client at `/opt/podman/bin/podman`,
-selects Automic Vault as the user's global containers/image credential helper,
-and removes migrated plaintext registry credentials. The shared helper derives
-whether Docker or Podman is requesting a credential from the live parent
-Target; each remains governed by its own Authorization Gate.
+selects a dedicated Automic Vault launcher as the user's global containers/image
+credential helper, and replaces migrated plaintext entries with registry-only
+helper markers. Docker and Podman share the registry credential Secret format,
+but each remains governed by its own Authorization Gate and exact launcher.
+Because the upstream remote protocol builds a header from every configured
+registry credential, Podman credential reads classify as a Secret Dump.
 
 Grants are memory-only and running countdowns use both wall-clock and monotonic
 deadlines. Suspending freezes the lesser remaining duration from those clocks

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -14,7 +14,7 @@ const MAX_SERVER_URL_BYTES: usize = 2048;
 const SECRET_PREFIX: &str = "DOCKER_REGISTRY_CREDENTIAL_";
 const CREDENTIALS_NOT_FOUND: &str = "credentials not found in native keychain";
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DockerCredential {
     pub(crate) server_url: String,
     pub(crate) username: String,

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -100,7 +100,7 @@ fn run_with_io(
     match action {
         "store" => {
             let credential = parse_credential(&read_limited(input)?)?;
-            crate::secrets::store_docker_credential(
+            crate::secrets::store_registry_credential(
                 &secret_name(&credential.server_url),
                 &credential.storage_json(),
             )?;
@@ -141,7 +141,7 @@ fn run_with_io(
         }
         "erase" => {
             let server_url = parse_server_url(&read_limited(input)?)?;
-            crate::secrets::delete_docker_credential(&secret_name(&server_url), &server_url)?;
+            crate::secrets::delete_registry_credential(&secret_name(&server_url), &server_url)?;
             if flavor == Flavor::Podman {
                 crate::isotopes::hardeners::podman::remove_helper_marker(&server_url)?;
             }
@@ -174,15 +174,15 @@ pub(crate) fn secret_name(server_url: &str) -> String {
 
 pub(crate) fn parse_credential(input: &str) -> Result<DockerCredential, String> {
     let value: Value = serde_json::from_str(input)
-        .map_err(|error| format!("invalid Docker credential JSON: {error}"))?;
+        .map_err(|error| format!("invalid registry credential JSON: {error}"))?;
     let object = value
         .as_object()
-        .ok_or_else(|| "Docker credential must be a JSON object".to_string())?;
+        .ok_or_else(|| "registry credential must be a JSON object".to_string())?;
     if object
         .keys()
         .any(|key| !["ServerURL", "Username", "Secret"].contains(&key.as_str()))
     {
-        return Err("Docker credential contains an unknown field".into());
+        return Err("registry credential contains an unknown field".into());
     }
     let string = |name: &str| {
         object
@@ -190,7 +190,7 @@ pub(crate) fn parse_credential(input: &str) -> Result<DockerCredential, String> 
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty())
             .map(str::to_string)
-            .ok_or_else(|| format!("Docker credential has no {name}"))
+            .ok_or_else(|| format!("registry credential has no {name}"))
     };
     let credential = DockerCredential {
         server_url: string("ServerURL")?,
@@ -199,7 +199,7 @@ pub(crate) fn parse_credential(input: &str) -> Result<DockerCredential, String> 
     };
     validate_server_url(&credential.server_url)?;
     if credential.username.as_bytes().contains(&0) || credential.secret.as_bytes().contains(&0) {
-        return Err("Docker credential contains NUL".into());
+        return Err("registry credential contains NUL".into());
     }
     Ok(credential)
 }
@@ -228,7 +228,7 @@ fn validate_server_url(server_url: &str) -> Result<(), String> {
             .bytes()
             .any(|byte| byte == 0 || byte == b'\r' || byte == b'\n')
     {
-        return Err("invalid Docker registry address".into());
+        return Err("invalid registry address".into());
     }
     Ok(())
 }

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -51,17 +51,21 @@ fn run_flavor(
     match run_with_io(flavor, args, &mut stdin, stdout) {
         Ok(()) => 0,
         Err(error) => {
-            write_error(&error, stdout, stderr);
+            write_error(flavor, &error, stdout, stderr);
             1
         }
     }
 }
 
-fn write_error(error: &str, stdout: &mut dyn Write, stderr: &mut dyn Write) {
+fn write_error(flavor: Flavor, error: &str, stdout: &mut dyn Write, stderr: &mut dyn Write) {
     if error == CREDENTIALS_NOT_FOUND {
         let _ = writeln!(stdout, "{error}");
     } else {
-        let _ = writeln!(stderr, "docker-credential-av: {error}");
+        let helper = match flavor {
+            Flavor::Docker => "docker-credential-av",
+            Flavor::Podman => "docker-credential-av-podman",
+        };
+        let _ = writeln!(stderr, "{helper}: {error}");
     }
 }
 
@@ -81,7 +85,11 @@ fn run_with_io(
     }
     args.remove(0);
     let [action] = args.as_slice() else {
-        return Err("usage: docker-credential-av <store|get|erase>".into());
+        return Err(match flavor {
+            Flavor::Docker => "usage: docker-credential-av <store|get|erase>",
+            Flavor::Podman => "usage: docker-credential-av-podman <store|get|erase|list>",
+        }
+        .into());
     };
     let action = action
         .to_str()
@@ -122,16 +130,14 @@ fn run_with_io(
             })?;
             let credential = parse_credential(&stored)?;
             if credential.server_url != server_url {
-                return Err(
-                    "stored Docker credential does not match the requested registry".into(),
-                );
+                return Err("stored credential does not match the requested registry".into());
             }
             writeln!(
                 output,
                 "{}",
                 json!({"Username": credential.username, "Secret": credential.secret})
             )
-            .map_err(|error| format!("failed to return Docker credential: {error}"))
+            .map_err(|error| format!("failed to return registry credential: {error}"))
         }
         "erase" => {
             let server_url = parse_server_url(&read_limited(input)?)?;
@@ -358,11 +364,11 @@ mod tests {
         .unwrap_err();
         assert_eq!(error, CREDENTIALS_NOT_FOUND);
         let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
-        write_error(&error, &mut stdout, &mut stderr);
+        write_error(Flavor::Docker, &error, &mut stdout, &mut stderr);
         assert_eq!(stdout, b"credentials not found in native keychain\n");
         assert!(stderr.is_empty());
         stdout.clear();
-        write_error("approval denied", &mut stdout, &mut stderr);
+        write_error(Flavor::Docker, "approval denied", &mut stdout, &mut stderr);
         assert!(stdout.is_empty());
         assert_eq!(stderr, b"docker-credential-av: approval denied\n");
         unsafe {

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -95,7 +95,7 @@ fn run_with_io(
         .to_str()
         .ok_or_else(|| "credential-helper action must be valid UTF-8".to_string())?;
     if matches!(action, "store" | "get" | "erase") {
-        crate::secrets::ensure_docker_helper_ready()?;
+        crate::secrets::ensure_registry_helper_ready()?;
     }
     match action {
         "store" => {

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -9,6 +9,8 @@ use super::inject;
 
 const HELPER_STUB: &str = "#!/usr/local/bin/av docker-credential\n";
 const HELPER_PATH: &str = "/usr/local/bin/docker-credential-av";
+const PODMAN_HELPER_STUB: &str = "#!/usr/local/bin/av podman-credential\n";
+const PODMAN_HELPER_PATH: &str = "/usr/local/bin/docker-credential-av-podman";
 const MAX_INPUT_BYTES: u64 = 64 * 1024;
 const MAX_SERVER_URL_BYTES: usize = 2048;
 const SECRET_PREFIX: &str = "DOCKER_REGISTRY_CREDENTIAL_";
@@ -21,9 +23,32 @@ pub(crate) struct DockerCredential {
     pub(crate) secret: String,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Flavor {
+    Docker,
+    Podman,
+}
+
 pub(crate) fn run(mut args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    run_flavor(Flavor::Docker, &mut args, stdout, stderr)
+}
+
+pub(crate) fn run_podman(
+    mut args: Vec<OsString>,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> i32 {
+    run_flavor(Flavor::Podman, &mut args, stdout, stderr)
+}
+
+fn run_flavor(
+    flavor: Flavor,
+    args: &mut Vec<OsString>,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> i32 {
     let mut stdin = std::io::stdin().lock();
-    match run_with_io(&mut args, &mut stdin, stdout) {
+    match run_with_io(flavor, args, &mut stdin, stdout) {
         Ok(()) => 0,
         Err(error) => {
             write_error(&error, stdout, stderr);
@@ -41,11 +66,15 @@ fn write_error(error: &str, stdout: &mut dyn Write, stderr: &mut dyn Write) {
 }
 
 fn run_with_io(
+    flavor: Flavor,
     args: &mut Vec<OsString>,
     input: &mut dyn Read,
     output: &mut dyn Write,
 ) -> Result<(), String> {
-    if !args.first().is_some_and(is_helper_stub_arg) {
+    if !args
+        .first()
+        .is_some_and(|arg| is_helper_stub_arg(flavor, arg))
+    {
         return Err(
             "refusing invocation without the installed Automic Vault helper launcher".into(),
         );
@@ -66,19 +95,31 @@ fn run_with_io(
             crate::secrets::store_docker_credential(
                 &secret_name(&credential.server_url),
                 &credential.storage_json(),
-            )
+            )?;
+            if flavor == Flavor::Podman {
+                crate::isotopes::hardeners::podman::add_helper_marker(&credential.server_url)?;
+            }
+            Ok(())
         }
         "get" => {
             let server_url = parse_server_url(&read_limited(input)?)?;
             let key = secret_name(&server_url);
-            let stored =
-                inject::docker_credential(key.clone(), server_url.clone()).map_err(|error| {
-                    if error == format!("failed to load secret {key}: -25300") {
-                        CREDENTIALS_NOT_FOUND.into()
-                    } else {
-                        error
-                    }
-                })?;
+            let stored = inject::docker_credential(
+                key.clone(),
+                server_url.clone(),
+                if flavor == Flavor::Podman {
+                    "podman"
+                } else {
+                    "docker"
+                },
+            )
+            .map_err(|error| {
+                if error == format!("failed to load secret {key}: -25300") {
+                    CREDENTIALS_NOT_FOUND.into()
+                } else {
+                    error
+                }
+            })?;
             let credential = parse_credential(&stored)?;
             if credential.server_url != server_url {
                 return Err(
@@ -94,8 +135,19 @@ fn run_with_io(
         }
         "erase" => {
             let server_url = parse_server_url(&read_limited(input)?)?;
-            crate::secrets::delete_docker_credential(&secret_name(&server_url), &server_url)
+            crate::secrets::delete_docker_credential(&secret_name(&server_url), &server_url)?;
+            if flavor == Flavor::Podman {
+                crate::isotopes::hardeners::podman::remove_helper_marker(&server_url)?;
+            }
+            Ok(())
         }
+        "list" if flavor == Flavor::Podman => writeln!(
+            output,
+            "{}",
+            serde_json::to_string(&crate::isotopes::hardeners::podman::helper_markers()?)
+                .map_err(|error| format!("failed to encode Podman registry markers: {error}"))?
+        )
+        .map_err(|error| format!("failed to return Podman registry markers: {error}")),
         "list" => Err(
             "list is intentionally unsupported because it discloses registry account metadata"
                 .into(),
@@ -189,11 +241,15 @@ fn read_limited(input: &mut dyn Read) -> Result<String, String> {
     String::from_utf8(bytes).map_err(|_| "credential-helper input must be valid UTF-8".into())
 }
 
-fn is_helper_stub_arg(arg: &OsString) -> bool {
+fn is_helper_stub_arg(flavor: Flavor, arg: &OsString) -> bool {
     let path = PathBuf::from(arg);
-    path == helper_path()
+    let (expected_path, stub) = match flavor {
+        Flavor::Docker => (helper_path(), HELPER_STUB),
+        Flavor::Podman => (podman_helper_path(), PODMAN_HELPER_STUB),
+    };
+    path == expected_path
         && std::fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_file())
-        && std::fs::read_to_string(path).is_ok_and(|contents| contents == HELPER_STUB)
+        && std::fs::read_to_string(path).is_ok_and(|contents| contents == stub)
 }
 
 pub(crate) fn helper_path() -> PathBuf {
@@ -209,6 +265,21 @@ pub(crate) fn helper_stub_valid(path: &Path) -> bool {
 
 pub(crate) const fn helper_stub() -> &'static str {
     HELPER_STUB
+}
+
+pub(crate) fn podman_helper_path() -> PathBuf {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_HELPER_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(PODMAN_HELPER_PATH))
+}
+
+pub(crate) fn podman_helper_stub_valid(path: &Path) -> bool {
+    std::fs::read_to_string(path).is_ok_and(|contents| contents == PODMAN_HELPER_STUB)
+        && std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+}
+
+pub(crate) const fn podman_helper_stub() -> &'static str {
+    PODMAN_HELPER_STUB
 }
 
 #[cfg(test)]
@@ -248,6 +319,7 @@ mod tests {
         }
         let mut args = vec![helper.clone().into_os_string(), "store".into()];
         run_with_io(
+            Flavor::Docker,
             &mut args,
             &mut r#"{"ServerURL":"registry.example","Username":"user","Secret":"secret"}"#
                 .as_bytes(),
@@ -256,13 +328,20 @@ mod tests {
         .unwrap();
         let mut args = vec![helper.clone().into_os_string(), "get".into()];
         let mut output = Vec::new();
-        run_with_io(&mut args, &mut "registry.example\n".as_bytes(), &mut output).unwrap();
+        run_with_io(
+            Flavor::Docker,
+            &mut args,
+            &mut "registry.example\n".as_bytes(),
+            &mut output,
+        )
+        .unwrap();
         assert_eq!(
             serde_json::from_slice::<Value>(&output).unwrap(),
             json!({"Username":"user", "Secret":"secret"})
         );
         let mut args = vec![helper.clone().into_os_string(), "erase".into()];
         run_with_io(
+            Flavor::Docker,
             &mut args,
             &mut "registry.example\n".as_bytes(),
             &mut Vec::new(),
@@ -271,6 +350,7 @@ mod tests {
         assert!(!keychain.join(secret_name("registry.example")).exists());
         let mut args = vec![helper.clone().into_os_string(), "get".into()];
         let error = run_with_io(
+            Flavor::Docker,
             &mut args,
             &mut "registry.example\n".as_bytes(),
             &mut Vec::new(),
@@ -288,6 +368,61 @@ mod tests {
         unsafe {
             std::env::remove_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH");
             std::env::remove_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR");
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn podman_helper_tracks_non_secret_registry_markers_for_list() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-podman-helper-{}", std::process::id()));
+        let helper = root.join("docker-credential-av-podman");
+        let auth = root.join("auth.json");
+        let keychain = root.join("keychain");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&helper, PODMAN_HELPER_STUB).unwrap();
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_HELPER_PATH", &helper);
+            std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_AUTH", &auth);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        }
+        let mut args = vec![helper.clone().into_os_string(), "store".into()];
+        run_with_io(
+            Flavor::Podman,
+            &mut args,
+            &mut r#"{"ServerURL":"registry.example","Username":"user","Secret":"secret"}"#
+                .as_bytes(),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        let mut args = vec![helper.clone().into_os_string(), "list".into()];
+        let mut output = Vec::new();
+        run_with_io(Flavor::Podman, &mut args, &mut "".as_bytes(), &mut output).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output).unwrap(),
+            json!({"registry.example": ""})
+        );
+        let mut args = vec![helper.clone().into_os_string(), "erase".into()];
+        run_with_io(
+            Flavor::Podman,
+            &mut args,
+            &mut "registry.example\n".as_bytes(),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&fs::read(&auth).unwrap()).unwrap(),
+            json!({})
+        );
+        unsafe {
+            for name in [
+                "AUTOMIC_VAULT_TEST_PODMAN_HELPER_PATH",
+                "AUTOMIC_VAULT_TEST_PODMAN_AUTH",
+                "AUTOMIC_VAULT_TEST_KEYCHAIN_DIR",
+            ] {
+                std::env::remove_var(name);
+            }
         }
         let _ = fs::remove_dir_all(root);
     }

--- a/src/cli/docker_credential.rs
+++ b/src/cli/docker_credential.rs
@@ -141,9 +141,22 @@ fn run_with_io(
         }
         "erase" => {
             let server_url = parse_server_url(&read_limited(input)?)?;
-            crate::secrets::delete_registry_credential(&secret_name(&server_url), &server_url)?;
             if flavor == Flavor::Podman {
                 crate::isotopes::hardeners::podman::remove_helper_marker(&server_url)?;
+                if let Err(error) = crate::secrets::delete_registry_credential(
+                    &secret_name(&server_url),
+                    &server_url,
+                ) {
+                    return match crate::isotopes::hardeners::podman::add_helper_marker(&server_url)
+                    {
+                        Ok(()) => Err(error),
+                        Err(rollback) => Err(format!(
+                            "{error}; additionally failed to restore Podman registry marker: {rollback}"
+                        )),
+                    };
+                }
+            } else {
+                crate::secrets::delete_registry_credential(&secret_name(&server_url), &server_url)?;
             }
             Ok(())
         }
@@ -409,6 +422,26 @@ mod tests {
             serde_json::from_slice::<Value>(&output).unwrap(),
             json!({"registry.example": ""})
         );
+        let secret = keychain.join(secret_name("registry.example"));
+        let backup = keychain.join("credential-backup");
+        fs::rename(&secret, &backup).unwrap();
+        fs::create_dir(&secret).unwrap();
+        let mut args = vec![helper.clone().into_os_string(), "erase".into()];
+        assert!(
+            run_with_io(
+                Flavor::Podman,
+                &mut args,
+                &mut "registry.example\n".as_bytes(),
+                &mut Vec::new(),
+            )
+            .is_err()
+        );
+        assert_eq!(
+            crate::isotopes::hardeners::podman::helper_markers().unwrap(),
+            std::iter::once(("registry.example".into(), String::new())).collect()
+        );
+        fs::remove_dir(&secret).unwrap();
+        fs::rename(&backup, &secret).unwrap();
         let mut args = vec![helper.clone().into_os_string(), "erase".into()];
         run_with_io(
             Flavor::Podman,

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -373,7 +373,11 @@ fn approval_request(
     })
 }
 
-pub(super) fn docker_credential(key: String, server_url: String) -> Result<String, String> {
+pub(super) fn docker_credential(
+    key: String,
+    server_url: String,
+    tool: &'static str,
+) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
         op: "docker-get",
@@ -387,7 +391,7 @@ pub(super) fn docker_credential(key: String, server_url: String) -> Result<Strin
         shebang_script: None,
         script_data: None,
         snapshot_incompatible_interpreter: None,
-        tool: Some("docker"),
+        tool: Some(tool),
         docker_server_url: Some(server_url),
         terraform_hostname: None,
         aliyun_profile: None,

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -410,7 +410,7 @@ pub(super) fn docker_credential(
     }
     xpc_approve_injection(&request)?
         .remove(&key)
-        .ok_or_else(|| format!("Automic Vault returned no Docker credential for {key}"))
+        .ok_or_else(|| format!("Automic Vault returned no registry credential for {key}"))
 }
 
 pub(super) fn terraform_credential(key: String, hostname: String) -> Result<String, String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -379,6 +379,10 @@ where
                 let result = hardeners::docker::run(stdout, yes);
                 return finish_hardening(result, "docker", stdout, stderr);
             }
+            if target == "podman" {
+                let result = hardeners::podman::run(stdout, yes);
+                return finish_hardening(result, "podman", stdout, stderr);
+            }
             if target == "terraform" || target == "terraform-core" {
                 let result =
                     hardeners::terraform::run(hardeners::terraform::Tool::Terraform, stdout, yes);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -57,7 +57,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 42;
+pub(crate) const INSTALL_REVISION: u32 = 43;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -267,6 +267,15 @@ where
         }
         Some("__install-docker-helper") if rest.is_empty() => {
             match hardeners::docker::install_privileged() {
+                Ok(()) => 0,
+                Err(err) => {
+                    let _ = writeln!(stderr, "av: {err}");
+                    1
+                }
+            }
+        }
+        Some("__install-podman-helper") if rest.is_empty() => {
+            match hardeners::podman::install_privileged() {
                 Ok(()) => 0,
                 Err(err) => {
                     let _ = writeln!(stderr, "av: {err}");
@@ -491,6 +500,7 @@ where
             aws::credentials(Some("official-v2"), stdout, stderr)
         }
         Some("docker-credential") => docker_credential::run(rest, stdout, stderr),
+        Some("podman-credential") => docker_credential::run_podman(rest, stdout, stderr),
         Some("terraform-credential") => terraform_credential::run(rest, stdout, stderr),
         Some("aliyun-credential") => aliyun_credential::run(rest, stdout, stderr),
         Some("oxide-credential") => oxide_credential::run(rest, stdout, stderr),

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -106,6 +106,7 @@ mod pianobar;
 mod plumber;
 mod pnpm;
 mod podman;
+pub(crate) use podman::candidate_auth_paths as podman_auth_paths;
 mod poetry;
 mod pulumi;
 mod qwen_code;

--- a/src/isotopes/detectors/podman/detector.md
+++ b/src/isotopes/detectors/podman/detector.md
@@ -11,14 +11,9 @@
 - `$XDG_CONFIG_HOME/containers/auth.json`
 - `~/.config/containers/auth.json`
 
-## Why This is not Yet Hardened
+## Hardened State
 
-The retired `podman` hardener moved the detected secret to the macOS Keychain,
-then recreated `$REGISTRY_AUTH_FILE` inside a temporary directory for each run.
-We no longer consider a temporary plaintext file a sufficient security boundary,
-so this detector remains report-only.
-
-If a narrow environment-variable or credential-helper interface can cover this
-state without writing the secret back to disk, we can reconsider the hardener.
-
-[Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+`av harden podman` migrates supported registry-level credentials into Secret
+Custody and selects Automic Vault through containers/image's native global
+credential-helper setting. The official Red Hat-signed macOS Podman client is
+the verified Target; no plaintext auth file is recreated.

--- a/src/isotopes/detectors/podman/mod.rs
+++ b/src/isotopes/detectors/podman/mod.rs
@@ -18,7 +18,7 @@ pub fn install_insecurity_reasons() -> Result<Vec<String>, String> {
     Ok(Vec::new())
 }
 
-fn candidate_auth_paths() -> Result<Vec<PathBuf>, String> {
+pub(crate) fn candidate_auth_paths() -> Result<Vec<PathBuf>, String> {
     if let Some(path) = std::env::var_os("REGISTRY_AUTH_FILE").filter(|value| !value.is_empty()) {
         return Ok(vec![PathBuf::from(path)]);
     }

--- a/src/isotopes/hardeners/docker.rs
+++ b/src/isotopes/hardeners/docker.rs
@@ -488,9 +488,9 @@ pub(super) fn install_shared_helper(testing: bool) -> Result<(), String> {
 pub(super) fn install_stub(path: &Path, contents: &str) -> Result<(), String> {
     let parent = path
         .parent()
-        .ok_or_else(|| format!("Docker helper has no parent: {}", path.display()))?;
+        .ok_or_else(|| format!("registry helper has no parent: {}", path.display()))?;
     let staging = parent.join(format!(
-        ".docker-credential-av.{}.{}.tmp",
+        ".registry-credential-helper.{}.{}.tmp",
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -525,13 +525,13 @@ pub(super) fn helper_path() -> PathBuf {
 pub(super) fn validate_helper_install_path(path: &Path) -> Result<(), String> {
     let parent = path
         .parent()
-        .ok_or_else(|| format!("Docker helper has no parent: {}", path.display()))?;
+        .ok_or_else(|| format!("registry helper has no parent: {}", path.display()))?;
     for ancestor in parent.ancestors() {
         let metadata = fs::symlink_metadata(ancestor)
             .map_err(|error| format!("failed to inspect {}: {error}", ancestor.display()))?;
         if !secure_install_directory(&metadata, 0) {
             return Err(format!(
-                "refusing Docker helper path through unsafe directory {}: every containing directory must be root-owned and protected from group/world writes",
+                "refusing registry helper path through unsafe directory {}: every containing directory must be root-owned and protected from group/world writes",
                 ancestor.display()
             ));
         }

--- a/src/isotopes/hardeners/docker.rs
+++ b/src/isotopes/hardeners/docker.rs
@@ -80,7 +80,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
             &credential.storage_json(),
         )?;
     }
-    install_helper()?;
+    install_shared_helper(testing)?;
     let source = old_store
         .as_deref()
         .filter(|store| *store != "av")
@@ -139,7 +139,7 @@ pub(crate) fn detect() -> HardenerDetection {
         .as_deref()
         .and_then(|path| read_config(path).ok())
         .is_some_and(|value| validate_config(&value).ok().flatten().as_deref() == Some("av"));
-    let stub_valid = helper_valid(&helper);
+    let stub_valid = helper_valid(&helper, test_config_path().is_some());
     let vendor = test_config_path().is_some() || verify_vendor_install().is_ok();
     let hardened = config_valid && stub_valid && vendor;
     let commands = TARGETS
@@ -158,7 +158,7 @@ pub(crate) fn detect() -> HardenerDetection {
                     path: AV_PATH.into(),
                 }]
             },
-            stub_requirements: Some(stub_requirements(&helper)),
+            stub_requirements: Some(stub_requirements(&helper, test_config_path().is_some())),
             injected_keys: Vec::new(),
             assignment_keys: Vec::new(),
             isotope: None,
@@ -458,8 +458,8 @@ fn write_config(path: &Path, value: &Value) -> Result<(), String> {
     result
 }
 
-fn install_helper() -> Result<(), String> {
-    if test_config_path().is_some() {
+pub(super) fn install_shared_helper(testing: bool) -> Result<(), String> {
+    if testing {
         return install_stub(&helper_path());
     }
     super::env_wrapper::validate_privileged_av(Path::new(AV_PATH))?;
@@ -518,11 +518,11 @@ fn install_stub(path: &Path) -> Result<(), String> {
     result
 }
 
-fn helper_path() -> PathBuf {
+pub(super) fn helper_path() -> PathBuf {
     crate::cli::docker_credential::helper_path()
 }
 
-fn validate_helper_install_path(path: &Path) -> Result<(), String> {
+pub(super) fn validate_helper_install_path(path: &Path) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| format!("Docker helper has no parent: {}", path.display()))?;
@@ -545,22 +545,23 @@ fn secure_install_directory(metadata: &fs::Metadata, owner_uid: u32) -> bool {
         && metadata.permissions().mode() & 0o022 == 0
 }
 
-fn helper_valid(path: &Path) -> bool {
+pub(super) fn helper_valid(path: &Path, testing: bool) -> bool {
     let metadata = fs::symlink_metadata(path).ok();
     crate::cli::docker_credential::helper_stub_valid(path)
         && metadata.as_ref().is_some_and(|metadata| {
             metadata.permissions().mode() & 0o777 == 0o755
-                && (test_config_path().is_some()
-                    || (metadata.uid() == 0 && validate_helper_install_path(path).is_ok()))
+                && (testing || (metadata.uid() == 0 && validate_helper_install_path(path).is_ok()))
         })
 }
 
-fn stub_requirements(path: &Path) -> StubRequirements {
-    let test_ids = test_config_path().and_then(|_| {
-        path.parent()
-            .and_then(|parent| parent.metadata().ok())
-            .map(|metadata| (metadata.uid(), metadata.gid()))
-    });
+pub(super) fn stub_requirements(path: &Path, testing: bool) -> StubRequirements {
+    let test_ids = testing
+        .then(|| {
+            path.parent()
+                .and_then(|parent| parent.metadata().ok())
+                .map(|metadata| (metadata.uid(), metadata.gid()))
+        })
+        .flatten();
     StubRequirements {
         mode: 0o755,
         owner: RequiredIdentity {
@@ -775,7 +776,7 @@ mod tests {
                 .secret,
             "token"
         );
-        assert!(helper_valid(&installed));
+        assert!(helper_valid(&installed, true));
         unsafe {
             for name in [
                 "AUTOMIC_VAULT_TEST_DOCKER_CONFIG",

--- a/src/isotopes/hardeners/docker.rs
+++ b/src/isotopes/hardeners/docker.rs
@@ -42,7 +42,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     let testing = test_config_path().is_some();
     PRIVILEGE_MODE.require_user("docker", testing)?;
     if !testing {
-        crate::secrets::ensure_docker_helper_ready()?;
+        crate::secrets::ensure_registry_helper_ready()?;
         verify_vendor_install()?;
         validate_helper_install_path(&helper_path())?;
     }

--- a/src/isotopes/hardeners/docker.rs
+++ b/src/isotopes/hardeners/docker.rs
@@ -129,7 +129,7 @@ pub(crate) fn install_privileged() -> Result<(), String> {
     }
     let helper = helper_path();
     validate_helper_install_path(&helper)?;
-    install_stub(&helper)
+    install_stub(&helper, crate::cli::docker_credential::helper_stub())
 }
 
 pub(crate) fn detect() -> HardenerDetection {
@@ -460,7 +460,7 @@ fn write_config(path: &Path, value: &Value) -> Result<(), String> {
 
 pub(super) fn install_shared_helper(testing: bool) -> Result<(), String> {
     if testing {
-        return install_stub(&helper_path());
+        return install_stub(&helper_path(), crate::cli::docker_credential::helper_stub());
     }
     super::env_wrapper::validate_privileged_av(Path::new(AV_PATH))?;
     let revision = Command::new(AV_PATH)
@@ -485,7 +485,7 @@ pub(super) fn install_shared_helper(testing: bool) -> Result<(), String> {
         .ok_or_else(|| format!("Docker helper installation failed: {status}"))
 }
 
-fn install_stub(path: &Path) -> Result<(), String> {
+pub(super) fn install_stub(path: &Path, contents: &str) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| format!("Docker helper has no parent: {}", path.display()))?;
@@ -504,7 +504,7 @@ fn install_stub(path: &Path) -> Result<(), String> {
             .mode(0o600)
             .open(&staging)
             .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
-        file.write_all(crate::cli::docker_credential::helper_stub().as_bytes())
+        file.write_all(contents.as_bytes())
             .and_then(|()| file.sync_all())
             .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
         file.set_permissions(fs::Permissions::from_mode(0o755))

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod openhue_cli;
 pub(crate) mod ordercli;
 pub(crate) mod oxide_cli;
 pub(crate) mod plumber;
+pub(crate) mod podman;
 pub(crate) mod railway;
 pub(crate) mod rclone;
 pub(crate) mod stripe_cli;
@@ -309,6 +310,7 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
         gated_hardener!(ordercli, "ordercli"),
         gated_hardener!(openhue_cli, "openhue-cli"),
         gated_hardener!(plumber, "plumber"),
+        gated_hardener!(podman, "podman"),
         gated_hardener!(uaa_cli, "uaa-cli"),
         gated_hardener!(railway, "railway"),
         gated_hardener!(rclone, "rclone"),
@@ -347,6 +349,7 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
         ordercli::secret_gate(),
         openhue_cli::secret_gate(),
         plumber::secret_gate(),
+        podman::secret_gate(),
         uaa_cli::secret_gate(),
         railway::secret_gate(),
         rclone::secret_gate(),

--- a/src/isotopes/hardeners/podman.md
+++ b/src/isotopes/hardeners/podman.md
@@ -1,0 +1,19 @@
+# Podman
+
+`av harden podman` keeps Red Hat's official Developer ID-signed, Hardened
+Runtime client at `/opt/podman/bin/podman`. It migrates supported registry-level
+credentials from Podman's macOS `auth.json`, installs Automic Vault's protected
+registry credential helper, and selects it through a user
+`registries.conf.d` drop-in.
+
+Podman's macOS remote client resolves the credential locally before sending it
+to the Linux service. Automic Vault verifies that live client, its complete
+arguments, its registry, and its Launcher before releasing the credential.
+Docker and Podman share registry credentials but use separate Authorization
+Gates. Namespaced credentials and competing helpers fail closed because the
+external helper protocol cannot preserve them safely.
+
+Install Podman with the [official macOS installer] before hardening. An Isotope
+is unnecessary while Red Hat ships an eligible signed client.
+
+[official macOS installer]: https://podman.io/docs/installation

--- a/src/isotopes/hardeners/podman.md
+++ b/src/isotopes/hardeners/podman.md
@@ -3,15 +3,19 @@
 `av harden podman` keeps Red Hat's official Developer ID-signed, Hardened
 Runtime client at `/opt/podman/bin/podman`. It migrates supported registry-level
 credentials from Podman's macOS `auth.json`, installs Automic Vault's protected
-registry credential helper, and selects it through a user
-`registries.conf.d` drop-in.
+Podman registry credential helper, and selects it through a user
+`registries.conf.d` drop-in. Registry addresses remain as non-secret helper
+markers so Podman's remote protocol can discover the credentials it must ask
+Automic Vault to release.
 
 Podman's macOS remote client resolves the credential locally before sending it
 to the Linux service. Automic Vault verifies that live client, its complete
 arguments, its registry, and its Launcher before releasing the credential.
 Docker and Podman share registry credentials but use separate Authorization
-Gates. Namespaced credentials and competing helpers fail closed because the
-external helper protocol cannot preserve them safely.
+Gates and exact helper launchers. Podman's upstream remote protocol sends all
+configured registry credentials to its Linux service, so every credential read
+is classified as a Secret Dump. Namespaced credentials and competing helpers
+fail closed because the external helper protocol cannot preserve them safely.
 
 Install Podman with the [official macOS installer] before hardening. An Isotope
 is unnecessary while Red Hat ships an eligible signed client.

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -17,7 +17,7 @@ use super::{
 const AV_PATH: &str = "/usr/local/bin/av";
 const TARGET_PATH: &str = "/opt/podman/bin/podman";
 const TEAM_IDENTIFIER: &str = "HYSCB8KRL2";
-const DROP_IN: &str = "credential-helpers = [\"av\"]\n";
+const DROP_IN: &str = "credential-helpers = [\"av-podman\"]\n";
 const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
 
 struct AuthState {
@@ -36,25 +36,26 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     if !testing {
         crate::secrets::ensure_docker_helper_ready()?;
         verify_target(&target())?;
-        super::docker::validate_helper_install_path(&super::docker::helper_path())?;
+        super::docker::validate_helper_install_path(&helper_path())?;
     }
 
     let states = auth_states()?;
     let credentials = merge_credentials(&states)?;
+    let markers = auth_markers(&states);
     let drop_in = drop_in_path()?;
 
     writeln!(stdout, "╭─ harden podman").ok();
     writeln!(stdout, "│").ok();
     writeln!(stdout, "├─ keep Red Hat's signed Podman client").ok();
+    writeln!(stdout, "├─ install {}", helper_path().display()).ok();
     writeln!(
         stdout,
-        "├─ install {}",
-        super::docker::helper_path().display()
+        "├─ select Automic Vault as Podman's registry credential helper"
     )
     .ok();
     writeln!(
         stdout,
-        "├─ select Automic Vault as Podman's registry credential helper"
+        "├─ treat every remote registry request as a Secret Dump (upstream sends all credentials)"
     )
     .ok();
     if !credentials.is_empty() {
@@ -78,12 +79,15 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
             &credential.storage_json(),
         )?;
     }
-    super::docker::install_shared_helper(testing)?;
+    install_helper(testing)?;
     write_drop_in(&drop_in)?;
     for state in &states {
         if state.existed && state.original != state.sanitized {
             write_json(&state.path, &state.sanitized)?;
         }
+    }
+    for registry in &markers {
+        add_helper_marker(registry)?;
     }
     verify_hardened_state()?;
 
@@ -96,8 +100,8 @@ pub(crate) fn detect() -> HardenerDetection {
     let testing = test_auth_path().is_some();
     let target = target();
     let target_valid = testing || verify_target(&target).is_ok();
-    let helper = super::docker::helper_path();
-    let helper_valid = super::docker::helper_valid(&helper, testing);
+    let helper = helper_path();
+    let helper_valid = podman_helper_valid(&helper, testing);
     let config_valid = reject_competing_config().is_ok()
         && reject_fallback_auth_sources().is_ok()
         && drop_in_path().is_ok_and(|path| drop_in_is_effective(&path))
@@ -105,6 +109,7 @@ pub(crate) fn detect() -> HardenerDetection {
             states
                 .iter()
                 .all(|state| state.credentials.is_empty() && state.original == state.sanitized)
+                && markers_are_discoverable(&states)
         });
     let hardened = target_valid && helper_valid && config_valid;
     let command = HardenerCommand {
@@ -202,6 +207,22 @@ fn merge_credentials(
     Ok(merged)
 }
 
+fn auth_markers(states: &[AuthState]) -> BTreeSet<String> {
+    states
+        .iter()
+        .filter_map(|state| state.sanitized.get("credHelpers")?.as_object())
+        .flat_map(|helpers| helpers.keys().cloned())
+        .collect()
+}
+
+fn markers_are_discoverable(states: &[AuthState]) -> bool {
+    helper_markers().is_ok_and(|primary| {
+        auth_markers(states)
+            .iter()
+            .all(|registry| primary.contains_key(registry))
+    })
+}
+
 fn sanitize_auth(
     mut value: Value,
 ) -> Result<(Value, Vec<crate::cli::docker_credential::DockerCredential>), String> {
@@ -212,10 +233,25 @@ fn sanitize_auth(
         let helpers = helpers
             .as_object()
             .ok_or_else(|| "Podman `credHelpers` must be an object".to_string())?;
-        if helpers.values().any(|helper| helper.as_str() != Some("av")) {
+        if helpers
+            .values()
+            .any(|helper| helper.as_str() != Some("av-podman"))
+        {
             return Err("competing Podman credential helpers are not supported yet".into());
         }
+        for registry in helpers.keys() {
+            if normalize_registry(registry)? != *registry {
+                return Err(format!(
+                    "invalid Podman credential-helper registry `{registry}`"
+                ));
+            }
+        }
     }
+    let mut markers = object
+        .get("credHelpers")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
     let Some(auths) = object.get_mut("auths") else {
         return Ok((value, Vec::new()));
     };
@@ -250,14 +286,19 @@ fn sanitize_auth(
         else {
             continue;
         };
+        let server_url = normalize_registry(registry)?;
+        markers.insert(server_url.clone(), Value::String("av-podman".into()));
         credentials.push(crate::cli::docker_credential::DockerCredential {
-            server_url: normalize_registry(registry)?,
+            server_url,
             username,
             secret,
         });
     }
     auths.clear();
     object.remove("auths");
+    if !markers.is_empty() {
+        object.insert("credHelpers".into(), Value::Object(markers));
+    }
     Ok((value, credentials))
 }
 
@@ -336,6 +377,129 @@ fn target() -> PathBuf {
     crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_TARGET")
         .map(PathBuf::from)
         .unwrap_or_else(|| TARGET_PATH.into())
+}
+
+fn helper_path() -> PathBuf {
+    crate::cli::docker_credential::podman_helper_path()
+}
+
+fn podman_helper_valid(path: &Path, testing: bool) -> bool {
+    let metadata = fs::symlink_metadata(path).ok();
+    crate::cli::docker_credential::podman_helper_stub_valid(path)
+        && metadata.as_ref().is_some_and(|metadata| {
+            metadata.permissions().mode() & 0o777 == 0o755
+                && (testing
+                    || (metadata.uid() == 0
+                        && super::docker::validate_helper_install_path(path).is_ok()))
+        })
+}
+
+fn install_helper(testing: bool) -> Result<(), String> {
+    if testing {
+        return super::docker::install_stub(
+            &helper_path(),
+            crate::cli::docker_credential::podman_helper_stub(),
+        );
+    }
+    super::env_wrapper::validate_privileged_av(Path::new(AV_PATH))?;
+    let revision = Command::new(AV_PATH)
+        .arg("__version")
+        .output()
+        .map_err(|error| format!("failed to check {AV_PATH}: {error}"))?;
+    if !revision.status.success()
+        || std::str::from_utf8(&revision.stdout)
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            != Some(crate::cli::INSTALL_REVISION)
+    {
+        return Err("update the av CLI from the Automic Vault app before hardening Podman".into());
+    }
+    let status = Command::new("/usr/bin/sudo")
+        .args([AV_PATH, "__install-podman-helper"])
+        .status()
+        .map_err(|error| format!("failed to run sudo: {error}"))?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| format!("Podman helper installation failed: {status}"))
+}
+
+pub(crate) fn install_privileged() -> Result<(), String> {
+    if test_auth_path().is_some()
+        || crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_HELPER_PATH").is_some()
+    {
+        return Err("test path overrides are forbidden during privileged installation".into());
+    }
+    if super::effective_uid() != 0 {
+        return Err("Podman helper installation requires root".into());
+    }
+    let path = helper_path();
+    super::docker::validate_helper_install_path(&path)?;
+    super::docker::install_stub(&path, crate::cli::docker_credential::podman_helper_stub())
+}
+
+pub(crate) fn helper_markers() -> Result<BTreeMap<String, String>, String> {
+    let (_, value) = read_json(&primary_auth_path()?)?;
+    let (value, credentials) = sanitize_auth(value)?;
+    if !credentials.is_empty() {
+        return Err("Podman auth file contains unmigrated credentials".into());
+    }
+    Ok(value
+        .get("credHelpers")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flatten()
+        .map(|(registry, _)| (registry.clone(), String::new()))
+        .collect())
+}
+
+pub(crate) fn add_helper_marker(registry: &str) -> Result<(), String> {
+    update_helper_marker(registry, true)
+}
+
+pub(crate) fn remove_helper_marker(registry: &str) -> Result<(), String> {
+    update_helper_marker(registry, false)
+}
+
+fn update_helper_marker(registry: &str, add: bool) -> Result<(), String> {
+    if normalize_registry(registry)? != registry {
+        return Err("Podman helper received a non-canonical registry".into());
+    }
+    let path = primary_auth_path()?;
+    let (_, value) = read_json(&path)?;
+    let (mut value, credentials) = sanitize_auth(value)?;
+    if !credentials.is_empty() {
+        return Err("Podman auth file contains unmigrated credentials".into());
+    }
+    let object = value.as_object_mut().expect("sanitized object");
+    let helpers = object
+        .entry("credHelpers")
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .expect("sanitized helpers");
+    if add {
+        helpers.insert(registry.into(), Value::String("av-podman".into()));
+    } else {
+        helpers.remove(registry);
+        if helpers.is_empty() {
+            object.remove("credHelpers");
+        }
+    }
+    write_json(&path, &value)
+}
+
+fn primary_auth_path() -> Result<PathBuf, String> {
+    if let Some(path) = test_auth_path() {
+        return Ok(path);
+    }
+    if let Some(path) = std::env::var_os("REGISTRY_AUTH_FILE").filter(|value| !value.is_empty()) {
+        return Ok(path.into());
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is not set".to_string())?;
+    Ok(home.join(".config/containers/auth.json"))
 }
 
 fn drop_in_path() -> Result<PathBuf, String> {
@@ -519,10 +683,12 @@ fn write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
 
 fn verify_hardened_state() -> Result<(), String> {
     let path = drop_in_path()?;
+    let states = auth_states()?;
     if !drop_in_is_effective(&path)
-        || auth_states()?
+        || states
             .iter()
             .any(|state| !state.credentials.is_empty() || state.original != state.sanitized)
+        || !markers_are_discoverable(&states)
     {
         return Err("Podman hardening postcondition failed".into());
     }
@@ -625,7 +791,13 @@ mod tests {
             }
         }))
         .unwrap();
-        assert_eq!(sanitized, json!({}));
+        assert_eq!(
+            sanitized,
+            json!({"credHelpers": {
+                "index.docker.io": "av-podman",
+                "quay.io": "av-podman"
+            }})
+        );
         assert_eq!(credentials.len(), 2);
         assert_eq!(credentials[0].server_url, "index.docker.io");
         assert_eq!(credentials[0].username, "user");
@@ -663,7 +835,7 @@ mod tests {
         let root = std::env::temp_dir().join(format!("av-podman-hardener-{}", std::process::id()));
         let auth = root.join("auth.json");
         let drop_in = root.join("registries.conf.d/999-automic-vault.conf");
-        let helper = root.join("docker-credential-av");
+        let helper = root.join("docker-credential-av-podman");
         let keychain = root.join("keychain");
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
@@ -676,7 +848,7 @@ mod tests {
         unsafe {
             std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_AUTH", &auth);
             std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_DROP_IN", &drop_in);
-            std::env::set_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH", &helper);
+            std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_HELPER_PATH", &helper);
             std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
             std::env::remove_var("CONTAINERS_REGISTRIES_CONF");
         }
@@ -686,7 +858,7 @@ mod tests {
         assert_eq!(fs::read_to_string(&drop_in).unwrap(), DROP_IN);
         assert_eq!(
             serde_json::from_slice::<Value>(&fs::read(&auth).unwrap()).unwrap(),
-            json!({})
+            json!({"credHelpers": {"quay.io": "av-podman"}})
         );
         let saved = fs::read_to_string(
             keychain.join(crate::cli::docker_credential::secret_name("quay.io")),
@@ -704,7 +876,7 @@ mod tests {
             for name in [
                 "AUTOMIC_VAULT_TEST_PODMAN_AUTH",
                 "AUTOMIC_VAULT_TEST_PODMAN_DROP_IN",
-                "AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH",
+                "AUTOMIC_VAULT_TEST_PODMAN_HELPER_PATH",
                 "AUTOMIC_VAULT_TEST_KEYCHAIN_DIR",
             ] {
                 std::env::remove_var(name);

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -334,7 +334,20 @@ fn normalize_registry(value: &str) -> Result<String, String> {
         .or_else(|| value.strip_prefix("http://").map(|value| (value, true)))
         .unwrap_or((value, false));
     let registry = if had_scheme {
-        registry.split('/').next().unwrap_or_default()
+        let (authority, path) = registry.split_once('/').unwrap_or((registry, ""));
+        let legacy_docker_path = matches!(
+            (authority, path),
+            (
+                "docker.io" | "index.docker.io" | "registry-1.docker.io",
+                "v1" | "v1/"
+            )
+        );
+        if !path.is_empty() && !legacy_docker_path {
+            return Err(format!(
+                "namespaced Podman credential `{value}` cannot be preserved by an external helper"
+            ));
+        }
+        authority
     } else {
         if registry.contains('/') {
             return Err(format!(
@@ -351,7 +364,7 @@ fn normalize_registry(value: &str) -> Result<String, String> {
         || registry.len() > 2048
         || registry
             .bytes()
-            .any(|byte| byte == 0 || byte == b'\r' || byte == b'\n')
+            .any(|byte| matches!(byte, 0 | b'\r' | b'\n' | b'?' | b'#' | b'@'))
     {
         return Err("invalid Podman registry address".into());
     }
@@ -822,6 +835,12 @@ mod tests {
                 "auths": {"quay.io/team": {"auth": "dXNlcjp0b2tlbg=="}}
             }))
             .is_err()
+        );
+        assert!(normalize_registry("https://quay.io/team").is_err());
+        assert!(normalize_registry("https://quay.io?scope=team").is_err());
+        assert_eq!(
+            normalize_registry("https://index.docker.io/v1/").unwrap(),
+            "index.docker.io"
         );
         assert!(
             sanitize_auth(json!({

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -1,0 +1,718 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use serde_json::{Map, Value, json};
+
+use super::{
+    HardenerCommand, HardenerDetection, HardenerDiagnostic, RequiredExecutable,
+    SecretGateDescriptor, SecretGateRoute,
+};
+
+const AV_PATH: &str = "/usr/local/bin/av";
+const TARGET_PATH: &str = "/opt/podman/bin/podman";
+const TEAM_IDENTIFIER: &str = "HYSCB8KRL2";
+const DROP_IN: &str = "credential-helpers = [\"av\"]\n";
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+
+struct AuthState {
+    path: PathBuf,
+    existed: bool,
+    original: Value,
+    sanitized: Value,
+    credentials: Vec<crate::cli::docker_credential::DockerCredential>,
+}
+
+pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
+    let testing = test_auth_path().is_some();
+    super::PrivilegeMode::Mixed.require_user("podman", testing)?;
+    reject_competing_config()?;
+    reject_fallback_auth_sources()?;
+    if !testing {
+        crate::secrets::ensure_docker_helper_ready()?;
+        verify_target(&target())?;
+        super::docker::validate_helper_install_path(&super::docker::helper_path())?;
+    }
+
+    let states = auth_states()?;
+    let credentials = merge_credentials(&states)?;
+    let drop_in = drop_in_path()?;
+
+    writeln!(stdout, "╭─ harden podman").ok();
+    writeln!(stdout, "│").ok();
+    writeln!(stdout, "├─ keep Red Hat's signed Podman client").ok();
+    writeln!(
+        stdout,
+        "├─ install {}",
+        super::docker::helper_path().display()
+    )
+    .ok();
+    writeln!(
+        stdout,
+        "├─ select Automic Vault as Podman's registry credential helper"
+    )
+    .ok();
+    if !credentials.is_empty() {
+        writeln!(
+            stdout,
+            "├─ migrate {} registry credential{} without printing them",
+            credentials.len(),
+            if credentials.len() == 1 { "" } else { "s" }
+        )
+        .ok();
+    }
+    writeln!(stdout, "│").ok();
+    if !super::gh_cli::confirm(stdout, yes)? {
+        writeln!(stdout, "╰─ cancelled").ok();
+        return Ok(());
+    }
+
+    for credential in credentials.values() {
+        crate::secrets::store_secret_if_absent_or_equal(
+            &crate::cli::docker_credential::secret_name(&credential.server_url),
+            &credential.storage_json(),
+        )?;
+    }
+    super::docker::install_shared_helper(testing)?;
+    write_drop_in(&drop_in)?;
+    for state in &states {
+        if state.existed && state.original != state.sanitized {
+            write_json(&state.path, &state.sanitized)?;
+        }
+    }
+    verify_hardened_state()?;
+
+    writeln!(stdout, "╰─ hardened podman").ok();
+    super::write_secret_gate_notice(stdout, "podman");
+    Ok(())
+}
+
+pub(crate) fn detect() -> HardenerDetection {
+    let testing = test_auth_path().is_some();
+    let target = target();
+    let target_valid = testing || verify_target(&target).is_ok();
+    let helper = super::docker::helper_path();
+    let helper_valid = super::docker::helper_valid(&helper, testing);
+    let config_valid = reject_competing_config().is_ok()
+        && reject_fallback_auth_sources().is_ok()
+        && drop_in_path().is_ok_and(|path| drop_in_is_effective(&path))
+        && auth_states().is_ok_and(|states| {
+            states
+                .iter()
+                .all(|state| state.credentials.is_empty() && state.original == state.sanitized)
+        });
+    let hardened = target_valid && helper_valid && config_valid;
+    let command = HardenerCommand {
+        name: "podman".into(),
+        hardened,
+        stub_valid: helper_valid,
+        stub_path: Some(helper.display().to_string()),
+        target_path: target.display().to_string(),
+        required_paths: if testing {
+            Vec::new()
+        } else {
+            vec![RequiredExecutable {
+                name: "Automic Vault CLI",
+                path: AV_PATH.into(),
+            }]
+        },
+        stub_requirements: Some(super::docker::stub_requirements(&helper, testing)),
+        injected_keys: Vec::new(),
+        assignment_keys: Vec::new(),
+        isotope: None,
+    };
+    let mut detection = HardenerDetection::commands(hardened, vec![command]);
+    detection.applicable =
+        target.exists() || auth_paths().is_ok_and(|paths| paths.iter().any(|path| path.exists()));
+    if target.exists() && !target_valid && !testing {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "podman_vendor_cli_invalid",
+            message: verify_target(&target).unwrap_err(),
+            remediation: "Install or update Podman using Red Hat's official macOS installer, then rerun `av harden podman`.".into(),
+            path: Some(target.display().to_string()),
+        });
+    }
+    if detection.applicable && !config_valid {
+        detection.diagnostics.push(HardenerDiagnostic {
+            kind: "podman_config_not_hardened",
+            message: "Podman registry authentication is not in the supported Hardened State."
+                .into(),
+            remediation: "Rerun `av harden podman`; competing helpers and namespaced credentials must be resolved manually.".into(),
+            path: drop_in_path().ok().map(|path| path.display().to_string()),
+        });
+    }
+    detection
+}
+
+pub(crate) fn secret_gate() -> SecretGateDescriptor {
+    SecretGateDescriptor {
+        id: "podman",
+        key_patterns: vec!["DOCKER_REGISTRY_CREDENTIAL_*".into()],
+        routes: vec![SecretGateRoute {
+            operation: "docker-get",
+            script_path: None,
+            target_path: target().display().to_string(),
+            caller_identifiers: vec!["com.automicvault.av"],
+            key_patterns: vec!["DOCKER_REGISTRY_CREDENTIAL_*".into()],
+            replace_existing_env: false,
+            allow_missing_keys: false,
+        }],
+    }
+}
+
+fn auth_states() -> Result<Vec<AuthState>, String> {
+    auth_paths()?
+        .into_iter()
+        .map(|path| {
+            let (existed, original) = read_json(&path)?;
+            let (sanitized, credentials) = sanitize_auth(original.clone())?;
+            Ok(AuthState {
+                path,
+                existed,
+                original,
+                sanitized,
+                credentials,
+            })
+        })
+        .collect()
+}
+
+fn merge_credentials(
+    states: &[AuthState],
+) -> Result<BTreeMap<String, crate::cli::docker_credential::DockerCredential>, String> {
+    let mut merged = BTreeMap::new();
+    for credential in states.iter().flat_map(|state| &state.credentials) {
+        match merged.get(&credential.server_url) {
+            Some(existing) if existing != credential => {
+                return Err(format!(
+                    "conflicting Podman credentials exist for {}",
+                    credential.server_url
+                ));
+            }
+            _ => {
+                merged.insert(credential.server_url.clone(), credential.clone());
+            }
+        }
+    }
+    Ok(merged)
+}
+
+fn sanitize_auth(
+    mut value: Value,
+) -> Result<(Value, Vec<crate::cli::docker_credential::DockerCredential>), String> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "Podman auth config must be a JSON object".to_string())?;
+    if let Some(helpers) = object.get("credHelpers") {
+        let helpers = helpers
+            .as_object()
+            .ok_or_else(|| "Podman `credHelpers` must be an object".to_string())?;
+        if helpers.values().any(|helper| helper.as_str() != Some("av")) {
+            return Err("competing Podman credential helpers are not supported yet".into());
+        }
+    }
+    let Some(auths) = object.get_mut("auths") else {
+        return Ok((value, Vec::new()));
+    };
+    let auths = auths
+        .as_object_mut()
+        .ok_or_else(|| "Podman `auths` must be an object".to_string())?;
+    let mut credentials = Vec::new();
+    for (registry, entry) in auths.iter() {
+        let entry = entry
+            .as_object()
+            .ok_or_else(|| format!("Podman credential for {registry} must be an object"))?;
+        if entry
+            .keys()
+            .any(|key| !["auth", "identitytoken", "identityToken"].contains(&key.as_str()))
+        {
+            return Err(format!(
+                "Podman credential for {registry} contains unsupported fields"
+            ));
+        }
+        let auth = optional_string(entry, "auth")?;
+        let identity =
+            optional_string(entry, "identitytoken")?.or(optional_string(entry, "identityToken")?);
+        if auth.is_some() && identity.is_some() {
+            return Err(format!(
+                "Podman credential for {registry} contains both basic and identity credentials"
+            ));
+        }
+        let Some((username, secret)) = auth
+            .map(decode_auth)
+            .transpose()?
+            .or_else(|| identity.map(|secret| ("<token>".into(), secret)))
+        else {
+            continue;
+        };
+        credentials.push(crate::cli::docker_credential::DockerCredential {
+            server_url: normalize_registry(registry)?,
+            username,
+            secret,
+        });
+    }
+    auths.clear();
+    object.remove("auths");
+    Ok((value, credentials))
+}
+
+fn optional_string(entry: &Map<String, Value>, key: &str) -> Result<Option<String>, String> {
+    match entry.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if value.is_empty() => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(format!("Podman credential field `{key}` must be a string")),
+    }
+}
+
+fn decode_auth(encoded: String) -> Result<(String, String), String> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "Podman credential contains invalid base64".to_string())?;
+    let decoded = String::from_utf8(decoded)
+        .map_err(|_| "Podman credential is not valid UTF-8".to_string())?;
+    let (username, secret) = decoded
+        .split_once(':')
+        .ok_or_else(|| "Podman credential has no username/password separator".to_string())?;
+    let secret = secret.trim_matches('\0');
+    if username.is_empty() || secret.is_empty() || username.contains('\0') {
+        return Err("Podman credential has an empty or invalid username/password".into());
+    }
+    Ok((username.into(), secret.into()))
+}
+
+fn normalize_registry(value: &str) -> Result<String, String> {
+    let (registry, had_scheme) = value
+        .strip_prefix("https://")
+        .map(|value| (value, true))
+        .or_else(|| value.strip_prefix("http://").map(|value| (value, true)))
+        .unwrap_or((value, false));
+    let registry = if had_scheme {
+        registry.split('/').next().unwrap_or_default()
+    } else {
+        if registry.contains('/') {
+            return Err(format!(
+                "namespaced Podman credential `{value}` cannot be preserved by an external helper"
+            ));
+        }
+        registry
+    };
+    let registry = match registry {
+        "docker.io" | "registry-1.docker.io" => "index.docker.io",
+        registry => registry,
+    };
+    if registry.is_empty()
+        || registry.len() > 2048
+        || registry
+            .bytes()
+            .any(|byte| byte == 0 || byte == b'\r' || byte == b'\n')
+    {
+        return Err("invalid Podman registry address".into());
+    }
+    Ok(registry.into())
+}
+
+fn auth_paths() -> Result<Vec<PathBuf>, String> {
+    if let Some(path) = test_auth_path() {
+        return Ok(vec![path]);
+    }
+    let mut unique = BTreeSet::new();
+    Ok(crate::isotopes::detectors::podman_auth_paths()?
+        .into_iter()
+        .filter(|path| unique.insert(path.clone()))
+        .collect())
+}
+
+fn test_auth_path() -> Option<PathBuf> {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_AUTH").map(PathBuf::from)
+}
+
+fn target() -> PathBuf {
+    crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_TARGET")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| TARGET_PATH.into())
+}
+
+fn drop_in_path() -> Result<PathBuf, String> {
+    if let Some(path) = crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_DROP_IN") {
+        return Ok(path.into());
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is not set".to_string())?;
+    Ok(home.join(".config/containers/registries.conf.d/999-automic-vault.conf"))
+}
+
+fn reject_competing_config() -> Result<(), String> {
+    if std::env::var_os("CONTAINERS_REGISTRIES_CONF").is_some_and(|value| !value.is_empty()) {
+        return Err("CONTAINERS_REGISTRIES_CONF bypasses the Podman hardener configuration".into());
+    }
+    Ok(())
+}
+
+fn reject_fallback_auth_sources() -> Result<(), String> {
+    if test_auth_path().is_some()
+        || std::env::var_os("REGISTRY_AUTH_FILE").is_some_and(|value| !value.is_empty())
+    {
+        return Ok(());
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is not set".to_string())?;
+    let docker = std::env::var_os("DOCKER_CONFIG")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".docker"))
+        .join("config.json");
+    let (exists, value) = read_json(&docker)?;
+    if exists {
+        let (_, credentials) = sanitize_auth(value).map_err(|error| {
+            format!("Docker's fallback auth config must be hardened before Podman: {error}")
+        })?;
+        if !credentials.is_empty() {
+            return Err(
+                "Docker's fallback auth config contains credentials; harden or remove that fallback before Podman"
+                    .into(),
+            );
+        }
+    }
+    let legacy = home.join(".dockercfg");
+    let (exists, value) = read_json(&legacy)?;
+    if exists && value.as_object().is_some_and(|object| !object.is_empty()) {
+        return Err(format!(
+            "legacy Docker fallback {} must be removed before hardening Podman",
+            legacy.display()
+        ));
+    }
+    Ok(())
+}
+
+fn drop_in_is_effective(path: &Path) -> bool {
+    if fs::read_to_string(path).ok().as_deref() != Some(DROP_IN) {
+        return false;
+    }
+    let Some(directory) = path.parent() else {
+        return false;
+    };
+    let Ok(entries) = fs::read_dir(directory) else {
+        return false;
+    };
+    !entries.filter_map(Result::ok).any(|entry| {
+        let candidate = entry.path();
+        candidate.extension().and_then(|value| value.to_str()) == Some("conf")
+            && candidate.file_name() > path.file_name()
+            && fs::read_to_string(candidate).map_or(true, |contents| {
+                toml::from_str::<toml::Value>(&contents).map_or(true, |value| {
+                    value
+                        .as_table()
+                        .is_some_and(|table| table.contains_key("credential-helpers"))
+                })
+            })
+    })
+}
+
+fn write_drop_in(path: &Path) -> Result<(), String> {
+    if path.exists() && fs::read_to_string(path).ok().as_deref() != Some(DROP_IN) {
+        return Err(format!(
+            "refusing to replace unexpected Podman config {}",
+            path.display()
+        ));
+    }
+    write_bytes(path, DROP_IN.as_bytes())?;
+    if !drop_in_is_effective(path) {
+        return Err("a later Podman registry config overrides Automic Vault's helper".into());
+    }
+    Ok(())
+}
+
+fn read_json(path: &Path) -> Result<(bool, Value), String> {
+    let file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((false, json!({})));
+        }
+        Err(error) => return Err(format!("failed to open {}: {error}", path.display())),
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    if !metadata.file_type().is_file()
+        || metadata.len() > MAX_CONFIG_BYTES
+        || metadata.uid() != super::effective_uid()
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(format!(
+            "refusing unsafe Podman auth file {}",
+            path.display()
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_CONFIG_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if bytes.len() as u64 > MAX_CONFIG_BYTES {
+        return Err("Podman auth file exceeds 1 MiB".into());
+    }
+    serde_json::from_slice(&bytes)
+        .map(|value| (true, value))
+        .map_err(|error| format!("invalid Podman auth file {}: {error}", path.display()))
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<(), String> {
+    let mut bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("failed to encode Podman auth config: {error}"))?;
+    bytes.push(b'\n');
+    write_bytes(path, &bytes)
+}
+
+fn write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("config path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let staging = parent.join(format!(
+        ".{}.av.{}.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("config"),
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&staging)
+            .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
+        file.write_all(bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("failed to write {}: {error}", staging.display()))?;
+        fs::rename(&staging, path)
+            .map_err(|error| format!("failed to replace {}: {error}", path.display()))?;
+        OpenOptions::new()
+            .read(true)
+            .open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("failed to sync {}: {error}", parent.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(staging);
+    }
+    result
+}
+
+fn verify_hardened_state() -> Result<(), String> {
+    let path = drop_in_path()?;
+    if !drop_in_is_effective(&path)
+        || auth_states()?
+            .iter()
+            .any(|state| !state.credentials.is_empty() || state.original != state.sanitized)
+    {
+        return Err("Podman hardening postcondition failed".into());
+    }
+    Ok(())
+}
+
+fn verify_target(path: &Path) -> Result<(), String> {
+    if path != Path::new(TARGET_PATH) {
+        return Err(format!("Podman must be installed at {TARGET_PATH}"));
+    }
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    if !metadata.file_type().is_file()
+        || metadata.uid() != 0
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err("official Podman executable is not a protected root-owned file".into());
+    }
+    for ancestor in path.parent().into_iter().flat_map(Path::ancestors) {
+        let metadata = fs::symlink_metadata(ancestor)
+            .map_err(|error| format!("failed to inspect {}: {error}", ancestor.display()))?;
+        if !metadata.file_type().is_dir()
+            || metadata.uid() != 0
+            || metadata.permissions().mode() & 0o022 != 0
+        {
+            return Err(format!(
+                "official Podman path crosses unsafe directory {}",
+                ancestor.display()
+            ));
+        }
+    }
+    let requirement = format!(
+        "=identifier \"podman\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"{TEAM_IDENTIFIER}\""
+    );
+    let status = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--strict", "-R", &requirement])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to verify Podman: {error}"))?;
+    if !status.success() {
+        return Err("Podman Developer ID signature is invalid".into());
+    }
+    let details = codesign_output(&["-d", "-vvv"], path)?;
+    for required in [
+        "flags=0x10000(runtime)",
+        "Authority=Developer ID Application: Red Hat, Inc. (HYSCB8KRL2)",
+        "TeamIdentifier=HYSCB8KRL2",
+        "Timestamp=",
+    ] {
+        if !details.contains(required) {
+            return Err(format!("Podman signature did not confirm {required:?}"));
+        }
+    }
+    let entitlements = codesign_output(&["-d", "--entitlements", ":-"], path)?;
+    if entitlements.contains("<key>") {
+        return Err("Podman executable has unexpected entitlements".into());
+    }
+    Ok(())
+}
+
+fn codesign_output(args: &[&str], path: &Path) -> Result<String, String> {
+    let output = Command::new("/usr/bin/codesign")
+        .args(args)
+        .arg(path)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .env("LANG", "C")
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if output.status.success() {
+        Ok(text)
+    } else {
+        Err(format!(
+            "failed to inspect Podman signature: {}",
+            text.trim()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrates_registry_credentials_and_rejects_lossy_cases() {
+        let (sanitized, credentials) = sanitize_auth(json!({
+            "auths": {
+                "docker.io": {"auth": "dXNlcjp0b2tlbg=="},
+                "quay.io": {"identitytoken": "identity"}
+            }
+        }))
+        .unwrap();
+        assert_eq!(sanitized, json!({}));
+        assert_eq!(credentials.len(), 2);
+        assert_eq!(credentials[0].server_url, "index.docker.io");
+        assert_eq!(credentials[0].username, "user");
+        assert_eq!(credentials[1].username, "<token>");
+        assert!(
+            sanitize_auth(json!({
+                "auths": {"quay.io/team": {"auth": "dXNlcjp0b2tlbg=="}}
+            }))
+            .is_err()
+        );
+        assert!(
+            sanitize_auth(json!({
+                "credHelpers": {"quay.io": "osxkeychain"}
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn later_helper_override_is_not_hardened() {
+        let root = std::env::temp_dir().join(format!("av-podman-drop-in-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let ours = root.join("999-automic-vault.conf");
+        fs::write(&ours, DROP_IN).unwrap();
+        assert!(drop_in_is_effective(&ours));
+        fs::write(root.join("zzz.conf"), "credential-helpers = [\"other\"]\n").unwrap();
+        assert!(!drop_in_is_effective(&ours));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn hardening_migrates_auth_and_configures_shared_helper() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let root = std::env::temp_dir().join(format!("av-podman-hardener-{}", std::process::id()));
+        let auth = root.join("auth.json");
+        let drop_in = root.join("registries.conf.d/999-automic-vault.conf");
+        let helper = root.join("docker-credential-av");
+        let keychain = root.join("keychain");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            &auth,
+            r#"{"auths":{"quay.io":{"auth":"dXNlcjp0b2tlbg=="}}}"#,
+        )
+        .unwrap();
+        let previous_registries_conf = std::env::var_os("CONTAINERS_REGISTRIES_CONF");
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_AUTH", &auth);
+            std::env::set_var("AUTOMIC_VAULT_TEST_PODMAN_DROP_IN", &drop_in);
+            std::env::set_var("AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH", &helper);
+            std::env::set_var("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+            std::env::remove_var("CONTAINERS_REGISTRIES_CONF");
+        }
+
+        run(&mut Vec::new(), true).unwrap();
+
+        assert_eq!(fs::read_to_string(&drop_in).unwrap(), DROP_IN);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&fs::read(&auth).unwrap()).unwrap(),
+            json!({})
+        );
+        let saved = fs::read_to_string(
+            keychain.join(crate::cli::docker_credential::secret_name("quay.io")),
+        )
+        .unwrap();
+        assert_eq!(
+            crate::cli::docker_credential::parse_credential(&saved)
+                .unwrap()
+                .secret,
+            "token"
+        );
+        assert!(super::detect().hardened);
+
+        unsafe {
+            for name in [
+                "AUTOMIC_VAULT_TEST_PODMAN_AUTH",
+                "AUTOMIC_VAULT_TEST_PODMAN_DROP_IN",
+                "AUTOMIC_VAULT_TEST_DOCKER_HELPER_PATH",
+                "AUTOMIC_VAULT_TEST_KEYCHAIN_DIR",
+            ] {
+                std::env::remove_var(name);
+            }
+            if let Some(value) = previous_registries_conf {
+                std::env::set_var("CONTAINERS_REGISTRIES_CONF", value);
+            }
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -34,7 +34,7 @@ pub(crate) fn run(stdout: &mut dyn Write, yes: bool) -> Result<(), String> {
     reject_competing_config()?;
     reject_fallback_auth_sources()?;
     if !testing {
-        crate::secrets::ensure_docker_helper_ready()?;
+        crate::secrets::ensure_registry_helper_ready()?;
         verify_target(&target())?;
         super::docker::validate_helper_install_path(&helper_path())?;
     }
@@ -228,16 +228,16 @@ fn sanitize_auth(
 ) -> Result<(Value, Vec<crate::cli::docker_credential::DockerCredential>), String> {
     let object = value
         .as_object_mut()
-        .ok_or_else(|| "Podman auth config must be a JSON object".to_string())?;
+        .ok_or_else(|| "registry auth config must be a JSON object".to_string())?;
     if let Some(helpers) = object.get("credHelpers") {
         let helpers = helpers
             .as_object()
-            .ok_or_else(|| "Podman `credHelpers` must be an object".to_string())?;
+            .ok_or_else(|| "registry `credHelpers` must be an object".to_string())?;
         if helpers
             .values()
             .any(|helper| helper.as_str() != Some("av-podman"))
         {
-            return Err("competing Podman credential helpers are not supported yet".into());
+            return Err("competing registry credential helpers are not supported yet".into());
         }
         for registry in helpers.keys() {
             if normalize_registry(registry)? != *registry {

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -363,10 +363,17 @@ fn auth_paths() -> Result<Vec<PathBuf>, String> {
         return Ok(vec![path]);
     }
     let mut unique = BTreeSet::new();
-    Ok(crate::isotopes::detectors::podman_auth_paths()?
+    let paths = crate::isotopes::detectors::podman_auth_paths()?
         .into_iter()
         .filter(|path| unique.insert(path.clone()))
-        .collect())
+        .collect::<Vec<_>>();
+    if let Some(path) = paths.iter().find(|path| !path.is_absolute()) {
+        return Err(format!(
+            "Podman auth path must be absolute: {}",
+            path.display()
+        ));
+    }
+    Ok(paths)
 }
 
 fn test_auth_path() -> Option<PathBuf> {
@@ -492,25 +499,33 @@ fn primary_auth_path() -> Result<PathBuf, String> {
     if let Some(path) = test_auth_path() {
         return Ok(path);
     }
-    if let Some(path) = std::env::var_os("REGISTRY_AUTH_FILE").filter(|value| !value.is_empty()) {
-        return Ok(path.into());
-    }
-    let home = std::env::var_os("HOME")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .ok_or_else(|| "HOME is not set".to_string())?;
-    Ok(home.join(".config/containers/auth.json"))
+    auth_paths()?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "Podman has no registry auth path".into())
 }
 
 fn drop_in_path() -> Result<PathBuf, String> {
     if let Some(path) = crate::test_env_var("AUTOMIC_VAULT_TEST_PODMAN_DROP_IN") {
         return Ok(path.into());
     }
-    let home = std::env::var_os("HOME")
+    let root = std::env::var_os("XDG_CONFIG_HOME")
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .map(|home| home.join(".config"))
+        })
         .ok_or_else(|| "HOME is not set".to_string())?;
-    Ok(home.join(".config/containers/registries.conf.d/999-automic-vault.conf"))
+    if !root.is_absolute() {
+        return Err(format!(
+            "Podman config path must be absolute: {}",
+            root.display()
+        ));
+    }
+    Ok(root.join("containers/registries.conf.d/999-automic-vault.conf"))
 }
 
 fn reject_competing_config() -> Result<(), String> {
@@ -828,6 +843,52 @@ mod tests {
         fs::write(root.join("zzz.conf"), "credential-helpers = [\"other\"]\n").unwrap();
         assert!(!drop_in_is_effective(&ours));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn xdg_paths_are_selected_and_relative_paths_fail_closed() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let names = [
+            "HOME",
+            "XDG_RUNTIME_DIR",
+            "XDG_CONFIG_HOME",
+            "REGISTRY_AUTH_FILE",
+            "AUTOMIC_VAULT_TEST_PODMAN_AUTH",
+            "AUTOMIC_VAULT_TEST_PODMAN_DROP_IN",
+        ];
+        let previous = names.map(|name| std::env::var_os(name));
+        unsafe {
+            std::env::set_var("HOME", "/tmp/av-podman-home");
+            std::env::set_var("XDG_RUNTIME_DIR", "/tmp/av-podman-runtime");
+            std::env::set_var("XDG_CONFIG_HOME", "/tmp/av-podman-config");
+            for name in &names[3..] {
+                std::env::remove_var(name);
+            }
+        }
+        assert_eq!(
+            primary_auth_path().unwrap(),
+            Path::new("/tmp/av-podman-runtime/containers/auth.json")
+        );
+        assert_eq!(
+            drop_in_path().unwrap(),
+            Path::new("/tmp/av-podman-config/containers/registries.conf.d/999-automic-vault.conf")
+        );
+        unsafe { std::env::set_var("XDG_RUNTIME_DIR", "relative") };
+        assert!(primary_auth_path().is_err());
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", "/tmp/av-podman-runtime");
+            std::env::set_var("XDG_CONFIG_HOME", "relative");
+        }
+        assert!(drop_in_path().is_err());
+
+        unsafe {
+            for (name, value) in names.into_iter().zip(previous) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -617,7 +617,7 @@ fn read_json(path: &Path) -> Result<(bool, Value), String> {
         || metadata.permissions().mode() & 0o022 != 0
     {
         return Err(format!(
-            "refusing unsafe Podman auth file {}",
+            "refusing unsafe registry auth file {}",
             path.display()
         ));
     }
@@ -626,11 +626,11 @@ fn read_json(path: &Path) -> Result<(bool, Value), String> {
         .read_to_end(&mut bytes)
         .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
     if bytes.len() as u64 > MAX_CONFIG_BYTES {
-        return Err("Podman auth file exceeds 1 MiB".into());
+        return Err("registry auth file exceeds 1 MiB".into());
     }
     serde_json::from_slice(&bytes)
         .map(|value| (true, value))
-        .map_err(|error| format!("invalid Podman auth file {}: {error}", path.display()))
+        .map_err(|error| format!("invalid registry auth file {}: {error}", path.display()))
 }
 
 fn write_json(path: &Path, value: &Value) -> Result<(), String> {

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -320,8 +320,8 @@ fn decode_auth(encoded: String) -> Result<(String, String), String> {
     let (username, secret) = decoded
         .split_once(':')
         .ok_or_else(|| "Podman credential has no username/password separator".to_string())?;
-    let secret = secret.trim_matches('\0');
-    if username.is_empty() || secret.is_empty() || username.contains('\0') {
+    if username.is_empty() || secret.is_empty() || username.contains('\0') || secret.contains('\0')
+    {
         return Err("Podman credential has an empty or invalid username/password".into());
     }
     Ok((username.into(), secret.into()))
@@ -814,6 +814,7 @@ mod tests {
             }))
             .is_err()
         );
+        assert!(decode_auth("dXNlcjp0b2tlbgA=".into()).is_err());
     }
 
     #[test]

--- a/src/isotopes/hardeners/podman.rs
+++ b/src/isotopes/hardeners/podman.rs
@@ -229,32 +229,34 @@ fn sanitize_auth(
     let object = value
         .as_object_mut()
         .ok_or_else(|| "registry auth config must be a JSON object".to_string())?;
-    if let Some(helpers) = object.get("credHelpers") {
-        let helpers = helpers
-            .as_object()
-            .ok_or_else(|| "registry `credHelpers` must be an object".to_string())?;
-        if helpers
-            .values()
-            .any(|helper| helper.as_str() != Some("av-podman"))
-        {
-            return Err("competing registry credential helpers are not supported yet".into());
-        }
-        for registry in helpers.keys() {
-            if normalize_registry(registry)? != *registry {
-                return Err(format!(
-                    "invalid Podman credential-helper registry `{registry}`"
-                ));
+    let mut markers = match object.get("credHelpers") {
+        Some(Value::Object(helpers)) => {
+            let mut markers = Map::new();
+            for (registry, helper) in helpers {
+                if helper.as_str() != Some("av-podman") {
+                    return Err(
+                        "competing registry credential helpers are not supported yet".into(),
+                    );
+                }
+                markers.insert(
+                    normalize_registry(registry)?,
+                    Value::String("av-podman".into()),
+                );
             }
+            markers
         }
-    }
-    let mut markers = object
-        .get("credHelpers")
-        .and_then(Value::as_object)
-        .cloned()
-        .unwrap_or_default();
-    let Some(auths) = object.get_mut("auths") else {
-        return Ok((value, Vec::new()));
+        Some(_) => return Err("registry `credHelpers` must be an object".into()),
+        None => Map::new(),
     };
+    if !object.contains_key("auths") {
+        if markers.is_empty() {
+            object.remove("credHelpers");
+        } else {
+            object.insert("credHelpers".into(), Value::Object(markers));
+        }
+        return Ok((value, Vec::new()));
+    }
+    let auths = object.get_mut("auths").expect("checked above");
     let auths = auths
         .as_object_mut()
         .ok_or_else(|| "Podman `auths` must be an object".to_string())?;
@@ -849,6 +851,23 @@ mod tests {
             .is_err()
         );
         assert!(decode_auth("dXNlcjp0b2tlbgA=".into()).is_err());
+    }
+
+    #[test]
+    fn normalizes_existing_helper_markers() {
+        let (sanitized, credentials) = sanitize_auth(json!({
+            "credHelpers": {
+                "docker.io": "av-podman",
+                "index.docker.io": "av-podman"
+            }
+        }))
+        .unwrap();
+
+        assert!(credentials.is_empty());
+        assert_eq!(
+            sanitized,
+            json!({"credHelpers": {"index.docker.io": "av-podman"}})
+        );
     }
 
     #[test]

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2979,7 +2979,7 @@ private struct ApprovedFulfillmentMaterial: Sendable {
     let awsRegistration: AWSRegistration?
 }
 
-private let dockerHelperProtocolVersion: UInt64 = 3
+private let registryHelperProtocolVersion: UInt64 = 3
 
 private final class ApprovalServer: @unchecked Sendable {
     private let serviceName: String
@@ -3178,11 +3178,11 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: true, error: nil, value: String(negotiated))
         case .dockerHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
             let requested = xpc_dictionary_get_uint64(message, "requested_version")
-            guard requested == dockerHelperProtocolVersion else {
+            guard requested == registryHelperProtocolVersion else {
                 reply(peer, to: message, ok: false, error: "Registry helper protocol upgrade is required")
                 return
             }
-            reply(peer, to: message, ok: true, error: nil, value: String(dockerHelperProtocolVersion))
+            reply(peer, to: message, ok: true, error: nil, value: String(registryHelperProtocolVersion))
         case .goatHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
             let requested = xpc_dictionary_get_uint64(message, "requested_version")
             guard requested == 1 else {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2979,7 +2979,7 @@ private struct ApprovedFulfillmentMaterial: Sendable {
     let awsRegistration: AWSRegistration?
 }
 
-private let dockerHelperProtocolVersion: UInt64 = 2
+private let dockerHelperProtocolVersion: UInt64 = 3
 
 private final class ApprovalServer: @unchecked Sendable {
     private let serviceName: String
@@ -3179,7 +3179,7 @@ private final class ApprovalServer: @unchecked Sendable {
         case .dockerHelperVersion where isTrustedAvCaller(path: callerPath, signing: signing):
             let requested = xpc_dictionary_get_uint64(message, "requested_version")
             guard requested == dockerHelperProtocolVersion else {
-                reply(peer, to: message, ok: false, error: "Docker helper protocol upgrade is required")
+                reply(peer, to: message, ok: false, error: "Registry helper protocol upgrade is required")
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: String(dockerHelperProtocolVersion))
@@ -6116,12 +6116,12 @@ private final class ApprovalServer: @unchecked Sendable {
         helperSigning: SigningInfo
     ) throws -> ApprovalRequest {
         guard request.op == "docker-get" else {
-            guard request.tool != "docker" else {
+            guard request.tool != "docker" && request.tool != "podman" else {
                 throw AppError("Docker credentials require the Docker helper protocol")
             }
             return request
         }
-        guard request.tool == "docker",
+        guard request.tool == "docker" || request.tool == "podman",
               isTrustedAvCaller(path: helperPath, signing: helperSigning),
               request.target.isEmpty,
               request.args.isEmpty,
@@ -6140,7 +6140,7 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         let parent = try dockerCredentialParent(for: helperIdentity)
         let tool = credentialHelperTool(parent)
-        guard tool == "docker" || tool == "podman" else {
+        guard (tool == "docker" || tool == "podman"), request.tool == tool else {
             throw AppError("registry credential helper parent is not a supported Target")
         }
         let displayName = tool == "podman" ? "Podman" : "Docker"
@@ -8015,8 +8015,10 @@ private func classifySecretGateRequest(
         return .localWrite
     case "gh":
         return ghRequestClassification(request.args)
-    case "docker", "podman":
+    case "docker":
         return dockerRequestClassification(request.args)
+    case "podman":
+        return .secretDump
     case "goat":
         return goatRequestClassification(request.args)
     case "ordercli":

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2030,6 +2030,8 @@ enum SecretMutation {
     case delete(account: String)
     case dockerSave(account: String, value: String, serverURL: String, username: String)
     case dockerDelete(account: String, serverURL: String)
+    case podmanSave(account: String, value: String, serverURL: String, username: String)
+    case podmanDelete(account: String, serverURL: String)
     case goatSave(account: String, value: String, scope: String)
     case goatDelete(account: String, scope: String)
     case ordercliSave(account: String, value: String, scope: String)
@@ -2091,6 +2093,18 @@ enum SecretMutation {
                 "docker-delete", [account], ["credential", "erase", serverURL],
                 "Delete Docker credential for \(serverURL)?",
                 "Docker will no longer be able to authenticate to this registry with the stored credential."
+            )
+        case .podmanSave(let account, _, let serverURL, let username):
+            properties = (
+                "docker-save", [account], ["credential", "store", serverURL],
+                "Store Podman credential for \(serverURL)?",
+                "Podman will use the \(username) credential for this registry through its Automic Vault Secret Gate."
+            )
+        case .podmanDelete(let account, let serverURL):
+            properties = (
+                "docker-delete", [account], ["credential", "erase", serverURL],
+                "Delete Podman credential for \(serverURL)?",
+                "Podman will no longer be able to authenticate to this registry with the stored credential."
             )
         case .goatSave(let account, _, let scope):
             properties = (
@@ -2198,6 +2212,7 @@ enum SecretMutation {
         }
         let tool = switch self {
         case .dockerSave, .dockerDelete: "docker"
+        case .podmanSave, .podmanDelete: "podman"
         case .goatSave, .goatDelete: "goat"
         case .ordercliSave, .ordercliDelete: "ordercli"
         case .openhueSave: "openhue-cli"
@@ -2224,7 +2239,8 @@ enum SecretMutation {
                 keychainProperties: []
             )])
             credentialScope = nil
-        case .dockerSave(_, _, let serverURL, _), .dockerDelete(_, let serverURL):
+        case .dockerSave(_, _, let serverURL, _), .dockerDelete(_, let serverURL),
+             .podmanSave(_, _, let serverURL, _), .podmanDelete(_, let serverURL):
             cwd = requestCWD
             selectedSecretValues = SelectedSecretValues(values: [:])
             credentialScope = serverURL
@@ -2326,6 +2342,10 @@ enum SecretMutation {
         case .dockerSave(let account, let value, _, _):
             return saveStoredSecret(account: account, value: value, accessibility: .whenUnlocked)
         case .dockerDelete(let account, _):
+            return deleteStoredSecretRevokingDirectAccess(account: account)
+        case .podmanSave(let account, let value, _, _):
+            return saveStoredSecret(account: account, value: value, accessibility: .whenUnlocked)
+        case .podmanDelete(let account, _):
             return deleteStoredSecretRevokingDirectAccess(account: account)
         case .goatSave(let account, let value, _):
             return saveStoredSecret(account: account, value: value, accessibility: .whenUnlocked)
@@ -5453,8 +5473,11 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         do {
             let parent = try dockerCredentialParent(for: caller.identity)
+            let mutation: SecretMutation = credentialHelperTool(parent) == "podman"
+                ? .podmanSave(account: key, value: value, serverURL: credential.serverURL, username: credential.username)
+                : .dockerSave(account: key, value: value, serverURL: credential.serverURL, username: credential.username)
             handleMutation(
-                .dockerSave(account: key, value: value, serverURL: credential.serverURL, username: credential.username),
+                mutation,
                 on: peer,
                 message: message,
                 cancellation: cancellation,
@@ -5486,8 +5509,11 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         do {
             let parent = try dockerCredentialParent(for: caller.identity)
+            let mutation: SecretMutation = credentialHelperTool(parent) == "podman"
+                ? .podmanDelete(account: key, serverURL: serverURL)
+                : .dockerDelete(account: key, serverURL: serverURL)
             handleMutation(
-                .dockerDelete(account: key, serverURL: serverURL),
+                mutation,
                 on: peer,
                 message: message,
                 cancellation: cancellation,
@@ -5974,6 +6000,7 @@ private final class ApprovalServer: @unchecked Sendable {
                  .saveProject(let account, _, _, _, _),
                  .saveIfAbsentOrEqual(let account, _, _),
                  .dockerSave(let account, _, _, _),
+                 .podmanSave(let account, _, _, _),
                  .goatSave(let account, _, _),
                  .ordercliSave(let account, _, _),
                  .openhueSave(let account, _, _),
@@ -5993,6 +6020,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     )
                 }
             case .delete(let account), .dockerDelete(let account, _),
+                 .podmanDelete(let account, _),
                  .goatDelete(let account, _),
                  .ordercliDelete(let account, _),
                  .uaaDelete(let account, _),
@@ -6111,6 +6139,11 @@ private final class ApprovalServer: @unchecked Sendable {
             throw AppError("Docker registry Secret Name does not match its address")
         }
         let parent = try dockerCredentialParent(for: helperIdentity)
+        let tool = credentialHelperTool(parent)
+        guard tool == "docker" || tool == "podman" else {
+            throw AppError("registry credential helper parent is not a supported Target")
+        }
+        let displayName = tool == "podman" ? "Podman" : "Docker"
         return ApprovalRequest(
             op: request.op,
             keys: [secretName],
@@ -6122,9 +6155,9 @@ private final class ApprovalServer: @unchecked Sendable {
             envConflicts: [],
             shebangScript: nil,
             scriptData: nil,
-            tool: "docker",
-            title: "Use Docker credential for \(serverURL)?",
-            detail: "The verified Docker Target will receive the usable registry credential in plaintext, as required by Docker's credential-helper protocol.",
+            tool: tool,
+            title: "Use \(displayName) credential for \(serverURL)?",
+            detail: "The verified \(displayName) Target will receive the usable registry credential in plaintext, as required by the credential-helper protocol.",
             credentialScope: serverURL,
             credentialParent: parent
         )
@@ -6142,8 +6175,10 @@ private final class ApprovalServer: @unchecked Sendable {
               !arguments.isEmpty
         else { throw AppError("Docker credential helper has no live parent") }
         let target = pathString(parentIdentity)
-        guard dockerTargetIdentityValid(pid: parentPID, path: target) else {
-            throw AppError("Docker credential helper parent is not an eligible Docker Target")
+        guard dockerTargetIdentityValid(pid: parentPID, path: target)
+                || podmanTargetIdentityValid(pid: parentPID, path: target)
+        else {
+            throw AppError("registry credential helper parent is not an eligible Docker or Podman Target")
         }
         return CredentialHelperParent(
             pid: parentPID,
@@ -6178,6 +6213,18 @@ private final class ApprovalServer: @unchecked Sendable {
             && signing.teamIdentifier == "9BNSXJN65R"
             && signing.isDeveloperID
             && signing.runtimeProtection.allowsSecretGateAccess
+    }
+
+    private func podmanTargetIdentityValid(pid: pid_t, path: String) -> Bool {
+        guard configuredSecretGateTarget("podman", matches: path),
+              let signing = liveSigningInfo(pid: pid),
+              signing.mainExecutable == path
+        else { return false }
+        return signing.identifier == "podman"
+            && signing.teamIdentifier == "HYSCB8KRL2"
+            && signing.isDeveloperID
+            && signing.runtimeProtection == .hardened
+            && liveProcessHasNoEntitlements(pid: pid)
     }
 
     private func goatCredentialRequest(
@@ -6859,6 +6906,7 @@ private final class ApprovalServer: @unchecked Sendable {
         case "ordercli": "ordercli"
         case "oxide": "oxide-cli"
         case "plumber": "plumber"
+        case "podman": "podman"
         case "railway": "railway"
         case "rclone": "rclone"
         case "kubectl": "kubectl"
@@ -6886,6 +6934,7 @@ private final class ApprovalServer: @unchecked Sendable {
             return credentialHelperTool(parent) == tool
                 && aliyunTargetIdentityValid(pid: parent.pid, path: parent.target)
         case "docker": return dockerTargetIdentityValid(pid: parent.pid, path: parent.target)
+        case "podman": return podmanTargetIdentityValid(pid: parent.pid, path: parent.target)
         case "goat":
             return credentialHelperTool(parent) == tool
                 && goatTargetIdentityValid(pid: parent.pid, path: parent.target)
@@ -7966,7 +8015,7 @@ private func classifySecretGateRequest(
         return .localWrite
     case "gh":
         return ghRequestClassification(request.args)
-    case "docker":
+    case "docker", "podman":
         return dockerRequestClassification(request.args)
     case "goat":
         return goatRequestClassification(request.args)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -6117,7 +6117,7 @@ private final class ApprovalServer: @unchecked Sendable {
     ) throws -> ApprovalRequest {
         guard request.op == "docker-get" else {
             guard request.tool != "docker" && request.tool != "podman" else {
-                throw AppError("Docker credentials require the Docker helper protocol")
+                throw AppError("registry credentials require the credential-helper protocol")
             }
             return request
         }
@@ -6132,11 +6132,11 @@ private final class ApprovalServer: @unchecked Sendable {
               request.shebangScript == nil,
               request.scriptData == nil,
               let serverPointer = xpc_dictionary_get_string(message, "docker_server_url")
-        else { throw AppError("invalid Docker credential request") }
+        else { throw AppError("invalid registry credential request") }
         let serverURL = String(cString: serverPointer)
         let secretName = dockerCredentialSecretName(serverURL)
         guard validDockerServerURL(serverURL), request.keys == [secretName] else {
-            throw AppError("Docker registry Secret Name does not match its address")
+            throw AppError("registry Secret Name does not match its address")
         }
         let parent = try dockerCredentialParent(for: helperIdentity)
         let tool = credentialHelperTool(parent)

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -5460,7 +5460,7 @@ private final class ApprovalServer: @unchecked Sendable {
         guard let keyPointer = xpc_dictionary_get_string(message, "key"),
               let valuePointer = xpc_dictionary_get_string(message, "value")
         else {
-            reply(peer, to: message, ok: false, error: "invalid Docker credential store request")
+            reply(peer, to: message, ok: false, error: "invalid registry credential store request")
             return
         }
         let key = String(cString: keyPointer)
@@ -5468,7 +5468,7 @@ private final class ApprovalServer: @unchecked Sendable {
         guard let credential = parseDockerCredential(value),
               key == dockerCredentialSecretName(credential.serverURL)
         else {
-            reply(peer, to: message, ok: false, error: "invalid Docker credential")
+            reply(peer, to: message, ok: false, error: "invalid registry credential")
             return
         }
         do {
@@ -5498,13 +5498,13 @@ private final class ApprovalServer: @unchecked Sendable {
         guard let keyPointer = xpc_dictionary_get_string(message, "key"),
               let serverPointer = xpc_dictionary_get_string(message, "docker_server_url")
         else {
-            reply(peer, to: message, ok: false, error: "invalid Docker credential erase request")
+            reply(peer, to: message, ok: false, error: "invalid registry credential erase request")
             return
         }
         let key = String(cString: keyPointer)
         let serverURL = String(cString: serverPointer)
         guard validDockerServerURL(serverURL), key == dockerCredentialSecretName(serverURL) else {
-            reply(peer, to: message, ok: false, error: "invalid Docker credential")
+            reply(peer, to: message, ok: false, error: "invalid registry credential")
             return
         }
         do {
@@ -6173,7 +6173,7 @@ private final class ApprovalServer: @unchecked Sendable {
               parentIdentity.euid == helperIdentity.euid,
               let arguments = processArguments(parentPID),
               !arguments.isEmpty
-        else { throw AppError("Docker credential helper has no live parent") }
+        else { throw AppError("registry credential helper has no live parent") }
         let target = pathString(parentIdentity)
         guard dockerTargetIdentityValid(pid: parentPID, path: target)
                 || podmanTargetIdentityValid(pid: parentPID, path: target)

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const ALIYUN_HELPER_PROTOCOL_VERSION: u64 = 1;
-const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 2;
+const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 3;
 const OXIDE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const GOAT_HELPER_PROTOCOL_VERSION: u64 = 1;
 const KUBECTL_HELPER_PROTOCOL_VERSION: u64 = 1;
@@ -197,15 +197,15 @@ pub(crate) fn ensure_docker_helper_ready() -> Result<(), String> {
     )
     .map_err(|error| {
         format!(
-            "Docker credential-helper protocol negotiation failed; update and open the Automic Vault app: {error}"
+            "Registry credential-helper protocol negotiation failed; update and open the Automic Vault app: {error}"
         )
     })?;
     match reply.value.as_deref() {
         Some(version) if version == DOCKER_HELPER_PROTOCOL_VERSION.to_string() => Ok(()),
         Some(version) => Err(format!(
-            "the running Automic Vault app reported unsupported Docker helper version {version}"
+            "the running Automic Vault app reported unsupported registry helper version {version}"
         )),
-        None => Err("the running Automic Vault app returned no Docker helper version".into()),
+        None => Err("the running Automic Vault app returned no registry helper version".into()),
     }
 }
 

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const ALIYUN_HELPER_PROTOCOL_VERSION: u64 = 1;
-const DOCKER_HELPER_PROTOCOL_VERSION: u64 = 3;
+const REGISTRY_HELPER_PROTOCOL_VERSION: u64 = 3;
 const OXIDE_HELPER_PROTOCOL_VERSION: u64 = 1;
 const GOAT_HELPER_PROTOCOL_VERSION: u64 = 1;
 const KUBECTL_HELPER_PROTOCOL_VERSION: u64 = 1;
@@ -184,7 +184,7 @@ fn list_secret_names_filtered(global_only: bool) -> Result<Vec<String>, String> 
     .names)
 }
 
-pub(crate) fn ensure_docker_helper_ready() -> Result<(), String> {
+pub(crate) fn ensure_registry_helper_ready() -> Result<(), String> {
     if crate::test_keychain_dir().is_some() {
         return Ok(());
     }
@@ -193,7 +193,7 @@ pub(crate) fn ensure_docker_helper_ready() -> Result<(), String> {
         None,
         None,
         None,
-        Some((b"requested_version\0", DOCKER_HELPER_PROTOCOL_VERSION)),
+        Some((b"requested_version\0", REGISTRY_HELPER_PROTOCOL_VERSION)),
     )
     .map_err(|error| {
         format!(
@@ -201,7 +201,7 @@ pub(crate) fn ensure_docker_helper_ready() -> Result<(), String> {
         )
     })?;
     match reply.value.as_deref() {
-        Some(version) if version == DOCKER_HELPER_PROTOCOL_VERSION.to_string() => Ok(()),
+        Some(version) if version == REGISTRY_HELPER_PROTOCOL_VERSION.to_string() => Ok(()),
         Some(version) => Err(format!(
             "the running Automic Vault app reported unsupported registry helper version {version}"
         )),

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -210,7 +210,7 @@ pub(crate) fn ensure_registry_helper_ready() -> Result<(), String> {
     }
 }
 
-pub(crate) fn store_docker_credential(account: &str, value: &str) -> Result<(), String> {
+pub(crate) fn store_registry_credential(account: &str, value: &str) -> Result<(), String> {
     if let Some(dir) = crate::test_keychain_dir() {
         std::fs::create_dir_all(&dir)
             .map_err(|err| format!("failed to create test keychain dir: {err}"))?;
@@ -218,6 +218,7 @@ pub(crate) fn store_docker_credential(account: &str, value: &str) -> Result<(), 
         return std::fs::write(&path, value)
             .map_err(|err| format!("failed to write {}: {err}", path.display()));
     }
+    // Stable compatibility wire name shared by Docker and Podman.
     xpc_request(
         "docker-save",
         Some((b"key\0", account)),
@@ -228,14 +229,15 @@ pub(crate) fn store_docker_credential(account: &str, value: &str) -> Result<(), 
     .map(|_| ())
 }
 
-pub(crate) fn delete_docker_credential(account: &str, server_url: &str) -> Result<(), String> {
+pub(crate) fn delete_registry_credential(account: &str, server_url: &str) -> Result<(), String> {
     if let Some(dir) = crate::test_keychain_dir() {
         return match std::fs::remove_file(dir.join(account)) {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(format!("failed to delete test Docker credential: {err}")),
+            Err(err) => Err(format!("failed to delete test registry credential: {err}")),
         };
     }
+    // Stable compatibility wire names and field shared by Docker and Podman.
     xpc_request(
         "docker-delete",
         Some((b"key\0", account)),

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -188,6 +188,7 @@ pub(crate) fn ensure_registry_helper_ready() -> Result<(), String> {
     if crate::test_keychain_dir().is_some() {
         return Ok(());
     }
+    // Stable compatibility wire name shared by Docker and Podman registry helpers.
     let reply = xpc_request(
         "docker-helper-version",
         None,


### PR DESCRIPTION
## Summary

- retain the official Red Hat-signed, hardened-runtime Podman client at `/opt/podman/bin/podman`
- migrate supported registry credentials out of Podman auth JSON into Automic Vault custody
- configure a dedicated `av-podman` credential helper and verify its root-owned launcher
- gate every credential retrieval as a Secret Dump because Podman's remote client enumerates all configured registry credentials before sending auth to its service
- fail closed for competing helpers, ambiguous credentials, unsafe files, config overrides, Docker fallback credentials, signature drift, entitlements, and lossy migration cases
- record the credential-custody boundary in ADR 0038

No Podman Isotope or tap formula is added: the official package already provides the eligible signed Target, and this is a configuration-only hardener.

## Security boundary

The helper's `list` response contains only registry names already present as non-secret markers in the user's Podman auth JSON. Credential values and usernames remain in Automic Vault. Each subsequent `get` is bound to the live Red Hat-signed Podman parent, its configured gate target, the canonical registry-derived Secret Name, and Secret Dump authorization.

## Tests

- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`

Updates #186.
