### PR TITLE
Route Transifex credentials only to remote commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "tx" => transifex_cli_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -205,6 +206,121 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn transifex_cli_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let args = &args[..args
+        .iter()
+        .position(|arg| *arg == "--")
+        .unwrap_or(args.len())];
+
+    if args
+        .iter()
+        .any(|arg| matches!(*arg, "--help" | "-h" | "--version" | "-v"))
+    {
+        return true;
+    }
+    let Some((command_index, caller_supplied_authority)) = transifex_root_command(args) else {
+        return true;
+    };
+    if caller_supplied_authority
+        || ["TX_TOKEN", "TX_HOSTNAME"]
+            .iter()
+            .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+    {
+        return true;
+    }
+
+    let words = &args[command_index..];
+    !match words[0] {
+        "merge" | "push" | "pull" | "delete" | "status" => true,
+        "add" | "a" => transifex_add_requires_secret(&words[1..]),
+        _ => false,
+    }
+}
+
+// Reviewed against Transifex CLI v1.6.17 (30dac142). New commands remain
+// tokenless until their use of the migrated credential is reviewed.
+fn transifex_root_command(args: &[&str]) -> Option<(usize, bool)> {
+    let mut index = 0;
+    let mut caller_supplied_authority = false;
+    while index < args.len() {
+        let argument = args[index];
+        if matches!(argument, "--token" | "-t") {
+            let value = *args.get(index + 1)?;
+            caller_supplied_authority |= !value.is_empty();
+            index += 2;
+        } else if let Some(value) = argument.strip_prefix("--token=") {
+            caller_supplied_authority |= !value.is_empty();
+            index += 1;
+        } else if matches!(argument, "--hostname" | "-H") {
+            let value = *args.get(index + 1)?;
+            caller_supplied_authority |= !value.is_empty();
+            index += 2;
+        } else if let Some(value) = argument.strip_prefix("--hostname=") {
+            caller_supplied_authority |= !value.is_empty();
+            index += 1;
+        } else if let Some(value) = argument.strip_prefix("-H=") {
+            caller_supplied_authority |= !value.is_empty();
+            index += 1;
+        } else if matches!(argument, "--root-config" | "--config" | "-c" | "--cacert") {
+            args.get(index + 1)?;
+            index += 2;
+        } else if ["--root-config=", "--config=", "-c=", "--cacert="]
+            .iter()
+            .any(|prefix| argument.starts_with(prefix))
+        {
+            index += 1;
+        } else if argument.starts_with('-') {
+            return None;
+        } else {
+            return Some((index, caller_supplied_authority));
+        }
+    }
+    None
+}
+
+fn transifex_add_requires_secret(args: &[&str]) -> bool {
+    const LOCAL_OPTIONS: &[&str] = &[
+        "--organization",
+        "--project",
+        "--resource",
+        "--file-filter",
+        "--type",
+    ];
+    let mut index = 0;
+    let mut has_local_option = false;
+    let mut first_positional = None;
+    while index < args.len() {
+        let argument = args[index];
+        if LOCAL_OPTIONS.contains(&argument) || argument == "--resource-name" {
+            has_local_option |= LOCAL_OPTIONS.contains(&argument);
+            if args.get(index + 1).is_none() {
+                return false;
+            }
+            index += 2;
+        } else if LOCAL_OPTIONS
+            .iter()
+            .any(|option| argument.starts_with(&format!("{option}=")))
+            || argument.starts_with("--resource-name=")
+        {
+            has_local_option |= !argument.starts_with("--resource-name=");
+            index += 1;
+        } else if argument.starts_with('-') {
+            return false;
+        } else {
+            first_positional.get_or_insert(argument);
+            index += 1;
+        }
+    }
+    first_positional == Some("remote") || !has_local_option
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -981,6 +1097,98 @@ mod tests {
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn transifex_requests_secrets_only_for_commands_that_consume_its_token() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-transifex");
+        let previous_authority =
+            ["TX_TOKEN", "TX_HOSTNAME"].map(|name| (name, std::env::var_os(name)));
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            std::env::remove_var("TX_TOKEN");
+            std::env::remove_var("TX_HOSTNAME");
+        }
+        let script_path = dir.join("tx");
+        let script = stub_script(
+            &wrapper("transifex-cli").unwrap().primary,
+            Path::new("/opt/homebrew/bin/tx"),
+        );
+        let invokes_secretlessly = |values: &[&str]| {
+            let invocation = std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>();
+            invocation_is_secretless(&script_path, script.as_bytes(), &invocation)
+        };
+
+        for command in [
+            vec![],
+            vec!["help", "push"],
+            vec!["push", "--help"],
+            vec!["--version"],
+            vec!["init"],
+            vec!["update", "--check"],
+            vec!["migrate"],
+            vec!["mg"],
+            vec!["add", "messages.po", "--organization", "example"],
+            vec!["a", "messages.po", "--type=PO"],
+            vec!["--hostname=https://example.invalid", "pull"],
+            vec!["-H", "https://example.invalid", "status"],
+            vec!["future-command"],
+            vec!["--future-option", "push"],
+            vec!["--", "push"],
+        ] {
+            assert!(invokes_secretlessly(&command), "tx {command:?}");
+        }
+        for command in [
+            vec!["status"],
+            vec!["--config", ".tx/config", "status"],
+            vec!["merge", "project.resource"],
+            vec!["push"],
+            vec!["push", "--", "--help"],
+            vec!["pull"],
+            vec!["delete", "project.resource"],
+            vec!["add"],
+            vec!["a", "messages.po"],
+            vec!["add", "--organization", "example", "remote"],
+            vec!["add", "remote", "https://app.transifex.com/o/p/dashboard/"],
+        ] {
+            assert!(!invokes_secretlessly(&command), "tx {command:?}");
+        }
+
+        for command in [
+            vec!["--token", "caller-token", "status"],
+            vec!["--token=caller-token", "push"],
+        ] {
+            assert!(invokes_secretlessly(&command), "tx {command:?}");
+        }
+        unsafe { std::env::set_var("TX_TOKEN", "caller-token") };
+        assert!(invokes_secretlessly(&["pull"]));
+        unsafe {
+            std::env::remove_var("TX_TOKEN");
+            std::env::set_var("TX_HOSTNAME", "https://example.invalid");
+        }
+        assert!(invokes_secretlessly(&["status"]));
+
+        let altered_script = format!("{script}# changed\n");
+        let invocation = [script_path.clone().into_os_string(), OsString::from("init")];
+        assert!(!invocation_is_secretless(
+            &script_path,
+            altered_script.as_bytes(),
+            &invocation,
+        ));
+
+        unsafe {
+            for (name, value) in previous_authority {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,6 +18,7 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
+    if gateID == "transifex-cli" { return transifexRequestClassification(arguments) }
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
@@ -34,6 +35,68 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+private func transifexRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let words = Array(arguments.prefix { $0 != "--" })
+    if words.contains(where: { ["--help", "-h", "--version", "-v"].contains($0) }) {
+        return .readOnly
+    }
+
+    let optionsWithValues = ["--root-config", "--config", "-c", "--token", "-t", "--hostname", "-H", "--cacert"]
+    let optionsWithJoinedValues = ["--root-config=", "--config=", "-c=", "--token=", "--hostname=", "-H=", "--cacert="]
+    var index = 0
+    while index < words.count {
+        let argument = words[index]
+        if optionsWithValues.contains(argument) {
+            guard index + 1 < words.count else { return .unknown }
+            index += 2
+        } else if optionsWithJoinedValues.contains(where: { argument.hasPrefix($0) }) {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            break
+        }
+    }
+    guard index < words.count else { return .unknown }
+
+    switch words[index].lowercased() {
+    case "status":
+        return .readOnly
+    case "merge", "push", "pull", "delete":
+        return .mutating
+    case "add", "a":
+        return transifexAddRequestClassification(Array(words.dropFirst(index + 1)))
+    default:
+        return .unknown
+    }
+}
+
+private func transifexAddRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let localOptions = ["--organization", "--project", "--resource", "--file-filter", "--type"]
+    var index = 0
+    var hasLocalOption = false
+    var firstPositional: String?
+    while index < arguments.count {
+        let argument = arguments[index]
+        if localOptions.contains(argument) || argument == "--resource-name" {
+            hasLocalOption = hasLocalOption || localOptions.contains(argument)
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+        } else if localOptions.contains(where: { argument.hasPrefix("\($0)=") })
+            || argument.hasPrefix("--resource-name=")
+        {
+            hasLocalOption = hasLocalOption || !argument.hasPrefix("--resource-name=")
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            if firstPositional == nil { firstPositional = argument.lowercased() }
+            index += 1
+        }
+    }
+    return firstPositional == "remote" || !hasLocalOption ? .mutating : .unknown
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -162,7 +225,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "sentry-cli": .init("projects list,organizations list,releases list", "send-event,releases new,releases deploys new,upload-dif"),
     "snowflake-cli": .init("object list,object describe,connection test", "object create,object drop,stage copy"),
     "snyk": .init("", "monitor,auth"),
-    "transifex-cli": .init("status", "pull,push"),
+    "transifex-cli": .init("", ""),
     "travis": .init("whoami,repos,history,show,logs", "restart,cancel,enable,disable", secretDump: "token"),
     "twine": .init("check", "upload"),
     "vagrant": .init("status,global-status,validate,version", "up,destroy,halt,reload,suspend,resume,cloud publish"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,42 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func transifexPolicyClassifiesOnlyRequestsThatReceiveTheMigratedToken() {
+    let readOnly = [
+        ["status"],
+        ["--config", ".tx/config", "status"],
+        ["-H", "https://rest.api.transifex.com", "status"],
+        ["push", "--help"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "transifex-cli", arguments: arguments) == .readOnly)
+    }
+
+    let mutating = [
+        ["merge", "project.resource"],
+        ["--hostname=https://rest.api.transifex.com", "push"],
+        ["pull"],
+        ["delete", "project.resource"],
+        ["add"],
+        ["a", "messages.po"],
+        ["add", "--organization", "example", "remote"],
+        ["add", "remote", "https://app.transifex.com/o/p/dashboard/"],
+        ["push", "--", "--help"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(gateID: "transifex-cli", arguments: arguments) == .mutating)
+    }
+
+    for arguments in [
+        ["init"],
+        ["update", "--check"],
+        ["migrate"],
+        ["add", "messages.po", "--organization", "example"],
+        ["future-command"],
+        ["--future-option", "push"],
+        ["--", "push"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "transifex-cli", arguments: arguments) == .unknown)
+    }
+}


### PR DESCRIPTION
## Summary
- route the migrated Transifex token only to audited commands that consume it
- keep init, update, migrate, local/error-only add forms, help/version, and unknown invocations tokenless
- withhold the migrated token from caller-supplied token or hostname authority and classify legitimate requests as read-only or mutating

## Verification
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`