### PR TITLE
Route Wsk secrets only to authenticated commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -116,6 +116,7 @@ pub(crate) fn invocation_is_secretless(
                 "validate",
             ],
         ),
+        "wsk" => wsk_invocation_is_secretless(args),
         _ => false,
     }
 }
@@ -205,6 +206,173 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+fn wsk_invocation_is_secretless(args: &[OsString]) -> bool {
+    let args = args
+        .split(|arg| arg == "--")
+        .next()
+        .unwrap_or_default()
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>();
+    let Some(args) = args else { return true };
+    let Some((root, mut index, caller_auth)) = wsk_root_command(&args) else {
+        return true;
+    };
+    if root == "list" {
+        return caller_auth || super::migrations::wsk_selected_props_have_auth();
+    }
+
+    while index < args.len() {
+        match wsk_global_option(&args, index) {
+            Some((next, _)) => index = next,
+            None => break,
+        }
+    }
+    let Some(operation) = args.get(index).copied() else {
+        return true;
+    };
+    if is_help_argument(operation) {
+        return true;
+    }
+    index += 1;
+    if args.get(index).is_some_and(|arg| is_help_argument(arg)) {
+        return true;
+    }
+
+    let needs_auth = match (root, operation) {
+        ("action", "create" | "delete" | "get" | "invoke" | "list" | "update")
+        | ("activation", "get" | "list" | "logs" | "poll" | "result")
+        | ("api", "create" | "delete" | "get" | "list")
+        | ("namespace", "get" | "list")
+        | ("package", "bind" | "create" | "delete" | "get" | "list" | "refresh" | "update")
+        | ("project", "deploy" | "export" | "sync" | "undeploy")
+        | (
+            "rule",
+            "create" | "delete" | "disable" | "enable" | "get" | "list" | "status" | "update",
+        )
+        | ("trigger", "create" | "delete" | "fire" | "get" | "list" | "update") => true,
+        ("property", "get") => wsk_property_get_needs_auth(&args[index..]),
+        _ => false,
+    };
+    !needs_auth || caller_auth || super::migrations::wsk_selected_props_have_auth()
+}
+
+fn wsk_root_command<'a>(args: &'a [&str]) -> Option<(&'a str, usize, bool)> {
+    let mut index = 0;
+    let mut caller_auth = false;
+    while index < args.len() {
+        if is_help_argument(args[index]) || matches!(args[index], "--version" | "version") {
+            return None;
+        }
+        let Some((next, auth)) = wsk_global_option(args, index) else {
+            break;
+        };
+        caller_auth |= auth;
+        index = next;
+    }
+    let root = *args.get(index)?;
+    if root.starts_with('-') || matches!(root, "help" | "version") {
+        return None;
+    }
+    Some((root, index + 1, caller_auth))
+}
+
+fn wsk_global_option(args: &[&str], index: usize) -> Option<(usize, bool)> {
+    let argument = *args.get(index)?;
+    if matches!(
+        argument,
+        "--debug" | "-d" | "--insecure" | "-i" | "--verbose" | "-v"
+    ) {
+        return Some((index + 1, false));
+    }
+    if [
+        "--cert",
+        "--key",
+        "--auth",
+        "-u",
+        "--apihost",
+        "--apiversion",
+    ]
+    .contains(&argument)
+    {
+        let value = *args.get(index + 1)?;
+        return Some((
+            index + 2,
+            matches!(argument, "--auth" | "-u") && !value.is_empty(),
+        ));
+    }
+    for option in ["--cert=", "--key=", "--apihost=", "--apiversion="] {
+        if argument.starts_with(option) {
+            return Some((index + 1, false));
+        }
+    }
+    if let Some(value) = argument.strip_prefix("--auth=") {
+        return Some((index + 1, !value.is_empty()));
+    }
+    if let Some(value) = argument.strip_prefix("-u") {
+        if !value.is_empty() {
+            return Some((index + 1, true));
+        }
+    }
+    None
+}
+
+fn is_help_argument(argument: &str) -> bool {
+    matches!(argument, "help" | "--help" | "-h")
+}
+
+fn wsk_property_get_needs_auth(args: &[&str]) -> bool {
+    if args.is_empty() {
+        return true;
+    }
+    let mut selected_property = false;
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index];
+        if matches!(argument, "--auth" | "--all" | "--namespace")
+            || argument.starts_with("--auth=")
+            || argument.starts_with("--all=")
+            || argument.starts_with("--namespace=")
+        {
+            return true;
+        }
+        if matches!(
+            argument,
+            "--cert"
+                | "--key"
+                | "--apihost"
+                | "--apiversion"
+                | "--apibuild"
+                | "--apibuildno"
+                | "--cliversion"
+        ) {
+            selected_property = true;
+            index += 1;
+            continue;
+        }
+        if matches!(
+            argument,
+            "--debug" | "-d" | "--insecure" | "-i" | "--verbose" | "-v"
+        ) {
+            index += 1;
+            continue;
+        }
+        if matches!(argument, "--output" | "-o") {
+            if args.get(index + 1).is_none() {
+                return false;
+            }
+            index += 2;
+            continue;
+        }
+        if argument.starts_with("--output=") {
+            index += 1;
+            continue;
+        }
+        return false;
+    }
+    !selected_property
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -982,6 +1150,150 @@ mod tests {
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn wsk_requests_secrets_only_for_reviewed_remote_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-wsk");
+        let home = dir.join("home");
+        let selected = home.join("selected.wskprops");
+        fs::create_dir_all(&home).unwrap();
+        let previous_home = std::env::var_os("HOME");
+        let previous_config = std::env::var_os("WSK_CONFIG_FILE");
+        let previous_auth = std::env::var_os("WHISK_AUTH");
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            std::env::set_var("HOME", &home);
+            std::env::set_var("WSK_CONFIG_FILE", &selected);
+            std::env::remove_var("WHISK_AUTH");
+        }
+        let script_path = dir.join("wsk");
+        let script = stub_script(
+            &wrapper("wsk").unwrap().primary,
+            Path::new("/opt/homebrew/bin/wsk"),
+        );
+        let secretless = |values: &[&str]| {
+            let args = std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>();
+            invocation_is_secretless(&script_path, script.as_bytes(), &args)
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["--help"],
+            vec!["--version"],
+            vec!["action"],
+            vec!["action", "--help"],
+            vec!["action", "list", "--help"],
+            vec!["action", "future"],
+            vec!["future", "list"],
+            vec!["action", "--", "list"],
+            vec!["sdk", "install", "bashauto"],
+            vec!["sdk", "install", "docker"],
+            vec!["property", "set", "--auth", "caller"],
+            vec!["property", "unset", "--auth"],
+            vec!["property", "get", "--cert"],
+            vec!["property", "get", "--key"],
+            vec!["property", "get", "--apihost"],
+            vec!["property", "get", "--apiversion"],
+            vec!["property", "get", "--apibuild"],
+            vec!["property", "get", "--apibuildno"],
+            vec!["property", "get", "--cliversion"],
+        ] {
+            assert!(secretless(&command), "wsk {command:?}");
+        }
+
+        for command in [
+            vec!["list"],
+            vec!["action", "create"],
+            vec!["action", "delete"],
+            vec!["action", "get"],
+            vec!["action", "invoke"],
+            vec!["action", "list"],
+            vec!["action", "update"],
+            vec!["activation", "get"],
+            vec!["activation", "list"],
+            vec!["activation", "logs"],
+            vec!["activation", "poll"],
+            vec!["activation", "result"],
+            vec!["api", "create"],
+            vec!["api", "delete"],
+            vec!["api", "get"],
+            vec!["api", "list"],
+            vec!["namespace", "get"],
+            vec!["namespace", "list"],
+            vec!["package", "bind"],
+            vec!["package", "create"],
+            vec!["package", "delete"],
+            vec!["package", "get"],
+            vec!["package", "list"],
+            vec!["package", "refresh"],
+            vec!["package", "update"],
+            vec!["project", "deploy"],
+            vec!["project", "export"],
+            vec!["project", "sync"],
+            vec!["project", "undeploy"],
+            vec!["rule", "create"],
+            vec!["rule", "delete"],
+            vec!["rule", "disable"],
+            vec!["rule", "enable"],
+            vec!["rule", "get"],
+            vec!["rule", "list"],
+            vec!["rule", "status"],
+            vec!["rule", "update"],
+            vec!["trigger", "create"],
+            vec!["trigger", "delete"],
+            vec!["trigger", "fire"],
+            vec!["trigger", "get"],
+            vec!["trigger", "list"],
+            vec!["trigger", "update"],
+            vec!["property", "get"],
+            vec!["property", "get", "--all"],
+            vec!["property", "get", "--auth"],
+            vec!["property", "get", "--namespace"],
+            vec!["property", "get", "--output", "raw"],
+            vec!["--debug", "action", "list"],
+            vec!["action", "--insecure", "list"],
+            vec!["action", "create", "name", "--param", "key", "-h"],
+            vec!["action", "create", "--", "payload"],
+        ] {
+            assert!(!secretless(&command), "wsk {command:?}");
+        }
+
+        unsafe { std::env::set_var("WHISK_AUTH", "ambient-caller-auth") };
+        assert!(!secretless(&["action", "list"]));
+        assert!(secretless(&["--auth", "caller-auth", "action", "list"]));
+        assert!(secretless(&["-u", "caller-auth", "action", "list"]));
+        assert!(secretless(&["-ucaller-auth", "action", "list"]));
+        fs::write(&selected, "AUTH=caller-file-auth\n").unwrap();
+        assert!(secretless(&["action", "list"]));
+
+        let invocation = [script_path.clone().into_os_string(), OsString::from("help")];
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation,
+        ));
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+            match previous_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match previous_config {
+                Some(value) => std::env::set_var("WSK_CONFIG_FILE", value),
+                None => std::env::remove_var("WSK_CONFIG_FILE"),
+            }
+            match previous_auth {
+                Some(value) => std::env::set_var("WHISK_AUTH", value),
+                None => std::env::remove_var("WHISK_AUTH"),
+            }
+        }
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/src/isotopes/hardeners/migrations/mod.rs
+++ b/src/isotopes/hardeners/migrations/mod.rs
@@ -101,6 +101,10 @@ pub(super) fn names() -> impl Iterator<Item = &'static str> {
     MIGRATIONS.iter().map(|(name, _)| *name)
 }
 
+pub(super) fn wsk_selected_props_have_auth() -> bool {
+    wsk::selected_props_have_auth()
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn isotope_store_generic_password_json(
     service: *const std::ffi::c_char,

--- a/src/isotopes/hardeners/migrations/wsk.rs
+++ b/src/isotopes/hardeners/migrations/wsk.rs
@@ -70,6 +70,18 @@ fn wsk_props_path() -> Result<PathBuf, String> {
     Ok(user_home()?.join(".wskprops"))
 }
 
+pub(super) fn selected_props_have_auth() -> bool {
+    let path = match std::env::var_os("WSK_CONFIG_FILE") {
+        Some(path) => PathBuf::from(path),
+        None => match wsk_props_path() {
+            Ok(path) => path,
+            Err(_) => return false,
+        },
+    };
+    fs::read_to_string(path)
+        .is_ok_and(|contents| contents.lines().any(|line| parse_auth_line(line).is_some()))
+}
+
 fn user_home() -> Result<PathBuf, String> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
@@ -295,5 +307,42 @@ mod tests {
             keychain_store_secret(KEYCHAIN_SERVICE, WHISK_AUTH_ENV_KEY, "value").unwrap_err(),
             "Automic Vault secret storage is only available on macOS"
         );
+    }
+
+    #[test]
+    fn token_routing_honors_only_the_selected_properties_file() {
+        let _lock = crate::global_test_env_lock().lock().unwrap();
+        let home = std::env::temp_dir().join(format!("wsk-routing-{}", std::process::id()));
+        let default = home.join(".wskprops");
+        let selected = home.join("selected.wskprops");
+        let previous_home = std::env::var_os("HOME");
+        let previous_config = std::env::var_os("WSK_CONFIG_FILE");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::remove_var("WSK_CONFIG_FILE");
+        }
+
+        assert!(!selected_props_have_auth());
+        fs::write(&default, "AUTH=caller-default\n").unwrap();
+        assert!(selected_props_have_auth());
+        fs::write(&selected, "APIHOST=https://openwhisk.example\n").unwrap();
+        unsafe { std::env::set_var("WSK_CONFIG_FILE", &selected) };
+        assert!(!selected_props_have_auth());
+        fs::write(&selected, "AUTH=caller-selected\n").unwrap();
+        assert!(selected_props_have_auth());
+
+        unsafe {
+            match previous_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match previous_config {
+                Some(value) => std::env::set_var("WSK_CONFIG_FILE", value),
+                None => std::env::remove_var("WSK_CONFIG_FILE"),
+            }
+        }
+        fs::remove_dir_all(home).unwrap();
     }
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "wsk" { return wskRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -34,6 +35,119 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+// Reviewed against Apache OpenWhisk CLI 1.2.0 (7c47ef1). Unknown commands
+// remain Unknown until their authority is reviewed.
+private func wskRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    var index = 0
+    while index < arguments.count {
+        if ["help", "--help", "-h", "version", "--version"].contains(arguments[index]) {
+            return .readOnly
+        }
+        guard let next = wskIndexAfterGlobalOption(arguments, index) else { break }
+        index = next
+    }
+    guard index < arguments.count else { return .unknown }
+    let root = arguments[index]
+    guard !root.hasPrefix("-") else { return .unknown }
+    index += 1
+    if root == "list" { return .readOnly }
+
+    while index < arguments.count, let next = wskIndexAfterGlobalOption(arguments, index) {
+        index = next
+    }
+    guard index < arguments.count else { return .unknown }
+    let operation = arguments[index]
+    if ["help", "--help", "-h"].contains(operation) { return .readOnly }
+    index += 1
+    if index < arguments.count, ["help", "--help", "-h"].contains(arguments[index]) {
+        return .readOnly
+    }
+    let command = "\(root) \(operation)"
+    let trailing = Array(arguments.dropFirst(index))
+
+    switch command {
+    case "action get", "package get", "trigger get":
+        return trailing.contains("--summary") || trailing.contains("-s") ? .readOnly : .secretDump
+    case "activation get", "activation logs", "activation poll", "activation result":
+        return .secretDump
+    case "activation list":
+        return trailing.contains("--full") || trailing.contains("-f") ? .secretDump : .readOnly
+    case "action invoke":
+        return trailing.contains("--result") || trailing.contains("-r") ? .secretDump : .mutating
+    case "property get":
+        return wskPropertyGetClassification(trailing)
+    case "property set", "property unset", "sdk install", "project export":
+        return .localWrite
+    case "action list", "api get", "api list", "namespace get", "namespace list", "package list",
+         "rule get", "rule list", "rule status", "trigger list":
+        return .readOnly
+    case "action create", "action delete", "action update", "api create", "api delete", "package bind",
+         "package create", "package delete", "package refresh", "package update", "project deploy",
+         "project sync", "project undeploy", "rule create", "rule delete", "rule disable", "rule enable",
+         "rule update", "trigger create", "trigger delete", "trigger fire", "trigger update":
+        return .mutating
+    default:
+        return .unknown
+    }
+}
+
+private func wskIndexAfterGlobalOption(_ arguments: [String], _ index: Int) -> Int? {
+    let argument = arguments[index]
+    if ["--debug", "-d", "--insecure", "-i", "--verbose", "-v"].contains(argument) {
+        return index + 1
+    }
+    if ["--cert", "--key", "--auth", "-u", "--apihost", "--apiversion"].contains(argument) {
+        return index + 1 < arguments.count ? index + 2 : nil
+    }
+    if ["--cert=", "--key=", "--auth=", "--apihost=", "--apiversion="].contains(where: {
+        argument.hasPrefix($0)
+    }) || argument.hasPrefix("-u") && argument.count > 2 {
+        return index + 1
+    }
+    return nil
+}
+
+private func wskPropertyGetClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    guard !arguments.isEmpty else { return .secretDump }
+    var selectedProperty = false
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if ["--auth", "--all"].contains(argument)
+            || ["--auth=", "--all="].contains(where: { argument.hasPrefix($0) })
+        {
+            return .secretDump
+        }
+        if argument == "--namespace" || argument.hasPrefix("--namespace=") {
+            selectedProperty = true
+            index += 1
+            continue
+        }
+        if ["--cert", "--key", "--apihost", "--apiversion", "--apibuild", "--apibuildno", "--cliversion"]
+            .contains(argument)
+        {
+            selectedProperty = true
+            index += 1
+            continue
+        }
+        if ["--debug", "-d", "--insecure", "-i", "--verbose", "-v"].contains(argument) {
+            index += 1
+            continue
+        }
+        if ["--output", "-o"].contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+            continue
+        }
+        if argument.hasPrefix("--output=") {
+            index += 1
+            continue
+        }
+        return .unknown
+    }
+    return selectedProperty ? .readOnly : .secretDump
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -169,7 +283,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "vault": .init("status,list,kv list,token lookup", "write,delete,kv put,kv delete", secretDump: "read,kv get,login,token create,token generate"),
     "virustotal-cli": .init("file,url,domain,ip,collection", "scan,upload"),
     "vultr": .init("instance list,instance get,region list,plan list", "instance create,instance delete,instance start,instance stop"),
-    "wsk": .init("action list,action get,namespace list,package list,trigger list", "action create,action update,action delete,action invoke", secretDump: "property get"),
+    "wsk": .init("", ""),
     "stripe": .init("", ""),
     "supabase": .init("projects list,functions list,status,inspect", "link,unlink,db push,db reset,functions deploy,secrets set,secrets unset"),
 ]

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -123,3 +123,70 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["stage", "publish"]) == .mutating)
     #expect(genericSecretGateRequestClassification(gateID: "node", arguments: ["ls"]) == .unknown)
 }
+
+@Test func wskPolicyClassifiesItsReviewedCommandMap() {
+    let readOnly = [
+        ["list"],
+        ["action", "list"],
+        ["action", "get", "example", "--summary"],
+        ["activation", "list"],
+        ["api", "get"],
+        ["namespace", "get"],
+        ["package", "get", "example", "-s"],
+        ["property", "get", "--namespace"],
+        ["property", "get", "--cliversion"],
+        ["rule", "status"],
+        ["trigger", "get", "example", "--summary"],
+        ["--debug", "action", "list"],
+        ["action", "--insecure", "list"],
+        ["action", "list", "--help"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "wsk", arguments: arguments) == .readOnly)
+    }
+
+    let localWrites = [
+        ["sdk", "install", "docker"],
+        ["property", "set", "--auth", "caller"],
+        ["property", "unset", "--auth"],
+        ["project", "export"],
+    ]
+    for arguments in localWrites {
+        #expect(genericSecretGateRequestClassification(gateID: "wsk", arguments: arguments) == .localWrite)
+    }
+
+    let mutations = [
+        ["action", "create"],
+        ["action", "invoke"],
+        ["api", "delete"],
+        ["package", "bind"],
+        ["project", "deploy"],
+        ["rule", "enable"],
+        ["trigger", "fire"],
+        ["action", "create", "name", "--param", "key", "-h"],
+    ]
+    for arguments in mutations {
+        #expect(genericSecretGateRequestClassification(gateID: "wsk", arguments: arguments) == .mutating)
+    }
+
+    let secretDisclosures = [
+        ["action", "get", "example"],
+        ["activation", "get", "id"],
+        ["activation", "list", "--full"],
+        ["action", "invoke", "example", "--result"],
+        ["package", "get", "example"],
+        ["property", "get"],
+        ["property", "get", "--all"],
+        ["property", "get", "--auth"],
+        ["trigger", "get", "example"],
+    ]
+    for arguments in secretDisclosures {
+        #expect(genericSecretGateRequestClassification(gateID: "wsk", arguments: arguments) == .secretDump)
+    }
+
+    #expect(genericSecretGateRequestClassification(gateID: "wsk", arguments: ["action"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "wsk", arguments: ["action", "future"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "wsk", arguments: ["property", "get", "--future"]
+    ) == .unknown)
+}


### PR DESCRIPTION
## Summary
- bypass Wsk Secret Application for help, unknown/group-only forms, SDK installs, property writes, and local/public property reads
- preserve the Secret Gate for the reviewed remote command map and auth-bearing property reads, including leading global options and passthrough forms
- honor explicit caller auth and the selected Wsk properties file without treating ambient `WHISK_AUTH` as tokenless
- classify Wsk requests by actual authority, including Secret Disclosure for activation output and unsummarized entity reads

Reviewed against Apache OpenWhisk CLI 1.2.0 (`7c47ef1dbad550566114baf976c091b4cdd9e678`).

## Security
- launcher path, embedded target, and exact stub contents still fail closed before tokenless routing
- unknown command paths never receive the protected Secret
- ambient managed credentials remain gated so conflict preservation continues to work
- credential-independent execution approval remains out of scope

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`