### PR TITLE
Route Composer credentials only to repository operations

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -106,16 +106,7 @@ pub(crate) fn invocation_is_secretless(
         "twine" => local_command(args, &["check"]),
         "vagrant" => local_command(args, &["global-status", "validate", "version"]),
         "hf" => local_command(args, &["cache"]),
-        "composer" => local_command(
-            args,
-            &[
-                "clear-cache",
-                "clearcache",
-                "licenses",
-                "status",
-                "validate",
-            ],
-        ),
+        "composer" => composer_invocation_is_secretless(args),
         _ => false,
     }
 }
@@ -205,6 +196,260 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+const COMPOSER_COMMANDS: &[(&str, &[&str])] = &[
+    ("about", &["about"]),
+    ("archive", &["archive"]),
+    ("audit", &["audit"]),
+    ("browse", &["browse", "home"]),
+    ("bump", &["bump"]),
+    ("check-platform-reqs", &["check-platform-reqs"]),
+    ("clear-cache", &["clear-cache", "clearcache", "cc"]),
+    ("completion", &["completion", "_complete"]),
+    ("config", &["config"]),
+    ("create-project", &["create-project"]),
+    ("depends", &["depends", "why"]),
+    ("diagnose", &["diagnose"]),
+    ("dump-autoload", &["dump-autoload", "dumpautoload"]),
+    ("exec", &["exec"]),
+    ("fund", &["fund"]),
+    ("global", &["global"]),
+    ("help", &["help"]),
+    ("init", &["init"]),
+    ("install", &["install", "i"]),
+    ("licenses", &["licenses"]),
+    ("list", &["list"]),
+    ("outdated", &["outdated"]),
+    ("policy", &["policy"]),
+    ("prohibits", &["prohibits", "why-not"]),
+    ("reinstall", &["reinstall"]),
+    ("remove", &["remove", "rm", "uninstall"]),
+    ("repository", &["repository", "repo"]),
+    ("require", &["require", "r"]),
+    ("run-script", &["run-script", "run"]),
+    ("search", &["search"]),
+    ("self-update", &["self-update", "selfupdate"]),
+    ("show", &["show", "info"]),
+    ("status", &["status"]),
+    ("suggests", &["suggests"]),
+    ("update", &["update", "u", "upgrade"]),
+    ("validate", &["validate"]),
+];
+
+fn composer_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    !composer_invocation_may_need_secret(&args)
+}
+
+fn composer_invocation_may_need_secret(args: &[&str]) -> bool {
+    composer_invocation_may_need_secret_with_options(args, false)
+}
+
+fn composer_invocation_may_need_secret_with_options(
+    args: &[&str],
+    inherited_non_interactive: bool,
+) -> bool {
+    let option_end = args
+        .iter()
+        .position(|arg| *arg == "--")
+        .unwrap_or(args.len());
+    let option_args = &args[..option_end];
+    if option_args
+        .iter()
+        .any(|arg| matches!(*arg, "--help" | "-h" | "--version" | "-V"))
+    {
+        return false;
+    }
+    let non_interactive = inherited_non_interactive
+        || option_args
+            .iter()
+            .any(|arg| matches!(*arg, "--no-interaction" | "-n"));
+    let Some((command, args)) = composer_command_and_args(args) else {
+        return false;
+    };
+    let network_enabled = std::env::var_os("COMPOSER_DISABLE_NETWORK")
+        .is_none_or(|value| value.is_empty() || value == "0");
+
+    // Reviewed against Composer 85ae025. Script aliases, plugin commands,
+    // vendored binaries, and future commands stay tokenless so arbitrary code
+    // never inherits COMPOSER_AUTH merely because Composer launched it.
+    match command {
+        "install" | "create-project" | "update" | "search" | "audit" | "reinstall" | "outdated"
+        | "fund" | "diagnose" | "prohibits" => network_enabled,
+        "require" => composer_require_may_need_secret(args, non_interactive, network_enabled),
+        "remove" => network_enabled && !args.contains(&"--no-update"),
+        "archive" | "browse" => network_enabled && composer_has_positional(args),
+        "config" => composer_config_reads_auth(args),
+        "global" => composer_invocation_may_need_secret_with_options(args, non_interactive),
+        "init" => {
+            network_enabled
+                && !non_interactive
+                && args
+                    .iter()
+                    .any(|arg| *arg == "--repository" || arg.starts_with("--repository="))
+        }
+        "show" => {
+            network_enabled
+                && args[..args
+                    .iter()
+                    .position(|arg| *arg == "--")
+                    .unwrap_or(args.len())]
+                    .iter()
+                    .any(|arg| {
+                        matches!(
+                            *arg,
+                            "--all"
+                                | "--available"
+                                | "-a"
+                                | "--latest"
+                                | "-l"
+                                | "--outdated"
+                                | "-o"
+                        )
+                    })
+        }
+        _ => false,
+    }
+}
+
+fn composer_command_and_args<'a>(args: &'a [&'a str]) -> Option<(&'static str, &'a [&'a str])> {
+    let mut index = 0;
+    while let Some(argument) = args.get(index).copied() {
+        if matches!(
+            argument,
+            "--profile"
+                | "--no-plugins"
+                | "--no-scripts"
+                | "--no-cache"
+                | "--quiet"
+                | "-q"
+                | "--verbose"
+                | "-v"
+                | "-vv"
+                | "-vvv"
+                | "--ansi"
+                | "--no-ansi"
+                | "--no-interaction"
+                | "-n"
+        ) {
+            index += 1;
+        } else if matches!(argument, "--working-dir" | "-d") {
+            index += 2;
+        } else if argument.starts_with("--working-dir=")
+            || (argument.starts_with("-d") && argument.len() > 2)
+        {
+            index += 1;
+        } else if argument.starts_with('-') {
+            return None;
+        } else {
+            return composer_command(argument).map(|command| (command, &args[index + 1..]));
+        }
+    }
+    None
+}
+
+fn composer_command(argument: &str) -> Option<&'static str> {
+    if let Some((command, _)) = COMPOSER_COMMANDS
+        .iter()
+        .find(|(_, aliases)| aliases.contains(&argument))
+    {
+        return Some(command);
+    }
+    let mut matches = COMPOSER_COMMANDS
+        .iter()
+        .filter(|(_, aliases)| aliases.iter().any(|alias| alias.starts_with(argument)))
+        .map(|(command, _)| *command);
+    let command = matches.next()?;
+    matches
+        .all(|candidate| candidate == command)
+        .then_some(command)
+}
+
+fn composer_has_positional(args: &[&str]) -> bool {
+    !composer_positionals(
+        args,
+        &["--working-dir", "-d", "--format", "-f", "--dir", "--file"],
+    )
+    .is_empty()
+}
+
+fn composer_positionals<'a>(args: &[&'a str], options_with_values: &[&str]) -> Vec<&'a str> {
+    let mut positionals = Vec::new();
+    let mut skip_value = false;
+    let mut options_ended = false;
+    for argument in args {
+        if skip_value {
+            skip_value = false;
+        } else if *argument == "--" {
+            options_ended = true;
+        } else if options_with_values.contains(argument) {
+            skip_value = true;
+        } else if options_ended || !argument.starts_with('-') {
+            positionals.push(*argument);
+        }
+    }
+    positionals
+}
+
+fn composer_require_may_need_secret(
+    args: &[&str],
+    non_interactive: bool,
+    network_enabled: bool,
+) -> bool {
+    if !network_enabled {
+        return false;
+    }
+    if !args.contains(&"--no-update") || !non_interactive {
+        return true;
+    }
+    composer_positionals(
+        args,
+        &[
+            "--working-dir",
+            "-d",
+            "--prefer-install",
+            "--audit-format",
+            "--ignore-platform-req",
+            "--apcu-autoloader-prefix",
+        ],
+    )
+    .iter()
+    .any(|package| !package.contains(':') && !package.contains('=') && !package.contains(' '))
+}
+
+fn composer_config_reads_auth(args: &[&str]) -> bool {
+    if args.iter().any(|arg| matches!(*arg, "--list" | "-l")) {
+        return true;
+    }
+    if args
+        .iter()
+        .any(|arg| matches!(*arg, "--editor" | "-e" | "--unset"))
+    {
+        return false;
+    }
+    let positionals = composer_positionals(args, &["--working-dir", "-d", "--file", "-f"]);
+    positionals.len() == 1
+        && matches!(
+            positionals[0].split('.').next(),
+            Some(
+                "bitbucket-oauth"
+                    | "github-oauth"
+                    | "gitlab-oauth"
+                    | "gitlab-token"
+                    | "http-basic"
+                    | "custom-headers"
+                    | "bearer"
+                    | "client-certificate"
+                    | "forgejo-token"
+            )
+        )
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -1025,6 +1270,167 @@ mod tests {
         }
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn composer_requests_auth_only_for_private_repository_capable_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-composer");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let previous_disable_network = std::env::var_os("COMPOSER_DISABLE_NETWORK");
+        unsafe { std::env::remove_var("COMPOSER_DISABLE_NETWORK") };
+        let script_path = dir.join("composer");
+        let script = stub_script(
+            &wrapper("composer").unwrap().primary,
+            Path::new("/opt/homebrew/bin/composer"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["--help"],
+            vec!["-V"],
+            vec!["install", "--help"],
+            vec!["--profile", "--working-dir", "/tmp", "validate"],
+            vec!["about"],
+            vec!["archive"],
+            vec!["bump"],
+            vec!["check-platform-reqs"],
+            vec!["cc"],
+            vec!["completion"],
+            vec!["config", "preferred-install"],
+            vec![
+                "config",
+                "http-basic.private.example",
+                "user",
+                "replacement",
+            ],
+            vec!["config", "--unset", "bearer.private.example"],
+            vec!["config", "--auth", "--editor"],
+            vec!["depends", "private/package"],
+            vec!["dumpautoload"],
+            vec!["exec", "vendor/bin/tool", "install"],
+            vec!["home"],
+            vec!["-n", "init"],
+            vec!["init"],
+            vec!["-n", "global", "init"],
+            vec!["-n", "require", "--no-update", "private/package:^1"],
+            vec!["-n", "global", "req", "--no-update", "private/package=^1"],
+            vec!["licenses"],
+            vec![
+                "policy",
+                "add-source",
+                "custom",
+                "url",
+                "https://example.invalid/list.json",
+            ],
+            vec!["repo", "list"],
+            vec!["remove", "--no-update", "private/package"],
+            vec!["run-script", "deploy", "--", "install"],
+            vec!["self-update"],
+            vec!["show"],
+            vec!["show", "private/package"],
+            vec!["show", "--", "--available"],
+            vec!["status"],
+            vec!["suggests"],
+            vec!["validate"],
+            vec!["deploy"],
+            vec!["plugin-command", "install"],
+            vec!["future-command"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "composer {command:?}",
+            );
+        }
+
+        for command in [
+            vec!["install"],
+            vec!["i"],
+            vec!["ins"],
+            vec!["create-project", "private/package"],
+            vec!["update"],
+            vec!["up"],
+            vec!["search", "private"],
+            vec!["audit"],
+            vec!["require", "private/package:^1"],
+            vec!["req", "private/package:^1"],
+            vec!["-n", "require", "--no-update", "private/package"],
+            vec!["remove", "private/package"],
+            vec!["reinstall", "private/package"],
+            vec!["outdated"],
+            vec!["fund"],
+            vec!["diagnose"],
+            vec!["why-not", "private/package", "2"],
+            vec!["archive", "private/package"],
+            vec!["archive", "--", "private/package"],
+            vec!["browse", "private/package"],
+            vec!["browse", "--", "private/package"],
+            vec![
+                "init",
+                "--repository",
+                "https://private.example.invalid/packages.json",
+            ],
+            vec!["show", "--available", "private/package"],
+            vec!["show", "--latest"],
+            vec!["config", "--list"],
+            vec!["config", "http-basic.private.example"],
+            vec!["config", "--source", "bearer.private.example"],
+            vec!["config", "client-certificate.private.example"],
+            vec!["config", "--", "bearer.private.example"],
+            vec!["global", "require", "private/package:^1"],
+            vec!["--profile", "-d", "/tmp", "require", "private/package:^1"],
+            vec!["install", "--", "--help"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "composer {command:?}",
+            );
+        }
+
+        unsafe { std::env::set_var("COMPOSER_DISABLE_NETWORK", "1") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["install"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["config", "github-oauth.github.com"]),
+        ));
+        unsafe { std::env::set_var("COMPOSER_DISABLE_NETWORK", "0") };
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["install"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["validate"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &[
+                Path::new("/tmp/not-composer").into(),
+                OsString::from("validate")
+            ],
+        ));
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+            match previous_disable_network {
+                Some(value) => std::env::set_var("COMPOSER_DISABLE_NETWORK", value),
+                None => std::env::remove_var("COMPOSER_DISABLE_NETWORK"),
+            }
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,6 +18,7 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
+    if gateID == "composer" { return composerRequestClassification(arguments) }
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
@@ -35,6 +36,152 @@ public func genericSecretGateRequestClassification(
     }
     return .unknown
 }
+
+private func composerRequestClassification(
+    _ arguments: [String],
+    inheritedNonInteractive: Bool = false
+) -> SecretGateRequestClassification {
+    let separator = arguments.firstIndex(of: "--") ?? arguments.endIndex
+    let optionArguments = Array(arguments[..<separator])
+    if optionArguments.contains(where: { ["--help", "-h", "--version", "-V"].contains($0) }) {
+        return .readOnly
+    }
+    let nonInteractive = inheritedNonInteractive
+        || optionArguments.contains(where: { ["--no-interaction", "-n"].contains($0) })
+    guard let (command, commandArguments) = composerCommandAndArguments(arguments) else { return .unknown }
+
+    switch command {
+    case "install", "create-project", "update", "reinstall":
+        return .mutating
+    case "require":
+        if nonInteractive && commandArguments.contains("--no-update") {
+            let packages = composerPositionals(
+                commandArguments,
+                optionsWithValues: [
+                    "--working-dir", "-d", "--prefer-install", "--audit-format",
+                    "--ignore-platform-req", "--apcu-autoloader-prefix",
+                ]
+            )
+            return packages.contains(where: {
+                !$0.contains(":") && !$0.contains("=") && !$0.contains(" ")
+            }) ? .mutating : .unknown
+        }
+        return .mutating
+    case "remove":
+        return commandArguments.contains("--no-update") ? .unknown : .mutating
+    case "search", "audit", "outdated", "fund", "diagnose", "prohibits":
+        return .readOnly
+    case "archive":
+        return composerHasPositional(commandArguments) ? .mutating : .unknown
+    case "browse":
+        return composerHasPositional(commandArguments) ? .readOnly : .unknown
+    case "config":
+        return composerConfigReadsAuth(commandArguments) ? .secretDump : .unknown
+    case "global":
+        return composerRequestClassification(commandArguments, inheritedNonInteractive: nonInteractive)
+    case "init":
+        return !nonInteractive && commandArguments.contains(where: {
+            $0 == "--repository" || $0.hasPrefix("--repository=")
+        }) ? .mutating : .unknown
+    case "show":
+        let optionEnd = commandArguments.firstIndex(of: "--") ?? commandArguments.endIndex
+        return commandArguments[..<optionEnd].contains(where: {
+            ["--all", "--available", "-a", "--latest", "-l", "--outdated", "-o"].contains($0)
+        }) ? .readOnly : .unknown
+    default:
+        return .unknown
+    }
+}
+
+private func composerCommandAndArguments(_ arguments: [String]) -> (String, [String])? {
+    let flags = Set([
+        "--profile", "--no-plugins", "--no-scripts", "--no-cache", "--quiet", "-q",
+        "--verbose", "-v", "-vv", "-vvv", "--ansi", "--no-ansi", "--no-interaction", "-n",
+    ])
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if flags.contains(argument) {
+            index += 1
+        } else if ["--working-dir", "-d"].contains(argument) {
+            guard index + 1 < arguments.count else { return nil }
+            index += 2
+        } else if argument.hasPrefix("--working-dir=") || (argument.hasPrefix("-d") && argument.count > 2) {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return nil
+        } else {
+            guard let command = composerCommand(argument) else { return nil }
+            return (command, Array(arguments.dropFirst(index + 1)))
+        }
+    }
+    return nil
+}
+
+private func composerCommand(_ argument: String) -> String? {
+    if composerCommands.contains(argument) { return argument }
+    if let command = composerAliases[argument] { return command }
+    let candidates = Set(
+        composerCommands.filter { $0.hasPrefix(argument) }
+            + composerAliases.compactMap { alias, command in alias.hasPrefix(argument) ? command : nil }
+    )
+    return candidates.count == 1 ? candidates.first : nil
+}
+
+private func composerHasPositional(_ arguments: [String]) -> Bool {
+    !composerPositionals(
+        arguments,
+        optionsWithValues: ["--working-dir", "-d", "--format", "-f", "--dir", "--file"]
+    ).isEmpty
+}
+
+private func composerPositionals(_ arguments: [String], optionsWithValues: Set<String>) -> [String] {
+    var positionals: [String] = []
+    var skipValue = false
+    var optionsEnded = false
+    for argument in arguments {
+        if skipValue {
+            skipValue = false
+        } else if argument == "--" {
+            optionsEnded = true
+        } else if optionsWithValues.contains(argument) {
+            skipValue = true
+        } else if optionsEnded || !argument.hasPrefix("-") {
+            positionals.append(argument)
+        }
+    }
+    return positionals
+}
+
+private func composerConfigReadsAuth(_ arguments: [String]) -> Bool {
+    if arguments.contains(where: { ["--list", "-l"].contains($0) }) { return true }
+    if arguments.contains(where: { ["--editor", "-e", "--unset"].contains($0) }) {
+        return false
+    }
+    let positionals = composerPositionals(
+        arguments,
+        optionsWithValues: ["--working-dir", "-d", "--file", "-f"]
+    )
+    guard positionals.count == 1, let root = positionals[0].split(separator: ".").first else { return false }
+    return composerAuthConfigRoots.contains(String(root))
+}
+
+private let composerCommands = SecretGateCommandPolicy.commands("""
+about,archive,audit,browse,bump,check-platform-reqs,clear-cache,completion,config,create-project,depends,diagnose,dump-autoload,exec,fund,global,help,init,install,licenses,list,outdated,policy,prohibits,reinstall,remove,repository,require,run-script,search,self-update,show,status,suggests,update,validate
+""")
+
+private let composerAliases = [
+    "_complete": "completion", "cc": "clear-cache", "clearcache": "clear-cache",
+    "dumpautoload": "dump-autoload", "home": "browse", "i": "install", "info": "show",
+    "r": "require", "repo": "repository", "rm": "remove", "run": "run-script",
+    "selfupdate": "self-update", "u": "update", "uninstall": "remove", "upgrade": "update",
+    "why": "depends", "why-not": "prohibits",
+]
+
+private let composerAuthConfigRoots = Set([
+    "bitbucket-oauth", "github-oauth", "gitlab-oauth", "gitlab-token", "http-basic",
+    "custom-headers", "bearer", "client-certificate", "forgejo-token",
+])
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
     let optionsWithValues = ["--api-key", "--color", "--config", "--device-name", "--log-level", "--project-name", "-p"]
@@ -134,7 +281,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "circleci": .init("project list,pipeline list,config validate", "pipeline run,context create,context delete,context store-secret"),
     "civo": .init("instance list,instance show,kubernetes list,kubernetes show", "instance create,instance remove,kubernetes create,kubernetes remove", secretDump: "apikey show"),
     "cloudsmith-cli": .init("whoami,repos list,packages list,packages search", "push,packages delete,repos create,repos delete"),
-    "composer": .init("show,search,outdated,audit,diagnose", "install,update,require,remove,publish", secretDump: "config --auth,config --global --auth"),
+    "composer": .init("", ""),
     "doctl": .init("account get,compute droplet list,compute droplet get,kubernetes cluster list,kubernetes cluster get", "compute droplet create,compute droplet delete,kubernetes cluster create,kubernetes cluster delete"),
     "flyctl": .init("status,apps list,machine list,machine status,secrets list,auth whoami", "deploy,scale,apps create,apps destroy,machine run,machine destroy,secrets set,secrets unset,secrets import", secretDump: "auth token"),
     "glab": .init("repo view,repo list,issue list,issue view,mr list,mr view,pipeline list,pipeline view", "repo create,repo delete,issue create,mr create,pipeline run", secretDump: "auth token,auth status --show-token"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,73 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func composerPolicyClassifiesOnlyCredentialedBuiltIns() {
+    for arguments in [
+        ["audit"],
+        ["dia"],
+        ["search", "private"],
+        ["why-not", "private/package", "2"],
+        ["show", "--latest"],
+        ["browse", "private/package"],
+    ] {
+        #expect(genericSecretGateRequestClassification(
+            gateID: "composer",
+            arguments: arguments
+        ) == .readOnly)
+    }
+
+    for arguments in [
+        ["install"],
+        ["ins"],
+        ["req", "private/package:^1"],
+        ["archive", "private/package"],
+        ["archive", "--", "private/package"],
+        ["init", "--repository", "https://private.example.invalid/packages.json"],
+        ["global", "require", "private/package:^1"],
+        ["--profile", "-d", "/tmp", "update"],
+    ] {
+        #expect(genericSecretGateRequestClassification(
+            gateID: "composer",
+            arguments: arguments
+        ) == .mutating)
+    }
+
+    for arguments in [
+        ["config", "http-basic.private.example"],
+        ["config", "client-certificate.private.example"],
+        ["config", "--list"],
+    ] {
+        #expect(genericSecretGateRequestClassification(
+            gateID: "composer",
+            arguments: arguments
+        ) == .secretDump)
+    }
+
+    for arguments in [
+        ["show", "private/package"],
+        ["show", "--", "--available"],
+        ["config", "http-basic.private.example", "user", "replacement"],
+        ["-n", "init"],
+        ["init"],
+        ["-n", "require", "--no-update", "private/package:^1"],
+        ["remove", "--no-update", "private/package"],
+        ["exec", "vendor/bin/tool", "install"],
+        ["run-script", "deploy"],
+        ["plugin-command", "install"],
+    ] {
+        #expect(genericSecretGateRequestClassification(
+            gateID: "composer",
+            arguments: arguments
+        ) == .unknown)
+    }
+
+    #expect(genericSecretGateRequestClassification(
+        gateID: "composer",
+        arguments: ["install", "--help"]
+    ) == .readOnly)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "composer",
+        arguments: ["-V"]
+    ) == .readOnly)
+}


### PR DESCRIPTION
## Summary
- route COMPOSER_AUTH only to Composer built-ins that can contact authenticated repositories or display merged auth configuration
- keep local commands, non-updating edits, project scripts, plugin commands, vendored executables, and unknown future commands tokenless after verified stub identity
- mirror the command policy in the macOS authorization UI, including Composer aliases, unique abbreviations, global options, nested global commands, and config secret dumps

Reviewed against Composer 2.9.8 and upstream main at 85ae025. Existing positive Secret-routing terminology and ADR 0032 already cover this change, so no canonical documentation update is needed.

## Verification
- cargo test --all-targets --all-features --locked --quiet
- swift test -q --package-path src/menu-helper --disable-automatic-resolution
- cargo fmt --all -- --check
- git diff --check

Install execution approval remains separate and is intentionally not implemented here.