### PR TITLE
Route pnpm secrets through a positive command catalog

### DIFF
--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -234,7 +234,12 @@ fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
         )
     });
     let prepared = if secretless {
-        resolve_target(&options.target).map(|target| (target, secretless_environment(&options)))
+        let substitute_empty = verified_script
+            .as_ref()
+            .and_then(|script| script.path.file_name())
+            .is_some_and(|name| name == "pnpm");
+        resolve_target(&options.target)
+            .map(|target| (target, secretless_environment(&options, substitute_empty)))
     } else {
         prepare_injection(
             &options,
@@ -287,10 +292,19 @@ fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
     1
 }
 
-fn secretless_environment(options: &Options) -> BTreeMap<OsString, OsString> {
+fn secretless_environment(
+    options: &Options,
+    substitute_empty: bool,
+) -> BTreeMap<OsString, OsString> {
     let mut env = std::env::vars_os().collect::<BTreeMap<_, _>>();
     for key in &options.keys {
-        env.remove(std::ffi::OsStr::new(key));
+        if substitute_empty {
+            // pnpm expands NODE_AUTH_TOKEN while loading .npmrc and warns when
+            // it is absent. An empty value is unauthenticated and stays quiet.
+            env.insert(OsString::from(key), OsString::new());
+        } else {
+            env.remove(std::ffi::OsStr::new(key));
+        }
     }
     env
 }
@@ -1597,11 +1611,33 @@ mod tests {
             shebang_script: None,
         };
 
-        let env = secretless_environment(&options);
+        let env = secretless_environment(&options, false);
 
         unsafe { std::env::remove_var("SOME_SECRET") };
         assert!(!env.contains_key(std::ffi::OsStr::new("SOME_SECRET")));
         assert!(env.contains_key(std::ffi::OsStr::new("PATH")));
+    }
+
+    #[test]
+    fn pnpm_secretless_environment_substitutes_an_empty_token() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        unsafe { std::env::set_var("NODE_AUTH_TOKEN", "ambient") };
+        let options = Options {
+            replace_existing_env: false,
+            allow_missing_keys: true,
+            keys: vec!["NODE_AUTH_TOKEN".into()],
+            target: "/bin/echo".into(),
+            args: Vec::new(),
+            shebang_script: None,
+        };
+
+        let env = secretless_environment(&options, true);
+
+        unsafe { std::env::remove_var("NODE_AUTH_TOKEN") };
+        assert_eq!(
+            env.get(std::ffi::OsStr::new("NODE_AUTH_TOKEN")),
+            Some(&OsString::new())
+        );
     }
 
     #[test]

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,13 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
-        "pnpm" => {
-            local_command(
-                args,
-                &["bin", "help", "list", "ls", "prefix", "root", "why"],
-            ) || args.first().is_some_and(|arg| arg == "store")
-                && args.get(1).is_some_and(|arg| arg == "path")
-        }
+        "pnpm" => pnpm_invocation_is_secretless(args),
         "fly" | "flyctl" => local_command(args, &["completion", "help", "version"]),
         "k6" => local_command(
             args,
@@ -205,6 +199,65 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn pnpm_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(command) = args.first().and_then(|arg| arg.to_str()) else {
+        return true;
+    };
+    // Keep this positive list exact. Unknown commands and commands whose
+    // purpose is arbitrary package or project code must not inherit
+    // NODE_AUTH_TOKEN.
+    !matches!(
+        command,
+        "access"
+            | "add"
+            | "audit"
+            | "ci"
+            | "clean-install"
+            | "dedupe"
+            | "deprecate"
+            | "dist-tag"
+            | "dist-tags"
+            | "fetch"
+            | "find"
+            | "i"
+            | "ic"
+            | "info"
+            | "install"
+            | "install-clean"
+            | "logout"
+            | "outdated"
+            | "owner"
+            | "owners"
+            | "ping"
+            | "publish"
+            | "s"
+            | "se"
+            | "search"
+            | "show"
+            | "stage"
+            | "star"
+            | "stars"
+            | "team"
+            | "undeprecate"
+            | "unpublish"
+            | "unstar"
+            | "up"
+            | "update"
+            | "upgrade"
+            | "v"
+            | "view"
+            | "whoami"
+    ) && !(command == "store" && args.get(1).is_some_and(|arg| arg == "add"))
+        && !(command == "config"
+            && args.get(1).is_some_and(|arg| arg == "get")
+            && args.iter().skip(2).any(|arg| {
+                arg.to_str().is_some_and(|arg| {
+                    let key = arg.to_ascii_lowercase();
+                    key == "_authtoken" || key.ends_with(":_authtoken")
+                })
+            }))
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -979,6 +1032,87 @@ mod tests {
             format!("{script}# changed\n").as_bytes(),
             &args(&["root"]),
         ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn pnpm_requests_secrets_only_for_reviewed_registry_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-pnpm");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("pnpm");
+        let script = stub_script(
+            &wrapper("pnpm").unwrap().primary,
+            Path::new("/opt/homebrew/bin/pnpm"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec![
+                "--global-dir",
+                "/tmp/pnpm-sem/global",
+                "--global-bin-dir",
+                "/tmp/pnpm-sem/bin",
+                "list",
+                "-g",
+                "--depth=0",
+                "--json",
+            ],
+            vec!["list"],
+            vec!["why", "example"],
+            vec!["root", "-g"],
+            vec!["store", "path"],
+            vec!["store", "prune"],
+            vec!["config", "get", "store-dir"],
+            vec!["login"],
+            vec!["run", "build"],
+            vec!["exec", "example"],
+            vec!["dlx", "example"],
+            vec!["install-test"],
+            vec!["it"],
+            vec!["remove", "example"],
+            vec!["config", "get", "unrelated_authtoken"],
+            vec!["--version"],
+            vec!["future-command"],
+            vec!["--dir", "/tmp", "publish"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "pnpm {command:?}",
+            );
+        }
+        for command in [
+            vec!["add", "private-package"],
+            vec!["install"],
+            vec!["ci"],
+            vec!["dedupe"],
+            vec!["fetch"],
+            vec!["audit"],
+            vec!["outdated"],
+            vec!["view", "private-package"],
+            vec!["search", "private-package"],
+            vec!["publish"],
+            vec!["unpublish", "private-package"],
+            vec!["deprecate", "private-package", "message"],
+            vec!["dist-tag", "add", "private-package@1", "latest"],
+            vec!["whoami"],
+            vec!["logout"],
+            vec!["stage", "list", "private-package"],
+            vec!["store", "add", "private-package"],
+            vec!["config", "get", "//registry.example/:_authToken"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "pnpm {command:?}",
+            );
+        }
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         let _ = fs::remove_dir_all(dir);

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,15 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "pnpm", words.first == "audit" {
+        if words.dropFirst().contains(where: { $0 == "--fix" || $0.hasPrefix("--fix=") }) {
+            return .mutating
+        }
+        if words.dropFirst().contains(where: { !$0.hasPrefix("-") && $0 != "signatures" }) {
+            return .unknown
+        }
+        return .readOnly
+    }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -154,7 +163,11 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
         "access,audit fix,ci,clean-install,ic,install-clean,isntall-clean,deprecate,dist-tag,dist-tags,install,add,i,in,ins,inst,insta,instal,isnt,isnta,isntal,isntall,install-ci-test,cit,clean-install-test,sit,install-test,it,logout,org,ogr,owner,author,profile,publish,stage,star,team,token,trust,undeprecate,unpublish,unstar,update,u,up,upgrade,udpate",
         secretDump: "config get"
     ),
-    "pnpm": .init("view,info,search,audit,outdated,why,list", "publish,unpublish,deprecate,add,remove,update", secretDump: "config get"),
+    "pnpm": .init(
+        "view,info,show,v,search,s,se,find,outdated,why,list,ls,dist-tag ls,dist-tags ls,stage list,stage view,whoami,ping,stars",
+        "publish,unpublish,deprecate,undeprecate,add,remove,update,up,upgrade,dist-tag add,dist-tag rm,dist-tags add,dist-tags rm,stage publish,stage approve,stage reject,star,unstar",
+        secretDump: "config get"
+    ),
     "pulumi": .init("whoami,stack ls,preview,about,config get", "up,destroy,refresh,import,cancel", secretDump: "config get --show-secrets,stack export --show-secrets"),
     "qwen-code": .init("", "chat,run"),
     "runpodctl": .init("get,list", "create,remove,start,stop", secretDump: "config view"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,18 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func pnpmPolicyKeepsCompoundOperationsNarrow() {
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["audit"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["audit", "signatures"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["audit", "--fix"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["audit", "--fix=override"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["audit", "future-command"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["dist-tag", "ls"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["dist-tag", "add"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["stage", "list"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["stage", "download"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["stage", "approve"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["install"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["config", "get", "//registry.example/:_authToken"]) == .secretDump)
+}


### PR DESCRIPTION
## Summary

- request NODE_AUTH_TOKEN only for reviewed pnpm registry operations
- run local, help/version, unknown, leading-option-obscured, and arbitrary-code invocations before the Authorization Gate with no Secret Value
- keep pnpm quiet during tokenless .npmrc expansion by substituting an empty value
- narrow pnpm macOS operation classification, including audit --fix and unknown audit subcommands

## Security boundary

Executable identity and exact managed-stub integrity checks remain mandatory before tokenless routing. Unknown and future commands do not gain the protected Secret. Credential-independent execution approval, including approval-gating installs, is intentionally unchanged.

## Verification

- cargo test: 985 library tests plus all integration and doc tests passed
- swift test --package-path src/menu-helper: 244 tests passed
- focused pnpm routing, tokenless environment, and macOS policy tests passed
- cargo fmt --check
- git diff --check