### PR TITLE
Route k6 secrets only to cloud operations

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -93,10 +93,7 @@ pub(crate) fn invocation_is_secretless(
         "npm" => npm_invocation_is_secretless(args),
         "pnpm" => pnpm_invocation_is_secretless(args),
         "fly" | "flyctl" => local_command(args, &["completion", "help", "version"]),
-        "k6" => local_command(
-            args,
-            &["archive", "completion", "help", "inspect", "new", "version"],
-        ),
+        "k6" => k6_invocation_is_secretless(args),
         "twine" => local_command(args, &["check"]),
         "vagrant" => local_command(args, &["global-status", "validate", "version"]),
         "hf" => local_command(args, &["cache"]),
@@ -258,6 +255,127 @@ fn pnpm_invocation_is_secretless(args: &[OsString]) -> bool {
                     key == "_authtoken" || key.ends_with(":_authtoken")
                 })
             }))
+}
+
+fn k6_invocation_is_secretless(args: &[OsString]) -> bool {
+    // Only explicit cloud operations receive the token. Config, environment,
+    // extension, and future-command ambiguity must not expose it to scripts.
+    if args
+        .iter()
+        .any(|arg| arg == "--help" || arg == "-h" || arg == "--version")
+    {
+        return true;
+    }
+    let Some(command) = k6_command_index(args, 0) else {
+        return true;
+    };
+    match args[command].to_str() {
+        Some("cloud") => {
+            let Some(subcommand) = k6_command_index(args, command + 1) else {
+                return true;
+            };
+            match args[subcommand].to_str() {
+                Some("run" | "upload") => false,
+                Some("project" | "load-zone" | "test") => {
+                    k6_command_index(args, subcommand + 1).and_then(|index| args[index].to_str())
+                        != Some("list")
+                }
+                _ => true,
+            }
+        }
+        Some("run") => !k6_run_uses_cloud_output(&args[command + 1..]),
+        _ => true,
+    }
+}
+
+fn k6_command_index(args: &[OsString], mut index: usize) -> Option<usize> {
+    while let Some(arg) = args.get(index).and_then(|arg| arg.to_str()) {
+        if matches!(
+            arg,
+            "--no-color"
+                | "--log-ns-timestamps"
+                | "--verbose"
+                | "-v"
+                | "--quiet"
+                | "-q"
+                | "--profiling-enabled"
+        ) {
+            index += 1;
+        } else if matches!(
+            arg,
+            "--secret-source"
+                | "--log-output"
+                | "--log-format"
+                | "--config"
+                | "-c"
+                | "--address"
+                | "-a"
+        ) {
+            args.get(index + 1)?;
+            index += 2;
+        } else if [
+            "--secret-source=",
+            "--log-output=",
+            "--log-format=",
+            "--config=",
+            "--address=",
+        ]
+        .iter()
+        .any(|prefix| arg.starts_with(prefix))
+            || [
+                "--no-color=",
+                "--log-ns-timestamps=",
+                "--verbose=",
+                "--quiet=",
+                "--profiling-enabled=",
+            ]
+            .iter()
+            .any(|prefix| arg.starts_with(prefix))
+            || (arg.starts_with("-c") || arg.starts_with("-a")) && arg.len() > 2
+        {
+            index += 1;
+        } else if arg.starts_with('-') {
+            return None;
+        } else {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn k6_run_uses_cloud_output(args: &[OsString]) -> bool {
+    let mut index = 0;
+    while let Some(arg) = args.get(index).and_then(|arg| arg.to_str()) {
+        if arg == "--" {
+            return false;
+        }
+        if arg == "--out" || arg == "-o" {
+            if args
+                .get(index + 1)
+                .and_then(|value| value.to_str())
+                .is_some_and(k6_cloud_output)
+            {
+                return true;
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--out=") {
+            if k6_cloud_output(value) {
+                return true;
+            }
+        } else if let Some(value) = arg.strip_prefix("-o") {
+            if k6_cloud_output(value.strip_prefix('=').unwrap_or(value)) {
+                return true;
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
+fn k6_cloud_output(value: &str) -> bool {
+    value == "cloud" || value.starts_with("cloud=")
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -1132,7 +1250,7 @@ mod tests {
             ("flyctl", "fly", &["deploy", "--help"][..], true),
             ("flyctl", "fly", &["deploy"][..], false),
             ("k6", "k6", &["inspect", "script.js"][..], true),
-            ("k6", "k6", &["run", "script.js"][..], false),
+            ("k6", "k6", &["run", "script.js"][..], true),
             ("twine", "twine", &["check", "dist/*"][..], true),
             ("twine", "twine", &["upload", "dist/*"][..], false),
             ("vagrant", "vagrant", &["validate"][..], true),
@@ -1157,6 +1275,82 @@ mod tests {
                 "{command} {args:?}",
             );
         }
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn k6_requests_secrets_only_for_explicit_cloud_operations() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-k6");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("k6");
+        let script = stub_script(
+            &wrapper("k6").unwrap().primary,
+            Path::new("/opt/homebrew/bin/k6"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["--help"],
+            vec!["version"],
+            vec!["--version"],
+            vec!["archive", "script.js"],
+            vec!["inspect", "script.js"],
+            vec!["deps", "script.js"],
+            vec!["new", "script.js"],
+            vec!["run", "script.js"],
+            vec!["run", "--out", "json=results.json", "script.js"],
+            vec!["run", "--config", "cloud.json", "script.js"],
+            vec!["run", "--", "script.js", "--out", "cloud"],
+            vec!["cloud"],
+            vec!["cloud", "login"],
+            vec!["cloud", "future-command"],
+            vec!["x", "extension-command"],
+            vec!["future-command"],
+            vec!["--quiet", "run", "script.js"],
+            vec!["--future-option", "cloud", "run", "script.js"],
+            vec!["--quiet", "cloud", "run", "script.js", "--help"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "k6 {command:?}",
+            );
+        }
+        for command in [
+            vec!["cloud", "run", "script.js"],
+            vec!["cloud", "upload", "script.js"],
+            vec!["cloud", "project", "list"],
+            vec!["cloud", "load-zone", "list"],
+            vec!["cloud", "test", "list"],
+            vec!["run", "--out", "cloud", "script.js"],
+            vec!["run", "--out=cloud", "script.js"],
+            vec!["run", "--out=cloud=eu", "script.js"],
+            vec!["run", "-o", "cloud", "script.js"],
+            vec!["run", "-ocloud", "script.js"],
+            vec!["--quiet", "cloud", "run", "script.js"],
+            vec!["--quiet=false", "cloud", "run", "script.js"],
+            vec!["--config", "config.json", "cloud", "project", "list"],
+            vec!["-cconfig.json", "cloud", "upload", "script.js"],
+            vec!["cloud", "--quiet", "test", "list"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "k6 {command:?}",
+            );
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["run", "script.js"]),
+        ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         let _ = fs::remove_dir_all(dir);

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -30,6 +30,7 @@ public func genericSecretGateRequestClassification(
         }
         return .readOnly
     }
+    if gateID == "k6" { return k6RequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -43,6 +44,86 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+private func k6RequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    // Mirrors the wrapper's positive catalog so future forms stay Unknown.
+    if arguments.contains(where: { $0 == "--help" || $0 == "-h" })
+        || arguments == ["--version"]
+    {
+        return .readOnly
+    }
+    guard let command = k6CommandIndex(arguments, from: 0) else { return .unknown }
+    switch arguments[command] {
+    case "inspect", "version":
+        return .readOnly
+    case "run":
+        return k6RunUsesCloudOutput(Array(arguments.dropFirst(command + 1))) ? .mutating : .unknown
+    case "cloud":
+        guard let subcommand = k6CommandIndex(arguments, from: command + 1) else { return .unknown }
+        switch arguments[subcommand] {
+        case "run", "upload":
+            return .mutating
+        case "project", "load-zone", "test":
+            guard let operation = k6CommandIndex(arguments, from: subcommand + 1) else { return .unknown }
+            return arguments[operation] == "list" ? .readOnly : .unknown
+        default:
+            return .unknown
+        }
+    default:
+        return .unknown
+    }
+}
+
+private func k6CommandIndex(_ arguments: [String], from start: Int) -> Int? {
+    let flags = ["--no-color", "--log-ns-timestamps", "--verbose", "-v", "--quiet", "-q", "--profiling-enabled"]
+    let booleanOptions = ["--no-color=", "--log-ns-timestamps=", "--verbose=", "--quiet=", "--profiling-enabled="]
+    let options = ["--secret-source", "--log-output", "--log-format", "--config", "-c", "--address", "-a"]
+    var index = start
+    while index < arguments.count {
+        let argument = arguments[index]
+        if flags.contains(argument) {
+            index += 1
+        } else if options.contains(argument) {
+            guard index + 1 < arguments.count else { return nil }
+            index += 2
+        } else if booleanOptions.contains(where: { argument.hasPrefix($0) })
+            || options.contains(where: { argument.hasPrefix("\($0)=") })
+            || ((argument.hasPrefix("-c") || argument.hasPrefix("-a")) && argument.count > 2)
+        {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return nil
+        } else {
+            return index
+        }
+    }
+    return nil
+}
+
+private func k6RunUsesCloudOutput(_ arguments: [String]) -> Bool {
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if argument == "--" { return false }
+        if argument == "--out" || argument == "-o" {
+            if index + 1 < arguments.count, k6CloudOutput(arguments[index + 1]) { return true }
+            index += 2
+            continue
+        }
+        if argument.hasPrefix("--out=") {
+            if k6CloudOutput(String(argument.dropFirst("--out=".count))) { return true }
+        } else if argument.hasPrefix("-o") {
+            let value = argument.dropFirst(2)
+            if k6CloudOutput(String(value.first == "=" ? value.dropFirst() : value)) { return true }
+        }
+        index += 1
+    }
+    return false
+}
+
+private func k6CloudOutput(_ value: String) -> Bool {
+    value == "cloud" || value.hasPrefix("cloud=")
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -154,7 +235,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "hcloud": .init("server list,server describe,network list,network describe", "server create,server delete,network create,network delete"),
     "huggingface-cli": .init("auth whoami,repo list,cache scan", "upload,upload-large-folder,repo create,repo delete"),
     "jfrog-cli": .init("rt search,rt ping,rt build-info", "rt upload,rt delete,rt build-publish", secretDump: "config show,config export"),
-    "k6": .init("inspect", "run,cloud"),
+    "k6": .init("", ""),
     "luarocks": .init("search,show,list,which", "install,remove,upload,publish"),
     "minio-mc": .init("ls,stat,find,du,tree", "cp,mv,rm,mb,rb,mirror", secretDump: "alias export"),
     "netlify-cli": .init("status,sites list,functions list", "deploy,sites create,sites delete,functions create", secretDump: "env list,env get"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -138,3 +138,18 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["install"]) == .unknown)
     #expect(genericSecretGateRequestClassification(gateID: "pnpm", arguments: ["config", "get", "//registry.example/:_authToken"]) == .secretDump)
 }
+
+@Test func k6PolicyKeepsCloudCredentialRoutingNarrow() {
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["cloud", "project", "list"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["--quiet", "cloud", "test", "list"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["--quiet=false", "cloud", "test", "list"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["cloud", "run", "script.js"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["cloud", "upload", "script.js"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["run", "--out", "cloud", "script.js"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["run", "-ocloud", "script.js"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["run", "script.js"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["run", "--out", "json", "script.js"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["cloud", "login"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["cloud", "future-command"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["--future-option", "cloud", "run"]) == .unknown)
+}


### PR DESCRIPTION
## Summary

- inject K6_CLOUD_TOKEN only for reviewed Grafana Cloud commands and local runs with an explicit cloud output
- run ordinary local scripts, archive/inspect/deps/new, login, extension commands, help/version, and unknown forms before the Secret Gate
- parse reviewed k6 global options without letting unknown future options or subcommands inherit the token
- replace the broad macOS run/cloud policy prefixes with exact read-only, mutating, and Unknown classifications

## Security boundary

Executable identity and exact managed-stub integrity checks remain mandatory before tokenless routing. Hidden cloud output selected only by config or environment does not cause a token to be exposed to arbitrary test scripts; users can make the cloud choice explicit with --out cloud, while unsupported forms can use explicit av inject. Current upstream k6 v2.2 command and flag behavior was reviewed. This uses the accepted positive Secret-routing model and adds no new domain concept.

## Verification

- cargo test --all-targets --all-features --locked: 984 library tests plus all integration tests passed
- swift test --package-path src/menu-helper --disable-automatic-resolution: 244 tests passed
- focused environment-wrapper and Secret Gate policy suites passed after the final option cases
- cargo fmt --all -- --check
- git diff --check