### PR TITLE
Route Vault token only when required

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -208,6 +208,8 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
     )
 }
 
+// Reviewed against Vault v2.1.0. Unknown command paths remain tokenless: a
+// future command must not receive the protected token until its use is known.
 fn vault_invocation_is_secretless(args: &[OsString]) -> bool {
     let Some(args) = args
         .iter()
@@ -1318,6 +1320,7 @@ mod tests {
             vec!["future-command", "--", "payload"],
             vec!["read", "-tls-skip-verify", "secret/example"],
             vec!["read", "-address", "http://vault.example", "secret/example"],
+            vec!["read", "-address=hTtP://vault.example", "secret/example"],
         ] {
             assert!(
                 invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
@@ -1327,6 +1330,7 @@ mod tests {
 
         for command in [
             vec!["read", "secret/example"],
+            vec!["read", "-tls-skip-verify=false", "secret/example"],
             vec!["write", "-output-policy=false", "secret/example", "value=x"],
             vec![
                 "agent",
@@ -1397,6 +1401,14 @@ mod tests {
         ));
         unsafe {
             std::env::remove_var("VAULT_ADDR");
+            std::env::set_var("VAULT_SKIP_VERIFY", "false");
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["read", "secret/example"]),
+        ));
+        unsafe {
             std::env::set_var("VAULT_SKIP_VERIFY", "true");
         }
         assert!(invocation_is_secretless(

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "vault" => vault_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -205,6 +206,278 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn vault_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|argument| argument.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let before_separator = args
+        .split(|argument| *argument == "--")
+        .next()
+        .unwrap_or_default();
+    if before_separator.is_empty()
+        || before_separator
+            .iter()
+            .any(|argument| matches!(*argument, "-h" | "-help" | "--help"))
+        || before_separator.iter().any(|argument| {
+            [
+                "output-curl-string",
+                "output-policy",
+                "autocomplete-install",
+                "autocomplete-uninstall",
+            ]
+            .iter()
+            .any(|flag| vault_flag_is_enabled(argument, flag))
+        })
+        || std::env::var_os("VAULT_TOKEN").is_some_and(|value| !value.is_empty())
+        || vault_invocation_uses_unsafe_transport(before_separator)
+    {
+        return true;
+    }
+
+    let command = before_separator[0];
+    let subcommand = before_separator.get(1).copied();
+    let requires_token = match command {
+        "agent" => subcommand == Some("generate-config"),
+        "debug" | "delete" | "list" | "monitor" | "patch" | "read" | "ssh" | "version-history"
+        | "write" => true,
+        "unwrap" => vault_unwrap_uses_ambient_token(&args),
+        "events" => subcommand == Some("subscribe"),
+        "audit" => matches!(subcommand, Some("disable" | "enable" | "list")),
+        "auth" => match subcommand {
+            Some("help") => !vault_auth_help_is_local(before_separator),
+            command => matches!(
+                command,
+                Some("disable" | "enable" | "list" | "move" | "tune")
+            ),
+        },
+        "lease" => matches!(subcommand, Some("lookup" | "renew" | "revoke")),
+        "namespace" => matches!(
+            subcommand,
+            Some("create" | "delete" | "list" | "lock" | "lookup" | "patch" | "unlock")
+        ),
+        "operator" => vault_operator_invocation_requires_token(&before_separator[1..]),
+        "pki" => matches!(
+            subcommand,
+            Some("health-check" | "issue" | "list-intermediates" | "reissue" | "verify-sign")
+        ),
+        "plugin" => match subcommand {
+            Some("runtime") => matches!(
+                before_separator.get(2).copied(),
+                Some("deregister" | "info" | "list" | "register")
+            ),
+            command => matches!(
+                command,
+                Some("deregister" | "info" | "list" | "register" | "reload" | "reload-status")
+            ),
+        },
+        "policy" => matches!(subcommand, Some("delete" | "list" | "read" | "write")),
+        "print" => subcommand == Some("token"),
+        "secrets" => matches!(
+            subcommand,
+            Some("disable" | "enable" | "list" | "move" | "tune")
+        ),
+        "transform" | "transit" => matches!(subcommand, Some("import" | "import-version")),
+        "token" => matches!(
+            subcommand,
+            Some("capabilities" | "create" | "lookup" | "renew" | "revoke")
+        ),
+        "kv" => match subcommand {
+            Some("metadata") => matches!(
+                before_separator.get(2).copied(),
+                Some("delete" | "get" | "patch" | "put")
+            ),
+            command => matches!(
+                command,
+                Some(
+                    "delete"
+                        | "destroy"
+                        | "enable-versioning"
+                        | "get"
+                        | "list"
+                        | "patch"
+                        | "put"
+                        | "rollback"
+                        | "undelete"
+                )
+            ),
+        },
+        _ => false,
+    };
+    !requires_token
+}
+
+fn vault_operator_invocation_requires_token(args: &[&str]) -> bool {
+    let Some(command) = args.first() else {
+        return false;
+    };
+    match *command {
+        "generate-root" => !args.iter().skip(1).any(|argument| {
+            matches!(*argument, "-decode" | "--decode")
+                || argument.starts_with("-decode=")
+                || argument.starts_with("--decode=")
+        }),
+        "key-status" | "members" | "rekey" | "rotate" | "seal" | "step-down" | "usage"
+        | "utilization" => true,
+        "raft" => match args.get(1).copied() {
+            Some("autopilot") => matches!(
+                args.get(2).copied(),
+                Some("get-config" | "set-config" | "state")
+            ),
+            Some("snapshot") => {
+                matches!(args.get(2).copied(), Some("restore" | "save"))
+            }
+            command => matches!(command, Some("list-peers" | "remove-peer")),
+        },
+        _ => false,
+    }
+}
+
+fn vault_auth_help_is_local(args: &[&str]) -> bool {
+    matches!(
+        args.last().copied(),
+        Some(
+            "alicloud"
+                | "aws"
+                | "cert"
+                | "cf"
+                | "gcp"
+                | "github"
+                | "kerberos"
+                | "ldap"
+                | "oci"
+                | "oidc"
+                | "okta"
+                | "pcf"
+                | "radius"
+                | "token"
+                | "userpass"
+        )
+    )
+}
+
+fn vault_unwrap_uses_ambient_token(args: &[&str]) -> bool {
+    let options_with_values = [
+        "-address",
+        "--address",
+        "-agent-address",
+        "--agent-address",
+        "-ca-cert",
+        "--ca-cert",
+        "-ca-path",
+        "--ca-path",
+        "-client-cert",
+        "--client-cert",
+        "-client-key",
+        "--client-key",
+        "-field",
+        "--field",
+        "-format",
+        "--format",
+        "-header",
+        "--header",
+        "-mfa",
+        "--mfa",
+        "-namespace",
+        "--namespace",
+        "-ns",
+        "--ns",
+        "-tls-server-name",
+        "--tls-server-name",
+        "-wrap-ttl",
+        "--wrap-ttl",
+    ];
+    let mut index = 1;
+    while let Some(argument) = args.get(index) {
+        if *argument == "--" {
+            return args.get(index + 1).is_none();
+        }
+        if options_with_values.contains(argument) {
+            index += 2;
+        } else if argument.starts_with('-') {
+            index += 1;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn vault_invocation_uses_unsafe_transport(args: &[&str]) -> bool {
+    if std::env::var_os("VAULT_SKIP_VERIFY")
+        .and_then(|value| value.to_str().map(str::to_ascii_lowercase))
+        .is_some_and(|value| matches!(value.as_str(), "1" | "t" | "true"))
+        || ["VAULT_ADDR", "VAULT_AGENT_ADDR"].iter().any(|key| {
+            std::env::var_os(key)
+                .is_some_and(|value| value.to_str().is_none_or(vault_address_is_http))
+        })
+    {
+        return true;
+    }
+
+    let mut index = 0;
+    while let Some(argument) = args.get(index) {
+        if vault_flag_is_enabled(argument, "tls-skip-verify") {
+            return true;
+        }
+        if matches!(
+            *argument,
+            "-address" | "--address" | "-agent-address" | "--agent-address"
+        ) {
+            if args
+                .get(index + 1)
+                .is_some_and(|value| vault_address_is_http(value))
+            {
+                return true;
+            }
+            index += 2;
+            continue;
+        }
+        if [
+            "-address=",
+            "--address=",
+            "-agent-address=",
+            "--agent-address=",
+        ]
+        .iter()
+        .find_map(|prefix| argument.strip_prefix(prefix))
+        .is_some_and(vault_address_is_http)
+        {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+fn vault_flag_value_is_true(value: &str) -> bool {
+    matches!(value, "1" | "t" | "T" | "true" | "TRUE" | "True")
+}
+
+fn vault_flag_is_enabled(argument: &str, name: &str) -> bool {
+    ["-", "--"].iter().any(|dashes| {
+        let Some(value) = argument
+            .strip_prefix(dashes)
+            .and_then(|argument| argument.strip_prefix(name))
+        else {
+            return false;
+        };
+        value.is_empty()
+            || value
+                .strip_prefix('=')
+                .is_some_and(vault_flag_value_is_true)
+    })
+}
+
+fn vault_address_is_http(value: &str) -> bool {
+    value
+        .get(.."http://".len())
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("http://"))
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -981,6 +1254,174 @@ mod tests {
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn vault_requests_its_token_only_for_reviewed_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let previous_stub_dir = std::env::var_os("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        let previous_values = [
+            "VAULT_TOKEN",
+            "VAULT_SKIP_VERIFY",
+            "VAULT_ADDR",
+            "VAULT_AGENT_ADDR",
+        ]
+        .map(|key| (key, std::env::var_os(key)));
+        let dir = temp_dir("env-wrapper-secretless-vault");
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            for (key, _) in &previous_values {
+                std::env::remove_var(key);
+            }
+        }
+        let script_path = dir.join("vault");
+        let script = stub_script(
+            &wrapper("vault").unwrap().primary,
+            Path::new("/opt/homebrew/bin/vault"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["version"],
+            vec!["--version"],
+            vec!["status"],
+            vec!["path-help", "secret/"],
+            vec!["login"],
+            vec!["agent", "-config=agent.hcl"],
+            vec!["proxy", "-config=proxy.hcl"],
+            vec!["server", "-config=server.hcl"],
+            vec!["policy", "fmt", "policy.hcl"],
+            vec!["operator", "init"],
+            vec!["operator", "unseal"],
+            vec!["operator", "generate-root", "-decode=encoded", "-otp=otp"],
+            vec!["operator", "raft", "join", "https://vault-leader.example"],
+            vec!["operator", "raft", "snapshot", "inspect", "snapshot.snap"],
+            vec!["audit"],
+            vec!["auth", "help", "userpass"],
+            vec!["plugin", "runtime"],
+            vec!["kv", "metadata"],
+            vec!["unwrap", "caller-wrapping-token"],
+            vec!["unwrap", "--", "caller-wrapping-token"],
+            vec!["read", "-output-policy", "secret/example"],
+            vec!["read", "-output-policy=true", "secret/example"],
+            vec!["write", "--output-curl-string", "secret/example", "value=x"],
+            vec!["future-command"],
+            vec!["operator", "future-command"],
+            vec!["plugin", "runtime", "future-command"],
+            vec!["future-command", "--", "payload"],
+            vec!["read", "-tls-skip-verify", "secret/example"],
+            vec!["read", "-address", "http://vault.example", "secret/example"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vault {command:?}",
+            );
+        }
+
+        for command in [
+            vec!["read", "secret/example"],
+            vec!["write", "-output-policy=false", "secret/example", "value=x"],
+            vec![
+                "agent",
+                "generate-config",
+                "-type=env-template",
+                "secret/example",
+            ],
+            vec!["write", "secret/example", "value=x"],
+            vec!["delete", "secret/example"],
+            vec!["list", "secret/"],
+            vec!["patch", "secret/example", "value=x"],
+            vec!["debug"],
+            vec!["monitor"],
+            vec!["ssh", "-role", "admin", "host"],
+            vec!["unwrap"],
+            vec!["version-history"],
+            vec!["events", "subscribe", "*"],
+            vec!["audit", "list"],
+            vec!["auth", "list"],
+            vec!["lease", "lookup", "lease-id"],
+            vec!["namespace", "list"],
+            vec!["auth", "help", "custom/"],
+            vec!["operator", "generate-root", "-status"],
+            vec!["operator", "key-status"],
+            vec!["operator", "rekey", "-status"],
+            vec!["operator", "seal"],
+            vec!["operator", "raft", "list-peers"],
+            vec!["operator", "raft", "autopilot", "state"],
+            vec!["operator", "raft", "snapshot", "save", "snapshot.snap"],
+            vec!["pki", "health-check"],
+            vec!["plugin", "list"],
+            vec!["plugin", "runtime", "info", "container"],
+            vec!["policy", "read", "default"],
+            vec!["print", "token"],
+            vec!["secrets", "list"],
+            vec!["transform", "import", "role", "key"],
+            vec!["transit", "import", "key", "material"],
+            vec!["token", "lookup"],
+            vec!["kv", "get", "secret/example"],
+            vec!["kv", "metadata", "get", "secret/example"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vault {command:?}",
+            );
+        }
+
+        unsafe { std::env::set_var("VAULT_TOKEN", "caller-token") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["read", "secret/example"]),
+        ));
+        unsafe {
+            std::env::remove_var("VAULT_TOKEN");
+            std::env::set_var("VAULT_ADDR", "http://vault.example");
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["read", "secret/example"]),
+        ));
+        unsafe { std::env::set_var("VAULT_ADDR", "https://vault.example") };
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["read", "-format=json", "secret/example"]),
+        ));
+        unsafe {
+            std::env::remove_var("VAULT_ADDR");
+            std::env::set_var("VAULT_SKIP_VERIFY", "true");
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["read", "secret/example"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["status"]),
+        ));
+
+        unsafe {
+            match previous_stub_dir {
+                Some(value) => std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", value),
+                None => std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR"),
+            }
+            for (key, value) in previous_values {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,6 +18,7 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
+    if gateID == "vault" { return vaultRequestClassification(arguments) }
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
@@ -34,6 +35,141 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+private func vaultRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let words = arguments.prefix { $0 != "--" }.map { $0.lowercased() }
+    guard let command = words.first else { return .unknown }
+    if words.contains(where: { ["-h", "-help", "--help"].contains($0) })
+        || vaultFlagIsEnabled(words, "output-curl-string")
+        || vaultFlagIsEnabled(words, "output-policy")
+    {
+        return .readOnly
+    }
+    if vaultFlagIsEnabled(words, "autocomplete-install")
+        || vaultFlagIsEnabled(words, "autocomplete-uninstall")
+    {
+        return .localWrite
+    }
+
+    let subcommand = words.dropFirst().first
+    switch command {
+    case "help", "version", "--version", "-version", "-v", "status", "list", "path-help", "version-history":
+        return .readOnly
+    case "read", "debug", "monitor", "ssh", "unwrap", "login":
+        return .secretDump
+    case "write", "delete", "patch":
+        return .mutating
+    case "agent":
+        return subcommand == "generate-config" ? .localWrite : .unknown
+    case "events":
+        return subcommand == "subscribe" ? .secretDump : .unknown
+    case "audit":
+        if subcommand == "list" { return .readOnly }
+        return ["disable", "enable"].contains(subcommand) ? .mutating : .unknown
+    case "auth":
+        if ["help", "list"].contains(subcommand) { return .readOnly }
+        return ["disable", "enable", "move", "tune"].contains(subcommand) ? .mutating : .unknown
+    case "lease":
+        if subcommand == "lookup" { return .readOnly }
+        return ["renew", "revoke"].contains(subcommand) ? .mutating : .unknown
+    case "namespace":
+        if ["list", "lookup"].contains(subcommand) { return .readOnly }
+        return ["create", "delete", "lock", "patch", "unlock"].contains(subcommand) ? .mutating : .unknown
+    case "operator":
+        return vaultOperatorRequestClassification(Array(words.dropFirst()))
+    case "pki":
+        if ["health-check", "list-intermediates", "verify-sign"].contains(subcommand) { return .readOnly }
+        return ["issue", "reissue"].contains(subcommand) ? .secretDump : .unknown
+    case "plugin":
+        if subcommand == "runtime" {
+            let operation = words.dropFirst(2).first
+            if ["info", "list"].contains(operation) { return .readOnly }
+            return ["deregister", "register"].contains(operation) ? .mutating : .unknown
+        }
+        if ["info", "list", "reload-status"].contains(subcommand) { return .readOnly }
+        return ["deregister", "register", "reload"].contains(subcommand) ? .mutating : .unknown
+    case "policy":
+        if ["list", "read"].contains(subcommand) { return .readOnly }
+        if subcommand == "fmt" { return .localWrite }
+        return ["delete", "write"].contains(subcommand) ? .mutating : .unknown
+    case "print":
+        return subcommand == "token" ? .secretDump : .unknown
+    case "secrets":
+        if subcommand == "list" { return .readOnly }
+        return ["disable", "enable", "move", "tune"].contains(subcommand) ? .mutating : .unknown
+    case "transform", "transit":
+        return ["import", "import-version"].contains(subcommand) ? .mutating : .unknown
+    case "token":
+        if ["capabilities", "lookup"].contains(subcommand) { return .readOnly }
+        if subcommand == "create" { return .secretDump }
+        return ["renew", "revoke"].contains(subcommand) ? .mutating : .unknown
+    case "kv":
+        return vaultKVRequestClassification(Array(words.dropFirst()))
+    default:
+        return .unknown
+    }
+}
+
+private func vaultOperatorRequestClassification(_ words: [String]) -> SecretGateRequestClassification {
+    guard let command = words.first else { return .unknown }
+    if ["key-status", "members", "usage", "utilization"].contains(command) { return .readOnly }
+    if command == "generate-root" {
+        if vaultFlagIsEnabled(words, "status") { return .readOnly }
+        if vaultFlagIsEnabled(words, "cancel") { return .mutating }
+        return .secretDump
+    }
+    if ["diagnose", "init"].contains(command) { return .secretDump }
+    if ["migrate", "rotate", "seal", "step-down", "unseal"].contains(command) { return .mutating }
+    if command == "rekey" {
+        if vaultFlagIsEnabled(words, "status") { return .readOnly }
+        if vaultFlagIsEnabled(words, "cancel") || vaultFlagIsEnabled(words, "backup-delete")
+        {
+            return .mutating
+        }
+        return .secretDump
+    }
+    guard command == "raft", let operation = words.dropFirst().first else { return .unknown }
+    if ["join", "remove-peer"].contains(operation) { return .mutating }
+    if operation == "list-peers" { return .readOnly }
+    let nested = words.dropFirst(2).first
+    if operation == "autopilot" {
+        if ["get-config", "state"].contains(nested) { return .readOnly }
+        return nested == "set-config" ? .mutating : .unknown
+    }
+    if operation == "snapshot" {
+        if nested == "inspect" { return .readOnly }
+        if nested == "save" { return .secretDump }
+        return nested == "restore" ? .mutating : .unknown
+    }
+    return .unknown
+}
+
+private func vaultFlagIsEnabled(_ words: [String], _ name: String) -> Bool {
+    words.contains { word in
+        for flag in ["-\(name)", "--\(name)"] {
+            if word == flag { return true }
+            if word.hasPrefix("\(flag)=")
+                && ["1", "t", "true"].contains(String(word.dropFirst(flag.count + 1)))
+            {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+private func vaultKVRequestClassification(_ words: [String]) -> SecretGateRequestClassification {
+    guard let command = words.first else { return .unknown }
+    if command == "get" || (command == "metadata" && words.dropFirst().first == "get") {
+        return .secretDump
+    }
+    if command == "list" { return .readOnly }
+    if command == "metadata" {
+        return ["delete", "patch", "put"].contains(words.dropFirst().first) ? .mutating : .unknown
+    }
+    return ["delete", "destroy", "enable-versioning", "patch", "put", "rollback", "undelete"].contains(command)
+        ? .mutating : .unknown
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -166,7 +302,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "travis": .init("whoami,repos,history,show,logs", "restart,cancel,enable,disable", secretDump: "token"),
     "twine": .init("check", "upload"),
     "vagrant": .init("status,global-status,validate,version", "up,destroy,halt,reload,suspend,resume,cloud publish"),
-    "vault": .init("status,list,kv list,token lookup", "write,delete,kv put,kv delete", secretDump: "read,kv get,login,token create,token generate"),
+    "vault": .init("", ""),
     "virustotal-cli": .init("file,url,domain,ip,collection", "scan,upload"),
     "vultr": .init("instance list,instance get,region list,plan list", "instance create,instance delete,instance start,instance stop"),
     "wsk": .init("action list,action get,namespace list,package list,trigger list", "action create,action update,action delete,action invoke", secretDump: "property get"),

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -37,6 +37,8 @@ public func genericSecretGateRequestClassification(
     return .unknown
 }
 
+// Reviewed against Vault v2.1.0. New commands remain Unknown until their
+// authority and output sensitivity are reviewed.
 private func vaultRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
     let words = arguments.prefix { $0 != "--" }.map { $0.lowercased() }
     guard let command = words.first else { return .unknown }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,45 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func vaultPolicyClassifiesReviewedCommandShapes() {
+    for arguments in [
+        ["status"],
+        ["list", "secret/"],
+        ["operator", "raft", "list-peers"],
+        ["plugin", "runtime", "info", "container"],
+        ["read", "-output-policy", "secret/example"],
+        ["read", "-output-policy=true", "secret/example"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "vault", arguments: arguments) == .readOnly)
+    }
+
+    for arguments in [
+        ["write", "secret/example", "value=x"],
+        ["write", "-output-policy=false", "secret/example", "value=x"],
+        ["namespace", "lock"],
+        ["operator", "raft", "snapshot", "restore", "snapshot.snap"],
+        ["kv", "metadata", "patch", "secret/example"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "vault", arguments: arguments) == .mutating)
+    }
+
+    for arguments in [
+        ["read", "secret/example"],
+        ["unwrap"],
+        ["operator", "raft", "snapshot", "save", "snapshot.snap"],
+        ["pki", "issue", "role", "common_name=example.com"],
+        ["print", "token"],
+        ["kv", "metadata", "get", "secret/example"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "vault", arguments: arguments) == .secretDump)
+    }
+
+    #expect(genericSecretGateRequestClassification(gateID: "vault", arguments: ["policy", "fmt", "policy.hcl"]) == .localWrite)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "vault",
+        arguments: ["agent", "generate-config", "-type=env-template", "secret/example"]
+    ) == .localWrite)
+    #expect(genericSecretGateRequestClassification(gateID: "vault", arguments: ["future-command"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "vault", arguments: []) == .unknown)
+}


### PR DESCRIPTION
## Summary
- route `VAULT_TOKEN` only to Vault v2.1.0 commands that may use it
- run help/version/status/login, server/agent/proxy modes, local operator forms, explicit unwrap tokens, and unknown commands without a Secret Use
- refuse to inject the protected token over cleartext or TLS-verification-disabled transports
- classify reviewed Vault reads, mutations, local writes, and secret-producing operations in the macOS policy

Unknown future command paths remain tokenless; altered launcher stubs still fail closed. Credential-independent execution approval remains out of scope. This applies the existing positive Secret routing boundary, so no domain-language or ADR change is needed.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`
- checked credential requirements against the official Vault v2.1.0 source, checksum-verified macOS binary, and a live v2.1.0 dev server