### PR TITLE
Route Twine secrets only to uploads

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -94,7 +94,7 @@ pub(crate) fn invocation_is_secretless(
         "pnpm" => pnpm_invocation_is_secretless(args),
         "fly" | "flyctl" => local_command(args, &["completion", "help", "version"]),
         "k6" => k6_invocation_is_secretless(args),
-        "twine" => local_command(args, &["check"]),
+        "twine" => twine_invocation_is_secretless(args),
         "vagrant" => local_command(args, &["global-status", "validate", "version"]),
         "hf" => local_command(args, &["cache"]),
         "composer" => local_command(
@@ -376,6 +376,23 @@ fn k6_run_uses_cloud_output(args: &[OsString]) -> bool {
 
 fn k6_cloud_output(value: &str) -> bool {
     value == "cloud" || value.starts_with("cloud=")
+}
+
+fn twine_invocation_is_secretless(args: &[OsString]) -> bool {
+    if args
+        .iter()
+        .any(|arg| arg == "--help" || arg == "-h" || arg == "--version")
+    {
+        return true;
+    }
+    let mut args = args.iter().skip_while(|arg| *arg == "--no-color");
+    let command = args.next();
+    let command = if command.is_some_and(|arg| arg == "--") {
+        args.next()
+    } else {
+        command
+    };
+    command.is_none_or(|command| command != "upload")
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -1350,6 +1367,64 @@ mod tests {
             &script_path,
             format!("{script}# changed\n").as_bytes(),
             &args(&["run", "script.js"]),
+        ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn twine_requests_secrets_only_for_uploads() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-twine");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("twine");
+        let script = stub_script(
+            &wrapper("twine").unwrap().primary,
+            Path::new("/opt/homebrew/bin/twine"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["--help"],
+            vec!["--version"],
+            vec!["check", "dist/package.whl"],
+            vec!["check", "--strict", "dist/package.whl"],
+            vec!["register", "dist/package.whl"],
+            vec!["plugin-command", "argument"],
+            vec!["future-command"],
+            vec!["--no-color", "check", "dist/package.whl"],
+            vec!["--future-option", "upload", "dist/package.whl"],
+            vec!["--", "--no-color", "upload", "dist/package.whl"],
+            vec!["--", "--", "upload", "dist/package.whl"],
+            vec!["upload", "--help"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "twine {command:?}",
+            );
+        }
+        for command in [
+            vec!["upload", "dist/package.whl"],
+            vec!["upload", "--repository", "testpypi", "dist/package.whl"],
+            vec!["--no-color", "upload", "dist/package.whl"],
+            vec!["--no-color", "--no-color", "upload", "dist/package.whl"],
+            vec!["--", "upload", "dist/package.whl"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "twine {command:?}",
+            );
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["check", "dist/package.whl"]),
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -31,6 +31,7 @@ public func genericSecretGateRequestClassification(
         return .readOnly
     }
     if gateID == "k6" { return k6RequestClassification(words) }
+    if gateID == "twine" { return twineRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -124,6 +125,23 @@ private func k6RunUsesCloudOutput(_ arguments: [String]) -> Bool {
 
 private func k6CloudOutput(_ value: String) -> Bool {
     value == "cloud" || value.hasPrefix("cloud=")
+}
+
+private func twineRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    if arguments.contains(where: { $0 == "--help" || $0 == "-h" })
+        || arguments == ["--version"]
+    {
+        return .readOnly
+    }
+    var index = 0
+    while index < arguments.count, arguments[index] == "--no-color" { index += 1 }
+    if index < arguments.count, arguments[index] == "--" { index += 1 }
+    let command = index < arguments.count ? arguments[index] : nil
+    switch command {
+    case "check": return .readOnly
+    case "upload": return .mutating
+    default: return .unknown
+    }
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -258,7 +276,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "snyk": .init("", "monitor,auth"),
     "transifex-cli": .init("status", "pull,push"),
     "travis": .init("whoami,repos,history,show,logs", "restart,cancel,enable,disable", secretDump: "token"),
-    "twine": .init("check", "upload"),
+    "twine": .init("", ""),
     "vagrant": .init("status,global-status,validate,version", "up,destroy,halt,reload,suspend,resume,cloud publish"),
     "vault": .init("status,list,kv list,token lookup", "write,delete,kv put,kv delete", secretDump: "read,kv get,login,token create,token generate"),
     "virustotal-cli": .init("file,url,domain,ip,collection", "scan,upload"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -153,3 +153,16 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["cloud", "future-command"]) == .unknown)
     #expect(genericSecretGateRequestClassification(gateID: "k6", arguments: ["--future-option", "cloud", "run"]) == .unknown)
 }
+
+@Test func twinePolicyRecognizesOnlyBuiltInCommands() {
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["check", "dist/package.whl"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["upload", "dist/package.whl"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["--no-color", "check", "dist/package.whl"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["--no-color", "upload", "dist/package.whl"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["--", "upload", "dist/package.whl"]) == .mutating)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["--", "--no-color", "upload"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["--", "--", "upload"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["register", "dist/package.whl"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["plugin-command"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "twine", arguments: ["--future-option", "upload"]) == .unknown)
+}


### PR DESCRIPTION
## Summary
- route Twine credentials only to the built-in upload command
- keep check, help, version, unknown, legacy register, and plugin commands tokenless
- mirror Twine global-option parsing in the macOS authorization policy

## Security
- preserve fail-closed wrapper identity and integrity validation
- treat unreviewed options and plugin commands as tokenless instead of granting credentials
- no new authorization boundary or domain concept; existing positive Secret-routing ADR applies

## Tests
- cargo test --all-targets --all-features --locked --quiet
- swift test -q --package-path src/menu-helper --disable-automatic-resolution
- cargo fmt --all -- --check
- git diff --check