### PR TITLE
Add collapsible Temporary Access Grant strip

### DIFF
--- a/docs/adr/0041-collapsible-temporary-access-grant-strip.md
+++ b/docs/adr/0041-collapsible-temporary-access-grant-strip.md
@@ -1,0 +1,31 @@
+# ADR 0041: Permit an opt-in collapsible Temporary Access Grant strip
+
+Status: accepted
+
+## Context
+
+The persistent Temporary Access Grant strip keeps temporary Write Access
+conspicuous, but it can cover unrelated content for the grant's full lifetime.
+Hiding it completely would remove a deliberate safety signal while authority
+remains active. Its menu-bar item already turns orange and exposes every active
+grant and action.
+
+## Decision
+
+Keep the complete strip as the default. Add an off-by-default setting that
+collapses it after five seconds into a visible warning tab at the nearest
+horizontal screen edge. Selecting the tab or the menu action restores the
+complete strip and restarts the delay. Creating a new grant also restores it.
+
+Collapsing changes presentation only. It does not suspend, extend, end, or alter
+a grant. The status-item shield remains orange, the menu continues to list every
+active grant, and End remains immediately available. The warning tab uses a
+standard button with a full-size hit target and does not depend on color alone.
+
+## Consequences
+
+Users who enable the setting reclaim most of the covered screen area without
+making temporary Write Access invisible. The complete grant details are no
+longer continuously readable while collapsed, so the behavior remains an
+explicit opt-in rather than the default. The edge tab also avoids depending on
+the status item's horizontal position after the initial five-second display.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -652,13 +652,19 @@ recurring mutable or injectable harness up to Verified Launcher requirements.
 An enrolled Launcher Bundle payload representing its own bundle is not Retained
 Launcher Provenance and does not require this setting.
 
-While any Temporary Access Grant exists, a non-activating strip remains visible
-directly below the menu-bar item with every scoped grant, second-accurate
-remaining active time, suspension state, successful-use count, last-use time,
-and Add 10 Minutes, End, and countdown-toggle actions. The menu mirrors these
-actions and the shield turns orange. Automatic-request notifications stack
-below the strip. This continuous presentation is part of the temporary
-escalation's safety model, not a source of authority.
+While any Temporary Access Grant exists, a non-activating strip shows directly
+below the menu-bar item with every scoped grant, second-accurate remaining active
+time, suspension state, successful-use count, last-use time, and Add 10 Minutes,
+End, and countdown-toggle actions. The menu mirrors these actions and the shield
+turns orange. Automatic-request notifications stack below the strip.
+
+An off-by-default setting may collapse the strip after five seconds into a
+visible warning tab at the nearest horizontal screen edge. Selecting that tab,
+or the matching menu action, restores the complete strip and restarts the delay.
+A newly created grant always restores the complete strip. The orange menu-bar
+shield, active-grant menu entries, and immediate End action remain continuously
+available. This continuous indication is part of the temporary escalation's
+safety model, not a source of authority. See [ADR 0041](adr/0041-collapsible-temporary-access-grant-strip.md).
 
 ## Source of truth
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -453,11 +453,14 @@ Secret Gate, and Secret mutation operations remain outside the grant.
 
 A Temporary Access Grant can begin only when the user selects its explicit
 action in an eligible live write-request Approval. It is not a
-durable Authorization Policy or Blessing. Automic Vault shows every active
-grant continuously with its successful-use count and last-use time, lets the
-user add ten minutes of active countdown time, lets the user suspend or resume
-its countdown, lets the user end each grant immediately, and revokes all grants
-when the user session becomes inactive, displays sleep, an update begins, or the
+durable Authorization Policy or Blessing. Automic Vault continuously indicates
+every active grant. By default, a persistent strip shows each grant's
+successful-use count and last-use time. The user may opt to collapse the strip
+after five seconds into a visible warning tab at the nearest screen edge; the
+menu-bar item remains orange and continues to expose every grant and action.
+The user can add ten minutes of active countdown time, suspend or resume its
+countdown, or end each grant immediately. Automic Vault revokes all grants when
+the user session becomes inactive, displays sleep, an update begins, or the
 service terminates. A suspended countdown also suspends the grant's authority:
 requests cannot match it until the user resumes it. The remaining active time is
 preserved while suspended. Running countdowns and resumed deadlines use both

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -42,7 +42,8 @@ Automic Vault decides whether a complete operation may use it.
   Write Access to one Verified Launcher, Tool-specific Authorization Gate, and
   agent task. A persistent strip shows the grant and lets the user add ten
   minutes, suspend its countdown, or end it; suspension also suspends its
-  authority.
+  authority. The user may opt to collapse the strip after five seconds to a
+  visible warning tab while the menu-bar shield remains orange.
 - Existing developer commands continue to work above the security boundary.
 - An explicitly recognized, vendor-signed CLI sealed inside its vendor's app
   may represent that app as a Verified Launcher; unrelated bundled executables

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -6,7 +6,11 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 let automaticApprovalFeedbackDefaultsKey = "automaticApprovalFeedback"
+let autoCollapseTemporaryAccessGrantStripDefaultsKey = "autoCollapseTemporaryAccessGrantStrip"
 let keepLauncherAccessForDetachedProcessesDefaultsKey = "keepLauncherAccessForDetachedProcesses"
+let temporaryAccessGrantStripPresentationDidChange = Notification.Name(
+    "TemporaryAccessGrantStripPresentationDidChange"
+)
 private let directAccessDocumentationURL = URL(
     string: "https://github.com/automic-vault/automic-vault/blob/main/docs/direct-secret-access.md#safer-alternatives"
 )!
@@ -4034,6 +4038,8 @@ private struct TouchIDApprovalSettingsView: View {
 private struct AutomaticApprovalFeedbackSettingsView: View {
     @AppStorage(automaticApprovalFeedbackDefaultsKey)
     private var feedback = AutomaticApprovalFeedback.notification
+    @AppStorage(autoCollapseTemporaryAccessGrantStripDefaultsKey)
+    private var autoCollapseTemporaryAccessGrantStrip = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -4054,6 +4060,25 @@ private struct AutomaticApprovalFeedbackSettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+            Divider()
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Temporary Write Access")
+                    .font(.headline)
+                Toggle(
+                    "Auto-collapse Temporary Access Grant Strip",
+                    isOn: $autoCollapseTemporaryAccessGrantStrip
+                )
+                Text("After five seconds, the strip becomes a warning tab at the nearest screen edge. Select the tab or use the menu bar to restore it. New grants always show the complete strip.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .onChange(of: autoCollapseTemporaryAccessGrantStrip) {
+            NotificationCenter.default.post(
+                name: temporaryAccessGrantStripPresentationDidChange,
+                object: nil
+            )
         }
     }
 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -20,6 +20,7 @@ private let varlockProtocolVersion: UInt64 = 1
 let secCodeSignatureAdHoc: UInt32 = 0x2
 private let scanMaximumDelay: TimeInterval = 5
 private let scanQueue = DispatchQueue(label: "com.automicvault.av2.scan")
+private let temporaryAccessGrantCollapseDelay: TimeInterval = 5
 private let updateCheckInterval: Duration = .seconds(24 * 60 * 60)
 private var toastWindows: [NSWindow] = []
 private var temporaryAccessGrantStripFrame: NSRect?
@@ -114,6 +115,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var temporaryAccessGrantSeparator: NSMenuItem?
     private var temporaryAccessGrantPanel: TemporaryAccessGrantPanel?
     private var temporaryAccessGrantTimer: Timer?
+    private var temporaryAccessGrantCollapseWorkItem: DispatchWorkItem?
+    private var isTemporaryAccessGrantStripCollapsed = false
     private let liveSecretUses = LiveSecretUseController<LiveSecretUseProcess>()
     private var liveSecretUseSnapshots: [LiveSecretUseSnapshot] = []
     private var liveSecretUseMenuItems: [NSMenuItem] = []
@@ -175,6 +178,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             name: NSWorkspace.screensDidWakeNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(temporaryAccessGrantStripPresentationChanged(_:)),
+            name: temporaryAccessGrantStripPresentationDidChange,
+            object: nil
+        )
+    }
+
+    @objc private func temporaryAccessGrantStripPresentationChanged(_ notification: Notification) {
+        refreshTemporaryAccessGrantPanel()
+        refreshTemporaryAccessGrantMenuItems()
     }
 
     @objc private func userSessionDidResignActive(_ notification: Notification) {
@@ -365,6 +379,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         dailyHeartbeatTask?.cancel()
         #endif
         NSWorkspace.shared.notificationCenter.removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
         stopServices()
     }
 
@@ -373,6 +388,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         refreshTemporaryAccessGrants()
         temporaryAccessGrantTimer?.invalidate()
         temporaryAccessGrantTimer = nil
+        temporaryAccessGrantCollapseWorkItem?.cancel()
+        temporaryAccessGrantCollapseWorkItem = nil
         liveSecretUses.cancelAll()
         refreshLiveSecretUses()
         liveSecretUseTimer?.invalidate()
@@ -1098,7 +1115,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func refreshTemporaryAccessGrants() {
+        let previousGenerations = Set(temporaryAccessGrantSnapshots.map(\.generation))
         temporaryAccessGrantSnapshots = temporaryAccessGrants.snapshots()
+        if temporaryAccessGrantSnapshots.contains(where: {
+            !previousGenerations.contains($0.generation)
+        }) {
+            isTemporaryAccessGrantStripCollapsed = false
+            temporaryAccessGrantCollapseWorkItem?.cancel()
+            temporaryAccessGrantCollapseWorkItem = nil
+        } else if temporaryAccessGrantSnapshots.isEmpty {
+            isTemporaryAccessGrantStripCollapsed = false
+            temporaryAccessGrantCollapseWorkItem?.cancel()
+            temporaryAccessGrantCollapseWorkItem = nil
+        }
         if temporaryAccessGrantSnapshots.allSatisfy(\.isCountdownSuspended) {
             temporaryAccessGrantTimer?.invalidate()
             temporaryAccessGrantTimer = nil
@@ -1157,6 +1186,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             addTenMinutes.representedObject = grant.id.uuidString
             submenu.addItem(addTenMinutes)
             submenu.addItem(.separator())
+            if isTemporaryAccessGrantStripCollapsed {
+                let showStrip = NSMenuItem(
+                    title: "Show Temporary Access Grant Strip",
+                    action: #selector(showTemporaryAccessGrantStrip(_:)),
+                    keyEquivalent: ""
+                )
+                showStrip.target = self
+                submenu.addItem(showStrip)
+                submenu.addItem(.separator())
+            }
             let toggle = NSMenuItem(
                 title: grant.isCountdownSuspended
                     ? "Resume Write Access"
@@ -1195,6 +1234,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         else { return }
         _ = temporaryAccessGrants.cancel(id: id)
         refreshTemporaryAccessGrants()
+    }
+
+    @objc private func showTemporaryAccessGrantStrip(_ sender: NSMenuItem) {
+        revealTemporaryAccessGrantStrip()
     }
 
     @objc private func addTenMinutesToTemporaryAccessGrant(_ sender: NSMenuItem) {
@@ -1307,49 +1350,98 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               let button = statusItem.button,
               let statusWindow = button.window
         else {
+            temporaryAccessGrantCollapseWorkItem?.cancel()
+            temporaryAccessGrantCollapseWorkItem = nil
+            isTemporaryAccessGrantStripCollapsed = false
             temporaryAccessGrantPanel?.orderOut(nil)
             temporaryAccessGrantPanel = nil
             temporaryAccessGrantStripFrame = nil
             return
         }
+        let autoCollapse = UserDefaults.standard.bool(
+            forKey: autoCollapseTemporaryAccessGrantStripDefaultsKey
+        )
+        if !autoCollapse {
+            temporaryAccessGrantCollapseWorkItem?.cancel()
+            temporaryAccessGrantCollapseWorkItem = nil
+            isTemporaryAccessGrantStripCollapsed = false
+        }
         let panel = temporaryAccessGrantPanel ?? makeTemporaryAccessGrantPanel()
         temporaryAccessGrantPanel = panel
         let wallNow = Date()
         let monotonicNow = ProcessInfo.processInfo.systemUptime
-        let hostingView = NSHostingView(rootView: TemporaryAccessGrantStripView(
-            grants: temporaryAccessGrantSnapshots,
-            wallNow: wallNow,
-            monotonicNow: monotonicNow,
-            addTenMinutes: { [weak self] id in
-                guard let self else { return }
-                _ = self.temporaryAccessGrants.addTenMinutes(id: id)
-                self.refreshTemporaryAccessGrants()
-            },
-            end: { [weak self] id in
-                guard let self else { return }
-                _ = self.temporaryAccessGrants.cancel(id: id)
-                self.refreshTemporaryAccessGrants()
-            },
-            setCountdownSuspended: { [weak self] id, suspended in
-                guard let self else { return }
-                _ = self.temporaryAccessGrants.setCountdownSuspended(
-                    id: id,
-                    suspended: suspended
-                )
-                self.refreshTemporaryAccessGrants()
-            }
-        ))
+        let hostingView: NSView
+        if isTemporaryAccessGrantStripCollapsed {
+            hostingView = NSHostingView(rootView: CollapsedTemporaryAccessGrantStripView(
+                grantCount: temporaryAccessGrantSnapshots.count,
+                show: { [weak self] in self?.revealTemporaryAccessGrantStrip() }
+            ))
+        } else {
+            hostingView = NSHostingView(rootView: TemporaryAccessGrantStripView(
+                grants: temporaryAccessGrantSnapshots,
+                wallNow: wallNow,
+                monotonicNow: monotonicNow,
+                addTenMinutes: { [weak self] id in
+                    guard let self else { return }
+                    _ = self.temporaryAccessGrants.addTenMinutes(id: id)
+                    self.refreshTemporaryAccessGrants()
+                },
+                end: { [weak self] id in
+                    guard let self else { return }
+                    _ = self.temporaryAccessGrants.cancel(id: id)
+                    self.refreshTemporaryAccessGrants()
+                },
+                setCountdownSuspended: { [weak self] id, suspended in
+                    guard let self else { return }
+                    _ = self.temporaryAccessGrants.setCountdownSuspended(
+                        id: id,
+                        suspended: suspended
+                    )
+                    self.refreshTemporaryAccessGrants()
+                }
+            ))
+        }
         let size = hostingView.fittingSize
         hostingView.frame.size = size
         panel.contentView = hostingView
         let anchor = statusWindow.convertToScreen(button.convert(button.bounds, to: nil))
         let visibleFrame = statusWindow.screen?.visibleFrame ?? NSScreen.main?.visibleFrame
             ?? NSRect(x: 0, y: 0, width: 800, height: 600)
-        let frame = autoApprovalToastFrame(anchor: anchor, visibleFrame: visibleFrame, size: size)
+        let frame = isTemporaryAccessGrantStripCollapsed
+            ? temporaryAccessGrantTabFrame(anchor: anchor, visibleFrame: visibleFrame, size: size)
+            : autoApprovalToastFrame(anchor: anchor, visibleFrame: visibleFrame, size: size)
         panel.setFrame(frame, display: true)
         temporaryAccessGrantStripFrame = frame
         panel.orderFrontRegardless()
         reanchorToastWindows(below: frame, visibleFrame: visibleFrame)
+        if autoCollapse, !isTemporaryAccessGrantStripCollapsed,
+           temporaryAccessGrantCollapseWorkItem == nil
+        {
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.temporaryAccessGrantCollapseWorkItem = nil
+                guard UserDefaults.standard.bool(
+                    forKey: autoCollapseTemporaryAccessGrantStripDefaultsKey
+                ), !self.temporaryAccessGrantSnapshots.isEmpty
+                else { return }
+                self.isTemporaryAccessGrantStripCollapsed = true
+                self.refreshTemporaryAccessGrantPanel()
+                self.refreshTemporaryAccessGrantMenuItems()
+            }
+            temporaryAccessGrantCollapseWorkItem = workItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + temporaryAccessGrantCollapseDelay,
+                execute: workItem
+            )
+        }
+    }
+
+    private func revealTemporaryAccessGrantStrip() {
+        temporaryAccessGrantCollapseWorkItem?.cancel()
+        temporaryAccessGrantCollapseWorkItem = nil
+        isTemporaryAccessGrantStripCollapsed = false
+        refreshTemporaryAccessGrantPanel()
+        refreshTemporaryAccessGrantMenuItems()
     }
 
     private func setBaseStatusImage(_ image: NSImage?) {
@@ -12362,6 +12454,42 @@ private struct TemporaryAccessGrantStripView: View {
     }
 }
 
+private struct CollapsedTemporaryAccessGrantStripView: View {
+    let grantCount: Int
+    let show: () -> Void
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        Button(action: show) {
+            VStack(spacing: 1) {
+                Image(systemName: "exclamationmark.shield.fill")
+                    .font(.headline)
+                Text("\(grantCount)")
+                    .font(.caption2.monospacedDigit().weight(.semibold))
+            }
+            .foregroundStyle(.orange)
+            .frame(width: 44, height: 44)
+            .background {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(reduceTransparency
+                        ? AnyShapeStyle(Color(nsColor: .windowBackgroundColor))
+                        : AnyShapeStyle(.regularMaterial))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(.separator.opacity(0.8), lineWidth: 1)
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help("Show Temporary Access Grant Strip")
+        .accessibilityLabel(
+            "Show \(grantCount) active Temporary Access \(grantCount == 1 ? "Grant" : "Grants")"
+        )
+        .accessibilityHint("Opens the complete Temporary Access Grant Strip")
+    }
+}
+
 private struct TemporaryAccessGrantRow: View {
     let grant: TemporaryAccessGrantSnapshot
     let remaining: TimeInterval
@@ -12432,6 +12560,19 @@ private func autoApprovalToastFrame(anchor: NSRect, visibleFrame: NSRect, size: 
     let margin: CGFloat = 8
     let x = min(max(anchor.midX - size.width / 2, visibleFrame.minX + margin), visibleFrame.maxX - size.width - margin)
     let y = max(visibleFrame.minY + margin, min(anchor.minY - 4, visibleFrame.maxY) - size.height)
+    return NSRect(origin: NSPoint(x: x, y: y), size: size)
+}
+
+private func temporaryAccessGrantTabFrame(
+    anchor: NSRect,
+    visibleFrame: NSRect,
+    size: NSSize
+) -> NSRect {
+    let margin: CGFloat = 8
+    let x = anchor.midX < visibleFrame.midX
+        ? visibleFrame.minX
+        : visibleFrame.maxX - size.width
+    let y = max(visibleFrame.minY + margin, visibleFrame.maxY - size.height - margin)
     return NSRect(origin: NSPoint(x: x, y: y), size: size)
 }
 
@@ -15094,6 +15235,10 @@ private func runMenuStatusSelfCheck() -> Int32 {
         end: { _ in },
         setCountdownSuspended: { _, _ in }
     ))
+    let collapsedStripView = NSHostingView(rootView: CollapsedTemporaryAccessGrantStripView(
+        grantCount: grantSnapshots.count,
+        show: {}
+    ))
     let grantPanel = makeTemporaryAccessGrantPanel()
     let sampleStripFrame = NSRect(x: 200, y: 400, width: 430, height: 120)
     let stackedToastFrame = autoApprovalToastFrame(
@@ -15108,7 +15253,18 @@ private func runMenuStatusSelfCheck() -> Int32 {
               monotonicNow: grantMonotonicNow
           ).contains("Codex → AWS Authorization Gate · Codex task 11111111 · 10:00 · Write Access: 1 use · Last used "),
           stripView.fittingSize.width == 430,
+          collapsedStripView.fittingSize == NSSize(width: 44, height: 44),
           stackedToastFrame.maxY == sampleStripFrame.minY - 4,
+          temporaryAccessGrantTabFrame(
+              anchor: NSRect(x: 100, y: 576, width: 24, height: 24),
+              visibleFrame: NSRect(x: 0, y: 0, width: 800, height: 600),
+              size: collapsedStripView.fittingSize
+          ) == NSRect(x: 0, y: 548, width: 44, height: 44),
+          temporaryAccessGrantTabFrame(
+              anchor: NSRect(x: 700, y: 576, width: 24, height: 24),
+              visibleFrame: NSRect(x: 0, y: 0, width: 800, height: 600),
+              size: collapsedStripView.fittingSize
+          ) == NSRect(x: 756, y: 548, width: 44, height: 44),
           grantPanel.styleMask.contains(.borderless),
           grantPanel.styleMask.contains(.nonactivatingPanel),
           grantPanel.level == .statusBar,
@@ -15127,6 +15283,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
                 monotonicNow: grantMonotonicNow
             ),
             stripView.fittingSize,
+            collapsedStripView.fittingSize,
             stackedToastFrame,
             grantPanel.styleMask.rawValue,
             grantPanel.level.rawValue,

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1410,7 +1410,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let frame = isTemporaryAccessGrantStripCollapsed
             ? temporaryAccessGrantTabFrame(anchor: anchor, visibleFrame: visibleFrame, size: size)
             : autoApprovalToastFrame(anchor: anchor, visibleFrame: visibleFrame, size: size)
-        panel.setFrame(frame, display: true)
+        if shouldAnimateTemporaryAccessGrantPanelTransition(
+            isVisible: panel.isVisible,
+            reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+            from: panel.frame,
+            to: frame
+        ) {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.25
+                panel.animator().setFrame(frame, display: true)
+            }
+        } else {
+            panel.setFrame(frame, display: true)
+        }
         temporaryAccessGrantStripFrame = frame
         panel.orderFrontRegardless()
         reanchorToastWindows(below: frame, visibleFrame: visibleFrame)
@@ -12468,7 +12480,7 @@ private struct CollapsedTemporaryAccessGrantStripView: View {
                     .font(.caption2.monospacedDigit().weight(.semibold))
             }
             .foregroundStyle(.orange)
-            .frame(width: 44, height: 44)
+            .frame(width: 52, height: 44)
             .background {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(reduceTransparency
@@ -12569,11 +12581,21 @@ private func temporaryAccessGrantTabFrame(
     size: NSSize
 ) -> NSRect {
     let margin: CGFloat = 8
+    let peek: CGFloat = 8
     let x = anchor.midX < visibleFrame.midX
-        ? visibleFrame.minX
-        : visibleFrame.maxX - size.width
+        ? visibleFrame.minX - peek
+        : visibleFrame.maxX - size.width + peek
     let y = max(visibleFrame.minY + margin, visibleFrame.maxY - size.height - margin)
     return NSRect(origin: NSPoint(x: x, y: y), size: size)
+}
+
+private func shouldAnimateTemporaryAccessGrantPanelTransition(
+    isVisible: Bool,
+    reduceMotion: Bool,
+    from: NSRect,
+    to: NSRect
+) -> Bool {
+    isVisible && !reduceMotion && from != to
 }
 
 @MainActor
@@ -15253,18 +15275,30 @@ private func runMenuStatusSelfCheck() -> Int32 {
               monotonicNow: grantMonotonicNow
           ).contains("Codex → AWS Authorization Gate · Codex task 11111111 · 10:00 · Write Access: 1 use · Last used "),
           stripView.fittingSize.width == 430,
-          collapsedStripView.fittingSize == NSSize(width: 44, height: 44),
+          collapsedStripView.fittingSize == NSSize(width: 52, height: 44),
           stackedToastFrame.maxY == sampleStripFrame.minY - 4,
           temporaryAccessGrantTabFrame(
               anchor: NSRect(x: 100, y: 576, width: 24, height: 24),
               visibleFrame: NSRect(x: 0, y: 0, width: 800, height: 600),
               size: collapsedStripView.fittingSize
-          ) == NSRect(x: 0, y: 548, width: 44, height: 44),
+          ) == NSRect(x: -8, y: 548, width: 52, height: 44),
           temporaryAccessGrantTabFrame(
               anchor: NSRect(x: 700, y: 576, width: 24, height: 24),
               visibleFrame: NSRect(x: 0, y: 0, width: 800, height: 600),
               size: collapsedStripView.fittingSize
-          ) == NSRect(x: 756, y: 548, width: 44, height: 44),
+          ) == NSRect(x: 756, y: 548, width: 52, height: 44),
+          shouldAnimateTemporaryAccessGrantPanelTransition(
+              isVisible: true,
+              reduceMotion: false,
+              from: .zero,
+              to: sampleStripFrame
+          ),
+          !shouldAnimateTemporaryAccessGrantPanelTransition(
+              isVisible: true,
+              reduceMotion: true,
+              from: .zero,
+              to: sampleStripFrame
+          ),
           grantPanel.styleMask.contains(.borderless),
           grantPanel.styleMask.contains(.nonactivatingPanel),
           grantPanel.level == .statusBar,


### PR DESCRIPTION
## Summary

- add an off-by-default setting that shows the complete Temporary Access Grant strip for five seconds, then collapses it to the nearest screen edge
- preserve a 44-point visible warning target while clipping the outer border and animate the transition unless Reduce Motion is enabled
- restore the complete strip from the edge tab or menu, and whenever a new grant starts
- record the presentation tradeoff in the canonical domain language, architecture, positioning, and ADR 0041

The orange menu-bar shield, active-grant entries, and End action remain continuously available. Collapsing changes presentation only; it does not alter grant authority.

Addresses #249 and #250.

## Verification

- swift build --package-path src/menu-helper --product AutomicVaultMenubar --disable-automatic-resolution
- swift test --package-path src/menu-helper --disable-automatic-resolution (243 tests passed)
- scripts/test-menu-helper-self-checks.sh (28 checks passed)
- manually exercised an AWS dry-run Approval and confirmed the strip collapse/restore flow