### PR TITLE
Route Akamai secrets only to installed plugins

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -90,6 +90,7 @@ pub(crate) fn invocation_is_secretless(
     }
     let args = &args[1..];
     match stub.command {
+        "akamai" => akamai_invocation_is_secretless(args),
         "npm" => npm_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
@@ -118,6 +119,103 @@ pub(crate) fn invocation_is_secretless(
         ),
         _ => false,
     }
+}
+
+fn akamai_invocation_is_secretless(args: &[OsString]) -> bool {
+    let args = args
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>();
+    let Some(args) = args else { return true };
+    let mut index = 0;
+    let mut edgerc = None;
+    let mut section = std::env::var("AKAMAI_EDGERC_SECTION")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "default".to_string());
+    while index < args.len() {
+        let argument = args[index];
+        if matches!(argument, "--help" | "-h" | "--version") {
+            return true;
+        }
+        if argument == "--" {
+            index += 1;
+            break;
+        }
+        if matches!(argument, "--bash" | "--zsh" | "--generate-bash-completion") {
+            index += 1;
+            continue;
+        }
+        match argument {
+            "--edgerc" | "-e" => {
+                let Some(value) = args.get(index + 1) else {
+                    return true;
+                };
+                edgerc = Some(PathBuf::from(value));
+                index += 2;
+            }
+            "--section" | "-s" => {
+                let Some(value) = args.get(index + 1) else {
+                    return true;
+                };
+                section = (*value).to_string();
+                index += 2;
+            }
+            "--accountkey" | "--account-key" | "--proxy" => {
+                if args.get(index + 1).is_none() {
+                    return true;
+                }
+                index += 2;
+            }
+            "--daemon" => return true,
+            _ if argument.starts_with("--edgerc=") || argument.starts_with("-e=") => {
+                edgerc = argument
+                    .split_once('=')
+                    .map(|(_, value)| PathBuf::from(value));
+                index += 1;
+            }
+            _ if argument.starts_with("--section=") || argument.starts_with("-s=") => {
+                section = argument
+                    .split_once('=')
+                    .map(|(_, value)| value.to_string())
+                    .unwrap_or_default();
+                index += 1;
+            }
+            _ if ["--accountkey=", "--account-key=", "--proxy="]
+                .iter()
+                .any(|option| argument.starts_with(option)) =>
+            {
+                index += 1;
+            }
+            _ if argument.starts_with('-') => return true,
+            _ => break,
+        }
+    }
+    let Some(command) = args.get(index).copied() else {
+        return true;
+    };
+    if matches!(
+        command,
+        "config"
+            | "get"
+            | "help"
+            | "install"
+            | "list"
+            | "search"
+            | "uninstall"
+            | "update"
+            | "upgrade"
+    ) {
+        return true;
+    }
+    if args
+        .get(index + 1)
+        .is_some_and(|argument| matches!(*argument, "help" | "--help" | "-h" | "--version"))
+    {
+        return true;
+    }
+    !super::migrations::akamai_command_is_installed(command)
+        || super::migrations::akamai_caller_has_credentials(edgerc.as_deref(), &section)
 }
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
@@ -915,6 +1013,140 @@ mod tests {
         assert!(script.contains("+AKAMAI_ENV_ASSIGNMENTS"));
         assert!(script.contains("for assignment in ${AKAMAI_ENV_ASSIGNMENTS-}"));
         assert!(script.contains("export \"$assignment\""));
+    }
+
+    #[test]
+    fn akamai_requests_secrets_only_for_installed_plugin_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-akamai");
+        let home = dir.join("home");
+        let package = home.join(".akamai-cli/src/cli-property");
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join("cli.json"),
+            r#"{"commands":[{"name":"property-manager","aliases":["pm"]}]}"#,
+        )
+        .unwrap();
+        let env_keys = [
+            "HOME",
+            "AKAMAI_CLI_HOME",
+            "AKAMAI_EDGERC",
+            "AKAMAI_EDGERC_SECTION",
+            "AKAMAI_ENV_ASSIGNMENTS",
+            "AKAMAI_CLIENT_TOKEN",
+            "AKAMAI_CLIENT_SECRET",
+            "AKAMAI_ACCESS_TOKEN",
+            "AKAMAI_PROD_CLIENT_TOKEN",
+            "AKAMAI_PROD_CLIENT_SECRET",
+            "AKAMAI_PROD_ACCESS_TOKEN",
+        ];
+        let previous = env_keys.map(|key| (key, std::env::var_os(key)));
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            for key in env_keys {
+                std::env::remove_var(key);
+            }
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AKAMAI_ENV_ASSIGNMENTS", "AKAMAI_CLIENT_TOKEN=protected");
+        }
+        let script_path = dir.join("akamai");
+        let script = stub_script(
+            &wrapper("akamai").unwrap().primary,
+            Path::new("/opt/homebrew/bin/akamai"),
+        );
+        let secretless = |values: &[&str]| {
+            let args = std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>();
+            invocation_is_secretless(&script_path, script.as_bytes(), &args)
+        };
+
+        for command in [
+            vec![],
+            vec!["help"],
+            vec!["--help"],
+            vec!["--version"],
+            vec!["--bash"],
+            vec!["config", "list"],
+            vec!["config", "get", "cli.cache-path"],
+            vec!["config", "set", "cli.color", "true"],
+            vec!["config", "unset", "cli.color"],
+            vec!["get", "property-manager"],
+            vec!["install", "property-manager"],
+            vec!["list", "--remote"],
+            vec!["search", "property"],
+            vec!["uninstall", "property-manager"],
+            vec!["update", "property-manager"],
+            vec!["upgrade"],
+            vec!["future-command"],
+            vec!["property-manager", "--help"],
+        ] {
+            assert!(secretless(&command), "akamai {command:?}");
+        }
+
+        for command in [
+            vec!["property-manager", "list"],
+            vec!["pm", "list"],
+            vec!["property/property-manager", "list"],
+            vec!["--section", "prod", "property-manager", "list"],
+            vec!["--proxy=https://proxy.example", "property-manager", "list"],
+            vec!["property-manager", "action", "--param", "key", "-h"],
+            vec!["property-manager", "--", "payload"],
+        ] {
+            assert!(!secretless(&command), "akamai {command:?}");
+        }
+
+        let caller_edgerc = home.join("caller.edgerc");
+        fs::write(
+            &caller_edgerc,
+            "[prod]\nhost = example.luna.akamaiapis.net\nclient_token = caller\nclient_secret = caller\naccess_token = caller\n",
+        )
+        .unwrap();
+        let caller_edgerc = caller_edgerc.to_str().unwrap();
+        assert!(secretless(&[
+            "--edgerc",
+            caller_edgerc,
+            "--section",
+            "prod",
+            "property-manager",
+            "list",
+        ]));
+        unsafe {
+            std::env::set_var("AKAMAI_CLIENT_TOKEN", "caller");
+            std::env::set_var("AKAMAI_CLIENT_SECRET", "caller");
+            std::env::set_var("AKAMAI_ACCESS_TOKEN", "caller");
+        }
+        assert!(secretless(&["property-manager", "list"]));
+        unsafe {
+            std::env::set_var("AKAMAI_PROD_CLIENT_TOKEN", "caller");
+            std::env::set_var("AKAMAI_PROD_CLIENT_SECRET", "caller");
+            std::env::set_var("AKAMAI_PROD_ACCESS_TOKEN", "caller");
+        }
+        assert!(secretless(&[
+            "--account-key",
+            "acct",
+            "--section=prod",
+            "property-manager",
+            "list",
+        ]));
+
+        let invocation = [script_path.clone().into_os_string(), OsString::from("help")];
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation,
+        ));
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+            for (key, value) in previous {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/src/isotopes/hardeners/migrations/akamai.rs
+++ b/src/isotopes/hardeners/migrations/akamai.rs
@@ -52,6 +52,98 @@ fn edgerc_path() -> Result<PathBuf, String> {
     Ok(home.join(".edgerc"))
 }
 
+pub(super) fn caller_has_credentials(edgerc: Option<&Path>, section: &str) -> bool {
+    let prefix = match env_section_prefix(section) {
+        Ok(prefix) => format!("AKAMAI_{prefix}"),
+        Err(_) => return false,
+    };
+    if ["CLIENT_TOKEN", "CLIENT_SECRET", "ACCESS_TOKEN"]
+        .iter()
+        .all(|key| {
+            std::env::var_os(format!("{prefix}{key}")).is_some_and(|value| !value.is_empty())
+        })
+    {
+        return true;
+    }
+
+    let path = edgerc
+        .map(Path::to_path_buf)
+        .or_else(|| {
+            std::env::var_os("AKAMAI_EDGERC")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".edgerc")));
+    let Some(path) = path else { return false };
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    edgerc_section_has_credentials(&contents, section)
+}
+
+pub(super) fn command_is_installed(command: &str) -> bool {
+    let Some(home) = std::env::var_os("AKAMAI_CLI_HOME")
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var_os("HOME"))
+    else {
+        return false;
+    };
+    let Ok(packages) = fs::read_dir(PathBuf::from(home).join(".akamai-cli/src")) else {
+        return false;
+    };
+    packages.filter_map(Result::ok).any(|package| {
+        let path = package.path();
+        let package_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_prefix("cli-"));
+        let Ok(contents) = fs::read(path.join("cli.json")) else {
+            return false;
+        };
+        let Ok(metadata) = serde_json::from_slice::<serde_json::Value>(&contents) else {
+            return false;
+        };
+        metadata["commands"].as_array().is_some_and(|commands| {
+            commands.iter().any(|candidate| {
+                let Some(name) = candidate["name"].as_str() else {
+                    return false;
+                };
+                let name = name.to_ascii_lowercase();
+                command == name
+                    || candidate["aliases"].as_array().is_some_and(|aliases| {
+                        aliases.iter().any(|alias| alias.as_str() == Some(command))
+                    })
+                    || package_name.is_some_and(|package| command == format!("{package}/{name}"))
+            })
+        })
+    })
+}
+
+fn edgerc_section_has_credentials(contents: &str, wanted: &str) -> bool {
+    let mut section = String::new();
+    let mut values = Vec::new();
+    for line in contents.lines() {
+        if let Some(name) = section_name(line) {
+            section = name.to_string();
+            continue;
+        }
+        if (section == wanted || section.is_empty() && wanted == "default")
+            && let Some((key, value)) = config_value(line)
+        {
+            values.push((key.to_ascii_lowercase(), value));
+        }
+    }
+    ["host", "client_token", "client_secret", "access_token"]
+        .iter()
+        .all(|key| {
+            values
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == key)
+                .is_some_and(|(_, value)| !value.is_empty())
+        })
+}
+
 fn config_has_edgegrid_secrets(contents: &str) -> bool {
     config_values(contents).any(|(key, value)| {
         matches!(

--- a/src/isotopes/hardeners/migrations/mod.rs
+++ b/src/isotopes/hardeners/migrations/mod.rs
@@ -101,6 +101,17 @@ pub(super) fn names() -> impl Iterator<Item = &'static str> {
     MIGRATIONS.iter().map(|(name, _)| *name)
 }
 
+pub(super) fn akamai_caller_has_credentials(
+    edgerc: Option<&std::path::Path>,
+    section: &str,
+) -> bool {
+    akamai::caller_has_credentials(edgerc, section)
+}
+
+pub(super) fn akamai_command_is_installed(command: &str) -> bool {
+    akamai::command_is_installed(command)
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn isotope_store_generic_password_json(
     service: *const std::ffi::c_char,

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "akamai" { return akamaiRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -34,6 +35,57 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+// Reviewed against Akamai CLI 2.0.5 (cae602d). Installed package commands
+// remain Unknown because each package defines its own authority.
+private func akamaiRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if ["--help", "-h", "--version"].contains(argument) { return .readOnly }
+        if argument == "--" {
+            index += 1
+            break
+        }
+        if ["--bash", "--zsh", "--generate-bash-completion"].contains(argument) {
+            index += 1
+            continue
+        }
+        if ["--edgerc", "-e", "--section", "-s", "--accountkey", "--account-key", "--proxy"]
+            .contains(argument)
+        {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+            continue
+        }
+        if ["--edgerc=", "-e=", "--section=", "-s=", "--accountkey=", "--account-key=", "--proxy="]
+            .contains(where: { argument.hasPrefix($0) })
+        {
+            index += 1
+            continue
+        }
+        if argument == "--daemon" || argument.hasPrefix("-") { return .unknown }
+        break
+    }
+    guard index < arguments.count else { return .readOnly }
+    let command = arguments[index]
+    let trailing = Array(arguments.dropFirst(index + 1))
+    if trailing.first.map({ ["help", "--help", "-h", "--version"].contains($0) }) == true {
+        return .readOnly
+    }
+    switch command {
+    case "help", "list", "search":
+        return .readOnly
+    case "get", "install", "uninstall", "update", "upgrade":
+        return .localWrite
+    case "config":
+        guard let operation = trailing.first else { return .unknown }
+        if ["get", "list"].contains(operation) { return .readOnly }
+        return ["set", "unset", "rm"].contains(operation) ? .localWrite : .unknown
+    default:
+        return .unknown
+    }
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -124,7 +176,7 @@ accept,acknowledge_confirmation_of_payee,activate,add_lines,advance,apply_custom
 """)
 
 private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
-    "akamai": .init("config list", "config set,config remove", secretDump: "config show"),
+    "akamai": .init("", ""),
     "algolia": .init("profile list", "objects import,objects delete,indices delete", secretDump: "profile get"),
     "argocd": .init("app get,app list,app diff,cluster get,cluster list,account get-user-info", "app create,app set,app sync,app delete,app rollback", secretDump: "account generate-token"),
     "ast-cli": .init("scan list,scan show,project list,project show", "scan create,scan cancel,project create,project delete"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -72,6 +72,40 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "flyctl", arguments: []) == .unknown)
 }
 
+@Test func akamaiPolicyClassifiesBuiltInsAndLeavesPluginsUnknown() {
+    for arguments in [
+        ["help"],
+        ["list"],
+        ["search", "property"],
+        ["config", "get", "cli.cache-path"],
+        ["config", "list"],
+        ["--section", "prod", "list"],
+        ["--edgerc=/tmp/caller.edgerc", "--help"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "akamai", arguments: arguments) == .readOnly)
+    }
+    for arguments in [
+        ["get", "property-manager"],
+        ["install", "property-manager"],
+        ["uninstall", "property-manager"],
+        ["update", "property-manager"],
+        ["upgrade"],
+        ["config", "set", "cli.color", "true"],
+        ["config", "unset", "cli.color"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "akamai", arguments: arguments) == .localWrite)
+    }
+    #expect(genericSecretGateRequestClassification(
+        gateID: "akamai", arguments: ["property-manager", "--help"]
+    ) == .readOnly)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "akamai", arguments: ["property-manager", "list"]
+    ) == .unknown)
+    #expect(genericSecretGateRequestClassification(
+        gateID: "akamai", arguments: ["future-command"]
+    ) == .unknown)
+}
+
 @Test func stripePolicyClassifiesGeneratedBuiltInAndPluginCommands() {
     let readOnly = [
         ["customers", "list"],


### PR DESCRIPTION
## Summary
- bypass Akamai Secret Application for CLI/package-management built-ins, help/version/completion forms, and unrecognized commands
- request the EdgeGrid bundle only for command names or aliases present in the selected Akamai CLI package registry
- bypass Vault when the selected edgerc section or selected direct environment already supplies caller credentials
- classify actual v2.0.5 built-ins while leaving dynamic plugin authority Unknown

Reviewed against Akamai CLI 2.0.5 (`cae602db7ed79a173763da03a31614e8b60275ca`).

## Security
- exact launcher identity/integrity validation remains before tokenless routing
- malformed or unreadable plugin metadata and unknown commands receive no protected Secret
- ambient `AKAMAI_ENV_ASSIGNMENTS` does not bypass the gate
- installed plugin commands remain Unknown for macOS policy and therefore cannot be automatically authorized
- credential-independent execution approval remains out of scope

## Verification
- `cargo test akamai -- --nocapture`
- `swift test --package-path src/menu-helper --filter SecretGateCommandPolicyTests`
- `cargo test --workspace --all-targets`
- `cargo test --workspace --all-targets --profile test-release`
- `swift test --package-path src/menu-helper && src/menu-helper/scripts/run-self-checks.sh && src/launcher/macos/tests/launcher-boundary.sh && src/varlock/macos/tests/varlock-boundary.sh`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
