### PR TITLE
Route Algolia secrets only to API commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -90,6 +90,7 @@ pub(crate) fn invocation_is_secretless(
     }
     let args = &args[1..];
     match stub.command {
+        "algolia" => algolia_invocation_is_secretless(args),
         "npm" => npm_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
@@ -118,6 +119,141 @@ pub(crate) fn invocation_is_secretless(
         ),
         _ => false,
     }
+}
+
+fn algolia_invocation_is_secretless(args: &[OsString]) -> bool {
+    if algolia_help_requested(args) {
+        return true;
+    }
+    let Some(command_index) = algolia_command_index(args) else {
+        return true;
+    };
+    let Some(command) = args[command_index].to_str() else {
+        return true;
+    };
+
+    let needs_search_credentials =
+        matches!(
+            command,
+            "search"
+                | "indices"
+                | "index"
+                | "objects"
+                | "records"
+                | "settings"
+                | "rules"
+                | "rule"
+                | "synonyms"
+                | "synonym"
+                | "dictionary"
+                | "dictionaries"
+                | "dict"
+                | "events"
+                | "compositions"
+        ) || matches!(command, "apikeys" | "api-key" | "api-keys" | "apikey")
+            && args
+                .get(command_index + 1)
+                .is_none_or(|subcommand| subcommand != "rotate")
+            || command == "auth"
+                && args
+                    .get(command_index + 1)
+                    .is_some_and(|subcommand| subcommand == "status");
+    if needs_search_credentials {
+        return algolia_search_credentials_are_supplied(args);
+    }
+
+    if matches!(command, "crawler" | "crawlers") {
+        return std::env::var_os("ALGOLIA_CRAWLER_USER_ID").is_some_and(|value| !value.is_empty())
+            && std::env::var_os("ALGOLIA_CRAWLER_API_KEY").is_some_and(|value| !value.is_empty());
+    }
+
+    true
+}
+
+fn algolia_help_requested(args: &[OsString]) -> bool {
+    for (index, argument) in args.iter().enumerate() {
+        if argument == "--" {
+            break;
+        }
+        if matches!(
+            argument.to_str(),
+            Some("--help" | "-h" | "--version" | "-v")
+        ) && index
+            .checked_sub(1)
+            .and_then(|previous| args[previous].to_str())
+            .is_none_or(|previous| !previous.starts_with('-'))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn algolia_command_index(args: &[OsString]) -> Option<usize> {
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index].to_str()?;
+        if argument == "--" {
+            return None;
+        }
+        if matches!(argument, "--help" | "-h" | "--version" | "-v") {
+            return None;
+        }
+        if matches!(
+            argument,
+            "--profile"
+                | "-p"
+                | "--application-id"
+                | "--api-key"
+                | "--admin-api-key"
+                | "--search-hosts"
+        ) {
+            index += 2;
+            continue;
+        }
+        if [
+            "--profile=",
+            "--application-id=",
+            "--api-key=",
+            "--admin-api-key=",
+            "--search-hosts=",
+        ]
+        .iter()
+        .any(|option| argument.starts_with(option))
+        {
+            index += 1;
+            continue;
+        }
+        return (!argument.starts_with('-')).then_some(index);
+    }
+    None
+}
+
+fn algolia_search_credentials_are_supplied(args: &[OsString]) -> bool {
+    let application_id = algolia_option_value(args, "--application-id")
+        .or_else(|| std::env::var_os("ALGOLIA_APPLICATION_ID"));
+    let api_key = algolia_option_value(args, "--api-key")
+        .or_else(|| algolia_option_value(args, "--admin-api-key"))
+        .or_else(|| std::env::var_os("ALGOLIA_API_KEY"))
+        .or_else(|| std::env::var_os("ALGOLIA_ADMIN_API_KEY"));
+    application_id.is_some_and(|value| !value.is_empty())
+        && api_key.is_some_and(|value| !value.is_empty())
+}
+
+fn algolia_option_value(args: &[OsString], option: &str) -> Option<OsString> {
+    let equals = format!("{option}=");
+    for (index, argument) in args.iter().enumerate() {
+        if argument == "--" {
+            break;
+        }
+        if argument == option {
+            return args.get(index + 1).cloned();
+        }
+        if let Some(value) = argument.to_str()?.strip_prefix(&equals) {
+            return Some(OsString::from(value));
+        }
+    }
+    None
 }
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
@@ -981,6 +1117,129 @@ mod tests {
         ));
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn algolia_requests_secrets_only_for_commands_that_can_use_them() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-algolia");
+        unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
+        let script_path = dir.join("algolia");
+        let script = stub_script(
+            &wrapper("algolia").unwrap().primary,
+            Path::new("/opt/homebrew/bin/algolia"),
+        );
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["--help"],
+            vec!["search", "--help"],
+            vec!["--version"],
+            vec!["completion", "zsh"],
+            vec!["describe", "objects", "browse"],
+            vec!["schema", "search"],
+            vec!["application", "list"],
+            vec!["app", "select"],
+            vec!["open", "docs"],
+            vec!["profile", "list"],
+            vec!["auth", "login"],
+            vec!["future-command"],
+            vec!["--profile", "work", "describe"],
+            vec!["--future-global", "search", "INDEX"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "algolia {command:?}",
+            );
+        }
+        for command in [
+            vec!["search", "INDEX"],
+            vec!["indices", "list"],
+            vec!["records", "browse", "INDEX"],
+            vec!["api-keys", "list"],
+            vec!["settings", "get", "INDEX"],
+            vec!["rules", "browse", "INDEX"],
+            vec!["synonyms", "browse", "INDEX"],
+            vec!["dict", "entries", "browse"],
+            vec!["events", "tail"],
+            vec!["compositions", "list"],
+            vec!["crawler", "list"],
+            vec!["auth", "status"],
+            vec!["--profile", "work", "objects", "browse", "INDEX"],
+            vec!["search", "INDEX", "--query", "--help"],
+            vec!["search", "INDEX", "--", "--help"],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "algolia {command:?}",
+            );
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["apikeys", "rotate"]),
+        ));
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&[
+                "--application-id=APP",
+                "--api-key",
+                "caller-key",
+                "search",
+                "INDEX",
+            ]),
+        ));
+
+        unsafe {
+            std::env::set_var("ALGOLIA_APPLICATION_ID", "APP");
+            std::env::set_var("ALGOLIA_API_KEY", "caller-key");
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["objects", "browse", "INDEX"]),
+        ));
+        unsafe {
+            std::env::remove_var("ALGOLIA_APPLICATION_ID");
+            std::env::remove_var("ALGOLIA_API_KEY");
+            std::env::set_var("ALGOLIA_CRAWLER_USER_ID", "caller-user");
+            std::env::set_var("ALGOLIA_CRAWLER_API_KEY", "caller-key");
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["crawler", "list"]),
+        ));
+        unsafe {
+            std::env::remove_var("ALGOLIA_CRAWLER_USER_ID");
+            std::env::remove_var("ALGOLIA_CRAWLER_API_KEY");
+            std::env::set_var(
+                "ALGOLIA_ENV_ASSIGNMENTS",
+                "ALGOLIA_APPLICATION_ID=APP\nALGOLIA_API_KEY=vault-key",
+            );
+        }
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["search", "INDEX"]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["describe"]),
+        ));
+
+        unsafe {
+            std::env::remove_var("ALGOLIA_ENV_ASSIGNMENTS");
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -20,11 +20,49 @@ public func genericSecretGateRequestClassification(
 ) -> SecretGateRequestClassification {
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
+    if gateID == "algolia" { return algoliaRequestClassification(words) }
     if gateID == "stripe" { return stripeRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
     guard let policy = secretGateCommandPolicies[gateID] else { return .unknown }
+    let candidates = (1...min(3, words.count)).reversed().map {
+        words.prefix($0).joined(separator: " ")
+    }
+    for candidate in candidates {
+        if policy.secretDump.contains(candidate) { return .secretDump }
+        if policy.readOnly.contains(candidate) { return .readOnly }
+        if policy.mutating.contains(candidate) { return .mutating }
+    }
+    return .unknown
+}
+
+private func algoliaRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    for (index, argument) in arguments.prefix(while: { $0 != "--" }).enumerated() {
+        if ["--help", "-h", "--version", "-v"].contains(argument),
+           index == 0 || !arguments[index - 1].hasPrefix("-") {
+            return .readOnly
+        }
+    }
+
+    let optionsWithValues = ["--profile", "-p", "--application-id", "--api-key", "--admin-api-key", "--search-hosts"]
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if optionsWithValues.contains(argument) {
+            guard index + 1 < arguments.count else { return .unknown }
+            index += 2
+        } else if optionsWithValues.contains(where: { argument.hasPrefix("\($0)=") }) {
+            index += 1
+        } else if argument.hasPrefix("-") {
+            return .unknown
+        } else {
+            break
+        }
+    }
+    guard index < arguments.count,
+          let policy = secretGateCommandPolicies["algolia"] else { return .unknown }
+    let words = Array(arguments[index...])
     let candidates = (1...min(3, words.count)).reversed().map {
         words.prefix($0).joined(separator: " ")
     }
@@ -125,7 +163,11 @@ accept,acknowledge_confirmation_of_payee,activate,add_lines,advance,apply_custom
 
 private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "akamai": .init("config list", "config set,config remove", secretDump: "config show"),
-    "algolia": .init("profile list", "objects import,objects delete,indices delete", secretDump: "profile get"),
+    "algolia": .init(
+        "search,indices list,index list,indices analyze,index analyze,indices config export,index config export,objects browse,records browse,settings get,rules browse,rule browse,synonyms browse,synonym browse,dictionary entries browse,dictionaries entries browse,dict entries browse,dictionary settings get,dictionaries settings get,dict settings get,events tail,crawler list,crawlers list,crawler get,crawlers get,crawler stats,crawlers stats,crawler test,crawlers test,compositions list,compositions get,compositions search,compositions rules list,compositions rules get,auth status,completion,describe,schema,open,profile list,profiles list,application list,app list,application current,app current,application plans,app plans",
+        "indices clear,index clear,indices copy,index copy,indices delete,index delete,indices move,index move,indices config import,index config import,objects import,records import,objects delete,records delete,objects update,records update,objects operations,records operations,apikeys create,api-key create,api-keys create,apikey create,apikeys delete,api-key delete,api-keys delete,apikey delete,apikeys rotate,api-key rotate,api-keys rotate,apikey rotate,settings set,settings import,rules import,rule import,rules delete,rule delete,synonyms import,synonym import,synonyms delete,synonym delete,synonyms save,synonym save,dictionary entries clear,dictionaries entries clear,dict entries clear,dictionary entries delete,dictionaries entries delete,dict entries delete,dictionary entries import,dictionaries entries import,dict entries import,dictionary settings set,dictionaries settings set,dict settings set,crawler crawl,crawlers crawl,crawler create,crawlers create,crawler pause,crawlers pause,crawler reindex,crawlers reindex,crawler run,crawlers run,crawler unblock,crawlers unblock,compositions delete,compositions upsert,compositions sorting-strategy,compositions rules delete,compositions rules upsert,profile add,profiles add,profile remove,profiles remove,profile setdefault,profiles setdefault,application create,app create,application select,app select,application update,app update,application upgrade,app upgrade,application downgrade,app downgrade",
+        secretDump: "apikeys list,api-key list,api-keys list,apikey list,apikeys get,api-key get,api-keys get,apikey get,auth get --with-access-token"
+    ),
     "argocd": .init("app get,app list,app diff,cluster get,cluster list,account get-user-info", "app create,app set,app sync,app delete,app rollback", secretDump: "account generate-token"),
     "ast-cli": .init("scan list,scan show,project list,project show", "scan create,scan cancel,project create,project delete"),
     "buf": .init("repository list,module list,organization list", "push,repository create,repository delete"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -72,6 +72,45 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "flyctl", arguments: []) == .unknown)
 }
 
+@Test func algoliaPolicyMatchesVersion116CommandAuthority() {
+    let readOnly = [
+        ["search", "INDEX"],
+        ["index", "analyze", "INDEX"],
+        ["records", "browse", "INDEX"],
+        ["dictionary", "entries", "browse"],
+        ["compositions", "rules", "get", "rule-id"],
+        ["crawler", "test", "crawler-id", "--url", "https://example.com"],
+        ["auth", "status"],
+        ["--profile", "work", "indices", "list"],
+        ["--application-id=APP", "--api-key=caller-key", "settings", "get", "INDEX"],
+        ["describe", "objects", "browse"],
+        ["objects", "delete", "--help"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: arguments) == .readOnly)
+    }
+
+    let mutating = [
+        ["indices", "delete", "INDEX"],
+        ["objects", "operations", "INDEX"],
+        ["objects", "delete", "INDEX", "--output", "--help"],
+        ["--api-key", "--help", "objects", "delete", "INDEX"],
+        ["api-keys", "rotate"],
+        ["dictionary", "settings", "set"],
+        ["crawler", "run", "crawler-id"],
+        ["compositions", "rules", "upsert", "rule-id"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: arguments) == .mutating)
+    }
+
+    #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: ["apikeys", "list"]) == .secretDump)
+    #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: ["api-key", "get", "key"]) == .secretDump)
+    #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: ["future-command"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: ["indices", "future-operation"]) == .unknown)
+    #expect(genericSecretGateRequestClassification(gateID: "algolia", arguments: ["--future-global", "indices", "list"]) == .unknown)
+}
+
 @Test func stripePolicyClassifiesGeneratedBuiltInAndPluginCommands() {
     let readOnly = [
         ["customers", "list"],


### PR DESCRIPTION
## Summary
- bypass Algolia Secret Application for help/version/completion, command description, application/session management, profile management, dashboard links, and unknown commands
- request the migrated Algolia assignment bundle only for Search API, crawler, compositions, API-key, and credential-status commands that can consume it
- bypass Vault when complete caller-supplied Search API or crawler credentials are already selected
- update macOS classifications to the Algolia CLI 1.16.0 command tree, including API-key value disclosure

Reviewed against Algolia CLI 1.16.0 (`8abeea0856fd2b936f9cfabcd6d351158dc7048b`).

## Security
- exact launcher identity and generated-stub integrity validation remain before tokenless routing
- unrecognized commands and global options receive no protected Secret
- ambient `ALGOLIA_ENV_ASSIGNMENTS` does not count as caller-supplied credentials
- help-like strings used as option values or after `--` do not bypass Secret Application
- API-key list/get operations are classified as Secret Dump
- credential-independent execution approval remains out of scope

## Verification
- `cargo test algolia -- --nocapture`
- `swift test --package-path src/menu-helper --filter SecretGateCommandPolicyTests`
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`
- `git diff --check origin/main...HEAD`
