### PR TITLE
Route sentry-cli token only to authenticated commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "sentry-cli" => sentry_cli_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -205,6 +206,92 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn sentry_cli_invocation_is_secretless(args: &[OsString]) -> bool {
+    // Reviewed against sentry-cli 3.7.0. Keep this positive: local commands,
+    // DSN-only envelope commands, and unrecognized future commands must not
+    // inherit the protected SENTRY_AUTH_TOKEN.
+    let Some(args) = args
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let before_passthrough = args.iter().take_while(|arg| **arg != "--");
+    if before_passthrough
+        .clone()
+        .any(|arg| matches!(*arg, "--help" | "-h" | "--version" | "-V"))
+        || before_passthrough
+            .clone()
+            .any(|arg| *arg == "--auth-token" || arg.starts_with("--auth-token="))
+    {
+        return true;
+    }
+    let no_upload = before_passthrough.clone().any(|arg| *arg == "--no-upload");
+
+    let Some((command_index, command)) = sentry_cli_positional(&args, 0, true) else {
+        return true;
+    };
+    let subcommand = sentry_cli_positional(&args, command_index + 1, false);
+    let requires_secret = match (command, subcommand.map(|(_, command)| command)) {
+        ("info" | "upload-dif" | "upload-dsym", _) => true,
+        ("upload-proguard", _) => !no_upload,
+        ("proguard", Some("upload")) => !no_upload,
+        ("build", Some("download" | "snapshots" | "upload"))
+        | ("code-mappings" | "dart-symbol-map", Some("upload"))
+        | ("debug-files" | "dif" | "difutil", Some("upload"))
+        | ("deploys", Some("list" | "new"))
+        | ("events", Some("list"))
+        | ("issues", Some("list" | "mute" | "resolve" | "unresolve"))
+        | ("logs", Some("list"))
+        | ("monitors", Some("list"))
+        | ("organizations", Some("list"))
+        | ("projects", Some("list"))
+        | ("react-native", Some("gradle" | "xcode"))
+        | ("repos", Some("list"))
+        | ("snapshots", Some("download" | "upload"))
+        | ("sourcemaps", Some("upload")) => true,
+        ("releases", Some("deploys")) => subcommand.is_some_and(|(index, _)| {
+            sentry_cli_positional(&args, index + 1, false)
+                .is_some_and(|(_, command)| matches!(command, "list" | "new"))
+        }),
+        (
+            "releases",
+            Some(
+                "archive" | "delete" | "finalize" | "info" | "list" | "new" | "restore"
+                | "set-commits",
+            ),
+        ) => true,
+        _ => false,
+    };
+    !requires_secret
+}
+
+fn sentry_cli_positional<'a>(
+    args: &'a [&'a str],
+    start: usize,
+    root: bool,
+) -> Option<(usize, &'a str)> {
+    let mut index = start;
+    while let Some(&arg) = args.get(index) {
+        if matches!(arg, "--header" | "--log-level" | "--auth-token") || root && arg == "--url" {
+            index += 2;
+        } else if matches!(arg, "--quiet" | "--silent" | "--allow-failure")
+            || arg.starts_with("--header=")
+            || arg.starts_with("--log-level=")
+            || arg.starts_with("--auth-token=")
+            || root && arg.starts_with("--url=")
+        {
+            index += 1;
+        } else if arg == "--" || arg.starts_with('-') {
+            return None;
+        } else {
+            return Some((index, arg));
+        }
+    }
+    None
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -978,6 +1065,118 @@ mod tests {
             &script_path,
             format!("{script}# changed\n").as_bytes(),
             &args(&["root"]),
+        ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn sentry_cli_requests_its_token_only_for_reviewed_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-sentry-cli");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("sentry-cli");
+        let script = stub_script(
+            &wrapper("sentry-cli").unwrap().primary,
+            Path::new("/opt/homebrew/bin/sentry-cli"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for invocation in [
+            vec![],
+            vec!["--help"],
+            vec!["--version"],
+            vec!["completions", "zsh"],
+            vec!["bash-hook"],
+            vec!["debug-files", "bundle-sources", "example.dSYM"],
+            vec!["debug-files", "check", "example.dSYM"],
+            vec!["debug-files", "bundle-jvm", "app.jar"],
+            vec!["debug-files", "find", "example.dSYM"],
+            vec!["debug-files", "print-sources", "example.dSYM"],
+            vec!["dif", "check", "example.dSYM"],
+            vec!["proguard", "uuid", "mapping.txt"],
+            vec!["proguard", "upload", "--no-upload", "mapping.txt"],
+            vec!["upload-proguard", "--no-upload", "mapping.txt"],
+            vec!["releases", "propose-version"],
+            vec!["sourcemaps", "inject", "dist"],
+            vec!["sourcemaps", "resolve", "bundle.js.map"],
+            vec!["snapshots", "diff", "base", "head"],
+            vec!["send-event", "--message", "broken"],
+            vec!["send-envelope", "event.envelope"],
+            vec!["monitors", "run", "nightly", "--", "sh", "--help"],
+            vec!["login"],
+            vec!["uninstall"],
+            vec!["update"],
+            vec!["future-command"],
+            vec!["releases", "future-command"],
+            vec!["projects", "list", "--help"],
+            vec!["projects", "--", "--help"],
+            vec!["--url", "https://sentry.example", "future-command"],
+            vec!["--auth-token", "explicit", "projects", "list"],
+            vec!["projects", "list", "--auth-token=explicit"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&invocation)),
+                "sentry-cli {invocation:?}",
+            );
+        }
+        for invocation in [
+            vec!["build", "download"],
+            vec!["build", "upload"],
+            vec!["build", "snapshots"],
+            vec!["code-mappings", "upload"],
+            vec!["dart-symbol-map", "upload"],
+            vec!["projects", "list"],
+            vec!["--url", "https://sentry.example", "projects", "list"],
+            vec!["--header=X-Test:value", "events", "list"],
+            vec!["deploys", "list"],
+            vec!["deploys", "new"],
+            vec!["info"],
+            vec!["issues", "list"],
+            vec!["issues", "mute", "123"],
+            vec!["issues", "unresolve", "123"],
+            vec!["logs", "list"],
+            vec!["monitors", "list"],
+            vec!["organizations", "list"],
+            vec!["proguard", "upload", "mapping.txt"],
+            vec!["react-native", "gradle"],
+            vec!["releases", "list"],
+            vec!["releases", "archive", "1.2.3"],
+            vec!["releases", "delete", "1.2.3"],
+            vec!["releases", "finalize", "1.2.3"],
+            vec!["releases", "info", "1.2.3"],
+            vec!["releases", "new", "1.2.3"],
+            vec!["releases", "restore", "1.2.3"],
+            vec!["releases", "set-commits", "1.2.3"],
+            vec!["releases", "deploys", "list", "1.2.3"],
+            vec!["releases", "deploys", "new", "1.2.3"],
+            vec!["repos", "list"],
+            vec!["issues", "resolve", "123"],
+            vec!["debug-files", "upload", "example.dSYM"],
+            vec!["dif", "upload", "example.dSYM"],
+            vec!["difutil", "upload", "example.dSYM"],
+            vec!["sourcemaps", "upload", "dist"],
+            vec!["snapshots", "download"],
+            vec!["snapshots", "upload"],
+            vec!["react-native", "xcode"],
+            vec!["upload-dif", "example.dSYM"],
+            vec!["upload-dsym", "example.dSYM"],
+            vec!["upload-proguard", "mapping.txt"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&invocation)),
+                "sentry-cli {invocation:?}",
+            );
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["completions", "zsh"]),
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "sentry-cli" { return sentryCLIRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -30,6 +31,45 @@ public func genericSecretGateRequestClassification(
     }
     for candidate in candidates {
         if policy.secretDump.contains(candidate) { return .secretDump }
+        if policy.readOnly.contains(candidate) { return .readOnly }
+        if policy.mutating.contains(candidate) { return .mutating }
+    }
+    return .unknown
+}
+
+private func sentryCLIRequestClassification(
+    _ arguments: [String]
+) -> SecretGateRequestClassification {
+    let optionsWithValues = ["--auth-token", "--header", "--log-level", "--url"]
+    var words: [String] = []
+    var index = 0
+    while index < arguments.count, words.count < 3 {
+        let argument = arguments[index]
+        if optionsWithValues.contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            if argument == "--auth-token" { return .secretDump }
+            index += 2
+        } else if optionsWithValues.contains(where: { argument.hasPrefix("\($0)=") }) {
+            if argument.hasPrefix("--auth-token=") { return .secretDump }
+            index += 1
+        } else if ["--help", "-h", "--version", "-v"].contains(argument) {
+            return .readOnly
+        } else if ["--quiet", "--silent", "--allow-failure"].contains(argument) {
+            index += 1
+        } else if argument == "--" || argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            words.append(argument)
+            index += 1
+        }
+    }
+    guard !words.isEmpty, let policy = secretGateCommandPolicies["sentry-cli"] else {
+        return .unknown
+    }
+    let candidates = (1...words.count).reversed().map {
+        words.prefix($0).joined(separator: " ")
+    }
+    for candidate in candidates {
         if policy.readOnly.contains(candidate) { return .readOnly }
         if policy.mutating.contains(candidate) { return .mutating }
     }
@@ -159,7 +199,10 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "qwen-code": .init("", "chat,run"),
     "runpodctl": .init("get,list", "create,remove,start,stop", secretDump: "config view"),
     "s3cmd": .init("ls,la,info,du", "put,get,del,rm,sync,cp,mv,mb,rb", secretDump: "--dump-config"),
-    "sentry-cli": .init("projects list,organizations list,releases list", "send-event,releases new,releases deploys new,upload-dif"),
+    "sentry-cli": .init(
+        "build download,deploys list,events list,info,issues list,logs list,monitors list,organizations list,projects list,releases info,releases list,releases deploys list,repos list,snapshots download",
+        "build upload,build snapshots,code-mappings upload,dart-symbol-map upload,debug-files upload,dif upload,difutil upload,deploys new,issues mute,issues resolve,issues unresolve,proguard upload,react-native gradle,react-native xcode,releases archive,releases delete,releases finalize,releases new,releases restore,releases set-commits,releases deploys new,snapshots upload,sourcemaps upload,upload-dif,upload-dsym,upload-proguard"
+    ),
     "snowflake-cli": .init("object list,object describe,connection test", "object create,object drop,stage copy"),
     "snyk": .init("", "monitor,auth"),
     "transifex-cli": .init("status", "pull,push"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,71 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func sentryCLIPolicyCoversEveryTokenRequiringCommandShape() {
+    let readOnly = [
+        ["build", "download"],
+        ["deploys", "list"],
+        ["events", "--quiet", "list"],
+        ["info"],
+        ["issues", "list"],
+        ["logs", "list"],
+        ["monitors", "list"],
+        ["organizations", "list"],
+        ["projects", "list"],
+        ["--url", "https://sentry.example", "releases", "list"],
+        ["releases", "info", "1.2.3"],
+        ["releases", "deploys", "list", "1.2.3"],
+        ["repos", "list"],
+        ["snapshots", "download"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(
+            gateID: "sentry-cli", arguments: arguments
+        ) == .readOnly)
+    }
+
+    let mutating = [
+        ["build", "upload"],
+        ["build", "snapshots"],
+        ["code-mappings", "upload"],
+        ["dart-symbol-map", "upload"],
+        ["--header=X-Test:value", "debug-files", "upload", "example.dSYM"],
+        ["dif", "upload", "example.dSYM"],
+        ["difutil", "upload", "example.dSYM"],
+        ["deploys", "new"],
+        ["issues", "mute", "123"],
+        ["issues", "resolve", "123"],
+        ["issues", "unresolve", "123"],
+        ["proguard", "upload", "mapping.txt"],
+        ["react-native", "gradle"],
+        ["react-native", "xcode"],
+        ["releases", "archive", "1.2.3"],
+        ["releases", "delete", "1.2.3"],
+        ["releases", "finalize", "1.2.3"],
+        ["releases", "new", "1.2.3"],
+        ["releases", "restore", "1.2.3"],
+        ["releases", "set-commits", "1.2.3"],
+        ["releases", "deploys", "new", "1.2.3"],
+        ["snapshots", "upload"],
+        ["sourcemaps", "upload", "dist"],
+        ["upload-dif", "example.dSYM"],
+        ["upload-dsym", "example.dSYM"],
+        ["upload-proguard", "mapping.txt"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(
+            gateID: "sentry-cli", arguments: arguments
+        ) == .mutating)
+    }
+
+    #expect(genericSecretGateRequestClassification(
+        gateID: "sentry-cli", arguments: ["projects", "list", "--help"]
+    ) == .readOnly)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "sentry-cli", arguments: ["--auth-token=explicit", "projects", "list"]
+    ) == .secretDump)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "sentry-cli", arguments: ["future-command"]
+    ) == .unknown)
+}


### PR DESCRIPTION
## Summary

- route `SENTRY_AUTH_TOKEN` only to sentry-cli 3.7.0 command shapes that actually use authenticated API endpoints
- run local, DSN-only, explicit-token, help/version, unknown, and arbitrary monitor passthrough forms without a Secret Authorization Request
- classify every routed read and mutation in the macOS Authorization Gate

## Security

Reviewed against official sentry-cli 3.7.0 at `8a16b06662ce98b3d030c3a80c3ab24305968ec6`. Unknown future commands remain tokenless; exact managed-stub identity and integrity checks still fail closed before routing. `debug-files upload --no-upload` remains gated because upstream still authenticates for server upload options, while `proguard upload --no-upload` is genuinely local. Credential-independent execution approval remains out of scope.

## Verification

- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`
- official 3.7.0 binary smoke checks for version, help, completions, unknown command, monitor passthrough help, and ProGuard no-upload