### PR TITLE
Route s3cmd secrets only to credential uses

### DIFF
--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -234,7 +234,12 @@ fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
         )
     });
     let prepared = if secretless {
-        resolve_target(&options.target).map(|target| (target, secretless_environment(&options)))
+        let s3cmd = verified_script
+            .as_ref()
+            .and_then(|script| script.path.file_name())
+            .is_some_and(|name| name == "s3cmd");
+        resolve_target(&options.target)
+            .map(|target| (target, secretless_environment(&options, s3cmd)))
     } else {
         prepare_injection(
             &options,
@@ -287,10 +292,34 @@ fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
     1
 }
 
-fn secretless_environment(options: &Options) -> BTreeMap<OsString, OsString> {
+fn secretless_environment(options: &Options, s3cmd: bool) -> BTreeMap<OsString, OsString> {
     let mut env = std::env::vars_os().collect::<BTreeMap<_, _>>();
     for key in &options.keys {
         env.remove(std::ffi::OsStr::new(key));
+    }
+    if s3cmd {
+        for key in [
+            "AWS_ACCESS_KEY",
+            "AWS_SECRET_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_SECURITY_TOKEN",
+            "AWS_CREDENTIAL_FILE",
+            "AWS_PROFILE",
+            "S3CMD_GPG_PASSPHRASE",
+        ] {
+            env.remove(std::ffi::OsStr::new(key));
+        }
+        // s3cmd otherwise probes instance metadata while loading its blanked
+        // config, even when it will only print usage or reject a command.
+        env.insert("AWS_ACCESS_KEY_ID".into(), "AUTOMIC_VAULT_TOKENLESS".into());
+        env.insert(
+            "AWS_SECRET_ACCESS_KEY".into(),
+            "AUTOMIC_VAULT_TOKENLESS".into(),
+        );
+        env.insert(
+            "S3CMD_GPG_PASSPHRASE".into(),
+            "AUTOMIC_VAULT_TOKENLESS".into(),
+        );
     }
     env
 }
@@ -1597,11 +1626,59 @@ mod tests {
             shebang_script: None,
         };
 
-        let env = secretless_environment(&options);
+        let env = secretless_environment(&options, false);
 
         unsafe { std::env::remove_var("SOME_SECRET") };
         assert!(!env.contains_key(std::ffi::OsStr::new("SOME_SECRET")));
         assert!(env.contains_key(std::ffi::OsStr::new("PATH")));
+    }
+
+    #[test]
+    fn s3cmd_secretless_environment_cannot_resolve_ambient_credentials() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        for (key, value) in [
+            ("AWS_ACCESS_KEY", "ambient-access"),
+            ("AWS_SECRET_KEY", "ambient-secret"),
+            ("AWS_SESSION_TOKEN", "ambient-session"),
+            ("AWS_PROFILE", "ambient-profile"),
+            ("S3CMD_GPG_PASSPHRASE", "ambient-passphrase"),
+        ] {
+            unsafe { std::env::set_var(key, value) };
+        }
+        let options = Options {
+            replace_existing_env: false,
+            allow_missing_keys: true,
+            keys: vec!["S3CMD_ENV_ASSIGNMENTS".into()],
+            target: "/bin/sh".into(),
+            args: Vec::new(),
+            shebang_script: None,
+        };
+
+        let env = secretless_environment(&options, true);
+
+        for key in [
+            "AWS_ACCESS_KEY",
+            "AWS_SECRET_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_PROFILE",
+            "S3CMD_GPG_PASSPHRASE",
+        ] {
+            unsafe { std::env::remove_var(key) };
+        }
+        assert_eq!(
+            env.get(std::ffi::OsStr::new("AWS_ACCESS_KEY_ID")),
+            Some(&OsString::from("AUTOMIC_VAULT_TOKENLESS"))
+        );
+        assert_eq!(
+            env.get(std::ffi::OsStr::new("AWS_SECRET_ACCESS_KEY")),
+            Some(&OsString::from("AUTOMIC_VAULT_TOKENLESS"))
+        );
+        assert_eq!(
+            env.get(std::ffi::OsStr::new("S3CMD_GPG_PASSPHRASE")),
+            Some(&OsString::from("AUTOMIC_VAULT_TOKENLESS"))
+        );
+        assert!(!env.contains_key(std::ffi::OsStr::new("AWS_PROFILE")));
+        assert!(!env.contains_key(std::ffi::OsStr::new("AWS_SESSION_TOKEN")));
     }
 
     #[test]

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -242,8 +242,12 @@ fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
             .as_ref()
             .and_then(|script| script.path.file_name())
             .is_some_and(|name| name == "s3cmd");
-        resolve_target(&options.target)
-            .map(|target| (target, secretless_environment(&options, substitute_empty, s3cmd)))
+        resolve_target(&options.target).map(|target| {
+            (
+                target,
+                secretless_environment(&options, substitute_empty, s3cmd),
+            )
+        })
     } else {
         prepare_injection(
             &options,

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "s3cmd" => s3cmd_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -119,6 +120,283 @@ pub(crate) fn invocation_is_secretless(
         _ => false,
     }
 }
+
+// Reviewed against s3cmd 2.4.0. Every real command signs an S3 or CloudFront
+// request; only parser exits and unknown commands run without the migrated
+// AWS/GPG assignment bundle.
+fn s3cmd_invocation_is_secretless(args: &[OsString]) -> bool {
+    let mut command = None;
+    let mut protected_option = false;
+    let mut index = 0;
+    while index < args.len() {
+        let Some(arg) = args[index].to_str() else {
+            return command.is_none();
+        };
+        if arg == "--" {
+            if command.is_none() {
+                command = args.get(index + 1).and_then(|arg| arg.to_str());
+            }
+            break;
+        }
+        if arg == "-" || !arg.starts_with('-') {
+            command.get_or_insert(arg);
+            index += 1;
+            continue;
+        }
+        if arg.starts_with("--") {
+            let (option, attached_value) = arg
+                .split_once('=')
+                .map_or((arg, false), |(key, _)| (key, true));
+            let Some(kind) = s3cmd_long_option(option) else {
+                return true;
+            };
+            if attached_value && kind != S3cmdOption::Value {
+                return true;
+            }
+            match kind {
+                S3cmdOption::LocalExit => return true,
+                S3cmdOption::Protected => protected_option = true,
+                S3cmdOption::Value if !attached_value => index += 1,
+                S3cmdOption::Value | S3cmdOption::Flag => {}
+            }
+            index += 1;
+            continue;
+        }
+
+        let Some((kind, consumes_next)) = s3cmd_short_options(arg) else {
+            return true;
+        };
+        if kind == S3cmdOption::LocalExit {
+            return true;
+        }
+        if consumes_next {
+            index += 1;
+        }
+        index += 1;
+    }
+
+    !protected_option && command.is_none_or(|command| !S3CMD_COMMANDS.contains(&command))
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum S3cmdOption {
+    LocalExit,
+    Protected,
+    Value,
+    Flag,
+}
+
+fn s3cmd_long_option(option: &str) -> Option<S3cmdOption> {
+    let options = [
+        (&["--help", "--version"][..], S3cmdOption::LocalExit),
+        (
+            &["--configure", "--dump-config"][..],
+            S3cmdOption::Protected,
+        ),
+        (S3CMD_VALUE_OPTIONS, S3cmdOption::Value),
+        (S3CMD_FLAG_OPTIONS, S3cmdOption::Flag),
+    ];
+    if let Some(kind) = options
+        .iter()
+        .find_map(|(names, kind)| names.contains(&option).then_some(*kind))
+    {
+        return Some(kind);
+    }
+
+    let mut matches = options.iter().flat_map(|(names, kind)| {
+        names
+            .iter()
+            .filter(move |name| name.starts_with(option))
+            .map(move |_| *kind)
+    });
+    let kind = matches.next()?;
+    matches.next().is_none().then_some(kind)
+}
+
+fn s3cmd_short_options(arg: &str) -> Option<(S3cmdOption, bool)> {
+    let mut flags = arg[1..].chars().peekable();
+    while let Some(flag) = flags.next() {
+        match flag {
+            'h' => return Some((S3cmdOption::LocalExit, false)),
+            'c' | 'D' | 'm' => return Some((S3cmdOption::Value, flags.peek().is_none())),
+            'n' | 's' | 'e' | 'f' | 'r' | 'P' | 'p' | 'M' | 'H' | 'v' | 'd' | 'F' | 'q' | 'l' => {}
+            _ => return None,
+        }
+    }
+    Some((S3cmdOption::Flag, false))
+}
+
+const S3CMD_VALUE_OPTIONS: &[&str] = &[
+    "--config",
+    "--access_key",
+    "--secret_key",
+    "--access_token",
+    "--upload-id",
+    "--acl-grant",
+    "--acl-revoke",
+    "--restore-days",
+    "--restore-priority",
+    "--max-delete",
+    "--limit",
+    "--add-destination",
+    "--exclude",
+    "--exclude-from",
+    "--rexclude",
+    "--rexclude-from",
+    "--include",
+    "--include-from",
+    "--rinclude",
+    "--rinclude-from",
+    "--files-from",
+    "--region",
+    "--bucket-location",
+    "--host",
+    "--host-bucket",
+    "--storage-class",
+    "--access-logging-target-prefix",
+    "--default-mime-type",
+    "--mime-type",
+    "--add-header",
+    "--remove-header",
+    "--server-side-encryption-kms-id",
+    "--encoding",
+    "--add-encoding-exts",
+    "--multipart-chunk-size-mb",
+    "--ws-index",
+    "--ws-error",
+    "--expiry-date",
+    "--expiry-days",
+    "--expiry-prefix",
+    "--cf-add-cname",
+    "--cf-remove-cname",
+    "--cf-comment",
+    "--cf-default-root-object",
+    "--cache-file",
+    "--ca-certs",
+    "--ssl-cert",
+    "--ssl-key",
+    "--limit-rate",
+    "--max-retries",
+    "--content-disposition",
+    "--content-type",
+];
+
+const S3CMD_FLAG_OPTIONS: &[&str] = &[
+    "--dry-run",
+    "--ssl",
+    "--no-ssl",
+    "--encrypt",
+    "--no-encrypt",
+    "--force",
+    "--continue",
+    "--continue-put",
+    "--skip-existing",
+    "--recursive",
+    "--check-md5",
+    "--no-check-md5",
+    "--acl-public",
+    "--acl-private",
+    "--delete-removed",
+    "--no-delete-removed",
+    "--delete-after",
+    "--delay-updates",
+    "--delete-after-fetch",
+    "--preserve",
+    "--no-preserve",
+    "--keep-dirs",
+    "--reduced-redundancy",
+    "--rr",
+    "--no-reduced-redundancy",
+    "--no-rr",
+    "--no-access-logging",
+    "--guess-mime-type",
+    "--no-guess-mime-type",
+    "--no-mime-magic",
+    "--server-side-encryption",
+    "--verbatim",
+    "--disable-multipart",
+    "--list-md5",
+    "--list-allow-unordered",
+    "--human-readable-sizes",
+    "--skip-destination-validation",
+    "--progress",
+    "--no-progress",
+    "--stats",
+    "--enable",
+    "--disable",
+    "--cf-invalidate",
+    "--cf-invalidate-default-index",
+    "--cf-no-invalidate-default-index-root",
+    "--verbose",
+    "--debug",
+    "--follow-symlinks",
+    "--quiet",
+    "--check-certificate",
+    "--no-check-certificate",
+    "--check-hostname",
+    "--no-check-hostname",
+    "--signature-v2",
+    "--no-connection-pooling",
+    "--requester-pays",
+    "--long-listing",
+    "--stop-on-error",
+];
+
+const S3CMD_COMMANDS: &[&str] = &[
+    "mb",
+    "rb",
+    "ls",
+    "la",
+    "put",
+    "get",
+    "del",
+    "rm",
+    "restore",
+    "sync",
+    "du",
+    "info",
+    "cp",
+    "modify",
+    "mv",
+    "setacl",
+    "setversioning",
+    "setownership",
+    "setblockpublicaccess",
+    "setobjectlegalhold",
+    "setobjectretention",
+    "setpolicy",
+    "delpolicy",
+    "setcors",
+    "delcors",
+    "payer",
+    "multipart",
+    "abortmp",
+    "listmp",
+    "accesslog",
+    "sign",
+    "signurl",
+    "fixbucket",
+    "settagging",
+    "gettagging",
+    "deltagging",
+    "ws-create",
+    "ws-delete",
+    "ws-info",
+    "expire",
+    "setlifecycle",
+    "getlifecycle",
+    "dellifecycle",
+    "setnotification",
+    "getnotification",
+    "delnotification",
+    "cflist",
+    "cfinfo",
+    "cfcreate",
+    "cfdelete",
+    "cfmodify",
+    "cfinval",
+    "cfinvalinfo",
+];
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
     args.is_empty()
@@ -978,6 +1256,75 @@ mod tests {
             &script_path,
             format!("{script}# changed\n").as_bytes(),
             &args(&["root"]),
+        ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn s3cmd_requests_secrets_only_for_reviewed_credential_uses() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-s3cmd");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("s3cmd");
+        let script = stub_script(
+            &wrapper("s3cmd").unwrap().primary,
+            Path::new("/opt/homebrew/bin/s3cmd"),
+        );
+        let invocation = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for args in [
+            vec![],
+            vec!["--help"],
+            vec!["-h"],
+            vec!["ls", "--help"],
+            vec!["--debug", "--version"],
+            vec!["--vers"],
+            vec!["future-command"],
+            vec!["--future-option", "ls"],
+            vec!["--confi", "/tmp/config", "ls"],
+            vec!["--version=true", "ls"],
+            vec!["--", "future-command"],
+            vec!["-qv"],
+            vec!["--dump-config", "--help"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&args)),
+                "s3cmd {args:?}",
+            );
+        }
+
+        for &command in S3CMD_COMMANDS {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&[command]),),
+                "s3cmd {command}",
+            );
+        }
+        for args in [
+            vec!["--config", "/tmp/config", "ls", "s3://bucket"],
+            vec!["--host=objects.example", "du"],
+            vec!["--long-l", "info", "s3://bucket"],
+            vec!["-qvc/tmp/config", "la"],
+            vec!["--", "ls"],
+            vec!["put", "--mime-type", "--help", "file", "s3://bucket"],
+            vec!["--configure"],
+            vec!["--dump-config"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &invocation(&args)),
+                "s3cmd {args:?}",
+            );
+        }
+
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation(&["--version"]),
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -158,7 +158,11 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "pulumi": .init("whoami,stack ls,preview,about,config get", "up,destroy,refresh,import,cancel", secretDump: "config get --show-secrets,stack export --show-secrets"),
     "qwen-code": .init("", "chat,run"),
     "runpodctl": .init("get,list", "create,remove,start,stop", secretDump: "config view"),
-    "s3cmd": .init("ls,la,info,du", "put,get,del,rm,sync,cp,mv,mb,rb", secretDump: "--dump-config"),
+    "s3cmd": .init(
+        "ls,la,du,info,multipart,listmp,gettagging,ws-info,getlifecycle,getnotification,cflist,cfinfo,cfinvalinfo",
+        "mb,rb,put,get,del,rm,restore,sync,cp,modify,mv,setacl,setversioning,setownership,setblockpublicaccess,setobjectlegalhold,setobjectretention,setpolicy,delpolicy,setcors,delcors,payer,abortmp,accesslog,signurl,fixbucket,settagging,deltagging,ws-create,ws-delete,expire,setlifecycle,dellifecycle,setnotification,delnotification,cfcreate,cfdelete,cfmodify,cfinval",
+        secretDump: "sign,--configure,--dump-config"
+    ),
     "sentry-cli": .init("projects list,organizations list,releases list", "send-event,releases new,releases deploys new,upload-dif"),
     "snowflake-cli": .init("object list,object describe,connection test", "object create,object drop,stage copy"),
     "snyk": .init("", "monitor,auth"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -72,6 +72,19 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "flyctl", arguments: []) == .unknown)
 }
 
+@Test func s3cmdPolicyCoversTheReviewedCommandCatalog() {
+    for command in ["ls", "multipart", "gettagging", "ws-info", "getlifecycle", "cflist", "cfinvalinfo"] {
+        #expect(genericSecretGateRequestClassification(gateID: "s3cmd", arguments: [command]) == .readOnly)
+    }
+    for command in ["put", "get", "restore", "modify", "setpolicy", "abortmp", "signurl", "fixbucket", "cfmodify"] {
+        #expect(genericSecretGateRequestClassification(gateID: "s3cmd", arguments: [command]) == .mutating)
+    }
+    for command in ["sign", "--configure", "--dump-config"] {
+        #expect(genericSecretGateRequestClassification(gateID: "s3cmd", arguments: [command]) == .secretDump)
+    }
+    #expect(genericSecretGateRequestClassification(gateID: "s3cmd", arguments: ["future-command"]) == .unknown)
+}
+
 @Test func stripePolicyClassifiesGeneratedBuiltInAndPluginCommands() {
     let readOnly = [
         ["customers", "list"],


### PR DESCRIPTION
## Summary
- route the migrated s3cmd AWS/GPG assignment bundle only to the complete s3cmd 2.4.0 command catalog and credential-management exits
- run help, version, empty, malformed-option, and unknown-command forms tokenlessly, including interspersed and abbreviated global options
- prevent s3cmd’s blank migrated config from falling back to ambient AWS aliases or instance metadata by supplying fixed non-secret compatibility values on tokenless runs
- expand macOS request classification across the reviewed read, mutation, signing, and credential-display commands

## Security
- preserves exact managed-stub identity validation before tokenless routing
- unknown future commands receive fixed dummy credentials rather than Vault or ambient credentials
- `sign`, `--configure`, and `--dump-config` remain classified with secret-dump-level sensitivity
- keeps credential routing separate from future credential-independent execution approval

## Verification
- exercised the tokenless compatibility environment against upstream s3cmd 2.4.0 (`9d17075b77e933cf9d7916435c426d38ab5bca5e`)
- `cargo test --all-targets` (985 library tests plus all integration targets)
- `swift test --package-path src/menu-helper` (244 tests)