### PR TITLE
Route Snowflake CLI passwords only when needed

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "snow" => snowflake_cli_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -205,6 +206,232 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn snowflake_cli_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let args = &args[..args
+        .iter()
+        .position(|arg| *arg == "--")
+        .unwrap_or(args.len())];
+
+    let Some(command_index) = snowflake_root_command_index(args) else {
+        return true;
+    };
+    let words = &args[command_index..];
+
+    if words.starts_with(&["dbt", "execute"]) {
+        return !snowflake_dbt_execute_requires_password(&words[2..]);
+    }
+    // Explicit authentication material supersedes the migrated connection
+    // password. Keeping that invocation tokenless also avoids repeating a
+    // command-line credential in an Authorization Request.
+    if args.iter().any(|arg| snowflake_auth_option(arg)) {
+        return true;
+    }
+    if args.iter().any(|arg| matches!(*arg, "--help" | "-h")) {
+        return true;
+    }
+
+    !SNOWFLAKE_PASSWORD_COMMANDS.split(',').any(|command| {
+        let mut command = command.split_whitespace();
+        command
+            .by_ref()
+            .zip(words.iter().copied())
+            .all(|(expected, actual)| expected == actual)
+            && command.next().is_none()
+    })
+}
+
+// Reviewed against Snowflake CLI v3.26.0's built-in command structure. New
+// commands and external plugins remain tokenless until their credential use is
+// reviewed.
+const SNOWFLAKE_PASSWORD_COMMANDS: &str = "
+app setup,app diff,app run,app open,app teardown,app deploy,app validate,app events,app publish,
+app version create,app version list,app version drop,app release-directive list,
+app release-directive set,app release-directive unset,app release-directive add-accounts,
+app release-directive remove-accounts,app release-channel list,app release-channel add-accounts,
+app release-channel remove-accounts,app release-channel set-accounts,app release-channel add-version,
+app release-channel remove-version,connection test,cortex search,cortex complete,
+cortex extract-answer,cortex sentiment,cortex summarize,cortex translate,dbt list,dbt drop,
+dbt describe,dbt copy,dbt deploy,dcm list,dcm deploy,dcm purge,dcm plan,dcm raw-analyze,
+dcm create,dcm drop,dcm describe,dcm list-deployments,dcm drop-deployment,dcm preview,dcm refresh,
+dcm test,git list,git drop,git describe,git setup,git list-branches,git list-tags,git list-files,
+git fetch,git copy,git execute,logs,notebook execute,notebook get-url,notebook open,notebook create,
+notebook deploy,object list,object drop,object describe,object create,snowpark deploy,snowpark build,
+snowpark execute,snowpark list,snowpark drop,snowpark describe,snowpark package lookup,
+snowpark package upload,snowpark package create,spcs compute-pool list,spcs compute-pool drop,
+spcs compute-pool describe,spcs compute-pool create,spcs compute-pool deploy,
+spcs compute-pool stop-all,spcs compute-pool suspend,spcs compute-pool resume,spcs compute-pool set,
+spcs compute-pool unset,spcs compute-pool status,spcs service list,spcs service describe,
+spcs service drop,spcs service create,spcs service deploy,spcs service execute-job,
+spcs service status,spcs service logs,spcs service events,spcs service metrics,spcs service upgrade,
+spcs service list-endpoints,spcs service list-instances,spcs service list-containers,
+spcs service list-roles,spcs service suspend,spcs service resume,spcs service set,
+spcs service unset,spcs service build-image,spcs service remote-build,
+spcs service remote-build-status,spcs service remote-build-history,spcs image-registry token,
+spcs image-registry url,spcs image-registry login,spcs image-repository list,
+spcs image-repository drop,spcs image-repository create,spcs image-repository deploy,
+spcs image-repository list-images,spcs image-repository list-tags,spcs image-repository url,sql,
+stage list,stage drop,stage describe,stage list-files,stage copy,stage create,stage remove,stage diff,
+stage execute,streamlit list,streamlit drop,streamlit describe,streamlit execute,streamlit share,
+streamlit deploy,streamlit get-url,streamlit logs,ws bundle,ws deploy,ws drop,ws validate,
+ws version list,ws version create,ws version drop";
+
+fn snowflake_root_command_index(args: &[&str]) -> Option<usize> {
+    const VALUE_OPTIONS: &[&str] = &[
+        "--config-file",
+        "--pycharm-debug-library-path",
+        "--pycharm-debug-server-host",
+        "--pycharm-debug-server-port",
+    ];
+    let mut index = 0;
+    while index < args.len() {
+        let arg = args[index];
+        if VALUE_OPTIONS.contains(&arg) {
+            index += 2;
+        } else if VALUE_OPTIONS
+            .iter()
+            .any(|option| arg.starts_with(&format!("{option}=")))
+            || matches!(
+                arg,
+                "--disable-external-command-plugins" | "--commands-registration"
+            )
+        {
+            index += 1;
+        } else if arg.starts_with('-') {
+            return None;
+        } else {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn snowflake_dbt_execute_requires_password(args: &[&str]) -> bool {
+    const VALUE_OPTIONS: &[&str] = &[
+        "--dbt-version",
+        "--env",
+        "--env-vars",
+        "--import",
+        "--connection",
+        "-c",
+        "--environment",
+        "--host",
+        "--port",
+        "--protocol",
+        "--account",
+        "--accountname",
+        "--user",
+        "--username",
+        "--authenticator",
+        "--database",
+        "--dbname",
+        "--schema",
+        "--schemaname",
+        "--role",
+        "--rolename",
+        "--warehouse",
+        "--mfa-passcode",
+        "--diag-log-path",
+        "--diag-allowlist-path",
+        "--oauth-client-id",
+        "--oauth-client-secret",
+        "--oauth-authorization-url",
+        "--oauth-token-request-url",
+        "--oauth-redirect-uri",
+        "--oauth-scope",
+        "--secondary-roles",
+        "--format",
+        "--decimal-precision",
+    ];
+    const FLAGS: &[&str] = &[
+        "--run-async",
+        "--no-run-async",
+        "--use-shell-env-vars",
+        "--writeback",
+        "--no-writeback",
+        "--temporary-connection",
+        "-x",
+        "--enable-diag",
+        "--oauth-disable-pkce",
+        "--oauth-enable-refresh-tokens",
+        "--oauth-enable-single-use-refresh-tokens",
+        "--client-store-temporary-credential",
+        "--server-session-keep-alive",
+        "--verbose",
+        "-v",
+        "--debug",
+        "--silent",
+        "--enhanced-exit-codes",
+    ];
+    const COMMANDS: &[&str] = &[
+        "build",
+        "compile",
+        "deps",
+        "list",
+        "parse",
+        "retry",
+        "run",
+        "run-operation",
+        "seed",
+        "show",
+        "snapshot",
+        "test",
+    ];
+
+    let mut index = 0;
+    let mut saw_name = false;
+    let mut has_explicit_auth = false;
+    while index < args.len() {
+        let arg = args[index];
+        if matches!(arg, "--help" | "-h") {
+            return false;
+        }
+        if snowflake_auth_option(arg) {
+            has_explicit_auth = true;
+            index += usize::from(!arg.contains('=')) + 1;
+        } else if VALUE_OPTIONS.contains(&arg) {
+            index += 2;
+        } else if VALUE_OPTIONS
+            .iter()
+            .any(|option| arg.starts_with(&format!("{option}=")))
+            || FLAGS.contains(&arg)
+        {
+            index += 1;
+        } else if arg.starts_with('-') {
+            return false;
+        } else if !saw_name {
+            saw_name = true;
+            index += 1;
+        } else {
+            return COMMANDS.contains(&arg) && !has_explicit_auth;
+        }
+    }
+    false
+}
+
+fn snowflake_auth_option(arg: &str) -> bool {
+    const OPTIONS: &[&str] = &[
+        "--password",
+        "--private-key-file",
+        "--private-key-path",
+        "--token",
+        "--token-file-path",
+        "--workload-identity-provider",
+        "--session-token",
+        "--master-token",
+    ];
+    OPTIONS.contains(&arg)
+        || OPTIONS
+            .iter()
+            .any(|option| arg.starts_with(&format!("{option}=")))
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -979,6 +1206,275 @@ mod tests {
             format!("{script}# changed\n").as_bytes(),
             &args(&["root"]),
         ));
+
+        unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn snowflake_cli_requests_passwords_only_for_reviewed_connection_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-snowflake-cli");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("snow");
+        let script = stub_script(
+            &wrapper("snowflake-cli").unwrap().primary,
+            Path::new("/opt/homebrew/bin/snow"),
+        );
+        let invokes_secretlessly = |values: &[&str]| {
+            let invocation = std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>();
+            invocation_is_secretless(&script_path, script.as_bytes(), &invocation)
+        };
+
+        for command in [
+            "app setup",
+            "app diff",
+            "app run",
+            "app open",
+            "app teardown",
+            "app deploy",
+            "app validate",
+            "app events",
+            "app publish",
+            "app version create",
+            "app version list",
+            "app version drop",
+            "app release-directive list",
+            "app release-directive set",
+            "app release-directive unset",
+            "app release-directive add-accounts",
+            "app release-directive remove-accounts",
+            "app release-channel list",
+            "app release-channel add-accounts",
+            "app release-channel remove-accounts",
+            "app release-channel set-accounts",
+            "app release-channel add-version",
+            "app release-channel remove-version",
+            "connection test",
+            "cortex search",
+            "cortex complete",
+            "cortex extract-answer",
+            "cortex sentiment",
+            "cortex summarize",
+            "cortex translate",
+            "dbt list",
+            "dbt drop",
+            "dbt describe",
+            "dbt copy",
+            "dbt deploy",
+            "dcm list",
+            "dcm deploy",
+            "dcm purge",
+            "dcm plan",
+            "dcm raw-analyze",
+            "dcm create",
+            "dcm drop",
+            "dcm describe",
+            "dcm list-deployments",
+            "dcm drop-deployment",
+            "dcm preview",
+            "dcm refresh",
+            "dcm test",
+            "git list",
+            "git drop",
+            "git describe",
+            "git setup",
+            "git list-branches",
+            "git list-tags",
+            "git list-files",
+            "git fetch",
+            "git copy",
+            "git execute",
+            "logs",
+            "notebook execute",
+            "notebook get-url",
+            "notebook open",
+            "notebook create",
+            "notebook deploy",
+            "object list",
+            "object drop",
+            "object describe",
+            "object create",
+            "snowpark deploy",
+            "snowpark build",
+            "snowpark execute",
+            "snowpark list",
+            "snowpark drop",
+            "snowpark describe",
+            "snowpark package lookup",
+            "snowpark package upload",
+            "snowpark package create",
+            "spcs compute-pool list",
+            "spcs compute-pool drop",
+            "spcs compute-pool describe",
+            "spcs compute-pool create",
+            "spcs compute-pool deploy",
+            "spcs compute-pool stop-all",
+            "spcs compute-pool suspend",
+            "spcs compute-pool resume",
+            "spcs compute-pool set",
+            "spcs compute-pool unset",
+            "spcs compute-pool status",
+            "spcs service list",
+            "spcs service describe",
+            "spcs service drop",
+            "spcs service create",
+            "spcs service deploy",
+            "spcs service execute-job",
+            "spcs service status",
+            "spcs service logs",
+            "spcs service events",
+            "spcs service metrics",
+            "spcs service upgrade",
+            "spcs service list-endpoints",
+            "spcs service list-instances",
+            "spcs service list-containers",
+            "spcs service list-roles",
+            "spcs service suspend",
+            "spcs service resume",
+            "spcs service set",
+            "spcs service unset",
+            "spcs service build-image",
+            "spcs service remote-build",
+            "spcs service remote-build-status",
+            "spcs service remote-build-history",
+            "spcs image-registry token",
+            "spcs image-registry url",
+            "spcs image-registry login",
+            "spcs image-repository list",
+            "spcs image-repository drop",
+            "spcs image-repository create",
+            "spcs image-repository deploy",
+            "spcs image-repository list-images",
+            "spcs image-repository list-tags",
+            "spcs image-repository url",
+            "sql",
+            "stage list",
+            "stage drop",
+            "stage describe",
+            "stage list-files",
+            "stage copy",
+            "stage create",
+            "stage remove",
+            "stage diff",
+            "stage execute",
+            "streamlit list",
+            "streamlit drop",
+            "streamlit describe",
+            "streamlit execute",
+            "streamlit share",
+            "streamlit deploy",
+            "streamlit get-url",
+            "streamlit logs",
+            "ws bundle",
+            "ws deploy",
+            "ws drop",
+            "ws validate",
+            "ws version list",
+            "ws version create",
+            "ws version drop",
+        ] {
+            let args = command.split_whitespace().collect::<Vec<_>>();
+            assert!(!invokes_secretlessly(&args), "snow {command}");
+        }
+        for dbt_command in [
+            "build",
+            "compile",
+            "deps",
+            "list",
+            "parse",
+            "retry",
+            "run",
+            "run-operation",
+            "seed",
+            "show",
+            "snapshot",
+            "test",
+        ] {
+            assert!(!invokes_secretlessly(&[
+                "dbt",
+                "execute",
+                "project",
+                dbt_command
+            ]));
+        }
+
+        for command in [
+            vec![],
+            vec!["--version"],
+            vec!["--info"],
+            vec!["--config-file", "/tmp/config.toml", "--help"],
+            vec!["app", "bundle"],
+            vec!["auth", "oidc", "read-token"],
+            vec!["connection", "list"],
+            vec!["connection", "generate-jwt"],
+            vec!["connection", "generate-workload-identity-token"],
+            vec!["custom-image", "validate"],
+            vec!["helpers", "show-config-sources"],
+            vec!["init"],
+            vec!["plugin", "list"],
+            vec!["ws", "dump"],
+            vec!["future-command"],
+            vec!["external-plugin", "deploy"],
+            vec!["object", "future-command"],
+            vec!["object", "list", "--help"],
+            vec!["object", "list", "--password", "from-command-line"],
+            vec!["sql", "--password=from-command-line", "-q", "select 1"],
+            vec!["object", "list", "--private-key-file", "/tmp/key.p8"],
+            vec![
+                "sql",
+                "--token-file-path=/tmp/oauth-token",
+                "-q",
+                "select 1",
+            ],
+            vec!["dbt", "execute", "project", "future-command", "--help"],
+            vec!["dbt", "execute", "--help"],
+        ] {
+            assert!(invokes_secretlessly(&command), "snow {command:?}");
+        }
+
+        assert!(!invokes_secretlessly(&[
+            "--disable-external-command-plugins",
+            "--config-file=/tmp/config.toml",
+            "object",
+            "list",
+        ]));
+        assert!(!invokes_secretlessly(&[
+            "dbt",
+            "execute",
+            "--dbt-version",
+            "1.9",
+            "project",
+            "run",
+            "--help",
+        ]));
+        assert!(!invokes_secretlessly(&[
+            "dbt",
+            "execute",
+            "project",
+            "run",
+            "--password",
+            "dbt-passthrough",
+        ]));
+        assert!(!invokes_secretlessly(&[
+            "dbt",
+            "execute",
+            "project",
+            "run",
+            "--",
+            "--password",
+            "passthrough",
+        ]));
+        assert!(invokes_secretlessly(&[
+            "dbt",
+            "execute",
+            "project",
+            "--password",
+            "from-command-line",
+            "run",
+        ]));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         let _ = fs::remove_dir_all(dir);

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -10,7 +10,7 @@ private struct SecretGateCommandPolicy: Sendable {
     }
 
     static func commands(_ value: String) -> Set<String> {
-        Set(value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) })
+        Set(value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
     }
 }
 
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "snowflake-cli" { return snowflakeCLIRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -35,6 +36,86 @@ public func genericSecretGateRequestClassification(
     }
     return .unknown
 }
+
+private func snowflakeCLIRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let optionsWithValues = [
+        "--config-file", "--pycharm-debug-library-path", "--pycharm-debug-server-host",
+        "--pycharm-debug-server-port",
+    ]
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if optionsWithValues.contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+        } else if optionsWithValues.contains(where: { argument.hasPrefix("\($0)=") })
+            || ["--disable-external-command-plugins", "--commands-registration"].contains(argument)
+        {
+            index += 1
+        } else if ["--help", "-h", "--version", "--info", "--docs", "--structure",
+                   "--install-completion", "--show-completion"].contains(argument)
+        {
+            return .readOnly
+        } else if argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            break
+        }
+    }
+    guard index < arguments.count else { return .unknown }
+    let words = Array(arguments[index...])
+    let candidates = (1...min(3, words.count)).reversed().map {
+        words.prefix($0).joined(separator: " ")
+    }
+    for candidate in candidates {
+        if snowflakeCLICommandPolicy.secretDump.contains(candidate) { return .secretDump }
+        if snowflakeCLICommandPolicy.readOnly.contains(candidate) { return .readOnly }
+        if snowflakeCLICommandPolicy.mutating.contains(candidate) { return .mutating }
+    }
+    return .unknown
+}
+
+// Reviewed against Snowflake CLI v3.26.0's built-in command structure. SQL,
+// dbt passthrough, external plugins, and future commands remain Unknown.
+private let snowflakeCLICommandPolicy = SecretGateCommandPolicy(
+    """
+    app diff,app open,app validate,app events,app version list,app release-directive list,
+    app release-channel list,connection test,cortex search,cortex complete,cortex extract-answer,
+    cortex sentiment,cortex summarize,cortex translate,dbt list,dbt describe,dcm list,dcm plan,
+    dcm raw-analyze,dcm describe,dcm list-deployments,dcm preview,dcm test,git list,git describe,
+    git list-branches,git list-tags,git list-files,logs,notebook get-url,notebook open,object list,
+    object describe,snowpark list,snowpark describe,snowpark package lookup,
+    spcs compute-pool list,spcs compute-pool describe,spcs compute-pool status,spcs service list,
+    spcs service describe,spcs service status,spcs service logs,spcs service events,
+    spcs service metrics,spcs service list-endpoints,spcs service list-instances,
+    spcs service list-containers,spcs service list-roles,spcs service remote-build-status,
+    spcs service remote-build-history,spcs image-registry url,spcs image-repository list,
+    spcs image-repository list-images,spcs image-repository list-tags,
+    spcs image-repository url,stage list,stage describe,stage list-files,stage diff,streamlit list,
+    streamlit describe,streamlit get-url,streamlit logs,ws version list
+    """,
+    """
+    app setup,app run,app teardown,app deploy,app publish,app version create,app version drop,
+    app release-directive set,app release-directive unset,app release-directive add-accounts,
+    app release-directive remove-accounts,app release-channel add-accounts,
+    app release-channel remove-accounts,app release-channel set-accounts,
+    app release-channel add-version,app release-channel remove-version,dbt drop,dbt copy,dbt deploy,
+    dcm deploy,dcm purge,dcm create,dcm drop,dcm drop-deployment,dcm refresh,git drop,git setup,
+    git fetch,git copy,git execute,notebook execute,notebook create,notebook deploy,object drop,
+    object create,snowpark deploy,snowpark build,snowpark execute,snowpark drop,
+    snowpark package upload,snowpark package create,spcs compute-pool drop,
+    spcs compute-pool create,spcs compute-pool deploy,spcs compute-pool stop-all,
+    spcs compute-pool suspend,spcs compute-pool resume,spcs compute-pool set,
+    spcs compute-pool unset,spcs service drop,spcs service create,spcs service deploy,
+    spcs service execute-job,spcs service upgrade,spcs service suspend,spcs service resume,
+    spcs service set,spcs service unset,spcs service build-image,spcs service remote-build,
+    spcs image-registry login,spcs image-repository drop,spcs image-repository create,
+    spcs image-repository deploy,stage drop,stage copy,stage create,stage remove,stage execute,
+    streamlit drop,streamlit execute,streamlit share,streamlit deploy,ws bundle,ws deploy,ws drop,
+    ws validate,ws version create,ws version drop
+    """,
+    secretDump: "spcs image-registry token"
+)
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
     let optionsWithValues = ["--api-key", "--color", "--config", "--device-name", "--log-level", "--project-name", "-p"]
@@ -160,7 +241,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "runpodctl": .init("get,list", "create,remove,start,stop", secretDump: "config view"),
     "s3cmd": .init("ls,la,info,du", "put,get,del,rm,sync,cp,mv,mb,rb", secretDump: "--dump-config"),
     "sentry-cli": .init("projects list,organizations list,releases list", "send-event,releases new,releases deploys new,upload-dif"),
-    "snowflake-cli": .init("object list,object describe,connection test", "object create,object drop,stage copy"),
+    "snowflake-cli": .init("", ""),
     "snyk": .init("", "monitor,auth"),
     "transifex-cli": .init("status", "pull,push"),
     "travis": .init("whoami,repos,history,show,logs", "restart,cancel,enable,disable", secretDump: "token"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,43 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func snowflakeCLIPolicyClassifiesAuditedCommandsAndOptions() {
+    let readOnly = [
+        ["object", "list"],
+        ["cortex", "summarize"],
+        ["spcs", "service", "remote-build-history"],
+        ["--disable-external-command-plugins", "--config-file=/tmp/config.toml", "stage", "list-files"],
+        ["--config-file", "/tmp/config.toml", "--version"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "snowflake-cli", arguments: arguments) == .readOnly)
+    }
+
+    let mutating = [
+        ["app", "release-channel", "add-version"],
+        ["object", "create"],
+        ["spcs", "service", "remote-build"],
+        ["stage", "copy"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(gateID: "snowflake-cli", arguments: arguments) == .mutating)
+    }
+
+    #expect(genericSecretGateRequestClassification(
+        gateID: "snowflake-cli",
+        arguments: ["spcs", "image-registry", "token"]
+    ) == .secretDump)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "snowflake-cli",
+        arguments: ["dbt", "execute", "project", "run", "--help"]
+    ) == .unknown)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "snowflake-cli",
+        arguments: ["sql", "-q", "select 1"]
+    ) == .unknown)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "snowflake-cli",
+        arguments: ["external-plugin", "deploy"]
+    ) == .unknown)
+}


### PR DESCRIPTION
## Summary
- route migrated Snowflake connection passwords only to audited built-in commands that can connect
- keep help, local utilities, unknown/external plugins, and explicit alternative-auth invocations tokenless
- preserve dbt passthrough semantics and classify Snowflake requests for macOS access grants

Reviewed against Snowflake CLI v3.26.0 at `5515a98f0999b846724ca53dfed1dd034e06ad19`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`