### PR TITLE
Route Qwen secrets only to agent execution

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "qwen" => qwen_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -118,6 +119,202 @@ pub(crate) fn invocation_is_secretless(
         ),
         _ => false,
     }
+}
+
+// Reviewed against @qwen-code/qwen-code 0.23.0. Keep this positive Secret
+// route exact: every unlisted management command runs without the migrated
+// environment assignment bundle.
+fn qwen_invocation_is_secretless(args: &[OsString]) -> bool {
+    if qwen_early_exit(args) {
+        return true;
+    }
+    if args
+        .iter()
+        .take_while(|arg| arg.as_os_str() != "--")
+        .filter_map(|arg| arg.to_str())
+        .any(|arg| {
+            arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 2 && !arg.contains('=')
+        })
+    {
+        // Qwen/yargs accepts some compact short-option clusters, but their
+        // interaction with the default agent command is not command-like.
+        return false;
+    }
+
+    let Some((command, command_index)) = qwen_next_word(args, 0) else {
+        return args
+            .iter()
+            .take_while(|arg| arg.as_os_str() != "--")
+            .any(|arg| {
+                arg.to_str()
+                    .is_some_and(|arg| arg.starts_with('-') && !qwen_known_option(arg))
+            });
+    };
+    match command {
+        "auth" | "hook" | "hooks" | "extensions" | "sessions" | "update" => true,
+        "serve" => false,
+        "mcp" => {
+            let subcommand = if command_index == 0 && args.get(1).is_some_and(|arg| arg == "--") {
+                args.get(2).and_then(|arg| arg.to_str())
+            } else {
+                qwen_next_word(args, command_index + 1).map(|(subcommand, _)| subcommand)
+            };
+            subcommand != Some("reconnect")
+        }
+        "channel" => qwen_next_word(args, command_index + 1)
+            .is_none_or(|(subcommand, _)| !matches!(subcommand, "start" | "daemon-worker")),
+        "review" => qwen_next_word(args, command_index + 1)
+            .is_none_or(|(subcommand, _)| subcommand != "run"),
+        // Qwen's default command treats every other positional as an agent prompt.
+        _ => false,
+    }
+}
+
+fn qwen_early_exit(args: &[OsString]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_os_str() != "--")
+        .filter_map(|arg| arg.to_str())
+        .any(|arg| {
+            matches!(
+                arg,
+                "--help"
+                    | "-h"
+                    | "--help=true"
+                    | "-h=true"
+                    | "--version"
+                    | "-v"
+                    | "--version=true"
+                    | "-v=true"
+                    | "--list-extensions"
+                    | "-l"
+                    | "--list-extensions=true"
+                    | "-l=true"
+            ) || arg.starts_with('-')
+                && !arg.starts_with("--")
+                && arg.len() > 2
+                && arg[1..].chars().all(|flag| "dhvlsyc".contains(flag))
+                && arg[1..].chars().any(|flag| "hvl".contains(flag))
+        })
+}
+
+fn qwen_next_word(args: &[OsString], mut index: usize) -> Option<(&str, usize)> {
+    while index < args.len() {
+        let arg = args[index].to_str()?;
+        if arg == "--" {
+            return None;
+        }
+        if !arg.starts_with('-') {
+            return Some((arg, index));
+        }
+        if !qwen_known_option(arg) {
+            return None;
+        }
+        if qwen_value_option(arg) && !arg.contains('=') {
+            index += 1;
+        } else if qwen_boolean_option(arg)
+            && args
+                .get(index + 1)
+                .and_then(|arg| arg.to_str())
+                .is_some_and(|arg| matches!(arg, "true" | "false"))
+        {
+            index += 1;
+        }
+        index += 1;
+    }
+    None
+}
+
+fn qwen_known_option(arg: &str) -> bool {
+    qwen_value_option(arg) || qwen_boolean_option(arg)
+}
+
+fn qwen_value_option(arg: &str) -> bool {
+    matches!(
+        arg.split_once('=').map_or(arg, |(flag, _)| flag),
+        "--telemetry-target"
+            | "--telemetry-otlp-endpoint"
+            | "--telemetry-otlp-protocol"
+            | "--telemetry-outfile"
+            | "--proxy"
+            | "--model"
+            | "-m"
+            | "--fallback-model"
+            | "--prompt"
+            | "-p"
+            | "--prompt-interactive"
+            | "-i"
+            | "--system-prompt"
+            | "--append-system-prompt"
+            | "--output-style"
+            | "--sandbox-image"
+            | "--approval-mode"
+            | "--channel"
+            | "--allowed-mcp-server-names"
+            | "--mcp-config"
+            | "--allowed-tools"
+            | "--extensions"
+            | "-e"
+            | "--include-directories"
+            | "--add-dir"
+            | "--openai-logging-dir"
+            | "--openai-api-key"
+            | "--openai-base-url"
+            | "--input-format"
+            | "--output-format"
+            | "-o"
+            | "--json-fd"
+            | "--json-file"
+            | "--json-schema"
+            | "--input-file"
+            | "--resume"
+            | "-r"
+            | "--session-id"
+            | "--worktree"
+            | "--max-session-turns"
+            | "--max-wall-time"
+            | "--max-tool-calls"
+            | "--max-subagent-depth"
+            | "--core-tools"
+            | "--exclude-tools"
+            | "--disabled-slash-commands"
+            | "--auth-type"
+            | "--sandbox-session-id"
+    )
+}
+
+fn qwen_boolean_option(arg: &str) -> bool {
+    matches!(
+        arg.split_once('=').map_or(arg, |(flag, _)| flag),
+        "--help"
+            | "-h"
+            | "--version"
+            | "-v"
+            | "--telemetry"
+            | "--telemetry-log-prompts"
+            | "--debug"
+            | "-d"
+            | "--bare"
+            | "--safe-mode"
+            | "--insecure"
+            | "--chat-recording"
+            | "--sandbox"
+            | "-s"
+            | "--yolo"
+            | "-y"
+            | "--acp"
+            | "--experimental-acp"
+            | "--experimental-skills"
+            | "--experimental-lsp"
+            | "--restore-ask-user-question"
+            | "--list-extensions"
+            | "-l"
+            | "--openai-logging"
+            | "--screen-reader"
+            | "--include-partial-messages"
+            | "--continue"
+            | "-c"
+            | "--fork-session"
+    )
 }
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
@@ -978,6 +1175,92 @@ mod tests {
             &script_path,
             format!("{script}# changed\n").as_bytes(),
             &args(&["root"]),
+        ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn qwen_requests_secrets_only_for_agent_execution() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-qwen");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("qwen");
+        let script = stub_script(
+            &wrapper("qwen-code").unwrap().primary,
+            Path::new("/opt/homebrew/bin/qwen"),
+        );
+        let invocation = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for args in [
+            vec!["--version"],
+            vec!["--version=true"],
+            vec!["--debug", "--help"],
+            vec!["--help=true"],
+            vec!["--list-extensions", "ignored-query"],
+            vec!["--telemetry-target", "local", "sessions", "ps"],
+            vec!["mcp"],
+            vec!["mcp", "list"],
+            vec!["mcp", "--", "list"],
+            vec!["mcp", "approve", "example"],
+            vec!["mcp", "future-command"],
+            vec!["extensions", "install", "example"],
+            vec!["auth"],
+            vec!["hooks"],
+            vec!["sessions", "list"],
+            vec!["update"],
+            vec!["channel", "status"],
+            vec!["channel", "pairing", "list", "telegram"],
+            vec!["channel", "future-command"],
+            vec!["review", "drive", "--script", "env"],
+            vec!["review", "submit"],
+            vec!["review", "future-command"],
+            vec!["review", "run", "--help"],
+            vec!["--future-option", "mcp", "list"],
+            vec!["-dl"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&args)),
+                "qwen {args:?}",
+            );
+        }
+
+        for args in [
+            vec![],
+            vec!["fix", "the", "tests"],
+            vec!["future-command"],
+            vec!["chat"],
+            vec!["--prompt", "fix the tests"],
+            vec!["--debug"],
+            vec!["--help=false"],
+            vec!["--version=false"],
+            vec!["--", "--help"],
+            vec!["serve"],
+            vec!["--debug", "serve"],
+            vec!["mcp", "reconnect", "example"],
+            vec!["mcp", "--", "reconnect", "--all"],
+            vec!["--debug", "mcp", "reconnect", "--all"],
+            vec!["channel", "start", "telegram"],
+            vec!["channel", "daemon-worker"],
+            vec!["review", "run", "123"],
+            vec!["-dy"],
+            vec!["-ds", "sessions", "ps"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&args)),
+                "qwen {args:?}",
+            );
+        }
+
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation(&["--version"]),
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -156,7 +156,9 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     ),
     "pnpm": .init("view,info,search,audit,outdated,why,list", "publish,unpublish,deprecate,add,remove,update", secretDump: "config get"),
     "pulumi": .init("whoami,stack ls,preview,about,config get", "up,destroy,refresh,import,cancel", secretDump: "config get --show-secrets,stack export --show-secrets"),
-    "qwen-code": .init("", "chat,run"),
+    // Qwen has no `chat` command and treats arbitrary positionals (including
+    // "chat" and "run") as agent prompts whose authority cannot be inferred.
+    "qwen-code": .init("", ""),
     "runpodctl": .init("get,list", "create,remove,start,stop", secretDump: "config view"),
     "s3cmd": .init("ls,la,info,du", "put,get,del,rm,sync,cp,mv,mb,rb", secretDump: "--dump-config"),
     "sentry-cli": .init("projects list,organizations list,releases list", "send-event,releases new,releases deploys new,upload-dif"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,10 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func qwenAgentPromptsRemainUnknown() {
+    #expect(genericSecretGateRequestClassification(gateID: "qwen-code", arguments: ["--version"]) == .readOnly)
+    #expect(genericSecretGateRequestClassification(gateID: "qwen-code", arguments: ["chat"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "qwen-code", arguments: ["run"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "qwen-code", arguments: ["review", "run"]) == .unknown)
+}


### PR DESCRIPTION
## Summary

- route `QWEN_ENV_ASSIGNMENTS` only to Qwen paths that actually execute an agent/model or reconnect configured MCP servers
- run help/version, extension/session/update/auth/hook management, non-starting channel management, and review helpers tokenlessly
- keep positional prompts, `serve`, `mcp reconnect`, `channel start`/the internal worker, and `review run` behind the Authorization Gate
- correct the macOS request policy so Qwen positional prompts remain Unknown instead of pretending `chat` and `run` are commands

Reviewed against `@qwen-code/qwen-code` 0.23.0 (release commit `98a9c964158697dd5631d15a62174684ff7bbb53`). Unknown options/subcommands are tokenless because Qwen rejects them; unknown positionals stay gated because Qwen treats them as agent prompts. Stub identity and exact-content validation remain fail-closed.

## Verification

- `cargo test --all-targets` (984 Rust library tests plus all integration targets)
- `swift test --package-path src/menu-helper` (244 tests)
- observed upstream behavior for help/version boolean forms, `--` handling, leading global options, compact short flags, and the `mcp -- <subcommand>` normalization