### PR TITLE
Route VirusTotal API key only when required

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "vt" => virustotal_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -118,6 +119,130 @@ pub(crate) fn invocation_is_secretless(
         ),
         _ => false,
     }
+}
+
+// Reviewed against vt-cli v1.3.1. Unknown command paths remain tokenless: a
+// future command must not receive the protected API key until it is reviewed.
+fn virustotal_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|argument| argument.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let args = args
+        .split(|argument| *argument == "--")
+        .next()
+        .unwrap_or_default();
+    if args.is_empty()
+        || args
+            .iter()
+            .any(|argument| matches!(*argument, "-h" | "--help"))
+        || virustotal_invocation_has_caller_api_key(args)
+        || std::env::var_os("VTCLI_APIKEY").is_some_and(|value| !value.is_empty())
+        || virustotal_invocation_selects_custom_host(args)
+    {
+        return true;
+    }
+
+    let Some(command) = virustotal_command(args) else {
+        return true;
+    };
+    let requires_api_key = matches!(
+        command,
+        "analysis"
+            | "an"
+            | "collection"
+            | "domain"
+            | "download"
+            | "dl"
+            | "file"
+            | "group"
+            | "hunting"
+            | "ht"
+            | "iocstream"
+            | "is"
+            | "ip"
+            | "meta"
+            | "monitor"
+            | "monitorpartner"
+            | "retrohunt"
+            | "rh"
+            | "scan"
+            | "search"
+            | "threatprofile"
+            | "url"
+            | "user"
+    );
+    !requires_api_key
+        || !(virustotal_invocation_selects_official_host(args)
+            || super::migrations::virustotal_default_config_is_safe_for_api_key())
+}
+
+fn virustotal_command<'a>(args: &'a [&str]) -> Option<&'a str> {
+    let options_with_values = ["--apikey", "-k", "--format", "--host", "--proxy"];
+    let mut index = 0;
+    while let Some(argument) = args.get(index) {
+        if options_with_values.contains(argument) {
+            index += 2;
+        } else if ["--apikey=", "-k=", "--format=", "--host=", "--proxy="]
+            .iter()
+            .any(|prefix| argument.starts_with(prefix))
+            || argument.starts_with("-k") && argument.len() > 2
+            || matches!(*argument, "--silent" | "-s" | "--verbose" | "-v")
+            || argument.strip_prefix('-').is_some_and(|flags| {
+                !flags.is_empty() && flags.chars().all(|flag| matches!(flag, 's' | 'v'))
+            })
+        {
+            index += 1;
+        } else if argument.starts_with('-') {
+            return None;
+        } else {
+            return Some(argument);
+        }
+    }
+    None
+}
+
+fn virustotal_invocation_has_caller_api_key(args: &[&str]) -> bool {
+    args.iter().enumerate().any(|(index, argument)| {
+        matches!(*argument, "--apikey" | "-k") && args.get(index + 1).is_some()
+            || argument.starts_with("--apikey=")
+            || argument.starts_with("-k=")
+            || argument.starts_with("-k") && argument.len() > 2
+    })
+}
+
+fn virustotal_invocation_selects_official_host(args: &[&str]) -> bool {
+    const OFFICIAL_HOST: &str = "www.virustotal.com";
+    args.iter().enumerate().any(|(index, argument)| {
+        let host = if *argument == "--host" {
+            args.get(index + 1).copied()
+        } else {
+            argument.strip_prefix("--host=")
+        };
+        host.is_some_and(|host| host.is_empty() || host.eq_ignore_ascii_case(OFFICIAL_HOST))
+    })
+}
+
+fn virustotal_invocation_selects_custom_host(args: &[&str]) -> bool {
+    const OFFICIAL_HOST: &str = "www.virustotal.com";
+    if std::env::var_os("VTCLI_HOST").is_some_and(|value| {
+        value
+            .to_str()
+            .is_none_or(|value| !value.is_empty() && !value.eq_ignore_ascii_case(OFFICIAL_HOST))
+    }) {
+        return true;
+    }
+    args.iter().enumerate().any(|(index, argument)| {
+        let host = if *argument == "--host" {
+            args.get(index + 1).copied()
+        } else {
+            argument.strip_prefix("--host=")
+        };
+        host.is_some_and(|host| !host.is_empty() && !host.eq_ignore_ascii_case(OFFICIAL_HOST))
+    })
 }
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
@@ -981,6 +1106,150 @@ mod tests {
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn virustotal_requests_its_api_key_only_for_reviewed_official_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        let previous_stub_dir = std::env::var_os("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        let previous_values =
+            ["VTCLI_APIKEY", "VTCLI_HOST"].map(|key| (key, std::env::var_os(key)));
+        let dir = temp_dir("env-wrapper-secretless-virustotal");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(".vt.toml"), "host=\"www.virustotal.com\"\n").unwrap();
+        unsafe {
+            std::env::set_var("HOME", &dir);
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            for (key, _) in &previous_values {
+                std::env::remove_var(key);
+            }
+        }
+        let script_path = dir.join("vt");
+        let script = stub_script(
+            &wrapper("virustotal-cli").unwrap().primary,
+            Path::new("/opt/homebrew/bin/vt"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["--help"],
+            vec!["file", "--help"],
+            vec!["version"],
+            vec!["completion", "zsh"],
+            vec!["gendoc", "docs"],
+            vec!["init"],
+            vec!["future-command"],
+            vec!["future-command", "--", "payload"],
+            vec!["file", "hash", "--apikey", "caller-key"],
+            vec!["file", "hash", "--apikey=caller-key"],
+            vec!["file", "hash", "-kcaller-key"],
+            vec!["file", "hash", "--apikey="],
+            vec!["file", "hash", "--host", "private.example"],
+            vec!["file", "hash", "--host=private.example"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vt {command:?}",
+            );
+        }
+
+        for command in [
+            vec!["analysis", "id"],
+            vec!["an", "id"],
+            vec!["collection", "id"],
+            vec!["domain", "example.com"],
+            vec!["download", "hash"],
+            vec!["dl", "hash"],
+            vec!["file", "hash"],
+            vec!["group", "name"],
+            vec!["hunting", "notification", "list"],
+            vec!["ht", "notification", "list"],
+            vec!["iocstream", "list"],
+            vec!["is", "list"],
+            vec!["ip", "192.0.2.1"],
+            vec!["meta"],
+            vec!["monitor", "list"],
+            vec!["monitorpartner", "list"],
+            vec!["retrohunt", "list"],
+            vec!["rh", "list"],
+            vec!["scan", "url", "https://example.com"],
+            vec!["search", "type:peexe"],
+            vec!["threatprofile", "list"],
+            vec!["url", "https://example.com"],
+            vec!["user", "name"],
+            vec!["--format", "json", "file", "hash"],
+            vec!["-sv", "file", "hash"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vt {command:?}",
+            );
+        }
+
+        unsafe { std::env::set_var("VTCLI_APIKEY", "caller-key") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["file", "hash"]),
+        ));
+        unsafe {
+            std::env::remove_var("VTCLI_APIKEY");
+            std::env::set_var("VTCLI_HOST", "private.example");
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["file", "hash"]),
+        ));
+        unsafe { std::env::remove_var("VTCLI_HOST") };
+
+        fs::write(dir.join(".vt.toml"), "host=\"private.example\"\n").unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["file", "hash"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["--host", "www.virustotal.com", "file", "hash"]),
+        ));
+        fs::write(dir.join(".vt.toml"), "apikey=\"caller-key\"\n").unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["file", "hash"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["version"]),
+        ));
+
+        unsafe {
+            match previous_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match previous_stub_dir {
+                Some(value) => std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", value),
+                None => std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR"),
+            }
+            for (key, value) in previous_values {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/isotopes/hardeners/migrations/mod.rs
+++ b/src/isotopes/hardeners/migrations/mod.rs
@@ -101,6 +101,10 @@ pub(super) fn names() -> impl Iterator<Item = &'static str> {
     MIGRATIONS.iter().map(|(name, _)| *name)
 }
 
+pub(super) fn virustotal_default_config_is_safe_for_api_key() -> bool {
+    virustotal_cli::default_config_is_safe_for_api_key()
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn isotope_store_generic_password_json(
     service: *const std::ffi::c_char,

--- a/src/isotopes/hardeners/migrations/virustotal_cli.rs
+++ b/src/isotopes/hardeners/migrations/virustotal_cli.rs
@@ -5,6 +5,21 @@ use std::path::{Path, PathBuf};
 
 const KEYCHAIN_SERVICE: &str = "com.automicvault.isotope";
 const VTCLI_APIKEY_ENV_KEY: &str = "VTCLI_APIKEY";
+const OFFICIAL_HOST: &str = "www.virustotal.com";
+const VIPER_CONFIG_EXTENSIONS: &[&str] = &[
+    "json",
+    "toml",
+    "yaml",
+    "yml",
+    "properties",
+    "props",
+    "prop",
+    "hcl",
+    "tfvars",
+    "dotenv",
+    "env",
+    "ini",
+];
 
 pub trait CredentialStore {
     fn store_secret(&self, key: &str, value: &str) -> Result<(), String>;
@@ -46,6 +61,51 @@ fn user_home() -> Result<PathBuf, String> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .ok_or_else(|| "HOME is not set".to_string())
+}
+
+pub(super) fn default_config_is_safe_for_api_key() -> bool {
+    let Ok(home) = user_home() else {
+        return false;
+    };
+    let Ok(cwd) = std::env::current_dir() else {
+        return false;
+    };
+    active_vt_config(&home, &cwd).is_none_or(|path| safe_vt_config(&path))
+}
+
+fn active_vt_config(home: &Path, cwd: &Path) -> Option<PathBuf> {
+    [home, cwd].iter().find_map(|directory| {
+        VIPER_CONFIG_EXTENSIONS.iter().find_map(|extension| {
+            let path = directory.join(format!(".vt.{extension}"));
+            fs::metadata(&path)
+                .ok()
+                .filter(|metadata| metadata.is_file())
+                .map(|_| path)
+        })
+    })
+}
+
+fn safe_vt_config(path: &Path) -> bool {
+    path.extension().and_then(|value| value.to_str()) == Some("toml")
+        && fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+        && fs::read_to_string(path).is_ok_and(|contents| toml_config_is_safe_for_api_key(&contents))
+}
+
+fn toml_config_is_safe_for_api_key(contents: &str) -> bool {
+    let Ok(config) = contents.parse::<toml::Table>() else {
+        return false;
+    };
+    config.iter().all(|(key, value)| {
+        if key.eq_ignore_ascii_case("apikey") {
+            value.as_str() == Some("")
+        } else if key.eq_ignore_ascii_case("host") {
+            value
+                .as_str()
+                .is_some_and(|host| host.is_empty() || host.eq_ignore_ascii_case(OFFICIAL_HOST))
+        } else {
+            true
+        }
+    })
 }
 
 fn toml_string_value_for_key<'a>(contents: &'a str, key: &str) -> Option<&'a str> {
@@ -265,5 +325,42 @@ mod tests {
             keychain_store_secret(KEYCHAIN_SERVICE, VTCLI_APIKEY_ENV_KEY, "value").unwrap_err(),
             "Automic Vault secret storage is only available on macOS"
         );
+    }
+
+    #[test]
+    fn token_routing_requires_the_active_config_to_use_the_official_host() {
+        let dir = std::env::temp_dir().join(format!("vt-config-safety-{}", std::process::id()));
+        let home = dir.join("home");
+        let cwd = dir.join("cwd");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        assert!(active_vt_config(&home, &cwd).is_none());
+        fs::write(home.join(".vt.toml"), "host=\"www.virustotal.com\"\n").unwrap();
+        assert!(safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+
+        fs::write(home.join(".vt.toml"), "host=\"evil.example\"\n").unwrap();
+        assert!(!safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+        fs::write(home.join(".vt.toml"), "apikey=\"caller-key\"\n").unwrap();
+        assert!(!safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+        fs::write(home.join(".vt.toml"), "apikey=\"\"\n").unwrap();
+        assert!(safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+        fs::write(home.join(".vt.toml"), "\"host\"=\"evil.example\"\n").unwrap();
+        assert!(!safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+        fs::write(home.join(".vt.toml"), "host=[\n").unwrap();
+        assert!(!safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+
+        fs::write(home.join(".vt.toml"), "host=\"www.virustotal.com\"\n").unwrap();
+        fs::write(home.join(".vt.json"), "{}\n").unwrap();
+        assert_eq!(active_vt_config(&home, &cwd), Some(home.join(".vt.json")));
+        assert!(!safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+
+        fs::remove_file(home.join(".vt.json")).unwrap();
+        fs::remove_file(home.join(".vt.toml")).unwrap();
+        fs::write(cwd.join(".vt.toml"), "host=\"www.virustotal.com\"\n").unwrap();
+        assert!(safe_vt_config(&active_vt_config(&home, &cwd).unwrap()));
+
+        fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -22,9 +22,9 @@ public func genericSecretGateRequestClassification(
     if gateID == "transifex-cli" { return transifexRequestClassification(arguments) }
     if gateID == "travis" { return travisRequestClassification(arguments) }
     if gateID == "vault" { return vaultRequestClassification(arguments) }
-    if gateID == "virustotal-cli" { return virustotalRequestClassification(words) }
     var words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
+    if gateID == "virustotal-cli" { return virustotalRequestClassification(words) }
     if gateID == "stripe" { return stripeRequestClassification(words) }
     if gateID == "netlify-cli" { return netlifyRequestClassification(words) }
     if gateID == "node" { return npmRequestClassification(arguments) }

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "virustotal-cli" { return virustotalRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -34,6 +35,100 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+// Reviewed against vt-cli v1.3.1. New top-level commands remain Unknown until
+// their authority and output behavior are reviewed.
+private func virustotalRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let arguments = Array(arguments.prefix { $0 != "--" })
+    if arguments.contains(where: { ["-h", "--help"].contains($0) }) { return .readOnly }
+    if arguments.contains(where: virustotalVerboseFlagIsEnabled) { return .secretDump }
+    if virustotalInvocationSelectsCustomHost(arguments) { return .secretDump }
+
+    let optionsWithValues = ["--apikey", "-k", "--format", "--host", "--proxy"]
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if optionsWithValues.contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+        } else if optionsWithValues.contains(where: { argument.hasPrefix("\($0)=") })
+            || (argument.hasPrefix("-k") && argument.count > 2)
+            || virustotalBooleanFlagIsRecognized(argument)
+        {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            break
+        }
+    }
+    guard index < arguments.count else { return .unknown }
+    let words = Array(arguments[index...])
+
+    switch words[0] {
+    case "completion", "version":
+        return .readOnly
+    case "gendoc", "init", "download", "dl":
+        return .localWrite
+    case "analysis", "an", "domain", "file", "ip", "meta", "search", "url":
+        return .readOnly
+    case "scan":
+        return .mutating
+    case "collection":
+        return ["create", "rename", "update", "remove", "delete"].contains(words.dropFirst().first) ? .mutating : .readOnly
+    case "group", "user":
+        guard words.dropFirst().first == "privileges" else { return .readOnly }
+        return ["grant", "revoke"].contains(words.dropFirst(2).first) ? .mutating : .unknown
+    case "iocstream", "is":
+        return words.dropFirst().first == "delete" ? .mutating : .readOnly
+    case "retrohunt", "rh":
+        return ["start", "abort", "delete", "del", "rm"].contains(words.dropFirst().first) ? .mutating : .readOnly
+    case "monitor":
+        if words.dropFirst().first == "download" { return .localWrite }
+        return ["upload", "delete", "deletedetails", "setdetails"].contains(words.dropFirst().first) ? .mutating : .readOnly
+    case "monitorpartner":
+        return words.dropFirst().first == "download" ? .localWrite : .readOnly
+    case "threatprofile":
+        return ["create", "update", "delete"].contains(words.dropFirst().first) ? .mutating : .readOnly
+    case "hunting", "ht":
+        guard let area = words.dropFirst().first else { return .unknown }
+        if ["notification", "nt"].contains(area) {
+            return words.dropFirst(2).first == "delete" ? .mutating : .readOnly
+        }
+        guard ["ruleset", "rs"].contains(area) else { return .unknown }
+        return ["add", "delete", "del", "rm", "disable", "enable", "notification_emails", "rename", "setlimit", "update"]
+            .contains(words.dropFirst(2).first) ? .mutating : .readOnly
+    default:
+        return .unknown
+    }
+}
+
+private func virustotalVerboseFlagIsEnabled(_ argument: String) -> Bool {
+    let parts = argument.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+    let flag = parts[0]
+    let isVerbose = flag == "--verbose"
+        || flag == "-v"
+        || (flag.hasPrefix("-") && flag.dropFirst().allSatisfy { ["s", "v"].contains($0) } && flag.contains("v"))
+    guard isVerbose else { return false }
+    guard parts.count == 2 else { return true }
+    return !["0", "f", "false"].contains(parts[1].lowercased())
+}
+
+private func virustotalBooleanFlagIsRecognized(_ argument: String) -> Bool {
+    let flag = argument.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)[0]
+    if ["--silent", "--verbose"].contains(flag) { return true }
+    let shortFlags = flag.dropFirst()
+    return flag.hasPrefix("-") && !shortFlags.isEmpty && shortFlags.allSatisfy { ["s", "v"].contains($0) }
+}
+
+private func virustotalInvocationSelectsCustomHost(_ arguments: [String]) -> Bool {
+    arguments.enumerated().contains { index, argument in
+        let host = argument == "--host"
+            ? arguments.dropFirst(index + 1).first
+            : argument.hasPrefix("--host=") ? String(argument.dropFirst("--host=".count)) : nil
+        return host.map { !$0.isEmpty && $0.caseInsensitiveCompare("www.virustotal.com") != .orderedSame } ?? false
+    }
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -167,7 +262,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "twine": .init("check", "upload"),
     "vagrant": .init("status,global-status,validate,version", "up,destroy,halt,reload,suspend,resume,cloud publish"),
     "vault": .init("status,list,kv list,token lookup", "write,delete,kv put,kv delete", secretDump: "read,kv get,login,token create,token generate"),
-    "virustotal-cli": .init("file,url,domain,ip,collection", "scan,upload"),
+    "virustotal-cli": .init("", ""),
     "vultr": .init("instance list,instance get,region list,plan list", "instance create,instance delete,instance start,instance stop"),
     "wsk": .init("action list,action get,namespace list,package list,trigger list", "action create,action update,action delete,action invoke", secretDump: "property get"),
     "stripe": .init("", ""),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,22 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func virustotalPolicyClassifiesReviewedCommandsFlagsAndAliases() {
+    let classify = { genericSecretGateRequestClassification(gateID: "virustotal-cli", arguments: $0) }
+
+    #expect(classify(["version"]) == .readOnly)
+    #expect(classify(["--format", "json", "file", "hash"]) == .readOnly)
+    #expect(classify(["collection", "create", "ioc"]) == .mutating)
+    #expect(classify(["ht", "ruleset", "enable", "id"]) == .mutating)
+    #expect(classify(["rh", "matches", "id"]) == .readOnly)
+    #expect(classify(["download", "hash"]) == .localWrite)
+    #expect(classify(["monitor", "download", "id"]) == .localWrite)
+    #expect(classify(["-sv", "file", "hash"]) == .secretDump)
+    #expect(classify(["file", "hash", "--verbose"]) == .secretDump)
+    #expect(classify(["file", "hash", "--host=private.example"]) == .secretDump)
+    #expect(classify(["--verbose=false", "file", "hash"]) == .readOnly)
+    #expect(classify(["-sv=false", "file", "hash"]) == .readOnly)
+    #expect(classify(["--verbose", "file", "--help"]) == .readOnly)
+    #expect(classify(["future-command"]) == .unknown)
+}


### PR DESCRIPTION
## Summary
- run `vt` help, version, completion, documentation, initialization, unknown, and caller-credential invocations without the protected API key
- inject the key only for reviewed VirusTotal API commands targeting the official host, accounting for Viper config precedence
- classify v1.3.1 operations on macOS and treat verbose output or a custom host as Secret Dump risk

## Security boundary
- exact wrapper identity and integrity checks remain fail closed
- unknown future commands remain tokenless until reviewed
- credential-independent execution approval is intentionally out of scope
- canonical authorization and Secret-routing semantics are unchanged, so no domain-language or ADR update is required

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`