### PR TITLE
Route runpodctl secrets only to API commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "runpodctl" => runpodctl_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -116,6 +117,201 @@ pub(crate) fn invocation_is_secretless(
                 "validate",
             ],
         ),
+        _ => false,
+    }
+}
+
+// Reviewed against runpodctl 2.8.0. Unknown commands stay tokenless because
+// Cobra rejects them; only commands that construct a RunPod API client receive
+// the migrated API key.
+fn runpodctl_invocation_is_secretless(args: &[OsString]) -> bool {
+    if args.is_empty() || runpodctl_help_request(args) {
+        return true;
+    }
+    let Some(words) = runpodctl_command_words(args) else {
+        return true;
+    };
+    !runpodctl_needs_api_key(&words)
+}
+
+fn runpodctl_help_request(args: &[OsString]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_os_str() != "--")
+        .enumerate()
+        .any(|(index, arg)| {
+            let Some(arg) = arg.to_str() else {
+                return false;
+            };
+            let enabled = matches!(arg, "--help" | "-h" | "--help=true" | "-h=true");
+            if !enabled || arg.contains('=') || index == 0 {
+                return enabled;
+            }
+            let Some(previous) = args[index - 1].to_str() else {
+                return false;
+            };
+            !previous.starts_with('-')
+                || previous.contains('=')
+                || runpodctl_boolean_option(previous)
+        })
+}
+
+fn runpodctl_command_words(args: &[OsString]) -> Option<Vec<&str>> {
+    let mut words = Vec::with_capacity(2);
+    let mut index = 0;
+    while index < args.len() && words.len() < 2 {
+        let arg = args[index].to_str()?;
+        if arg == "--" {
+            break;
+        }
+        if matches!(
+            arg,
+            "--version" | "-v" | "--version=true" | "-v=true" | "--version=false" | "-v=false"
+        ) && words.is_empty()
+        {
+            return Some(vec!["version"]);
+        }
+        if matches!(arg, "--output" | "-o") {
+            index += 2;
+            continue;
+        }
+        if arg.starts_with("--output=")
+            || arg.starts_with("-o=")
+            || arg.starts_with("-o") && arg.len() > 2
+        {
+            index += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            if words.is_empty() && matches!(arg, "--help=false" | "-h=false") {
+                index += 1;
+                continue;
+            }
+            return None;
+        }
+        words.push(arg);
+        index += 1;
+    }
+    Some(words)
+}
+
+fn runpodctl_boolean_option(arg: &str) -> bool {
+    matches!(
+        arg.split_once('=').map_or(arg, |(flag, _)| flag),
+        "--all"
+            | "-a"
+            | "--allfields"
+            | "--clear-models"
+            | "--community"
+            | "-c"
+            | "--communityCloud"
+            | "--create-upload"
+            | "--flash-boot"
+            | "--global-networking"
+            | "--include-env"
+            | "--include-machine"
+            | "--include-network-volume"
+            | "--include-template"
+            | "--include-unavailable"
+            | "--include-workers"
+            | "--init"
+            | "-i"
+            | "--prefix-pod-logs"
+            | "--public-ip"
+            | "--secure"
+            | "-s"
+            | "--secureCloud"
+            | "--select-volume"
+            | "--serverless"
+            | "--ssh"
+            | "--startSSH"
+            | "--verbose"
+            | "-v"
+            | "--wait-for-hash"
+    )
+}
+
+fn runpodctl_needs_api_key(words: &[&str]) -> bool {
+    let Some(command) = words.first().copied() else {
+        return false;
+    };
+    let subcommand = words.get(1).copied();
+    match command {
+        "doctor" | "user" | "account" | "me" => true,
+        "pod" | "pods" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list"
+                    | "get"
+                    | "create"
+                    | "update"
+                    | "start"
+                    | "stop"
+                    | "restart"
+                    | "reset"
+                    | "delete"
+                    | "rm"
+                    | "remove"
+            )
+        }),
+        "serverless" | "sls" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list" | "get" | "create" | "update" | "delete" | "rm" | "remove"
+            )
+        }),
+        "template" | "tpl" | "templates" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list" | "search" | "get" | "create" | "update" | "delete" | "rm" | "remove"
+            )
+        }),
+        "model" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list" | "ls" | "add" | "remove" | "rm" | "delete"
+            )
+        }),
+        "network-volume" | "nv" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list" | "get" | "create" | "update" | "delete" | "rm" | "remove"
+            )
+        }),
+        "registry" | "reg" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list" | "get" | "create" | "delete" | "rm" | "remove"
+            )
+        }),
+        "hub" => {
+            subcommand.is_some_and(|subcommand| matches!(subcommand, "list" | "search" | "get"))
+        }
+        "gpu" | "gpus" | "datacenter" | "dc" | "datacenters" => subcommand == Some("list"),
+        "billing" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "pods" | "serverless" | "sls" | "endpoints" | "network-volume" | "nv"
+            )
+        }),
+        "ssh" => subcommand.is_some_and(|subcommand| {
+            matches!(
+                subcommand,
+                "list-keys" | "add-key" | "remove-key" | "info" | "connect"
+            )
+        }),
+        "exec" => subcommand == Some("python"),
+        "project" => {
+            subcommand.is_some_and(|subcommand| matches!(subcommand, "dev" | "start" | "deploy"))
+        }
+        "get" => subcommand
+            .is_some_and(|subcommand| matches!(subcommand, "cloud" | "pod" | "models" | "model")),
+        "create" => {
+            subcommand.is_some_and(|subcommand| matches!(subcommand, "pod" | "pods" | "model"))
+        }
+        "remove" => {
+            subcommand.is_some_and(|subcommand| matches!(subcommand, "pod" | "pods" | "model"))
+        }
+        "start" | "stop" => subcommand == Some("pod"),
         _ => false,
     }
 }
@@ -978,6 +1174,90 @@ mod tests {
             &script_path,
             format!("{script}# changed\n").as_bytes(),
             &args(&["root"]),
+        ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn runpodctl_requests_secrets_only_for_reviewed_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-runpodctl");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("runpodctl");
+        let script = stub_script(
+            &wrapper("runpodctl").unwrap().primary,
+            Path::new("/opt/homebrew/bin/runpodctl"),
+        );
+        let invocation = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for args in [
+            vec![],
+            vec!["help"],
+            vec!["--help"],
+            vec!["--help=true"],
+            vec!["version"],
+            vec!["--version"],
+            vec!["--version=false", "pod", "list"],
+            vec!["completion", "generate", "zsh"],
+            vec!["send", "archive.tar"],
+            vec!["receive", "1234-example"],
+            vec!["update"],
+            vec!["config", "--apiKey", "explicit-key"],
+            vec!["project", "create", "--name", "example"],
+            vec!["project", "build", "--include-env"],
+            vec!["pod"],
+            vec!["registry", "update"],
+            vec!["future-command"],
+            vec!["--future-option", "pod", "list"],
+            vec!["pod", "list", "--all", "--help"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&args)),
+                "runpodctl {args:?}",
+            );
+        }
+
+        for args in [
+            vec!["pod", "list"],
+            vec!["--output", "yaml", "pod", "get", "pod-id"],
+            vec!["-oyaml", "pods", "create", "--image", "runpod/base"],
+            vec!["--help=false", "pod", "list"],
+            vec!["pod", "create", "--name", "--help"],
+            vec!["serverless", "update", "endpoint-id"],
+            vec!["tpl", "search", "pytorch"],
+            vec!["model", "add", "owner/model"],
+            vec!["nv", "delete", "volume-id"],
+            vec!["reg", "create"],
+            vec!["hub", "list"],
+            vec!["gpus", "list"],
+            vec!["dc", "list"],
+            vec!["billing", "endpoints"],
+            vec!["me"],
+            vec!["doctor"],
+            vec!["ssh", "connect", "pod-id"],
+            vec!["exec", "python", "script.py"],
+            vec!["project", "dev"],
+            vec!["get", "cloud"],
+            vec!["create", "pod"],
+            vec!["remove", "model"],
+            vec!["start", "pod"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&args)),
+                "runpodctl {args:?}",
+            );
+        }
+
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation(&["--version"]),
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,9 +18,13 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
-    let words = arguments.map { $0.lowercased() }
+    var words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "runpodctl" {
+        guard let normalized = runpodctlCommandWords(words) else { return .unknown }
+        words = normalized
+    }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -34,6 +38,32 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+// Keep global-option handling aligned with runpodctl 2.8.0 so the prompt can
+// describe gated API commands without treating their output format as a verb.
+private func runpodctlCommandWords(_ arguments: [String]) -> [String]? {
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if argument == "--output" || argument == "-o" {
+            guard index + 1 < arguments.count else { return nil }
+            index += 2
+        } else if argument.hasPrefix("--output=") || argument.hasPrefix("-o=")
+            || (argument.hasPrefix("-o") && argument.count > 2)
+        {
+            index += 1
+        } else if ["--help", "-h", "--help=true", "-h=true", "--version", "-v", "--version=true", "-v=true"].contains(argument) {
+            return ["help"]
+        } else if argument == "--help=false" || argument == "-h=false" {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return nil
+        } else {
+            return Array(arguments[index...])
+        }
+    }
+    return []
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -157,7 +187,10 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "pnpm": .init("view,info,search,audit,outdated,why,list", "publish,unpublish,deprecate,add,remove,update", secretDump: "config get"),
     "pulumi": .init("whoami,stack ls,preview,about,config get", "up,destroy,refresh,import,cancel", secretDump: "config get --show-secrets,stack export --show-secrets"),
     "qwen-code": .init("", "chat,run"),
-    "runpodctl": .init("get,list", "create,remove,start,stop", secretDump: "config view"),
+    "runpodctl": .init(
+        "pod list,pod get,pods list,pods get,serverless list,serverless get,sls list,sls get,template list,template search,template get,tpl list,tpl search,tpl get,templates list,templates search,templates get,model list,model ls,network-volume list,network-volume get,nv list,nv get,registry list,registry get,reg list,reg get,hub list,hub search,hub get,gpu list,gpus list,datacenter list,dc list,datacenters list,billing pods,billing serverless,billing sls,billing endpoints,billing network-volume,billing nv,user,account,me,ssh list-keys,ssh info,ssh connect,get cloud,get pod,get models,get model",
+        "pod create,pod update,pod start,pod stop,pod restart,pod reset,pod delete,pod rm,pod remove,pods create,pods update,pods start,pods stop,pods restart,pods reset,pods delete,pods rm,pods remove,serverless create,serverless update,serverless delete,serverless rm,serverless remove,sls create,sls update,sls delete,sls rm,sls remove,template create,template update,template delete,template rm,template remove,tpl create,tpl update,tpl delete,tpl rm,tpl remove,templates create,templates update,templates delete,templates rm,templates remove,model add,model remove,model rm,model delete,network-volume create,network-volume update,network-volume delete,network-volume rm,network-volume remove,nv create,nv update,nv delete,nv rm,nv remove,registry create,registry delete,registry rm,registry remove,reg create,reg delete,reg rm,reg remove,ssh add-key,ssh remove-key,doctor,exec python,project dev,project start,project deploy,create pod,create pods,create model,remove pod,remove pods,remove model,start pod,stop pod"
+    ),
     "s3cmd": .init("ls,la,info,du", "put,get,del,rm,sync,cp,mv,mb,rb", secretDump: "--dump-config"),
     "sentry-cli": .init("projects list,organizations list,releases list", "send-event,releases new,releases deploys new,upload-dif"),
     "snowflake-cli": .init("object list,object describe,connection test", "object create,object drop,stage copy"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -32,7 +32,7 @@ import Testing
         "pnpm": ["view", "example"],
         "pulumi": ["stack", "ls"],
         "qwen-code": ["--version"],
-        "runpodctl": ["get", "pod"],
+        "runpodctl": ["pod", "list"],
         "s3cmd": ["ls", "s3://bucket"],
         "sentry-cli": ["projects", "list"],
         "snowflake-cli": ["object", "list"],
@@ -57,6 +57,33 @@ import Testing
             "missing read-only policy for \(gateID)"
         )
     }
+}
+
+@Test func runpodctlPolicyUsesNounVerbCommandsAndLeadingOutputOptions() {
+    for arguments in [
+        ["pod", "list"],
+        ["--output", "yaml", "pod", "get", "pod-id"],
+        ["-oyaml", "ssh", "info", "pod-id"],
+        ["get", "models"],
+        ["me"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "runpodctl", arguments: arguments) == .readOnly)
+    }
+
+    for arguments in [
+        ["pod", "create", "--image", "runpod/base"],
+        ["--output=json", "serverless", "delete", "endpoint-id"],
+        ["ssh", "add-key", "--key-file", "id.pub"],
+        ["exec", "python", "script.py"],
+        ["project", "deploy"],
+        ["remove", "model"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "runpodctl", arguments: arguments) == .mutating)
+    }
+
+    #expect(genericSecretGateRequestClassification(gateID: "runpodctl", arguments: ["config", "view"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "runpodctl", arguments: ["registry", "update"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "runpodctl", arguments: ["--future", "pod", "list"]) == .unknown)
 }
 
 @Test func genericPoliciesClassifyMutationsSecretsAndUnknowns() {


### PR DESCRIPTION
## Summary
- route `RUNPOD_API_KEY` only to runpodctl 2.8.0 commands that construct an API client
- keep help/version, completion, transfer, update, explicit-key config, local project creation/build, and unknown commands tokenless
- update the macOS request classification for runpodctl’s noun–verb command shape and global output option

## Security
- preserves exact managed-stub identity validation before any tokenless route
- uses a positive, version-reviewed catalog; unreviewed API verbs do not receive the migrated credential
- keeps credential routing separate from future credential-independent execution approval

## Verification
- `cargo test --all-targets` (984 library tests plus all integration targets)
- `swift test --package-path src/menu-helper` (244 tests)