### PR TITLE
Route Buf token only to registry operations

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -122,7 +122,7 @@ pub(crate) fn invocation_is_secretless(
 }
 
 fn buf_invocation_is_secretless(args: &[OsString]) -> bool {
-    if buf_help_requested(args) {
+    if buf_help_requested(args) || args.iter().any(|argument| argument == "--") {
         return true;
     }
     let words = buf_command_words(args);
@@ -135,20 +135,25 @@ fn buf_invocation_is_secretless(args: &[OsString]) -> bool {
 // inherit BUF_TOKEN until their token use and subprocess behavior are reviewed.
 fn buf_command_needs_token(words: &[&str], args: &[OsString]) -> bool {
     match words {
-        [
-            "build" | "breaking" | "convert" | "export" | "format" | "lint" | "ls-files" | "stats",
-            ..,
-        ]
+        ["build" | "breaking" | "convert" | "export" | "lint", ..]
         | ["dep", "graph" | "prune" | "update", ..]
         | ["config", "ls-breaking-rules" | "ls-lint-rules", ..]
-        | ["source", "edit", "deprecate", ..]
         | [
             "mod",
             "prune" | "update" | "ls-breaking-rules" | "ls-lint-rules",
             ..,
         ]
-        | ["plugin" | "policy", "update", ..]
-        | ["beta", "price", ..] => buf_invocation_references_registry(args),
+        | ["plugin" | "policy", "update", ..] => buf_invocation_references_registry(args),
+        ["format" | "stats", ..] | ["beta", "price", ..] => args
+            .iter()
+            .any(|argument| argument.to_str().is_some_and(buf_value_references_registry)),
+        ["ls-files", ..] => {
+            args.iter()
+                .any(|argument| argument.to_str().is_some_and(buf_value_references_registry))
+                || (buf_flag_is_present(args, "--include-imports")
+                    || buf_flag_is_present(args, "--include-importable"))
+                    && buf_project_references_registry(args)
+        }
         ["curl", ..] => {
             buf_flag_is_present(args, "--schema") && buf_invocation_references_registry(args)
         }
@@ -1498,6 +1503,7 @@ mod tests {
             vec!["beta", "studio-agent"],
             vec!["future-command"],
             vec!["registry", "future-command"],
+            vec!["registry", "module", "info", "--", "--help"],
             vec!["--future-flag", "registry", "whoami"],
             vec![
                 "export",
@@ -1519,11 +1525,23 @@ mod tests {
             "version: v2\nmodules:\n  - path: proto\ndeps:\n  - buf.build/acme/private\nplugins:\n  - plugin: buf.build/acme/check\n",
         )
         .unwrap();
+        for command in [
+            vec!["format", project_path],
+            vec!["stats", project_path],
+            vec!["source", "edit", "deprecate", project_path],
+            vec!["ls-files", project_path],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "buf does not fetch configured dependencies for {command:?}",
+            );
+        }
 
         for command in [
             vec!["build", "buf.build/acme/petapis"],
             vec!["format", "buf.build/acme/petapis"],
             vec!["lint", project_path],
+            vec!["ls-files", project_path, "--include-imports"],
             vec!["breaking", "--against", "buf.build/acme/petapis"],
             vec!["convert", "buf.build/acme/petapis", "--type", "acme.v1.Pet"],
             vec![
@@ -1536,7 +1554,6 @@ mod tests {
             vec!["dep", "prune", project_path],
             vec!["dep", "update", project_path],
             vec!["config", "ls-lint-rules", "--config", config_path],
-            vec!["source", "edit", "deprecate", project_path],
             vec!["push"],
             vec!["plugin", "push", "buf.build/acme/check"],
             vec!["plugin", "update", project_path],
@@ -1572,7 +1589,7 @@ mod tests {
                 "--module",
                 "buf.build/acme/petapis",
             ],
-            vec!["beta", "price", project_path],
+            vec!["beta", "price", "buf.build/acme/petapis"],
             vec![
                 "beta",
                 "registry",

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -90,6 +90,7 @@ pub(crate) fn invocation_is_secretless(
     }
     let args = &args[1..];
     match stub.command {
+        "buf" => buf_invocation_is_secretless(args),
         "npm" => npm_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
@@ -118,6 +119,450 @@ pub(crate) fn invocation_is_secretless(
         ),
         _ => false,
     }
+}
+
+fn buf_invocation_is_secretless(args: &[OsString]) -> bool {
+    if buf_help_requested(args) {
+        return true;
+    }
+    let words = buf_command_words(args);
+    !buf_command_needs_token(&words, args)
+        || buf_may_launch_git_or_plugin(&words, args)
+        || buf_netrc_supplies_token(&words, args)
+}
+
+// Reviewed against Buf CLI v1.72.0. Keep this positive: new commands must not
+// inherit BUF_TOKEN until their token use and subprocess behavior are reviewed.
+fn buf_command_needs_token(words: &[&str], args: &[OsString]) -> bool {
+    match words {
+        [
+            "build" | "breaking" | "convert" | "export" | "format" | "lint" | "ls-files" | "stats",
+            ..,
+        ]
+        | ["dep", "graph" | "prune" | "update", ..]
+        | ["config", "ls-breaking-rules" | "ls-lint-rules", ..]
+        | ["source", "edit", "deprecate", ..]
+        | [
+            "mod",
+            "prune" | "update" | "ls-breaking-rules" | "ls-lint-rules",
+            ..,
+        ]
+        | ["plugin" | "policy", "update", ..]
+        | ["beta", "price", ..] => buf_invocation_references_registry(args),
+        ["curl", ..] => {
+            buf_flag_is_present(args, "--schema") && buf_invocation_references_registry(args)
+        }
+        ["push", ..] | ["plugin" | "policy", "push", ..] => true,
+        ["registry", "whoami", ..] => true,
+        [
+            "registry",
+            "commit",
+            "add-label" | "info" | "list" | "resolve",
+            ..,
+        ]
+        | [
+            "registry",
+            "label",
+            "archive" | "info" | "list" | "unarchive",
+            ..,
+        ]
+        | ["registry", "sdk", "info" | "version", ..] => true,
+        ["registry", "organization", command, ..]
+            if matches!(*command, "create" | "delete" | "info" | "update") =>
+        {
+            true
+        }
+        ["registry", resource, "create" | "delete" | "info", ..]
+            if matches!(*resource, "module" | "plugin" | "policy") =>
+        {
+            true
+        }
+        [
+            "registry",
+            "module",
+            "deprecate" | "undeprecate" | "update",
+            ..,
+        ] => true,
+        ["registry", resource, "commit", command, ..]
+            if matches!(*resource, "module" | "plugin" | "policy")
+                && matches!(*command, "add-label" | "info" | "list" | "resolve") =>
+        {
+            true
+        }
+        ["registry", resource, "label", command, ..]
+            if matches!(*resource, "module" | "plugin" | "policy")
+                && matches!(*command, "archive" | "info" | "list" | "unarchive") =>
+        {
+            true
+        }
+        ["registry", resource, "settings", "update", ..]
+            if matches!(*resource, "module" | "plugin" | "policy") =>
+        {
+            true
+        }
+        ["beta", "registry", "plugin", "delete" | "push", ..]
+        | [
+            "beta",
+            "registry",
+            "webhook",
+            "create" | "delete" | "list",
+            ..,
+        ] => true,
+        ["alpha", "registry", "token", "delete" | "get" | "list", ..] => true,
+        _ => false,
+    }
+}
+
+fn buf_invocation_references_registry(args: &[OsString]) -> bool {
+    args.iter()
+        .any(|argument| argument.to_str().is_some_and(buf_value_references_registry))
+        || buf_project_references_registry(args)
+}
+
+fn buf_value_references_registry(value: &str) -> bool {
+    let value = value
+        .split_once('=')
+        .map_or(value, |(_, value)| value)
+        .trim_matches(['\'', '"']);
+    if value.contains("://") {
+        return false;
+    }
+    let Some((remote, _)) = value.split_once('/') else {
+        return false;
+    };
+    remote != "."
+        && remote != ".."
+        && remote.contains('.')
+        && remote
+            .chars()
+            .any(|character| character.is_ascii_alphanumeric())
+}
+
+fn buf_targets_only_default_registry(words: &[&str], args: &[OsString]) -> bool {
+    let mut saw_default = false;
+    let mut saw_custom = false;
+    for (index, argument) in args.iter().enumerate() {
+        let Some(argument) = argument.to_str() else {
+            saw_custom = true;
+            continue;
+        };
+        let value = argument
+            .split_once('=')
+            .map_or(argument, |(_, value)| value);
+        let remote = buf_registry_remote(value)
+            .or_else(|| (index > 0 && args[index - 1] == "--remote").then_some(value));
+        match remote {
+            Some("buf.build" | "go.buf.build") => saw_default = true,
+            Some(_) => saw_custom = true,
+            None => {}
+        }
+    }
+    if matches!(words, ["registry", "whoami", remote, ..] if *remote != "buf.build" && *remote != "go.buf.build")
+    {
+        saw_custom = true;
+    }
+    !saw_custom && (saw_default || matches!(words, ["registry", "whoami"]))
+}
+
+fn buf_registry_remote(value: &str) -> Option<&str> {
+    let value = value.trim_matches(['\'', '"']);
+    if matches!(value, "buf.build" | "go.buf.build") {
+        return Some(value);
+    }
+    if value.contains("://") {
+        return None;
+    }
+    if !value.contains('/') && value.contains('.') && !value.starts_with('.') {
+        return Some(value);
+    }
+    let (remote, _) = value.split_once('/')?;
+    (remote != "."
+        && remote != ".."
+        && remote.contains('.')
+        && remote
+            .chars()
+            .any(|character| character.is_ascii_alphanumeric()))
+    .then_some(remote)
+}
+
+fn buf_netrc_supplies_token(words: &[&str], args: &[OsString]) -> bool {
+    let Some(path) = std::env::var_os("NETRC")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".netrc"))
+        })
+    else {
+        return false;
+    };
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    let fields = contents
+        .lines()
+        .flat_map(|line| {
+            line.split_once('#')
+                .map_or(line, |(line, _)| line)
+                .split_whitespace()
+        })
+        .collect::<Vec<_>>();
+    let mut machine = None;
+    let mut default_token = false;
+    let mut buf_token = false;
+    let mut index = 0;
+    while index < fields.len() {
+        match fields[index] {
+            "machine" if index + 1 < fields.len() => {
+                machine = Some(fields[index + 1]);
+                index += 2;
+            }
+            "default" => {
+                machine = Some("default");
+                index += 1;
+            }
+            "password" if index + 1 < fields.len() => {
+                if !fields[index + 1].is_empty() {
+                    default_token |= machine == Some("default");
+                    buf_token |= matches!(machine, Some("buf.build" | "go.buf.build"));
+                }
+                index += 2;
+            }
+            _ => index += 1,
+        }
+    }
+    default_token || buf_token && buf_targets_only_default_registry(words, args)
+}
+
+fn buf_project_references_registry(args: &[OsString]) -> bool {
+    let Ok(current_dir) = std::env::current_dir() else {
+        return false;
+    };
+    if buf_directory_references_registry(&current_dir) {
+        return true;
+    }
+    args.iter()
+        .filter_map(|argument| argument.to_str())
+        .any(|argument| {
+            let path = Path::new(
+                argument
+                    .split_once('=')
+                    .map_or(argument, |(_, value)| value),
+            );
+            if path.extension().is_some_and(|extension| {
+                matches!(extension.to_str(), Some("yaml" | "yml" | "lock"))
+            }) && fs::read_to_string(path)
+                .is_ok_and(|contents| buf_config_references_registry(&contents))
+            {
+                return true;
+            }
+            path.exists()
+                && buf_directory_references_registry(if path.is_dir() {
+                    path
+                } else {
+                    path.parent().unwrap_or(path)
+                })
+        })
+}
+
+fn buf_directory_references_registry(directory: &Path) -> bool {
+    directory.ancestors().any(|directory| {
+        ["buf.yaml", "buf.yml", "buf.lock"].iter().any(|name| {
+            fs::read_to_string(directory.join(name))
+                .is_ok_and(|contents| buf_config_references_registry(&contents))
+        })
+    })
+}
+
+fn buf_config_references_registry(contents: &str) -> bool {
+    let mut remote_section_indent = None;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if matches!(trimmed, "deps:" | "plugins:" | "policies:") {
+            remote_section_indent = Some(indent);
+            continue;
+        }
+        let Some(section_indent) = remote_section_indent else {
+            continue;
+        };
+        if indent <= section_indent {
+            remote_section_indent = None;
+            continue;
+        }
+        let value = trimmed
+            .strip_prefix("- ")
+            .unwrap_or(trimmed)
+            .split_once(": ")
+            .map_or(trimmed, |(_, value)| value);
+        if buf_value_references_registry(value) {
+            return true;
+        }
+    }
+    false
+}
+
+fn buf_flag_is_present(args: &[OsString], flag: &str) -> bool {
+    args.iter().any(|argument| {
+        argument == flag
+            || argument
+                .to_str()
+                .is_some_and(|argument| argument.starts_with(&format!("{flag}=")))
+    })
+}
+
+fn buf_help_requested(args: &[OsString]) -> bool {
+    args.iter()
+        .take_while(|argument| argument != &"--")
+        .any(|argument| {
+            matches!(
+                argument.to_str(),
+                Some("--help" | "-h" | "--help-tree" | "--version")
+            )
+        })
+}
+
+fn buf_command_words(args: &[OsString]) -> Vec<&str> {
+    let mut words = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        let Some(argument) = args[index].to_str() else {
+            return Vec::new();
+        };
+        if argument == "--" {
+            break;
+        }
+        if matches!(argument, "--log-format" | "--timeout") {
+            index += 2;
+            continue;
+        }
+        if matches!(argument, "--debug" | "--debug=true" | "--debug=false")
+            || argument.starts_with("--log-format=")
+            || argument.starts_with("--timeout=")
+        {
+            index += 1;
+            continue;
+        }
+        if argument.starts_with('-') {
+            break;
+        }
+        words.push(argument);
+        index += 1;
+    }
+    words
+}
+
+fn buf_may_launch_git_or_plugin(words: &[&str], args: &[OsString]) -> bool {
+    matches!(words, ["generate", ..] | ["alpha", "protoc", ..])
+        || matches!(words, ["beta", command, ..] if command.starts_with("buf-plugin-"))
+        || matches!(
+            words,
+            ["lint" | "breaking", ..]
+                | ["config" | "mod", "ls-breaking-rules" | "ls-lint-rules", ..]
+        ) && buf_project_launches_native_check_plugin(args)
+        || args.iter().any(|argument| {
+            argument.to_str().is_some_and(|argument| {
+                argument == "--git-metadata"
+                    || argument.starts_with("git@")
+                    || argument.starts_with("git://")
+                    || argument.starts_with("ssh://")
+                    || argument.contains(".git#")
+                    || argument.ends_with(".git")
+                    || argument.contains("format=git")
+            })
+        })
+}
+
+fn buf_project_launches_native_check_plugin(args: &[OsString]) -> bool {
+    let Ok(current_dir) = std::env::current_dir() else {
+        return false;
+    };
+    if buf_directory_launches_native_check_plugin(&current_dir) {
+        return true;
+    }
+    args.iter()
+        .filter_map(|argument| argument.to_str())
+        .any(|argument| {
+            if argument.contains("plugins:") || argument.contains("policies:") {
+                // --config accepts YAML data as well as a path. Keep inline
+                // plugin configuration tokenless instead of trying to prove
+                // that every flow-style value is a sandboxed remote plugin.
+                return true;
+            }
+            let path = Path::new(
+                argument
+                    .split_once('=')
+                    .map_or(argument, |(_, value)| value),
+            );
+            if path
+                .extension()
+                .is_some_and(|extension| matches!(extension.to_str(), Some("yaml" | "yml")))
+                && fs::read_to_string(path)
+                    .is_ok_and(|contents| buf_config_launches_native_check_plugin(&contents))
+            {
+                return true;
+            }
+            path.exists()
+                && buf_directory_launches_native_check_plugin(if path.is_dir() {
+                    path
+                } else {
+                    path.parent().unwrap_or(path)
+                })
+        })
+}
+
+fn buf_directory_launches_native_check_plugin(directory: &Path) -> bool {
+    directory.ancestors().any(|directory| {
+        ["buf.yaml", "buf.yml"].iter().any(|name| {
+            fs::read_to_string(directory.join(name))
+                .is_ok_and(|contents| buf_config_launches_native_check_plugin(&contents))
+        })
+    })
+}
+
+fn buf_config_launches_native_check_plugin(contents: &str) -> bool {
+    let mut section = None;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if matches!(trimmed, "plugins:" | "policies:") {
+            section = Some((trimmed, indent));
+            continue;
+        }
+        let Some((section_name, section_indent)) = section else {
+            continue;
+        };
+        if indent <= section_indent {
+            section = None;
+            continue;
+        }
+        let Some((key, value)) = trimmed
+            .strip_prefix("- ")
+            .unwrap_or(trimmed)
+            .split_once(": ")
+        else {
+            continue;
+        };
+        let value = value.trim_matches(['\'', '"']);
+        if section_name == "plugins:"
+            && key == "plugin"
+            && !value.ends_with(".wasm")
+            && !buf_value_references_registry(value)
+        {
+            return true;
+        }
+        if section_name == "policies:" && key == "policy" && !buf_value_references_registry(value) {
+            return true;
+        }
+    }
+    false
 }
 
 fn local_command(args: &[OsString], commands: &[&str]) -> bool {
@@ -985,12 +1430,255 @@ mod tests {
     }
 
     #[test]
+    fn buf_requests_its_token_only_for_reviewed_registry_uses() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-buf");
+        let previous_home = std::env::var_os("HOME");
+        let previous_netrc = std::env::var_os("NETRC");
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir);
+            std::env::set_var("HOME", &dir);
+            std::env::remove_var("NETRC");
+        }
+        let script_path = dir.join("buf");
+        let script = stub_script(
+            &wrapper("buf").unwrap().primary,
+            Path::new("/opt/homebrew/bin/buf"),
+        );
+        let project = dir.join("project");
+        fs::create_dir_all(&project).unwrap();
+        let config = project.join("buf.yaml");
+        fs::write(&config, "version: v2\nmodules:\n  - path: proto\n").unwrap();
+        let project_path = project.to_str().unwrap();
+        let config_path = config.to_str().unwrap();
+        let args = |values: &[&str]| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values.iter().map(OsString::from))
+                .collect::<Vec<_>>()
+        };
+
+        for command in [
+            vec![],
+            vec!["--help"],
+            vec!["--help-tree"],
+            vec![
+                "registry",
+                "module",
+                "info",
+                "buf.build/acme/petapis",
+                "--help",
+            ],
+            vec!["completion", "zsh"],
+            vec!["config", "init"],
+            vec!["config", "migrate"],
+            vec!["build", project_path],
+            vec!["format", project_path],
+            vec!["lint", project_path],
+            vec!["convert", project_path, "--type", "acme.v1.Pet"],
+            vec!["dep", "graph", project_path],
+            vec!["dep", "prune", project_path],
+            vec!["plugin", "update", project_path],
+            vec!["beta", "price", project_path],
+            vec![
+                "curl",
+                "--schema",
+                project_path,
+                "https://example.com/acme.v1.API/Get",
+            ],
+            vec!["lsp", "serve"],
+            vec!["registry", "login"],
+            vec!["registry", "logout"],
+            vec!["registry", "cc"],
+            vec!["plugin", "prune"],
+            vec!["policy", "prune"],
+            vec!["mod", "open"],
+            vec!["generate", "--template", "buf.gen.yaml", "."],
+            vec!["alpha", "protoc", "--", "--plugin=protoc-gen-owned"],
+            vec!["beta", "buf-plugin-v2"],
+            vec!["beta", "studio-agent"],
+            vec!["future-command"],
+            vec!["registry", "future-command"],
+            vec!["--future-flag", "registry", "whoami"],
+            vec![
+                "export",
+                "https://example.com/source.git",
+                "--output",
+                "out",
+            ],
+            vec!["breaking", "--against", "ssh://git@example.com/source.git"],
+            vec!["push", "--git-metadata"],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "buf {command:?}",
+            );
+        }
+
+        fs::write(
+            &config,
+            "version: v2\nmodules:\n  - path: proto\ndeps:\n  - buf.build/acme/private\nplugins:\n  - plugin: buf.build/acme/check\n",
+        )
+        .unwrap();
+
+        for command in [
+            vec!["build", "buf.build/acme/petapis"],
+            vec!["format", "buf.build/acme/petapis"],
+            vec!["lint", project_path],
+            vec!["breaking", "--against", "buf.build/acme/petapis"],
+            vec!["convert", "buf.build/acme/petapis", "--type", "acme.v1.Pet"],
+            vec![
+                "curl",
+                "--schema",
+                "buf.build/acme/petapis",
+                "https://example.com/acme.v1.API/Get",
+            ],
+            vec!["dep", "graph", project_path],
+            vec!["dep", "prune", project_path],
+            vec!["dep", "update", project_path],
+            vec!["config", "ls-lint-rules", "--config", config_path],
+            vec!["source", "edit", "deprecate", project_path],
+            vec!["push"],
+            vec!["plugin", "push", "buf.build/acme/check"],
+            vec!["plugin", "update", project_path],
+            vec!["policy", "push", "buf.build/acme/policy"],
+            vec!["registry", "whoami"],
+            vec!["registry", "organization", "info", "buf.build/acme"],
+            vec!["registry", "module", "create", "buf.build/acme/petapis"],
+            vec![
+                "registry",
+                "module",
+                "commit",
+                "list",
+                "buf.build/acme/petapis",
+            ],
+            vec![
+                "registry",
+                "plugin",
+                "label",
+                "archive",
+                "buf.build/acme/check:main",
+            ],
+            vec![
+                "registry",
+                "policy",
+                "settings",
+                "update",
+                "buf.build/acme/policy",
+            ],
+            vec![
+                "registry",
+                "sdk",
+                "version",
+                "--module",
+                "buf.build/acme/petapis",
+            ],
+            vec!["beta", "price", project_path],
+            vec![
+                "beta",
+                "registry",
+                "webhook",
+                "list",
+                "--remote",
+                "buf.build",
+            ],
+            vec!["alpha", "registry", "token", "list", "buf.build"],
+            vec!["--log-format", "json", "--timeout=5s", "registry", "whoami"],
+            vec![
+                "registry",
+                "--debug",
+                "module",
+                "info",
+                "buf.build/acme/petapis",
+            ],
+        ] {
+            assert!(
+                !invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "buf {command:?}",
+            );
+        }
+
+        fs::write(
+            &config,
+            "version: v2\nmodules:\n  - path: proto\ndeps:\n  - buf.build/acme/private\nplugins:\n  - plugin: buf.build/acme/check\n  - plugin: ./untrusted-check-plugin\n",
+        )
+        .unwrap();
+        for command in [
+            vec!["lint", project_path],
+            vec![
+                "breaking",
+                project_path,
+                "--against",
+                "buf.build/acme/petapis",
+            ],
+            vec!["config", "ls-lint-rules", "--config", config_path],
+            vec![
+                "lint",
+                "--config",
+                "version: v2\nplugins:\n  - plugin: ./untrusted-check-plugin\n",
+                "buf.build/acme/petapis",
+            ],
+        ] {
+            assert!(
+                invocation_is_secretless(&script_path, script.as_bytes(), &args(&command)),
+                "buf must not pass BUF_TOKEN to a local check plugin: {command:?}",
+            );
+        }
+
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &args(&["registry", "whoami"]),
+        ));
+
+        fs::write(
+            dir.join(".netrc"),
+            "machine buf.build login user password freshly-logged-in-token\n",
+        )
+        .unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["registry", "whoami"]),
+        ));
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&["registry", "module", "info", "buf.build/acme/petapis",]),
+        ));
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &args(&[
+                "registry",
+                "module",
+                "info",
+                "registry.example.com/acme/petapis",
+            ]),
+        ));
+
+        unsafe {
+            std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR");
+            match previous_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+            match previous_netrc {
+                Some(netrc) => std::env::set_var("NETRC", netrc),
+                None => std::env::remove_var("NETRC"),
+            }
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn local_env_wrapper_commands_bypass_secret_application() {
         let _guard = crate::global_test_env_lock().lock().unwrap();
         let dir = temp_dir("env-wrapper-secretless-commands");
         unsafe { std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &dir) };
 
         for (wrapper_name, command, args, expected) in [
+            ("buf", "buf", &["config", "init"][..], true),
+            ("buf", "buf", &["registry", "whoami"][..], false),
             ("pnpm", "pnpm", &["root", "-g"][..], true),
             ("pnpm", "pnpm", &["store", "path"][..], true),
             ("pnpm", "pnpm", &["install"][..], false),

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -21,6 +21,7 @@ public func genericSecretGateRequestClassification(
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
+    if gateID == "buf" { return bufRequestClassification(words) }
     if words == ["help"] || words == ["--help"] || words == ["version"] || words == ["--version"] {
         return .readOnly
     }
@@ -34,6 +35,114 @@ public func genericSecretGateRequestClassification(
         if policy.mutating.contains(candidate) { return .mutating }
     }
     return .unknown
+}
+
+private func bufRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    if arguments.prefix(while: { $0 != "--" }).contains(where: {
+        ["--help", "-h", "--help-tree", "--version"].contains($0)
+    }) {
+        return .readOnly
+    }
+    let words = bufCommandWords(arguments)
+
+    if words.starts(with: ["registry", "whoami"])
+        || words.starts(with: ["registry", "sdk", "info"])
+        || words.starts(with: ["registry", "sdk", "version"])
+        || words.starts(with: ["alpha", "registry", "token", "get"])
+        || words.starts(with: ["alpha", "registry", "token", "list"])
+        || words.starts(with: ["beta", "registry", "webhook", "list"])
+    {
+        return .readOnly
+    }
+    if words.starts(with: ["registry", "commit"])
+        || words.starts(with: ["registry", "label"])
+    {
+        return bufRegistryLeafClassification(words.dropFirst(2).first)
+    }
+    if words.starts(with: ["registry", "organization"]) {
+        return bufRegistryLeafClassification(words.dropFirst(2).first)
+    }
+    if words.count >= 3,
+       words[0] == "registry",
+       ["module", "plugin", "policy"].contains(words[1])
+    {
+        if ["commit", "label", "settings"].contains(words[2]) {
+            return bufRegistryLeafClassification(words.dropFirst(3).first)
+        }
+        return bufRegistryLeafClassification(words[2])
+    }
+    if words.starts(with: ["alpha", "registry", "token", "delete"])
+        || words.starts(with: ["beta", "registry", "plugin", "delete"])
+        || words.starts(with: ["beta", "registry", "plugin", "push"])
+        || words.starts(with: ["beta", "registry", "webhook", "create"])
+        || words.starts(with: ["beta", "registry", "webhook", "delete"])
+        || words.first == "push"
+        || words.starts(with: ["plugin", "push"])
+        || words.starts(with: ["policy", "push"])
+    {
+        return .mutating
+    }
+    if words.first == "export"
+        || words.starts(with: ["source", "edit", "deprecate"])
+        || words.starts(with: ["dep", "prune"])
+        || words.starts(with: ["dep", "update"])
+        || words.starts(with: ["mod", "prune"])
+        || words.starts(with: ["mod", "update"])
+        || words.starts(with: ["plugin", "update"])
+        || words.starts(with: ["policy", "update"])
+    {
+        return .localWrite
+    }
+    if words.first == "format" {
+        return arguments.contains(where: { ["--write", "-w"].contains($0) || $0.hasPrefix("--write=") || $0.hasPrefix("-w=") })
+            ? .localWrite : .readOnly
+    }
+    if ["build", "breaking", "convert", "lint", "ls-files", "stats"].contains(words.first)
+        || words.starts(with: ["dep", "graph"])
+        || words.starts(with: ["config", "ls-breaking-rules"])
+        || words.starts(with: ["config", "ls-lint-rules"])
+        || words.starts(with: ["mod", "ls-breaking-rules"])
+        || words.starts(with: ["mod", "ls-lint-rules"])
+        || words.starts(with: ["beta", "price"])
+    {
+        return .readOnly
+    }
+    // buf curl can invoke an arbitrary RPC and remains Unknown even when a BSR
+    // schema caused the launcher to request BUF_TOKEN.
+    return .unknown
+}
+
+private func bufRegistryLeafClassification(_ operation: String?) -> SecretGateRequestClassification {
+    guard let operation else { return .unknown }
+    if ["info", "list", "resolve"].contains(operation) { return .readOnly }
+    if ["add-label", "archive", "create", "delete", "deprecate", "unarchive", "undeprecate", "update"].contains(operation) {
+        return .mutating
+    }
+    return .unknown
+}
+
+private func bufCommandWords(_ arguments: [String]) -> [String] {
+    var words: [String] = []
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if argument == "--" { break }
+        if ["--log-format", "--timeout"].contains(argument) {
+            index += 2
+            continue
+        }
+        if ["--debug", "--debug=true", "--debug=false"].contains(argument)
+            || argument.hasPrefix("--log-format=")
+            || argument.hasPrefix("--timeout=")
+        {
+            index += 1
+            continue
+        }
+        if argument.hasPrefix("-") { break }
+        words.append(argument)
+        index += 1
+    }
+    return words
 }
 
 private func stripeRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
@@ -128,7 +237,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "algolia": .init("profile list", "objects import,objects delete,indices delete", secretDump: "profile get"),
     "argocd": .init("app get,app list,app diff,cluster get,cluster list,account get-user-info", "app create,app set,app sync,app delete,app rollback", secretDump: "account generate-token"),
     "ast-cli": .init("scan list,scan show,project list,project show", "scan create,scan cancel,project create,project delete"),
-    "buf": .init("repository list,module list,organization list", "push,repository create,repository delete"),
+    "buf": .init("", ""),
     "censys": .init("search,view,account", "asm seeds add,asm seeds delete"),
     "checkov": .init("frameworks", "submit"),
     "circleci": .init("project list,pipeline list,config validate", "pipeline run,context create,context delete,context store-secret"),

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -43,6 +43,7 @@ private func bufRequestClassification(_ arguments: [String]) -> SecretGateReques
     }) {
         return .readOnly
     }
+    if arguments.contains("--") { return .unknown }
     let words = bufCommandWords(arguments)
 
     if words.starts(with: ["registry", "whoami"])

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -7,7 +7,7 @@ import Testing
         "algolia": ["profile", "list"],
         "argocd": ["app", "get", "example"],
         "ast-cli": ["scan", "list"],
-        "buf": ["repository", "list"],
+        "buf": ["registry", "module", "info", "buf.build/acme/petapis"],
         "censys": ["search", "example"],
         "checkov": ["frameworks"],
         "circleci": ["pipeline", "list"],
@@ -57,6 +57,63 @@ import Testing
             "missing read-only policy for \(gateID)"
         )
     }
+}
+
+@Test func bufPolicyTracksTheCurrentRegistryTreeAndLocalEffects() {
+    let readOnly = [
+        ["build", "buf.build/acme/petapis"],
+        ["format", "buf.build/acme/petapis"],
+        ["dep", "graph"],
+        ["registry", "whoami"],
+        ["registry", "organization", "info", "buf.build/acme"],
+        ["registry", "module", "commit", "list", "buf.build/acme/petapis"],
+        ["registry", "plugin", "label", "info", "buf.build/acme/check:main"],
+        ["registry", "policy", "info", "buf.build/acme/policy"],
+        ["--log-format", "json", "--timeout=5s", "registry", "sdk", "version"],
+        ["beta", "registry", "webhook", "list"],
+        ["alpha", "registry", "token", "get", "buf.build"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "buf", arguments: arguments) == .readOnly)
+    }
+
+    let localWrite = [
+        ["export", "buf.build/acme/petapis", "--output", "gen"],
+        ["format", "--write", "buf.build/acme/petapis"],
+        ["source", "edit", "deprecate", "."],
+        ["dep", "update"],
+        ["plugin", "update"],
+    ]
+    for arguments in localWrite {
+        #expect(genericSecretGateRequestClassification(gateID: "buf", arguments: arguments) == .localWrite)
+    }
+
+    let mutating = [
+        ["push"],
+        ["plugin", "push", "buf.build/acme/check"],
+        ["registry", "organization", "create", "buf.build/acme"],
+        ["registry", "module", "settings", "update", "buf.build/acme/petapis"],
+        ["registry", "plugin", "commit", "add-label", "buf.build/acme/check"],
+        ["registry", "policy", "label", "archive", "buf.build/acme/policy:main"],
+        ["beta", "registry", "webhook", "delete"],
+        ["alpha", "registry", "token", "delete", "buf.build"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(gateID: "buf", arguments: arguments) == .mutating)
+    }
+
+    for arguments in [
+        ["curl", "--schema", "buf.build/acme/petapis", "https://example.com/acme.v1.API/Get"],
+        ["generate", "--template", "buf.gen.yaml"],
+        ["registry", "future-command"],
+        ["--future-flag", "registry", "whoami"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "buf", arguments: arguments) == .unknown)
+    }
+    #expect(genericSecretGateRequestClassification(
+        gateID: "buf",
+        arguments: ["registry", "module", "delete", "buf.build/acme/petapis", "--help"]
+    ) == .readOnly)
 }
 
 @Test func genericPoliciesClassifyMutationsSecretsAndUnknowns() {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -107,6 +107,7 @@ import Testing
         ["generate", "--template", "buf.gen.yaml"],
         ["registry", "future-command"],
         ["--future-flag", "registry", "whoami"],
+        ["registry", "whoami", "--", "--help"],
     ] {
         #expect(genericSecretGateRequestClassification(gateID: "buf", arguments: arguments) == .unknown)
     }


### PR DESCRIPTION
## Summary

- bypass `BUF_TOKEN` for local, help, version, unknown, login, cache, and config forms; require it only for reviewed BSR operations or local configuration that references remote dependencies
- honor fresh netrc authentication and keep Git, native-plugin, LSP, generate, protoc, and passthrough paths tokenless so child processes cannot inherit the credential
- classify the current Buf v1.72.0 command tree and local/remote effects in the macOS authorization UI

Credential-independent execution approval remains out of scope. The canonical Secret-routing model is unchanged, so no domain documentation changes are required.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`