### PR TITLE
Route npm secrets only to credentialed commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -134,12 +134,34 @@ fn local_command(args: &[OsString], commands: &[&str]) -> bool {
 }
 
 fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
-    let Some(command) = args.first().and_then(|arg| arg.to_str()) else {
+    let Some(args) = args
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
         return true;
     };
-    // Keep this positive list exact: npm's dynamic abbreviations can change
-    // meaning when npm adds commands, and arbitrary package scripts must not
-    // inherit NODE_AUTH_TOKEN merely because npm launched them.
+    let option_end = args
+        .iter()
+        .position(|argument| *argument == "--")
+        .unwrap_or(args.len());
+    let option_args = &args[..option_end];
+    if option_args.iter().any(|argument| {
+        matches!(
+            *argument,
+            "--help" | "-h" | "-?" | "-H" | "--version" | "--versions" | "-v"
+        )
+    }) || npm_uses_explicit_auth(option_args)
+    {
+        return true;
+    }
+    let Some(command) = npm_command(option_args) else {
+        return true;
+    };
+    // Reviewed against npm v11.19.0. Keep this positive list exact: npm's
+    // dynamic abbreviations can change meaning when npm adds commands, and
+    // arbitrary package scripts must not inherit NODE_AUTH_TOKEN merely because
+    // npm launched them.
     !matches!(
         command,
         "access"
@@ -205,6 +227,112 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn npm_command<'a>(args: &'a [&str]) -> Option<&'a str> {
+    const BOOLEAN_SHORT_OPTIONS: &str = "DEOPSadfglpqsy";
+    const BOOLEAN_OPTIONS: &[&str] = &[
+        "--all",
+        "--dry-run",
+        "--force",
+        "--fund",
+        "--global",
+        "--ignore-scripts",
+        "--include-workspace-root",
+        "--json",
+        "--local",
+        "--long",
+        "--offline",
+        "--parseable",
+        "--prefer-offline",
+        "--prefer-online",
+        "--quiet",
+        "--readonly",
+        "--silent",
+        "--timing",
+        "--verbose",
+        "--workspaces",
+        "--yes",
+        "-D",
+        "-E",
+        "-O",
+        "-P",
+        "-S",
+        "-a",
+        "-d",
+        "-dd",
+        "-ddd",
+        "-f",
+        "-g",
+        "-l",
+        "-p",
+        "-q",
+        "-s",
+        "-y",
+    ];
+    const VALUE_OPTIONS: &[&str] = &[
+        "--cache",
+        "--call",
+        "--location",
+        "--loglevel",
+        "--otp",
+        "--prefix",
+        "--registry",
+        "--reg",
+        "--scope",
+        "--tag",
+        "--userconfig",
+        "--workspace",
+        "-C",
+        "-L",
+        "-c",
+        "-m",
+        "-w",
+    ];
+    const VALUE_SHORT_OPTIONS: &[&str] = &["-C", "-L", "-c", "-m", "-w"];
+
+    let mut index = 0;
+    while let Some(argument) = args.get(index) {
+        if !argument.starts_with('-') {
+            return Some(argument);
+        }
+        if argument.contains('=')
+            || argument.starts_with("--no-")
+            || BOOLEAN_OPTIONS.contains(argument)
+            || argument.strip_prefix('-').is_some_and(|options| {
+                options.len() > 1
+                    && options
+                        .chars()
+                        .all(|option| BOOLEAN_SHORT_OPTIONS.contains(option))
+            })
+            || VALUE_SHORT_OPTIONS
+                .iter()
+                .any(|option| argument.starts_with(option) && argument.len() > option.len())
+        {
+            index += 1;
+        } else if VALUE_OPTIONS.contains(argument) {
+            args.get(index + 1)?;
+            index += 2;
+        } else {
+            return None;
+        }
+    }
+    None
+}
+
+fn npm_uses_explicit_auth(args: &[&str]) -> bool {
+    args.iter().any(|argument| {
+        let option = argument
+            .strip_prefix("--")
+            .unwrap_or(argument)
+            .split_once('=')
+            .map_or(*argument, |(name, _)| name)
+            .to_ascii_lowercase();
+        option == "_authtoken"
+            || option == "_auth-token"
+            || option.ends_with(":_authtoken")
+            || option.ends_with(":_auth-token")
+    })
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -947,7 +1075,17 @@ mod tests {
             vec!["config", "get", "//registry.npmjs.org/:_authToken"],
             vec!["login"],
             vec!["run", "build"],
+            vec!["exec", "eslint", "."],
+            vec!["init", "@scope/app"],
             vec!["version"],
+            vec!["install", "--help"],
+            vec!["install", "--version"],
+            vec!["--cache", "install", "run", "build"],
+            vec!["--future-option", "install"],
+            vec![
+                "install",
+                "--//registry.npmjs.org/:_authToken=provided-token",
+            ],
             vec!["future-command"],
         ] {
             assert!(invocation_is_secretless(
@@ -958,6 +1096,18 @@ mod tests {
         }
         for command in [
             vec!["install"],
+            vec!["--global", "install"],
+            vec![
+                "--registry",
+                "https://registry.npmjs.org",
+                "view",
+                "private-package",
+            ],
+            vec!["--workspace", "app", "audit"],
+            vec!["--loglevel", "verbose", "whoami"],
+            vec!["--color=always", "publish"],
+            vec!["-gq", "install"],
+            vec!["-C/tmp", "view", "private-package"],
             vec!["i", "private-package"],
             vec!["ci"],
             vec!["audit"],
@@ -967,6 +1117,7 @@ mod tests {
             vec!["publish"],
             vec!["dist-tags", "ls", "private-package"],
             vec!["trust", "list", "private-package"],
+            vec!["install", "--", "--version"],
         ] {
             assert!(!invocation_is_secretless(
                 &script_path,

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -322,11 +322,10 @@ fn npm_command<'a>(args: &'a [&str]) -> Option<&'a str> {
 
 fn npm_uses_explicit_auth(args: &[&str]) -> bool {
     args.iter().any(|argument| {
-        let option = argument
-            .strip_prefix("--")
-            .unwrap_or(argument)
+        let option = argument.strip_prefix("--").unwrap_or(argument);
+        let option = option
             .split_once('=')
-            .map_or(*argument, |(name, _)| name)
+            .map_or(option, |(name, _)| name)
             .to_ascii_lowercase();
         option == "_authtoken"
             || option == "_auth-token"
@@ -1086,6 +1085,8 @@ mod tests {
                 "install",
                 "--//registry.npmjs.org/:_authToken=provided-token",
             ],
+            vec!["install", "--_authToken"],
+            vec!["install", "--//registry.npmjs.org/:_authToken"],
             vec!["future-command"],
         ] {
             assert!(invocation_is_secretless(

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,10 +21,18 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "node" { return npmRequestClassification(arguments) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
     guard let policy = secretGateCommandPolicies[gateID] else { return .unknown }
+    return commandPolicyClassification(policy, words)
+}
+
+private func commandPolicyClassification(
+    _ policy: SecretGateCommandPolicy,
+    _ words: some Collection<String>
+) -> SecretGateRequestClassification {
     let candidates = (1...min(3, words.count)).reversed().map {
         words.prefix($0).joined(separator: " ")
     }
@@ -34,6 +42,52 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+private func npmRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let booleanShortOptions = "DEOPSadfglpqsy"
+    let booleanOptions: Set<String> = [
+        "--all", "--dry-run", "--force", "--fund", "--global", "--ignore-scripts",
+        "--include-workspace-root", "--json", "--local", "--long", "--offline", "--parseable",
+        "--prefer-offline", "--prefer-online", "--quiet", "--readonly", "--silent", "--timing",
+        "--verbose", "--workspaces", "--yes", "-D", "-E", "-O", "-P", "-S", "-a", "-d",
+        "-dd", "-ddd", "-f", "-g", "-l", "-p", "-q", "-s", "-y",
+    ]
+    let valueOptions: Set<String> = [
+        "--cache", "--call", "--location", "--loglevel", "--otp", "--prefix", "--reg",
+        "--registry", "--scope", "--tag", "--userconfig", "--workspace", "-C", "-L", "-c", "-m", "-w",
+    ]
+    let valueShortOptions = ["-C", "-L", "-c", "-m", "-w"]
+    let optionArguments = arguments.prefix { $0 != "--" }
+    if optionArguments.contains(where: { ["--help", "-h", "-H", "-?"].contains($0) }) {
+        return .readOnly
+    }
+    if optionArguments.contains(where: { ["--version", "--versions", "-v"].contains($0) }) {
+        return .readOnly
+    }
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if !argument.hasPrefix("-") { break }
+        let shortOptions = argument.dropFirst()
+        let isBooleanShortCluster = shortOptions.count > 1
+            && shortOptions.allSatisfy { booleanShortOptions.contains($0) }
+        let hasAttachedShortValue = valueShortOptions.contains {
+            argument.hasPrefix($0) && argument.count > $0.count
+        }
+        if argument.contains("=") || argument.hasPrefix("--no-")
+            || booleanOptions.contains(argument) || isBooleanShortCluster || hasAttachedShortValue
+        {
+            index += 1
+        } else if valueOptions.contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+        } else {
+            return .unknown
+        }
+    }
+    guard index < arguments.count, let policy = secretGateCommandPolicies["node"] else { return .unknown }
+    return commandPolicyClassification(policy, arguments[index...].map { $0.lowercased() })
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -122,4 +122,32 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "list"]) == .readOnly)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["--global", "install"]
+    ) == .mutating)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["--registry", "https://registry.npmjs.org", "view", "example"]
+    ) == .readOnly)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["install", "--version"]
+    ) == .readOnly)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["--cache", "install", "run", "build"]
+    ) == .unknown)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["-gq", "install"]
+    ) == .mutating)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["-C/tmp", "view", "example"]
+    ) == .readOnly)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "node",
+        arguments: ["install", "--", "--version"]
+    ) == .mutating)
 }


### PR DESCRIPTION
## Summary
- bypass NODE_AUTH_TOKEN delivery for npm help/version, unknown, arbitrary script/passthrough, and explicit auth-token forms
- recognize reviewed npm v11.19.0 leading global options, including short clusters and attached values, before positively matching credential-requiring commands
- keep the macOS Authorization Request classifier aligned with the wrapper parser

This changes Secret routing only. Credential-independent execution approval for installs remains out of scope. Launcher path, identity, and generated-stub integrity checks remain fail-closed.

## Verification
- `cargo test --all-targets`
- `swift test --package-path src/menu-helper`