### PR TITLE
Fix Varlock helper canonicalization under /tmp

### DIFF
--- a/scripts/test-varlock-plugin-helper.sh
+++ b/scripts/test-varlock-plugin-helper.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 repo=$(cd "$(dirname "$0")/.." && pwd)
 package="$repo/src/menu-helper"
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT
+alias_work=$(mktemp -d /tmp/varlock-plugin-helper.XXXXXX)
+trap 'rm -rf "$work" "$alias_work"' EXIT
 
 swift build \
   --package-path "$package" \
@@ -21,6 +22,17 @@ if [[ "$($helper --protocol-version)" != "1" ]]; then
   echo "error: Varlock helper reported the wrong protocol version" >&2
   exit 1
 fi
+
+for test_cwd in "$alias_work" "/private$alias_work"; do
+  expected_cwd=$(cd "$test_cwd" && /bin/pwd -P)
+  actual_cwd=$(cd "$test_cwd" && "$helper" --test-canonical-working-directory)
+  if [[ "$actual_cwd" != "$expected_cwd" ]]; then
+    echo "error: Varlock helper reported a non-canonical working directory" >&2
+    echo "expected: $expected_cwd" >&2
+    echo "actual:   $actual_cwd" >&2
+    exit 1
+  fi
+done
 
 assert_rejected() {
   local expected=$1

--- a/src/menu-helper/Sources/VarlockPluginHelper/main.swift
+++ b/src/menu-helper/Sources/VarlockPluginHelper/main.swift
@@ -17,11 +17,9 @@ private func fail(_ message: String) -> Never {
 private func canonicalWorkingDirectory() -> String? {
     var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
     guard realpath(FileManager.default.currentDirectoryPath, &resolved) != nil else { return nil }
-    let end = resolved.firstIndex(of: 0) ?? resolved.endIndex
-    return String(
-        data: Data(resolved[..<end].map { UInt8(bitPattern: $0) }),
-        encoding: .utf8
-    )
+    return resolved.withUnsafeBytes { bytes in
+        String(bytes: bytes.prefix { $0 != 0 }, encoding: .utf8)
+    }
 }
 
 if CommandLine.arguments.dropFirst().elementsEqual(["--protocol-version"]) {

--- a/src/menu-helper/Sources/VarlockPluginHelper/main.swift
+++ b/src/menu-helper/Sources/VarlockPluginHelper/main.swift
@@ -14,10 +14,28 @@ private func fail(_ message: String) -> Never {
     exit(1)
 }
 
+private func canonicalWorkingDirectory() -> String? {
+    var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(FileManager.default.currentDirectoryPath, &resolved) != nil else { return nil }
+    let end = resolved.firstIndex(of: 0) ?? resolved.endIndex
+    return String(
+        data: Data(resolved[..<end].map { UInt8(bitPattern: $0) }),
+        encoding: .utf8
+    )
+}
+
 if CommandLine.arguments.dropFirst().elementsEqual(["--protocol-version"]) {
     print(varlockProtocolVersion)
     exit(0)
 }
+
+#if DEBUG
+if CommandLine.arguments.dropFirst().elementsEqual(["--test-canonical-working-directory"]) {
+    guard let cwd = canonicalWorkingDirectory() else { fail("working directory is unavailable") }
+    print(cwd)
+    exit(0)
+}
+#endif
 
 guard 4...(maximumSecretNames + 3) ~= CommandLine.arguments.count else {
     fail("expected a protocol version, schema digest, and between 1 and \(maximumSecretNames) Secret Names")
@@ -44,8 +62,7 @@ guard Set(secretNames).count == secretNames.count,
 else {
     fail("invalid Secret Name")
 }
-let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-    .resolvingSymlinksInPath().path
+guard let cwd = canonicalWorkingDirectory() else { fail("working directory is unavailable") }
 
 let connection = xpc_connection_create_mach_service(approvalService, nil, 0)
 guard xpc_connection_set_peer_code_signing_requirement(


### PR DESCRIPTION
## Summary

- canonicalize the signed Varlock Gate Client’s working directory with `realpath()`, matching the approval service
- fail closed before XPC when the working directory cannot be canonicalized
- cover both `/tmp/...` and `/private/tmp/...` through the existing helper boundary check

## Security

The approval service’s exact canonical Project Directory validation is unchanged. The fix changes only the trusted Gate Client’s path representation and compiles its test probe out of release builds.

## Verification

- `scripts/test-varlock-plugin-helper.sh`
- `swift test --package-path src/menu-helper --disable-automatic-resolution` (240 tests passed)
- release build plus verification that the debug-only test probe is absent
- `cargo test --test release_workflow ci_tests_optimized_and_executable_boundaries`
- `bash -n scripts/test-varlock-plugin-helper.sh`
- `git diff --check`

Fixes automic-vault/varlock-plugin#1