### PR TITLE
Route Vultr API key only when required

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "vultr-cli" => vultr_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -118,6 +119,256 @@ pub(crate) fn invocation_is_secretless(
         ),
         _ => false,
     }
+}
+
+// Reviewed against vultr-cli v3.11.0. Unknown command paths remain tokenless:
+// a future command must not receive the protected API key until it is reviewed.
+fn vultr_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(args) = args
+        .iter()
+        .map(|argument| argument.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    let args = args
+        .split(|argument| *argument == "--")
+        .next()
+        .unwrap_or_default();
+    if args.is_empty()
+        || args
+            .iter()
+            .any(|argument| matches!(*argument, "-h" | "--help"))
+    {
+        return true;
+    }
+    let Some((command, command_index)) = vultr_command(args) else {
+        return true;
+    };
+    let authenticated_root = matches!(
+        command,
+        "account"
+            | "backups"
+            | "backup"
+            | "b"
+            | "bare-metal"
+            | "bm"
+            | "billing"
+            | "block-storage"
+            | "bs"
+            | "cdn"
+            | "container-registry"
+            | "cr"
+            | "database"
+            | "dns"
+            | "firewall"
+            | "fw"
+            | "inference"
+            | "instance"
+            | "iso"
+            | "kubernetes"
+            | "k"
+            | "load-balancer"
+            | "logs"
+            | "log"
+            | "object-storage"
+            | "reserved-ip"
+            | "rip"
+            | "script"
+            | "ss"
+            | "startup-script"
+            | "snapshot"
+            | "sn"
+            | "ssh-key"
+            | "ssh"
+            | "ssh-keys"
+            | "sshkeys"
+            | "user"
+            | "users"
+            | "u"
+            | "vpc"
+    );
+    !authenticated_root
+        || !vultr_command_path_requires_api_key(command, &args[command_index + 1..])
+        || std::env::var_os("VULTR_API_KEY").is_some_and(|value| !value.is_empty())
+        || super::migrations::vultr_config_has_api_key(vultr_config_argument(args))
+}
+
+fn vultr_command<'a>(args: &'a [&str]) -> Option<(&'a str, usize)> {
+    let mut index = 0;
+    while let Some(argument) = args.get(index) {
+        if matches!(*argument, "--config" | "--output" | "-o") {
+            index += 2;
+        } else if ["--config=", "--output=", "-o="]
+            .iter()
+            .any(|prefix| argument.starts_with(prefix))
+            || argument.starts_with("-o") && argument.len() > 2
+        {
+            index += 1;
+        } else if argument.starts_with('-') {
+            return None;
+        } else {
+            return Some((argument, index));
+        }
+    }
+    None
+}
+
+fn vultr_command_path_requires_api_key(root: &str, args: &[&str]) -> bool {
+    let groups = [
+        "acl",
+        "advanced-option",
+        "alert",
+        "app",
+        "artifact",
+        "available-connector",
+        "backup",
+        "cluster",
+        "connection-pool",
+        "connector",
+        "credentials",
+        "db",
+        "domain",
+        "firewall",
+        "firewall-rule",
+        "forwarding",
+        "group",
+        "history",
+        "image",
+        "invoice",
+        "ipv4",
+        "ipv6",
+        "iso",
+        "kafka-connect",
+        "kafka-rest",
+        "maintenance",
+        "migration",
+        "nat-gateway",
+        "node",
+        "node-pool",
+        "os",
+        "plan",
+        "port-forwarding-rule",
+        "pull",
+        "push",
+        "quota",
+        "read-replica",
+        "record",
+        "repository",
+        "reverse-dns",
+        "rule",
+        "schema-registry",
+        "ssl",
+        "tier",
+        "topic",
+        "upgrades",
+        "usage",
+        "user",
+        "user-data",
+        "version",
+        "vpc",
+    ];
+    let operations = [
+        "attach",
+        "bandwidth",
+        "change",
+        "config",
+        "convert",
+        "create",
+        "create-endpoint",
+        "create-url",
+        "default-ipv4",
+        "delete",
+        "delete-file",
+        "delete-ipv6",
+        "destroy",
+        "detach",
+        "disable-auto-ssl",
+        "dnssec",
+        "dnssec-info",
+        "docker",
+        "fork",
+        "get",
+        "get-file",
+        "get-schema",
+        "get-status",
+        "halt",
+        "info",
+        "items",
+        "label",
+        "list",
+        "list-files",
+        "list-ipv6",
+        "pause",
+        "plans",
+        "promote",
+        "public",
+        "purge",
+        "reboot",
+        "recycle",
+        "regenerate-keys",
+        "regions",
+        "reinstall",
+        "resize",
+        "restart",
+        "restart-task",
+        "restore",
+        "resume",
+        "set",
+        "set-auto-ssl",
+        "set-certificate",
+        "set-ipv4",
+        "set-ipv6",
+        "soa-info",
+        "soa-update",
+        "start",
+        "status",
+        "stop",
+        "tags",
+        "tiers",
+        "update",
+        "update-firewall-group",
+        "upgrade",
+        "versions",
+        "vnc",
+    ];
+    let aliases = ["a", "c", "d", "destroy", "g", "l", "u"];
+    let mut index = 0;
+    while let Some(argument) = args.get(index) {
+        if matches!(*argument, "--config" | "--output" | "-o") {
+            index += 2;
+            continue;
+        }
+        if ["--config=", "--output=", "-o="]
+            .iter()
+            .any(|prefix| argument.starts_with(prefix))
+            || argument.starts_with("-o") && argument.len() > 2
+        {
+            index += 1;
+            continue;
+        }
+        if (root == "bare-metal" || root == "bm") && matches!(*argument, "ipv4" | "ipv6")
+            || operations.contains(argument)
+            || aliases.contains(argument)
+        {
+            return true;
+        }
+        if !groups.contains(argument) {
+            return false;
+        }
+        index += 1;
+    }
+    false
+}
+
+fn vultr_config_argument<'a>(args: &'a [&'a str]) -> Option<&'a Path> {
+    args.iter().enumerate().rev().find_map(|(index, argument)| {
+        if *argument == "--config" {
+            args.get(index + 1).map(Path::new)
+        } else {
+            argument.strip_prefix("--config=").map(Path::new)
+        }
+    })
 }
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
@@ -982,6 +1233,168 @@ mod tests {
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn vultr_requests_its_api_key_only_for_reviewed_authenticated_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        let previous_stub_dir = std::env::var_os("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        let previous_api_key = std::env::var_os("VULTR_API_KEY");
+        let dir = temp_dir("env-wrapper-secretless-vultr");
+        fs::create_dir_all(&dir).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &dir);
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            std::env::remove_var("VULTR_API_KEY");
+        }
+        let script_path = dir.join("vultr-cli");
+        let script = stub_script(
+            &wrapper("vultr").unwrap().primary,
+            Path::new("/opt/homebrew/bin/vultr-cli"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["--help"],
+            vec!["instance", "--help"],
+            vec!["completion", "zsh"],
+            vec!["version"],
+            vec!["v"],
+            vec!["apps", "list"],
+            vec!["a", "l"],
+            vec!["marketplace", "app", "list-variables", "app"],
+            vec!["os", "list"],
+            vec!["o", "l"],
+            vec!["plans", "list"],
+            vec!["p", "m"],
+            vec!["regions", "availability", "ewr"],
+            vec!["r", "l"],
+            vec!["--output", "json", "apps", "list"],
+            vec!["future-command"],
+            vec!["future-command", "--", "payload"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vultr-cli {command:?}",
+            );
+        }
+
+        for command in [
+            vec!["account", "info"],
+            vec!["backups", "list"],
+            vec!["backup", "list"],
+            vec!["b", "list"],
+            vec!["bare-metal", "list"],
+            vec!["bm", "list"],
+            vec!["billing", "invoice", "list"],
+            vec!["block-storage", "list"],
+            vec!["bs", "list"],
+            vec!["cdn", "pull", "list"],
+            vec!["container-registry", "list"],
+            vec!["cr", "list"],
+            vec!["database", "list"],
+            vec!["dns", "domain", "list"],
+            vec!["firewall", "group", "list"],
+            vec!["fw", "group", "list"],
+            vec!["inference", "list"],
+            vec!["instance", "list"],
+            vec!["iso", "list"],
+            vec!["kubernetes", "list"],
+            vec!["k", "list"],
+            vec!["load-balancer", "list"],
+            vec!["logs", "list"],
+            vec!["log", "list"],
+            vec!["object-storage", "list"],
+            vec!["reserved-ip", "list"],
+            vec!["rip", "list"],
+            vec!["script", "list"],
+            vec!["ss", "list"],
+            vec!["startup-script", "list"],
+            vec!["snapshot", "list"],
+            vec!["sn", "list"],
+            vec!["ssh-key", "list"],
+            vec!["ssh", "list"],
+            vec!["ssh-keys", "list"],
+            vec!["sshkeys", "list"],
+            vec!["user", "list"],
+            vec!["users", "list"],
+            vec!["u", "list"],
+            vec!["vpc", "list"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vultr-cli {command:?}",
+            );
+        }
+        for command in [
+            vec!["instance"],
+            vec!["dns", "domain"],
+            vec!["database", "future-command"],
+            vec!["instance", "future-command"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "vultr-cli {command:?}",
+            );
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["-ojson", "instance", "list"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["instance", "list", "--", "payload"]),
+        ));
+
+        unsafe { std::env::set_var("VULTR_API_KEY", "caller-key") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["instance", "list"]),
+        ));
+        unsafe { std::env::remove_var("VULTR_API_KEY") };
+        let caller_config = dir.join("caller.yaml");
+        fs::write(&caller_config, "api-key: caller-key\n").unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&[
+                "--config",
+                caller_config.to_str().unwrap(),
+                "instance",
+                "list",
+            ]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["version"]),
+        ));
+
+        unsafe {
+            match previous_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match previous_stub_dir {
+                Some(value) => std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", value),
+                None => std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR"),
+            }
+            match previous_api_key {
+                Some(value) => std::env::set_var("VULTR_API_KEY", value),
+                None => std::env::remove_var("VULTR_API_KEY"),
+            }
+        }
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -135,11 +135,7 @@ fn vultr_invocation_is_secretless(args: &[OsString]) -> bool {
         .split(|argument| *argument == "--")
         .next()
         .unwrap_or_default();
-    if args.is_empty()
-        || args
-            .iter()
-            .any(|argument| matches!(*argument, "-h" | "--help"))
-    {
+    if args.is_empty() || vultr_help_requested(args) {
         return true;
     }
     let Some((command, command_index)) = vultr_command(args) else {
@@ -192,6 +188,12 @@ fn vultr_invocation_is_secretless(args: &[OsString]) -> bool {
         || !vultr_command_path_requires_api_key(command, &args[command_index + 1..])
         || std::env::var_os("VULTR_API_KEY").is_some_and(|value| !value.is_empty())
         || super::migrations::vultr_config_has_api_key(vultr_config_argument(args))
+}
+
+fn vultr_help_requested(args: &[&str]) -> bool {
+    args.iter().enumerate().any(|(index, argument)| {
+        matches!(*argument, "-h" | "--help") && (index == 0 || !args[index - 1].starts_with('-'))
+    })
 }
 
 fn vultr_command<'a>(args: &'a [&str]) -> Option<(&'a str, usize)> {
@@ -1353,6 +1355,16 @@ mod tests {
             &script_path,
             script.as_bytes(),
             &args(&["instance", "list", "--", "payload"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["user", "create", "--password", "-h"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["instance", "create", "--label", "--help"]),
         ));
 
         unsafe { std::env::set_var("VULTR_API_KEY", "caller-key") };

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -186,7 +186,6 @@ fn vultr_invocation_is_secretless(args: &[OsString]) -> bool {
     );
     !authenticated_root
         || !vultr_command_path_requires_api_key(command, &args[command_index + 1..])
-        || std::env::var_os("VULTR_API_KEY").is_some_and(|value| !value.is_empty())
         || super::migrations::vultr_config_has_api_key(vultr_config_argument(args))
 }
 
@@ -1368,7 +1367,7 @@ mod tests {
         ));
 
         unsafe { std::env::set_var("VULTR_API_KEY", "caller-key") };
-        assert!(invocation_is_secretless(
+        assert!(!invocation_is_secretless(
             &script_path,
             script.as_bytes(),
             &args(&["instance", "list"]),

--- a/src/isotopes/hardeners/migrations/mod.rs
+++ b/src/isotopes/hardeners/migrations/mod.rs
@@ -101,6 +101,10 @@ pub(super) fn names() -> impl Iterator<Item = &'static str> {
     MIGRATIONS.iter().map(|(name, _)| *name)
 }
 
+pub(super) fn vultr_config_has_api_key(path: Option<&std::path::Path>) -> bool {
+    vultr::config_has_api_key(path)
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn isotope_store_generic_password_json(
     service: *const std::ffi::c_char,

--- a/src/isotopes/hardeners/migrations/vultr.rs
+++ b/src/isotopes/hardeners/migrations/vultr.rs
@@ -57,6 +57,23 @@ fn user_home() -> Result<PathBuf, String> {
         .ok_or_else(|| "HOME is not set".to_string())
 }
 
+pub(super) fn config_has_api_key(path: Option<&Path>) -> bool {
+    let path = match path {
+        Some(path) => path.to_path_buf(),
+        None => {
+            let Ok(paths) = vultr_config_paths() else {
+                return false;
+            };
+            if fs::metadata(&paths[0]).is_ok() {
+                paths[0].clone()
+            } else {
+                paths[1].clone()
+            }
+        }
+    };
+    fs::read_to_string(path).is_ok_and(|contents| config_contains_api_key(&contents))
+}
+
 fn config_api_key(contents: &str) -> Option<String> {
     contents.lines().find_map(line_api_key)
 }
@@ -308,5 +325,36 @@ mod tests {
             keychain_store_secret(KEYCHAIN_SERVICE, VULTR_API_KEY_ENV_KEY, "value").unwrap_err(),
             "Automic Vault secret storage is only available on macOS"
         );
+    }
+
+    #[test]
+    fn token_routing_honors_the_selected_caller_config() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let home = std::env::temp_dir().join(format!("vultr-routing-{}", std::process::id()));
+        let app_support = home.join("Library/Application Support/vultr-cli.yaml");
+        let legacy = home.join(".vultr-cli.yaml");
+        let explicit = home.join("explicit.yaml");
+        let previous_home = std::env::var_os("HOME");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(app_support.parent().unwrap()).unwrap();
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert!(!config_has_api_key(None));
+        fs::write(&legacy, "api-key: caller-key\n").unwrap();
+        assert!(config_has_api_key(None));
+        fs::write(&app_support, "output: json\n").unwrap();
+        assert!(!config_has_api_key(None));
+        fs::write(&app_support, "api-key: app-support-key\n").unwrap();
+        assert!(config_has_api_key(None));
+        fs::write(&explicit, "api-key: explicit-key\n").unwrap();
+        assert!(config_has_api_key(Some(&explicit)));
+
+        unsafe {
+            match previous_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        fs::remove_dir_all(home).unwrap();
     }
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "vultr" { return vultrRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -35,6 +36,145 @@ public func genericSecretGateRequestClassification(
     }
     return .unknown
 }
+
+// Reviewed against vultr-cli v3.11.0. New command paths remain Unknown until
+// their authority and response fields are reviewed.
+private func vultrRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    let arguments = Array(arguments.prefix { $0 != "--" })
+
+    let optionsWithValues = ["--config", "--output", "-o"]
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if ["-h", "--help"].contains(argument) {
+            return .readOnly
+        } else if optionsWithValues.contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+        } else if optionsWithValues.contains(where: { argument.hasPrefix("\($0)=") })
+            || (argument.hasPrefix("-o") && argument.count > 2)
+        {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            break
+        }
+    }
+    guard index < arguments.count else { return .unknown }
+    let root = vultrCanonicalRoot(arguments[index])
+    let path = Array(arguments.dropFirst(index + 1))
+    if vultrPublicRoots.contains(root) { return .readOnly }
+    guard vultrAuthenticatedRoots.contains(root), let commandPath = vultrCommandPath(root: root, path: path),
+          let operation = commandPath.last
+    else {
+        return .unknown
+    }
+
+    if vultrUsesOrReturnsSecret(root: root, commandPath: commandPath, arguments: path) { return .secretDump }
+    if vultrReadOnlyOperations.contains(operation) { return .readOnly }
+    if vultrMutatingOperations.contains(operation) { return .mutating }
+    return .unknown
+}
+
+private func vultrCanonicalRoot(_ root: String) -> String {
+    switch root {
+    case "a", "app", "application", "applications": "apps"
+    case "b", "backup": "backups"
+    case "bm": "bare-metal"
+    case "bs": "block-storage"
+    case "cr": "container-registry"
+    case "fw": "firewall"
+    case "k": "kubernetes"
+    case "log": "logs"
+    case "o": "os"
+    case "p", "plan": "plans"
+    case "r", "region": "regions"
+    case "rip": "reserved-ip"
+    case "sn": "snapshot"
+    case "ss", "startup-script": "script"
+    case "ssh", "ssh-keys", "sshkeys": "ssh-key"
+    case "u", "users": "user"
+    case "v": "version"
+    default: root
+    }
+}
+
+private func vultrCommandPath(root: String, path: [String]) -> [String]? {
+    var commandPath: [String] = []
+    var index = 0
+    while index < path.count {
+        let word = path[index]
+        if ["--config", "--output", "-o"].contains(word) {
+            guard index + 1 < path.count else { return nil }
+            index += 2
+            continue
+        }
+        if word.hasPrefix("--config=") || word.hasPrefix("--output=") || (word.hasPrefix("-o") && word.count > 2) {
+            index += 1
+            continue
+        }
+        if root == "bare-metal" && ["ipv4", "ipv6"].contains(word) { return commandPath + [word] }
+        if vultrReadOnlyOperations.contains(word) || vultrMutatingOperations.contains(word) {
+            return commandPath + [word]
+        }
+        guard vultrCommandGroups.contains(word) else { return nil }
+        commandPath.append(word)
+        index += 1
+    }
+    return nil
+}
+
+private func vultrUsesOrReturnsSecret(root: String, commandPath: [String], arguments: [String]) -> Bool {
+    guard let operation = commandPath.last else { return false }
+    if root == "kubernetes" && commandPath == ["config"] { return true }
+    if root == "cdn" && commandPath == ["push", "create-endpoint"] { return true }
+    if root == "container-registry" {
+        return ["create", "get", "list"].contains(commandPath.first)
+            || commandPath == ["credentials", "docker"]
+    }
+    if root == "object-storage" {
+        return ["create", "get", "list", "regenerate-keys"].contains(commandPath.first)
+    }
+    if root == "inference" {
+        return ["create", "get", "list", "update"].contains(commandPath.first)
+    }
+    if ["bare-metal", "instance"].contains(root) {
+        return ["create", "get", "list"].contains(commandPath.first)
+            || commandPath == ["user-data", "get"]
+            || commandPath == ["user-data", "set"]
+            || root == "bare-metal" && commandPath == ["vnc"]
+    }
+    if root == "database" {
+        return ["create", "get", "list", "update"].contains(commandPath.first)
+            || commandPath.first == "user" && ["create", "get", "list", "update"].contains(operation)
+            || commandPath.first == "migration" && ["get", "start"].contains(operation)
+            || commandPath.first == "connector" && ["create", "get", "list", "update"].contains(operation)
+            || commandPath == ["read-replica", "create"]
+            || commandPath == ["backup", "fork"]
+    }
+    if root == "script" && ["create", "get", "list", "update"].contains(commandPath.first) { return true }
+    if root == "load-balancer" && commandPath == ["ssl", "set-certificate"] { return true }
+    if root == "load-balancer" && commandPath == ["create"]
+        && vultrHasAnyOption(arguments, ["--private-key", "--private-key-b64"])
+    { return true }
+    if root == "user" && ["create", "update"].contains(commandPath.first)
+        && vultrHasAnyOption(arguments, ["--password", "-p"])
+    { return true }
+    return false
+}
+
+private func vultrHasAnyOption(_ arguments: [String], _ options: Set<String>) -> Bool {
+    arguments.contains { argument in
+        options.contains(argument) || options.contains { argument.hasPrefix("\($0)=") }
+    }
+}
+
+private let vultrPublicRoots = SecretGateCommandPolicy.commands("apps,completion,help,marketplace,os,plans,regions,version")
+private let vultrAuthenticatedRoots = SecretGateCommandPolicy.commands("account,backups,bare-metal,billing,block-storage,cdn,container-registry,database,dns,firewall,inference,instance,iso,kubernetes,load-balancer,logs,object-storage,reserved-ip,script,snapshot,ssh-key,user,vpc")
+private let vultrCommandGroups = SecretGateCommandPolicy.commands("acl,advanced-option,alert,app,artifact,available-connector,backup,cluster,connection-pool,connector,credentials,db,domain,firewall,firewall-rule,forwarding,group,history,image,invoice,ipv4,ipv6,iso,kafka-connect,kafka-rest,maintenance,migration,nat-gateway,node,node-pool,os,plan,port-forwarding-rule,pull,push,quota,read-replica,record,repository,reverse-dns,rule,schema-registry,ssl,tier,topic,upgrades,usage,user,user-data,version,vpc")
+private let vultrReadOnlyOperations = SecretGateCommandPolicy.commands("bandwidth,dnssec-info,get,get-file,get-schema,get-status,info,items,list,list-files,list-ipv6,plans,public,regions,soa-info,status,tags,tiers,versions,vnc,ipv4,ipv6")
+private let vultrMutatingOperations = SecretGateCommandPolicy.commands("attach,change,config,convert,create,create-endpoint,create-url,default-ipv4,delete,delete-file,delete-ipv6,destroy,detach,disable-auto-ssl,dnssec,docker,fork,halt,label,pause,promote,purge,reboot,recycle,regenerate-keys,reinstall,resize,restart,restart-task,restore,resume,set,set-auto-ssl,set-certificate,set-ipv4,set-ipv6,soa-update,start,stop,update,update-firewall-group,upgrade")
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
     let optionsWithValues = ["--api-key", "--color", "--config", "--device-name", "--log-level", "--project-name", "-p"]
@@ -168,7 +308,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "vagrant": .init("status,global-status,validate,version", "up,destroy,halt,reload,suspend,resume,cloud publish"),
     "vault": .init("status,list,kv list,token lookup", "write,delete,kv put,kv delete", secretDump: "read,kv get,login,token create,token generate"),
     "virustotal-cli": .init("file,url,domain,ip,collection", "scan,upload"),
-    "vultr": .init("instance list,instance get,region list,plan list", "instance create,instance delete,instance start,instance stop"),
+    "vultr": .init("", ""),
     "wsk": .init("action list,action get,namespace list,package list,trigger list", "action create,action update,action delete,action invoke", secretDump: "property get"),
     "stripe": .init("", ""),
     "supabase": .init("projects list,functions list,status,inspect", "link,unlink,db push,db reset,functions deploy,secrets set,secrets unset"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -43,7 +43,7 @@ import Testing
         "vagrant": ["status"],
         "vault": ["token", "lookup"],
         "virustotal-cli": ["domain", "example.com"],
-        "vultr": ["instance", "list"],
+        "vultr": ["account", "info"],
         "wsk": ["action", "list"],
         "stripe": ["customers", "list"],
         "supabase": ["projects", "list"],
@@ -57,6 +57,64 @@ import Testing
             "missing read-only policy for \(gateID)"
         )
     }
+}
+
+@Test func vultrPolicyClassifiesReviewedCommands() {
+    let readOnly = [
+        ["regions", "list"],
+        ["--output", "json", "apps", "list"],
+        ["account", "info"],
+        ["dns", "domain", "list"],
+        ["fw", "group", "list"],
+        ["--config=/tmp/vultr.yaml", "billing", "history", "list"],
+        ["--help"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "vultr", arguments: arguments) == .readOnly)
+    }
+
+    let mutating = [
+        ["instance", "start", "instance-id"],
+        ["dns", "record", "create", "example.com"],
+        ["--config", "/tmp/vultr.yaml", "instance", "stop", "instance-id"],
+        ["load-balancer", "create", "--region", "ewr"],
+        ["user", "update", "user-id", "--name", "-h"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(gateID: "vultr", arguments: arguments) == .mutating)
+    }
+
+    let secretDump = [
+        ["instance", "get", "instance-id"],
+        ["bm", "vnc", "bare-metal-id"],
+        ["k", "config", "cluster-id"],
+        ["object-storage", "get", "storage-id"],
+        ["object-storage", "regenerate-keys", "storage-id"],
+        ["container-registry", "credentials", "docker", "registry-id"],
+        ["database", "user", "list", "database-id"],
+        ["database", "connector", "get", "database-id", "connector-id"],
+        ["script", "get", "script-id"],
+        ["instance", "user-data", "get", "instance-id"],
+        ["load-balancer", "ssl", "set-certificate", "load-balancer-id"],
+        ["load-balancer", "create", "--private-key=/tmp/key.pem"],
+        ["user", "create", "--password", "-h"],
+    ]
+    for arguments in secretDump {
+        #expect(genericSecretGateRequestClassification(gateID: "vultr", arguments: arguments) == .secretDump)
+    }
+
+    let unknown = [
+        ["future-command"],
+        ["instance", "future-command"],
+        ["dns", "domain"],
+    ]
+    for arguments in unknown {
+        #expect(genericSecretGateRequestClassification(gateID: "vultr", arguments: arguments) == .unknown)
+    }
+    #expect(genericSecretGateRequestClassification(
+        gateID: "vultr",
+        arguments: ["instance", "list", "--", "ignored"]
+    ) == .secretDump)
 }
 
 @Test func genericPoliciesClassifyMutationsSecretsAndUnknowns() {


### PR DESCRIPTION
## Summary
- route `VULTR_API_KEY` only to reviewed authenticated Vultr CLI v3.11.0 command leaves
- keep public, local, help, version, unknown, group-only, caller-authenticated environment, and caller-authenticated config invocations tokenless
- classify credential-returning and credential-applying Vultr commands as elevated Secret operations in the macOS policy

Wrapper identity and exact stub integrity still fail closed before tokenless routing. Credential-independent execution authorization remains out of scope.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`