### PR TITLE
Route Travis credentials only when required

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "travis" => travis_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -205,6 +206,119 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn travis_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|argument| argument.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let Some(command) = args.first() else {
+        return true;
+    };
+    let command = command.strip_prefix("--").unwrap_or(command);
+    if matches!(command, "help" | "version") || matches!(command, "-h" | "-?" | "-v") {
+        return true;
+    }
+
+    let options = args[1..]
+        .split(|argument| *argument == "--")
+        .next()
+        .unwrap_or_default();
+    if options
+        .iter()
+        .any(|argument| matches!(*argument, "-h" | "--help"))
+        || options.iter().any(|argument| {
+            matches!(*argument, "--token")
+                || argument.starts_with("--token=")
+                || command != "settings" && (*argument == "-t" || argument.starts_with("-t"))
+        })
+        || std::env::var_os("TRAVIS_TOKEN").is_some_and(|value| !value.is_empty())
+        || travis_invocation_selects_custom_authority(options)
+    {
+        return true;
+    }
+
+    // Travis loads plugins from the user's config directory. Keep this list
+    // exact so an unreviewed plugin cannot inherit the protected token.
+    let requires_token = matches!(
+        command,
+        "accounts"
+            | "branches"
+            | "cache"
+            | "cancel"
+            | "console"
+            | "disable"
+            | "enable"
+            | "encrypt"
+            | "encrypt-file"
+            | "env"
+            | "history"
+            | "init"
+            | "lint"
+            | "logs"
+            | "monitor"
+            | "open"
+            | "pubkey"
+            | "raw"
+            | "repos"
+            | "requests"
+            | "restart"
+            | "settings"
+            | "setup"
+            | "show"
+            | "sshkey"
+            | "status"
+            | "sync"
+            | "token"
+            | "whatsup"
+            | "whoami"
+    );
+    !requires_token || !super::migrations::travis_default_config_is_safe_for_token()
+}
+
+fn travis_invocation_selects_custom_authority(options: &[&str]) -> bool {
+    const OFFICIAL: &str = "https://api.travis-ci.com/";
+    if std::env::var_os("TRAVIS_CONFIG_PATH").is_some_and(|value| !value.is_empty())
+        || std::env::var_os("TRAVIS_ENDPOINT")
+            .is_some_and(|value| !value.is_empty() && value != OFFICIAL)
+    {
+        return true;
+    }
+    let mut index = 0;
+    while let Some(argument) = options.get(index) {
+        if matches!(*argument, "-I" | "--insecure" | "-X" | "--enterprise")
+            || argument.starts_with("-X")
+            || argument.starts_with("--enterprise=")
+        {
+            return true;
+        }
+        if matches!(*argument, "-e" | "--api-endpoint") {
+            if options
+                .get(index + 1)
+                .is_none_or(|value| *value != OFFICIAL)
+            {
+                return true;
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(value) = argument.strip_prefix("--api-endpoint=")
+            && value != OFFICIAL
+        {
+            return true;
+        }
+        if let Some(value) = argument.strip_prefix("-e").filter(|_| *argument != "-E")
+            && value != OFFICIAL
+        {
+            return true;
+        }
+        index += 1;
+    }
+    false
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -981,6 +1095,201 @@ mod tests {
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn travis_requests_its_token_only_for_reviewed_official_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        let previous_stub_dir = std::env::var_os("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        let previous_values = ["TRAVIS_TOKEN", "TRAVIS_ENDPOINT", "TRAVIS_CONFIG_PATH"]
+            .map(|key| (key, std::env::var_os(key)));
+        let dir = temp_dir("env-wrapper-secretless-travis");
+        let config_dir = dir.join(".travis");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.yml"),
+            "endpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\n",
+        )
+        .unwrap();
+        unsafe {
+            std::env::set_var("HOME", &dir);
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            for (key, _) in &previous_values {
+                std::env::remove_var(key);
+            }
+        }
+        let script_path = dir.join("travis");
+        let script = stub_script(
+            &wrapper("travis").unwrap().primary,
+            Path::new("/opt/homebrew/bin/travis"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["version"],
+            vec!["--version"],
+            vec!["whoami", "--help"],
+            vec!["endpoint"],
+            vec!["login"],
+            vec!["logout"],
+            vec!["regenerate-token"],
+            vec!["remove-token"],
+            vec!["report"],
+            vec!["plugin-command", "--", "payload"],
+            vec!["future-command"],
+            vec!["whoami", "--api-endpoint", "https://enterprise.example/api"],
+            vec![
+                "whoami",
+                "--api-endpoint",
+                "https://api.travis-ci.com/",
+                "--api-endpoint",
+                "https://enterprise.example/api",
+            ],
+            vec!["whoami", "-ehttps://enterprise.example/api"],
+            vec!["whoami", "--insecure"],
+            vec!["whoami", "-Xenterprise"],
+            vec!["whoami", "--token=caller-token"],
+            vec!["whoami", "-tcaller-token"],
+            vec!["settings", "--token=caller-token"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "travis {command:?}",
+            );
+        }
+        for command in [
+            "accounts",
+            "branches",
+            "cache",
+            "cancel",
+            "console",
+            "disable",
+            "enable",
+            "encrypt",
+            "encrypt-file",
+            "env",
+            "history",
+            "init",
+            "lint",
+            "logs",
+            "monitor",
+            "open",
+            "pubkey",
+            "raw",
+            "repos",
+            "requests",
+            "restart",
+            "settings",
+            "setup",
+            "show",
+            "sshkey",
+            "status",
+            "sync",
+            "token",
+            "whatsup",
+            "whoami",
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&[command])),
+                "travis {command}",
+            );
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["settings", "-t"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["whoami", "--skip-version-check"]),
+        ));
+        for command in [
+            vec!["whoami", "--com"],
+            vec!["whoami", "--pro"],
+            vec!["whoami", "--api-endpoint", "https://api.travis-ci.com/"],
+            vec!["whoami", "-ehttps://api.travis-ci.com/"],
+        ] {
+            assert!(!invocation_is_secretless(
+                &script_path,
+                script.as_bytes(),
+                &args(&command),
+            ));
+        }
+
+        unsafe { std::env::set_var("TRAVIS_TOKEN", "caller-token") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["whoami"]),
+        ));
+        unsafe { std::env::remove_var("TRAVIS_TOKEN") };
+        for key in ["TRAVIS_ENDPOINT", "TRAVIS_CONFIG_PATH"] {
+            unsafe { std::env::set_var(key, "caller-value") };
+            assert!(invocation_is_secretless(
+                &script_path,
+                script.as_bytes(),
+                &args(&["whoami"]),
+            ));
+            unsafe { std::env::remove_var(key) };
+        }
+        unsafe { std::env::set_var("TRAVIS_ENDPOINT", "https://api.travis-ci.com/") };
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["whoami"]),
+        ));
+        unsafe { std::env::remove_var("TRAVIS_ENDPOINT") };
+        fs::write(
+            config_dir.join("config.yml"),
+            "endpoints:\n  https://api.travis-ci.com/:\n",
+        )
+        .unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["whoami"]),
+        ));
+        fs::write(
+            config_dir.join("config.yml"),
+            "endpoints:\n  https://enterprise.example/api:\n    access_token: ''\n",
+        )
+        .unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["whoami"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["help"]),
+        ));
+
+        unsafe {
+            match previous_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match previous_stub_dir {
+                Some(value) => std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", value),
+                None => std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR"),
+            }
+            for (key, value) in previous_values {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/isotopes/hardeners/migrations/mod.rs
+++ b/src/isotopes/hardeners/migrations/mod.rs
@@ -101,6 +101,10 @@ pub(super) fn names() -> impl Iterator<Item = &'static str> {
     MIGRATIONS.iter().map(|(name, _)| *name)
 }
 
+pub(super) fn travis_default_config_is_safe_for_token() -> bool {
+    travis::default_config_is_safe_for_token()
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn isotope_store_generic_password_json(
     service: *const std::ffi::c_char,

--- a/src/isotopes/hardeners/migrations/travis.rs
+++ b/src/isotopes/hardeners/migrations/travis.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 const KEYCHAIN_SERVICE: &str = "com.automicvault.isotope";
 const TRAVIS_TOKEN_ENV_KEY: &str = "TRAVIS_TOKEN";
+const TRAVIS_COM_ENDPOINT: &str = "https://api.travis-ci.com/";
 
 pub trait CredentialStore {
     fn store_secret(&self, key: &str, value: &str) -> Result<(), String>;
@@ -28,17 +29,40 @@ pub fn migrate_credentials_file(path: &Path, store: &dyn CredentialStore) -> Res
     };
 
     let tokens = config_access_tokens(&contents);
-    if tokens.is_empty() {
-        return Ok(false);
-    }
     if tokens.len() > 1 {
         return Err("multiple Travis access tokens found; migrate them manually".to_string());
     }
+    let (guarded, has_endpoints) = guard_token_storage(&contents);
+    if !config_access_tokens(&guarded).is_empty() {
+        return Err("Travis access token is outside the supported endpoints config".to_string());
+    }
+    if tokens.is_empty() {
+        if !has_endpoints || guarded == contents {
+            return Ok(false);
+        }
+        fs::write(path, guarded)
+            .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
+        return Ok(true);
+    }
 
     store.store_secret(TRAVIS_TOKEN_ENV_KEY, &tokens[0])?;
-    fs::write(path, remove_access_token_lines(&contents))
-        .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
+    fs::write(path, guarded).map_err(|err| format!("failed to write {}: {err}", path.display()))?;
     Ok(true)
+}
+
+pub(super) fn default_config_is_safe_for_token() -> bool {
+    uses_default_config_path()
+        && travis_config_path()
+            .ok()
+            .and_then(|path| fs::read_to_string(path).ok())
+            .is_some_and(|contents| {
+                let (guarded, has_endpoints) = guard_token_storage(&contents);
+                has_endpoints && guarded == contents && config_uses_official_authority(&contents)
+            })
+}
+
+fn uses_default_config_path() -> bool {
+    std::env::var_os("TRAVIS_CONFIG_PATH").is_none_or(|value| value.is_empty())
 }
 
 fn travis_config_path() -> Result<PathBuf, String> {
@@ -76,8 +100,10 @@ fn line_access_token(line: &str) -> Option<String> {
     Some(value.to_string())
 }
 
-fn line_has_access_token(line: &str) -> bool {
-    line_access_token(line).is_some()
+fn line_is_access_token(line: &str) -> bool {
+    line.trim()
+        .split_once(':')
+        .is_some_and(|(key, _)| key.trim() == "access_token")
 }
 
 fn yaml_scalar_value(value: &str) -> Option<&str> {
@@ -88,16 +114,83 @@ fn yaml_scalar_value(value: &str) -> Option<&str> {
     Some(value.trim_matches('"').trim_matches('\'').trim())
 }
 
-fn remove_access_token_lines(contents: &str) -> String {
+fn guard_token_storage(contents: &str) -> (String, bool) {
     let mut output = String::new();
+    let mut in_endpoints = false;
+    let mut active_endpoint = false;
+    let mut endpoint_guarded = false;
+    let mut has_endpoints = false;
+
     for line in contents.lines() {
-        if line_has_access_token(line) {
+        let trimmed = line.trim();
+        let indentation = line.len() - line.trim_start_matches(' ').len();
+        let structural = !trimmed.is_empty() && !trimmed.starts_with('#');
+
+        if in_endpoints && structural && indentation == 2 && trimmed.ends_with(':') {
+            if active_endpoint && !endpoint_guarded {
+                output.push_str("    access_token: ''\n");
+            }
+            active_endpoint = true;
+            endpoint_guarded = false;
+            has_endpoints = true;
+        } else if in_endpoints && structural && indentation == 0 {
+            if active_endpoint && !endpoint_guarded {
+                output.push_str("    access_token: ''\n");
+            }
+            in_endpoints = false;
+            active_endpoint = false;
+        } else if in_endpoints && active_endpoint && line_is_access_token(line) {
+            output.push_str(&" ".repeat(indentation));
+            output.push_str("access_token: ''\n");
+            endpoint_guarded = true;
             continue;
         }
+
         output.push_str(line);
         output.push('\n');
+        if !in_endpoints && indentation == 0 && trimmed == "endpoints:" {
+            in_endpoints = true;
+        }
     }
-    output
+    if in_endpoints && active_endpoint && !endpoint_guarded {
+        output.push_str("    access_token: ''\n");
+    }
+    if !contents.ends_with('\n') {
+        output.pop();
+    }
+    (output, has_endpoints)
+}
+
+fn config_uses_official_authority(contents: &str) -> bool {
+    let mut in_endpoints = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indentation = line.len() - line.trim_start_matches(' ').len();
+        if indentation == 0 {
+            in_endpoints = trimmed == "endpoints:";
+        }
+        if in_endpoints && indentation == 2 && trimmed.ends_with(':') {
+            if trimmed.trim_end_matches(':').trim_matches(['\'', '"']) != TRAVIS_COM_ENDPOINT {
+                return false;
+            }
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = yaml_scalar_value(value).unwrap_or_default();
+        if key == "enterprise"
+            || key == "insecure" && !matches!(value, "" | "false")
+            || matches!(key, "default_endpoint" | "endpoint") && value != TRAVIS_COM_ENDPOINT
+        {
+            return false;
+        }
+    }
+    true
 }
 
 impl CredentialStore for KeychainCredentialStore {
@@ -205,7 +298,7 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(&path).unwrap(),
-            "endpoints:\n  https://api.travis-ci.com/:\n    insecure: false\n"
+            "endpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\n    insecure: false\n"
         );
         fs::remove_file(path).unwrap();
     }
@@ -242,6 +335,51 @@ mod tests {
         assert!(!migrate_credentials_file(&path, &store).unwrap());
         assert!(store.values.borrow().is_empty());
         fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn guards_every_endpoint_without_storing_a_secret() {
+        let path = std::env::temp_dir().join(format!("travis-guard-{}", std::process::id()));
+        fs::write(
+            &path,
+            "endpoints:\n  https://one.example/:\n    insecure: false\n  https://two.example/:\n    enterprise: true\nrepos: {}\n",
+        )
+        .unwrap();
+        let store = TestCredentialStore::default();
+
+        assert!(migrate_credentials_file(&path, &store).unwrap());
+        assert!(store.values.borrow().is_empty());
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "endpoints:\n  https://one.example/:\n    insecure: false\n    access_token: ''\n  https://two.example/:\n    enterprise: true\n    access_token: ''\nrepos: {}\n"
+        );
+        assert!(!migrate_credentials_file(&path, &store).unwrap());
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn only_the_guarded_official_config_is_safe_for_token_routing() {
+        let official = "endpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\n";
+        let (guarded, has_endpoints) = guard_token_storage(official);
+        assert!(has_endpoints);
+        assert_eq!(guarded, official);
+        assert!(config_uses_official_authority(official));
+
+        assert!(!config_uses_official_authority(
+            "default_endpoint: https://enterprise.example/api\nendpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\n"
+        ));
+        assert!(!config_uses_official_authority(
+            "endpoints:\n  https://enterprise.example/api:\n    access_token: ''\n"
+        ));
+        assert!(!config_uses_official_authority(
+            "endpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\nrepos:\n  owner/repo:\n    endpoint: https://enterprise.example/api\n"
+        ));
+        assert!(!config_uses_official_authority(
+            "endpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\nenterprise: {}\n"
+        ));
+        assert!(!config_uses_official_authority(
+            "endpoints:\n  https://api.travis-ci.com/:\n    access_token: ''\n    insecure: true\n"
+        ));
     }
 
     #[test]

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,6 +18,7 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
+    if gateID == "travis" { return travisRequestClassification(arguments) }
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
@@ -34,6 +35,46 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+private func travisRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    guard let first = arguments.first else { return .unknown }
+    let command = (first.hasPrefix("--") ? String(first.dropFirst(2)) : first).lowercased()
+    let options = arguments.dropFirst().prefix { $0 != "--" }
+    if options.contains("--debug-http") { return .secretDump }
+    if ["help", "version", "-h", "-?", "-v"].contains(command)
+        || options.contains(where: { ["-h", "--help"].contains($0) })
+    {
+        return .readOnly
+    }
+
+    switch command {
+    case "accounts", "branches", "history", "lint", "logs", "monitor", "open", "pubkey", "raw",
+         "repos", "requests", "show", "status", "whatsup", "whoami":
+        return .readOnly
+    case "cancel", "console", "disable", "enable", "encrypt", "encrypt-file", "init", "restart",
+         "setup", "sync":
+        return .mutating
+    case "token":
+        return .secretDump
+    case "cache":
+        return options.contains("-d") || options.contains("--delete") ? .mutating : .readOnly
+    case "env":
+        if !Set(options).isDisjoint(with: ["set", "unset", "copy", "clear"]) { return .mutating }
+        return options.contains("list") ? .readOnly : .unknown
+    case "settings":
+        return options.contains(where: {
+            ["-t", "--enable", "-f", "--disable", "-s", "--set", "-c", "--configure"].contains($0)
+                || $0.hasPrefix("--set=")
+        }) ? .mutating : .readOnly
+    case "sshkey":
+        return options.contains(where: {
+            ["-D", "--delete", "-u", "--upload", "-s", "--stdin", "-g", "--generate"].contains($0)
+                || $0.hasPrefix("--upload=")
+        }) ? .mutating : .readOnly
+    default:
+        return .unknown
+    }
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -163,7 +204,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "snowflake-cli": .init("object list,object describe,connection test", "object create,object drop,stage copy"),
     "snyk": .init("", "monitor,auth"),
     "transifex-cli": .init("status", "pull,push"),
-    "travis": .init("whoami,repos,history,show,logs", "restart,cancel,enable,disable", secretDump: "token"),
+    "travis": .init("", ""),
     "twine": .init("check", "upload"),
     "vagrant": .init("status,global-status,validate,version", "up,destroy,halt,reload,suspend,resume,cloud publish"),
     "vault": .init("status,list,kv list,token lookup", "write,delete,kv put,kv delete", secretDump: "read,kv get,login,token create,token generate"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -72,6 +72,39 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "flyctl", arguments: []) == .unknown)
 }
 
+@Test func travisPolicyClassifiesReviewedCommandShapes() {
+    for arguments in [
+        ["accounts"],
+        ["whoami", "--skip-version-check"],
+        ["cache", "--branch", "main"],
+        ["env", "-r", "owner/repo", "list"],
+        ["settings", "--keys"],
+        ["sshkey", "-d", "deployment key"],
+        ["restart", "--help"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "travis", arguments: arguments) == .readOnly)
+    }
+
+    for arguments in [
+        ["restart"],
+        ["cache", "--delete", "--force"],
+        ["env", "-r", "owner/repo", "set", "NAME", "value"],
+        ["settings", "--set=2", "maximum_number_of_builds"],
+        ["sshkey", "-D"],
+        ["sshkey", "--upload", "key.pem"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "travis", arguments: arguments) == .mutating)
+    }
+
+    #expect(genericSecretGateRequestClassification(gateID: "travis", arguments: ["token"]) == .secretDump)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "travis",
+        arguments: ["whoami", "--debug-http"]
+    ) == .secretDump)
+    #expect(genericSecretGateRequestClassification(gateID: "travis", arguments: ["plugin-command"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "travis", arguments: []) == .unknown)
+}
+
 @Test func stripePolicyClassifiesGeneratedBuiltInAndPluginCommands() {
     let readOnly = [
         ["customers", "list"],


### PR DESCRIPTION
## Summary
- route Travis CLI invocations tokenlessly unless they are reviewed built-in API commands
- prevent Travis CLI 1.14.0 from copying the injected token back into `~/.travis/config.yml`
- bind stored-token use to guarded configuration, the official Travis API, and verified TLS
- classify Travis read, mutation, and secret-display requests in the macOS policy

## Security review
Audited against official Travis CLI v1.14.0 source at commit `3b50fddbed79030549520d56b4419a15cf48a60c`. Unknown plugins, caller-selected credentials/configuration, enterprise endpoints, insecure TLS, login, and token rotation remain tokenless. The empty YAML token sentinel is non-secret and blocks Travis Ruby CLI's truthy `||=` persistence path.

## Validation
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- focused Travis routing, migration, and policy tests

No canonical documentation change: this implements the existing positive Secret-routing boundary without changing the authority model. Credential-independent execution approval remains out of scope.