### PR TITLE
Update AppUpdater to 4.1.2

### DIFF
--- a/src/menu-helper/Package.resolved
+++ b/src/menu-helper/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "2b5021eedc672644a563e0e553844d9c337ced6579c27983314e3d8634e8e611",
+  "originHash" : "e3ade26efd290aad63a74f3066c1792df65841ea112dd89a1e493c59c6299ccd",
   "pins" : [
     {
       "identity" : "appupdater",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/AppUpdater.git",
       "state" : {
-        "revision" : "5898041575a7a8ed5d44e7d31251156b3d463677",
-        "version" : "4.1.1"
+        "revision" : "4826e7205ed0159347de84b19960f4ba0e535504",
+        "version" : "4.1.2"
       }
     },
     {

--- a/src/menu-helper/Package.swift
+++ b/src/menu-helper/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "ApprovalCore", targets: ["ApprovalCore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mxcl/AppUpdater.git", from: "4.1.0"),
+        .package(url: "https://github.com/mxcl/AppUpdater.git", from: "4.1.2"),
         .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "4.2.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.1"),
     ],


### PR DESCRIPTION
## Summary

- require AppUpdater 4.1.2
- resolve the lockfile to the merged 4.1.2 release
- restore verified TUF fallback for mapped transient network failures

Cancellation and cryptographic verification failures remain fail-closed.

Fixes the updater failure diagnosed in #93.

## Tests

- `swift test --package-path src/menu-helper --disable-automatic-resolution` (241 passed)
- `scripts/test-menu-helper-self-checks.sh` (27 passed)