### PR TITLE
Route Cloudsmith keys only to reviewed API commands

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -91,6 +91,7 @@ pub(crate) fn invocation_is_secretless(
     let args = &args[1..];
     match stub.command {
         "npm" => npm_invocation_is_secretless(args),
+        "cloudsmith" => cloudsmith_invocation_is_secretless(args),
         "pnpm" => {
             local_command(
                 args,
@@ -205,6 +206,390 @@ fn npm_invocation_is_secretless(args: &[OsString]) -> bool {
             | "v"
             | "whoami"
     )
+}
+
+// Reviewed against cloudsmith-cli v1.26.0 (aac8c040). Keep this positive:
+// unknown commands and local credential-management flows must not inherit the
+// protected API key.
+fn cloudsmith_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(arguments) = args
+        .iter()
+        .map(|argument| argument.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    if arguments.is_empty()
+        || arguments.contains(&"--")
+        || std::env::var_os("CLOUDSMITH_API_KEY").is_some()
+    {
+        return true;
+    }
+
+    let Some((words, credentials_file, profile, has_api_key)) =
+        cloudsmith_command_words(&arguments)
+    else {
+        return true;
+    };
+    if has_api_key || !cloudsmith_command_uses_api(&words) {
+        return true;
+    }
+    if cloudsmith_credentials_have_key(credentials_file.as_deref(), profile.as_deref()) {
+        return true;
+    }
+    if matches!(words.as_slice(), ["domains" | "domain", "list" | "ls"])
+        && !cloudsmith_has_workspace(&arguments, profile.as_deref())
+    {
+        return true;
+    }
+    false
+}
+
+fn cloudsmith_command_words<'a>(
+    arguments: &[&'a str],
+) -> Option<(Vec<&'a str>, Option<PathBuf>, Option<String>, bool)> {
+    let mut words = Vec::new();
+    let mut credentials_file = std::env::var_os("CLOUDSMITH_CREDENTIALS_FILE")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let mut profile = std::env::var("CLOUDSMITH_PROFILE")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let mut has_api_key = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let argument = arguments[index];
+        if matches!(argument, "--help" | "-h" | "--version" | "-V") {
+            return None;
+        }
+        if let Some(name) = cloudsmith_value_option(argument) {
+            let value = *arguments.get(index + 1)?;
+            match name {
+                "credentials" => credentials_file = (!value.is_empty()).then(|| value.into()),
+                "profile" => profile = (!value.is_empty()).then(|| value.to_string()),
+                "api-key" => has_api_key = !value.trim().is_empty(),
+                _ => {}
+            }
+            index += 2;
+            continue;
+        }
+        if let Some((name, value)) = cloudsmith_inline_value_option(argument) {
+            match name {
+                "credentials" => credentials_file = (!value.is_empty()).then(|| value.into()),
+                "profile" => profile = (!value.is_empty()).then(|| value.to_string()),
+                "api-key" => has_api_key = !value.trim().is_empty(),
+                _ => {}
+            }
+            index += 1;
+            continue;
+        }
+        if cloudsmith_boolean_option(argument) {
+            index += 1;
+            continue;
+        }
+        words.push(argument);
+        index += 1;
+    }
+    Some((words, credentials_file, profile, has_api_key))
+}
+
+fn cloudsmith_value_option(argument: &str) -> Option<&'static str> {
+    Some(match argument {
+        "--credentials-file" => "credentials",
+        "-P" | "--profile" => "profile",
+        "-k" | "--api-key" => "api-key",
+        "-C"
+        | "--config-file"
+        | "-F"
+        | "--output-format"
+        | "--api-host"
+        | "--api-proxy"
+        | "--api-user-agent"
+        | "--api-headers"
+        | "--allowed-api-host-suffixes"
+        | "--allowed-api-proxy-suffixes"
+        | "--oidc-audience"
+        | "-w"
+        | "--workspace"
+        | "--org"
+        | "--organization"
+        | "--oidc-org"
+        | "-o"
+        | "--owner"
+        | "--oidc-service-slug"
+        | "--oidc-detector-order"
+        | "--rate-limit-warning"
+        | "--error-retry-max"
+        | "--error-retry-backoff"
+        | "--error-retry-codes" => "other",
+        _ => return None,
+    })
+}
+
+fn cloudsmith_inline_value_option(argument: &str) -> Option<(&'static str, &str)> {
+    for (option, name) in [
+        ("--credentials-file", "credentials"),
+        ("--profile", "profile"),
+        ("--api-key", "api-key"),
+        ("--config-file", "other"),
+        ("--output-format", "other"),
+        ("--api-host", "other"),
+        ("--api-proxy", "other"),
+        ("--api-user-agent", "other"),
+        ("--api-headers", "other"),
+        ("--allowed-api-host-suffixes", "other"),
+        ("--allowed-api-proxy-suffixes", "other"),
+        ("--oidc-audience", "other"),
+        ("--workspace", "other"),
+        ("--org", "other"),
+        ("--organization", "other"),
+        ("--oidc-org", "other"),
+        ("--owner", "other"),
+        ("--oidc-service-slug", "other"),
+        ("--oidc-detector-order", "other"),
+        ("--rate-limit-warning", "other"),
+        ("--error-retry-max", "other"),
+        ("--error-retry-backoff", "other"),
+        ("--error-retry-codes", "other"),
+    ] {
+        if let Some(value) = argument
+            .strip_prefix(option)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
+            return Some((name, value));
+        }
+    }
+    for (option, name) in [
+        ("-P", "profile"),
+        ("-k", "api-key"),
+        ("-C", "other"),
+        ("-F", "other"),
+        ("-w", "other"),
+        ("-o", "other"),
+    ] {
+        if let Some(value) = argument
+            .strip_prefix(option)
+            .filter(|value| !value.is_empty())
+        {
+            return Some((name, value));
+        }
+    }
+    None
+}
+
+fn cloudsmith_boolean_option(argument: &str) -> bool {
+    matches!(
+        argument,
+        "-d" | "--debug"
+            | "-v"
+            | "--verbose"
+            | "-S"
+            | "--without-api-ssl-verify"
+            | "-R"
+            | "--without-rate-limit"
+            | "--oidc-discovery-disabled"
+    ) || [
+        "--debug=",
+        "--verbose=",
+        "--without-api-ssl-verify=",
+        "--without-rate-limit=",
+        "--oidc-discovery-disabled=",
+    ]
+    .iter()
+    .any(|prefix| argument.starts_with(prefix))
+}
+
+fn cloudsmith_command_uses_api(words: &[&str]) -> bool {
+    let Some(root) = words.first().copied() else {
+        return false;
+    };
+    let action = words.get(1).copied();
+    match root {
+        "copy" | "cp" | "delete" | "rm" | "dependencies" | "deps" | "download" | "move" | "mv"
+        | "promote" | "resync" | "status" | "vulnerabilities" | "whoami" => true,
+        "check" => cloudsmith_action(action, "rates limits"),
+        "domains" | "domain" => cloudsmith_action(action, "list ls"),
+        "entitlements" | "ents" => cloudsmith_action(
+            action,
+            "create new delete rm list ls refresh restrict sync update set",
+        ),
+        "list" | "ls" => cloudsmith_action(
+            action,
+            "dependencies deps distros entitlements ents packages pkgs repos",
+        ),
+        "mcp" => action == Some("start"),
+        "metadata" => cloudsmith_action(action, "add list ls remove rm update"),
+        "metrics" => cloudsmith_action(action, "entitlements ents tokens packages pkgs"),
+        "policy" => cloudsmith_policy_command_uses_api(words),
+        "push" | "upload" | "deploy" => cloudsmith_action(
+            action,
+            "alpine cargo cocoapods composer conan conda cran dart deb docker generic go helm hex huggingface luarocks maven mcp nix npm nuget p2 python raw rpm ruby swift terraform vagrant vsx",
+        ),
+        "quarantine" | "block" => cloudsmith_action(action, "add remove rm restore"),
+        "quota" => cloudsmith_action(action, "history limits"),
+        "repositories" | "repos" => cloudsmith_repositories_command_uses_api(words),
+        "tags" | "tag" => cloudsmith_action(action, "add clear list ls remove rm replace"),
+        "tokens" => cloudsmith_action(action, "create list ls refresh"),
+        "upstream" => cloudsmith_upstream_command_uses_api(words),
+        "credential-helper" => match action {
+            Some("cargo" | "generic" | "pnpm") => true,
+            Some("docker") => matches!(words.get(2), None | Some(&"get")),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn cloudsmith_policy_command_uses_api(words: &[&str]) -> bool {
+    let action = words.get(2).copied();
+    match words.get(1).copied() {
+        Some("deny") => cloudsmith_action(action, "create new delete rm get list ls update set"),
+        Some("license" | "vulnerability") => {
+            cloudsmith_action(action, "create new delete rm list ls update")
+        }
+        _ => false,
+    }
+}
+
+fn cloudsmith_repositories_command_uses_api(words: &[&str]) -> bool {
+    match words.get(1).copied() {
+        Some("create" | "new" | "delete" | "rm" | "get" | "list" | "ls" | "update") => true,
+        Some("gpg") => cloudsmith_action(
+            words.get(2).copied(),
+            "get list ls regenerate regen upload set",
+        ),
+        Some("privileges" | "privilege") => {
+            cloudsmith_action(words.get(2).copied(), "list ls get replace revoke set")
+        }
+        _ => false,
+    }
+}
+
+fn cloudsmith_upstream_command_uses_api(words: &[&str]) -> bool {
+    cloudsmith_action(
+        words.get(1).copied(),
+        "alpine cargo conda cran dart deb docker generic go helm hex huggingface maven nix npm nuget python rpm ruby swift",
+    ) && cloudsmith_action(words.get(2).copied(), "create new delete rm list ls update")
+}
+
+fn cloudsmith_action(action: Option<&str>, allowed: &str) -> bool {
+    action.is_some_and(|action| allowed.split_ascii_whitespace().any(|item| item == action))
+}
+
+fn cloudsmith_credentials_have_key(explicit: Option<&Path>, profile: Option<&str>) -> bool {
+    cloudsmith_config_paths(explicit, "credentials.ini")
+        .iter()
+        .any(|path| {
+            fs::read_to_string(path)
+                .is_ok_and(|contents| cloudsmith_ini_has_value(&contents, profile, &["api_key"]))
+        })
+}
+
+fn cloudsmith_has_workspace(arguments: &[&str], profile: Option<&str>) -> bool {
+    if [
+        ("-w", "--workspace"),
+        ("-w", "--org"),
+        ("-w", "--organization"),
+        ("-w", "--oidc-org"),
+        ("-o", "--owner"),
+    ]
+    .iter()
+    .any(|(short, long)| cloudsmith_option_path(arguments, short, long).is_some())
+        || ["CLOUDSMITH_WORKSPACE", "CLOUDSMITH_ORG"]
+            .iter()
+            .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+    {
+        return true;
+    }
+    let explicit = cloudsmith_option_path(arguments, "-C", "--config-file").or_else(|| {
+        std::env::var_os("CLOUDSMITH_CONFIG_FILE")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    });
+    cloudsmith_config_paths(explicit.as_deref(), "config.ini")
+        .iter()
+        .any(|path| {
+            fs::read_to_string(path).is_ok_and(|contents| {
+                cloudsmith_ini_has_value(
+                    &contents,
+                    profile,
+                    &["workspace", "org", "organization", "oidc_org"],
+                )
+            })
+        })
+}
+
+fn cloudsmith_option_path(arguments: &[&str], short: &str, long: &str) -> Option<PathBuf> {
+    arguments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, argument)| {
+            if *argument == short || *argument == long {
+                return arguments
+                    .get(index + 1)
+                    .filter(|value| !value.is_empty())
+                    .map(PathBuf::from);
+            }
+            argument
+                .strip_prefix(long)
+                .and_then(|rest| rest.strip_prefix('='))
+                .or_else(|| {
+                    argument
+                        .strip_prefix(short)
+                        .filter(|value| !value.is_empty())
+                })
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .last()
+}
+
+fn cloudsmith_config_paths(explicit: Option<&Path>, filename: &str) -> Vec<PathBuf> {
+    if let Some(path) = explicit {
+        return vec![if path.is_dir() {
+            path.join(filename)
+        } else {
+            path.to_path_buf()
+        }];
+    }
+    let mut paths = std::env::current_dir()
+        .ok()
+        .map(|path| vec![path.join(filename)])
+        .unwrap_or_default();
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        paths.push(
+            home.join("Library/Application Support/cloudsmith")
+                .join(filename),
+        );
+        paths.push(home.join(".cloudsmith").join(filename));
+    }
+    paths
+}
+
+fn cloudsmith_ini_has_value(contents: &str, profile: Option<&str>, names: &[&str]) -> bool {
+    let mut selected = true;
+    for line in contents.lines() {
+        let line = line.split(['#', ';']).next().unwrap_or("").trim();
+        if let Some(section) = line
+            .strip_prefix('[')
+            .and_then(|line| line.strip_suffix(']'))
+        {
+            selected = section == "default"
+                || profile.is_some_and(|profile| section == format!("profile:{profile}"));
+            continue;
+        }
+        let Some((name, value)) = line.split_once('=') else {
+            continue;
+        };
+        if selected
+            && names.contains(&name.trim())
+            && !value.trim().trim_matches(['\'', '"']).trim().is_empty()
+        {
+            return true;
+        }
+    }
+    false
 }
 
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
@@ -791,6 +1176,7 @@ const fn stub(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::ffi::OsStringExt;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -982,6 +1368,205 @@ mod tests {
 
         unsafe { std::env::remove_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR") };
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn cloudsmith_requests_its_key_only_for_reviewed_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-cloudsmith");
+        let stub_dir = dir.join("stubs");
+        let credentials = dir.join("credentials.ini");
+        let environment_credentials = dir.join("environment-credentials.ini");
+        let config = dir.join("config.ini");
+        fs::create_dir_all(&stub_dir).unwrap();
+
+        let env_names = [
+            "AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR",
+            "CLOUDSMITH_API_KEY",
+            "CLOUDSMITH_CONFIG_FILE",
+            "CLOUDSMITH_CREDENTIALS_FILE",
+            "CLOUDSMITH_ORG",
+            "CLOUDSMITH_PROFILE",
+            "CLOUDSMITH_WORKSPACE",
+            "HOME",
+        ];
+        let previous = env_names.map(|name| (name, std::env::var_os(name)));
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &stub_dir);
+            std::env::set_var("HOME", &dir);
+            for name in &env_names[1..7] {
+                std::env::remove_var(name);
+            }
+        }
+
+        let script_path = stub_dir.join("cloudsmith");
+        let script = stub_script(
+            &wrapper("cloudsmith-cli").unwrap().primary,
+            Path::new("/opt/homebrew/bin/cloudsmith"),
+        );
+        let invocation = |values: Vec<OsString>| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values)
+                .collect::<Vec<_>>()
+        };
+        let args = |values: &[&str]| values.iter().map(OsString::from).collect::<Vec<_>>();
+
+        for values in [
+            vec![],
+            vec!["help"],
+            vec!["repositories", "list", "--help"],
+            vec!["--version"],
+            vec!["-V"],
+            vec!["docs"],
+            vec!["authenticate"],
+            vec!["login"],
+            vec!["logout"],
+            vec!["check", "service"],
+            vec!["domains", "list"],
+            vec!["mcp", "configure"],
+            vec!["mcp", "list_tools"],
+            vec!["credential-helper", "list"],
+            vec!["credential-helper", "install", "pnpm"],
+            vec!["credential-helper", "uninstall", "docker"],
+            vec!["credential-helper", "docker", "store"],
+            vec!["credential-helper", "docker", "erase"],
+            vec!["credential-helper", "docker", "list"],
+            vec!["credential-helper", "docker", "future-operation"],
+            vec!["policy", "license", "get"],
+            vec!["future-command"],
+            vec!["repositories"],
+            vec!["repositories", "future-command"],
+            vec!["whoami", "--", "anything"],
+        ] {
+            assert!(
+                invocation_is_secretless(
+                    &script_path,
+                    script.as_bytes(),
+                    &invocation(args(&values)),
+                ),
+                "cloudsmith {values:?}",
+            );
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(vec![OsString::from_vec(vec![0xff])]),
+        ));
+
+        for values in [
+            vec!["whoami"],
+            vec!["-F", "json", "-Pprod", "repositories", "list"],
+            vec!["check", "rates"],
+            vec!["list", "packages", "workspace/repo"],
+            vec!["entitlements", "list", "workspace/repo"],
+            vec!["metadata", "add", "workspace/repo/package"],
+            vec!["metrics", "packages", "workspace/repo"],
+            vec!["policy", "deny", "get", "workspace", "policy"],
+            vec!["push", "npm", "workspace/repo", "package.tgz"],
+            vec!["repositories", "gpg", "get", "workspace/repo"],
+            vec!["repositories", "privileges", "set", "workspace/repo"],
+            vec!["tokens", "refresh"],
+            vec!["upstream", "python", "list", "workspace/repo"],
+            vec!["mcp", "start"],
+            vec!["credential-helper", "cargo"],
+            vec!["credential-helper", "docker"],
+            vec!["credential-helper", "docker", "get"],
+            vec!["credential-helper", "generic"],
+            vec!["credential-helper", "pnpm"],
+            vec!["domains", "list", "--workspace", "workspace"],
+        ] {
+            assert!(
+                !invocation_is_secretless(
+                    &script_path,
+                    script.as_bytes(),
+                    &invocation(args(&values)),
+                ),
+                "cloudsmith {values:?}",
+            );
+        }
+
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&["repositories", "list", "--api-key=explicit"])),
+        ));
+        unsafe { std::env::set_var("CLOUDSMITH_API_KEY", "") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&["whoami"])),
+        ));
+        unsafe { std::env::remove_var("CLOUDSMITH_API_KEY") };
+
+        fs::write(
+            &credentials,
+            "[default]\napi_key = default-key\n[profile:prod]\napi_key = prod-key\n",
+        )
+        .unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&[
+                "--credentials-file",
+                credentials.to_str().unwrap(),
+                "--profile",
+                "prod",
+                "whoami",
+            ])),
+        ));
+        fs::write(
+            &environment_credentials,
+            "[default]\napi_key = environment-key\n",
+        )
+        .unwrap();
+        unsafe { std::env::set_var("CLOUDSMITH_CREDENTIALS_FILE", &environment_credentials) };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&["whoami"])),
+        ));
+        fs::write(&credentials, "[profile:other]\napi_key = other-key\n").unwrap();
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&[
+                "--credentials-file",
+                credentials.to_str().unwrap(),
+                "--profile",
+                "prod",
+                "whoami",
+            ])),
+        ));
+        unsafe { std::env::remove_var("CLOUDSMITH_CREDENTIALS_FILE") };
+
+        fs::write(&config, "[profile:prod]\nworkspace = configured\n").unwrap();
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&[
+                "--config-file",
+                config.to_str().unwrap(),
+                "--profile=prod",
+                "domains",
+                "list",
+            ])),
+        ));
+
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation(args(&["--help"])),
+        ));
+
+        for (name, value) in previous {
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -124,6 +124,7 @@ pub(crate) fn invocation_is_secretless(
         "checkov" => checkov_invocation_is_secretless(args),
         "circleci" => circleci_invocation_is_secretless(args),
         "civo" => civo_invocation_is_secretless(args),
+        "cloudsmith" => cloudsmith_invocation_is_secretless(args),
         "vultr-cli" => vultr_invocation_is_secretless(args),
         "wsk" => wsk_invocation_is_secretless(args),
         "vt" => virustotal_invocation_is_secretless(args),
@@ -7325,6 +7326,390 @@ fn civo_default_config_path() -> Option<PathBuf> {
     std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".civo.json"))
 }
 
+// Reviewed against cloudsmith-cli v1.26.0 (aac8c040). Keep this positive:
+// unknown commands and local credential-management flows must not inherit the
+// protected API key.
+fn cloudsmith_invocation_is_secretless(args: &[OsString]) -> bool {
+    let Some(arguments) = args
+        .iter()
+        .map(|argument| argument.to_str())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return true;
+    };
+    if arguments.is_empty()
+        || arguments.contains(&"--")
+        || std::env::var_os("CLOUDSMITH_API_KEY").is_some()
+    {
+        return true;
+    }
+
+    let Some((words, credentials_file, profile, has_api_key)) =
+        cloudsmith_command_words(&arguments)
+    else {
+        return true;
+    };
+    if has_api_key || !cloudsmith_command_uses_api(&words) {
+        return true;
+    }
+    if cloudsmith_credentials_have_key(credentials_file.as_deref(), profile.as_deref()) {
+        return true;
+    }
+    if matches!(words.as_slice(), ["domains" | "domain", "list" | "ls"])
+        && !cloudsmith_has_workspace(&arguments, profile.as_deref())
+    {
+        return true;
+    }
+    false
+}
+
+fn cloudsmith_command_words<'a>(
+    arguments: &[&'a str],
+) -> Option<(Vec<&'a str>, Option<PathBuf>, Option<String>, bool)> {
+    let mut words = Vec::new();
+    let mut credentials_file = std::env::var_os("CLOUDSMITH_CREDENTIALS_FILE")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let mut profile = std::env::var("CLOUDSMITH_PROFILE")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let mut has_api_key = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let argument = arguments[index];
+        if matches!(argument, "--help" | "-h" | "--version" | "-V") {
+            return None;
+        }
+        if let Some(name) = cloudsmith_value_option(argument) {
+            let value = *arguments.get(index + 1)?;
+            match name {
+                "credentials" => credentials_file = (!value.is_empty()).then(|| value.into()),
+                "profile" => profile = (!value.is_empty()).then(|| value.to_string()),
+                "api-key" => has_api_key = !value.trim().is_empty(),
+                _ => {}
+            }
+            index += 2;
+            continue;
+        }
+        if let Some((name, value)) = cloudsmith_inline_value_option(argument) {
+            match name {
+                "credentials" => credentials_file = (!value.is_empty()).then(|| value.into()),
+                "profile" => profile = (!value.is_empty()).then(|| value.to_string()),
+                "api-key" => has_api_key = !value.trim().is_empty(),
+                _ => {}
+            }
+            index += 1;
+            continue;
+        }
+        if cloudsmith_boolean_option(argument) {
+            index += 1;
+            continue;
+        }
+        words.push(argument);
+        index += 1;
+    }
+    Some((words, credentials_file, profile, has_api_key))
+}
+
+fn cloudsmith_value_option(argument: &str) -> Option<&'static str> {
+    Some(match argument {
+        "--credentials-file" => "credentials",
+        "-P" | "--profile" => "profile",
+        "-k" | "--api-key" => "api-key",
+        "-C"
+        | "--config-file"
+        | "-F"
+        | "--output-format"
+        | "--api-host"
+        | "--api-proxy"
+        | "--api-user-agent"
+        | "--api-headers"
+        | "--allowed-api-host-suffixes"
+        | "--allowed-api-proxy-suffixes"
+        | "--oidc-audience"
+        | "-w"
+        | "--workspace"
+        | "--org"
+        | "--organization"
+        | "--oidc-org"
+        | "-o"
+        | "--owner"
+        | "--oidc-service-slug"
+        | "--oidc-detector-order"
+        | "--rate-limit-warning"
+        | "--error-retry-max"
+        | "--error-retry-backoff"
+        | "--error-retry-codes" => "other",
+        _ => return None,
+    })
+}
+
+fn cloudsmith_inline_value_option(argument: &str) -> Option<(&'static str, &str)> {
+    for (option, name) in [
+        ("--credentials-file", "credentials"),
+        ("--profile", "profile"),
+        ("--api-key", "api-key"),
+        ("--config-file", "other"),
+        ("--output-format", "other"),
+        ("--api-host", "other"),
+        ("--api-proxy", "other"),
+        ("--api-user-agent", "other"),
+        ("--api-headers", "other"),
+        ("--allowed-api-host-suffixes", "other"),
+        ("--allowed-api-proxy-suffixes", "other"),
+        ("--oidc-audience", "other"),
+        ("--workspace", "other"),
+        ("--org", "other"),
+        ("--organization", "other"),
+        ("--oidc-org", "other"),
+        ("--owner", "other"),
+        ("--oidc-service-slug", "other"),
+        ("--oidc-detector-order", "other"),
+        ("--rate-limit-warning", "other"),
+        ("--error-retry-max", "other"),
+        ("--error-retry-backoff", "other"),
+        ("--error-retry-codes", "other"),
+    ] {
+        if let Some(value) = argument
+            .strip_prefix(option)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
+            return Some((name, value));
+        }
+    }
+    for (option, name) in [
+        ("-P", "profile"),
+        ("-k", "api-key"),
+        ("-C", "other"),
+        ("-F", "other"),
+        ("-w", "other"),
+        ("-o", "other"),
+    ] {
+        if let Some(value) = argument
+            .strip_prefix(option)
+            .filter(|value| !value.is_empty())
+        {
+            return Some((name, value));
+        }
+    }
+    None
+}
+
+fn cloudsmith_boolean_option(argument: &str) -> bool {
+    matches!(
+        argument,
+        "-d" | "--debug"
+            | "-v"
+            | "--verbose"
+            | "-S"
+            | "--without-api-ssl-verify"
+            | "-R"
+            | "--without-rate-limit"
+            | "--oidc-discovery-disabled"
+    ) || [
+        "--debug=",
+        "--verbose=",
+        "--without-api-ssl-verify=",
+        "--without-rate-limit=",
+        "--oidc-discovery-disabled=",
+    ]
+    .iter()
+    .any(|prefix| argument.starts_with(prefix))
+}
+
+fn cloudsmith_command_uses_api(words: &[&str]) -> bool {
+    let Some(root) = words.first().copied() else {
+        return false;
+    };
+    let action = words.get(1).copied();
+    match root {
+        "copy" | "cp" | "delete" | "rm" | "dependencies" | "deps" | "download" | "move" | "mv"
+        | "promote" | "resync" | "status" | "vulnerabilities" | "whoami" => true,
+        "check" => cloudsmith_action(action, "rates limits"),
+        "domains" | "domain" => cloudsmith_action(action, "list ls"),
+        "entitlements" | "ents" => cloudsmith_action(
+            action,
+            "create new delete rm list ls refresh restrict sync update set",
+        ),
+        "list" | "ls" => cloudsmith_action(
+            action,
+            "dependencies deps distros entitlements ents packages pkgs repos",
+        ),
+        "mcp" => action == Some("start"),
+        "metadata" => cloudsmith_action(action, "add list ls remove rm update"),
+        "metrics" => cloudsmith_action(action, "entitlements ents tokens packages pkgs"),
+        "policy" => cloudsmith_policy_command_uses_api(words),
+        "push" | "upload" | "deploy" => cloudsmith_action(
+            action,
+            "alpine cargo cocoapods composer conan conda cran dart deb docker generic go helm hex huggingface luarocks maven mcp nix npm nuget p2 python raw rpm ruby swift terraform vagrant vsx",
+        ),
+        "quarantine" | "block" => cloudsmith_action(action, "add remove rm restore"),
+        "quota" => cloudsmith_action(action, "history limits"),
+        "repositories" | "repos" => cloudsmith_repositories_command_uses_api(words),
+        "tags" | "tag" => cloudsmith_action(action, "add clear list ls remove rm replace"),
+        "tokens" => cloudsmith_action(action, "create list ls refresh"),
+        "upstream" => cloudsmith_upstream_command_uses_api(words),
+        "credential-helper" => match action {
+            Some("cargo" | "generic" | "pnpm") => true,
+            Some("docker") => matches!(words.get(2), None | Some(&"get")),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn cloudsmith_policy_command_uses_api(words: &[&str]) -> bool {
+    let action = words.get(2).copied();
+    match words.get(1).copied() {
+        Some("deny") => cloudsmith_action(action, "create new delete rm get list ls update set"),
+        Some("license" | "vulnerability") => {
+            cloudsmith_action(action, "create new delete rm list ls update")
+        }
+        _ => false,
+    }
+}
+
+fn cloudsmith_repositories_command_uses_api(words: &[&str]) -> bool {
+    match words.get(1).copied() {
+        Some("create" | "new" | "delete" | "rm" | "get" | "list" | "ls" | "update") => true,
+        Some("gpg") => cloudsmith_action(
+            words.get(2).copied(),
+            "get list ls regenerate regen upload set",
+        ),
+        Some("privileges" | "privilege") => {
+            cloudsmith_action(words.get(2).copied(), "list ls get replace revoke set")
+        }
+        _ => false,
+    }
+}
+
+fn cloudsmith_upstream_command_uses_api(words: &[&str]) -> bool {
+    cloudsmith_action(
+        words.get(1).copied(),
+        "alpine cargo conda cran dart deb docker generic go helm hex huggingface maven nix npm nuget python rpm ruby swift",
+    ) && cloudsmith_action(words.get(2).copied(), "create new delete rm list ls update")
+}
+
+fn cloudsmith_action(action: Option<&str>, allowed: &str) -> bool {
+    action.is_some_and(|action| allowed.split_ascii_whitespace().any(|item| item == action))
+}
+
+fn cloudsmith_credentials_have_key(explicit: Option<&Path>, profile: Option<&str>) -> bool {
+    cloudsmith_config_paths(explicit, "credentials.ini")
+        .iter()
+        .any(|path| {
+            fs::read_to_string(path)
+                .is_ok_and(|contents| cloudsmith_ini_has_value(&contents, profile, &["api_key"]))
+        })
+}
+
+fn cloudsmith_has_workspace(arguments: &[&str], profile: Option<&str>) -> bool {
+    if [
+        ("-w", "--workspace"),
+        ("-w", "--org"),
+        ("-w", "--organization"),
+        ("-w", "--oidc-org"),
+        ("-o", "--owner"),
+    ]
+    .iter()
+    .any(|(short, long)| cloudsmith_option_path(arguments, short, long).is_some())
+        || ["CLOUDSMITH_WORKSPACE", "CLOUDSMITH_ORG"]
+            .iter()
+            .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+    {
+        return true;
+    }
+    let explicit = cloudsmith_option_path(arguments, "-C", "--config-file").or_else(|| {
+        std::env::var_os("CLOUDSMITH_CONFIG_FILE")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    });
+    cloudsmith_config_paths(explicit.as_deref(), "config.ini")
+        .iter()
+        .any(|path| {
+            fs::read_to_string(path).is_ok_and(|contents| {
+                cloudsmith_ini_has_value(
+                    &contents,
+                    profile,
+                    &["workspace", "org", "organization", "oidc_org"],
+                )
+            })
+        })
+}
+
+fn cloudsmith_option_path(arguments: &[&str], short: &str, long: &str) -> Option<PathBuf> {
+    arguments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, argument)| {
+            if *argument == short || *argument == long {
+                return arguments
+                    .get(index + 1)
+                    .filter(|value| !value.is_empty())
+                    .map(PathBuf::from);
+            }
+            argument
+                .strip_prefix(long)
+                .and_then(|rest| rest.strip_prefix('='))
+                .or_else(|| {
+                    argument
+                        .strip_prefix(short)
+                        .filter(|value| !value.is_empty())
+                })
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .last()
+}
+
+fn cloudsmith_config_paths(explicit: Option<&Path>, filename: &str) -> Vec<PathBuf> {
+    if let Some(path) = explicit {
+        return vec![if path.is_dir() {
+            path.join(filename)
+        } else {
+            path.to_path_buf()
+        }];
+    }
+    let mut paths = std::env::current_dir()
+        .ok()
+        .map(|path| vec![path.join(filename)])
+        .unwrap_or_default();
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        paths.push(
+            home.join("Library/Application Support/cloudsmith")
+                .join(filename),
+        );
+        paths.push(home.join(".cloudsmith").join(filename));
+    }
+    paths
+}
+
+fn cloudsmith_ini_has_value(contents: &str, profile: Option<&str>, names: &[&str]) -> bool {
+    let mut selected = true;
+    for line in contents.lines() {
+        let line = line.split(['#', ';']).next().unwrap_or("").trim();
+        if let Some(section) = line
+            .strip_prefix('[')
+            .and_then(|line| line.strip_suffix(']'))
+        {
+            selected = section == "default"
+                || profile.is_some_and(|profile| section == format!("profile:{profile}"));
+            continue;
+        }
+        let Some((name, value)) = line.split_once('=') else {
+            continue;
+        };
+        if selected
+            && names.contains(&name.trim())
+            && !value.trim().trim_matches(['\'', '"']).trim().is_empty()
+        {
+            return true;
+        }
+    }
+    false
+}
+
 fn secret_gate(wrapper: &EnvWrapper) -> SecretGateDescriptor {
     let routes = stubs(wrapper)
         .map(|stub| SecretGateRoute {
@@ -12784,6 +13169,205 @@ mod tests {
                 "--config",
                 explicit_config.to_str().unwrap(),
                 "instance",
+                "list",
+            ])),
+        ));
+
+        assert!(!invocation_is_secretless(
+            &script_path,
+            format!("{script}# changed\n").as_bytes(),
+            &invocation(args(&["--help"])),
+        ));
+
+        for (name, value) in previous {
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn cloudsmith_requests_its_key_only_for_reviewed_api_commands() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let dir = temp_dir("env-wrapper-secretless-cloudsmith");
+        let stub_dir = dir.join("stubs");
+        let credentials = dir.join("credentials.ini");
+        let environment_credentials = dir.join("environment-credentials.ini");
+        let config = dir.join("config.ini");
+        fs::create_dir_all(&stub_dir).unwrap();
+
+        let env_names = [
+            "AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR",
+            "CLOUDSMITH_API_KEY",
+            "CLOUDSMITH_CONFIG_FILE",
+            "CLOUDSMITH_CREDENTIALS_FILE",
+            "CLOUDSMITH_ORG",
+            "CLOUDSMITH_PROFILE",
+            "CLOUDSMITH_WORKSPACE",
+            "HOME",
+        ];
+        let previous = env_names.map(|name| (name, std::env::var_os(name)));
+        unsafe {
+            std::env::set_var("AUTOMIC_VAULT_TEST_ENV_WRAPPER_STUB_DIR", &stub_dir);
+            std::env::set_var("HOME", &dir);
+            for name in &env_names[1..7] {
+                std::env::remove_var(name);
+            }
+        }
+
+        let script_path = stub_dir.join("cloudsmith");
+        let script = stub_script(
+            &wrapper("cloudsmith-cli").unwrap().primary,
+            Path::new("/opt/homebrew/bin/cloudsmith"),
+        );
+        let invocation = |values: Vec<OsString>| {
+            std::iter::once(script_path.clone().into_os_string())
+                .chain(values)
+                .collect::<Vec<_>>()
+        };
+        let args = |values: &[&str]| values.iter().map(OsString::from).collect::<Vec<_>>();
+
+        for values in [
+            vec![],
+            vec!["help"],
+            vec!["repositories", "list", "--help"],
+            vec!["--version"],
+            vec!["-V"],
+            vec!["docs"],
+            vec!["authenticate"],
+            vec!["login"],
+            vec!["logout"],
+            vec!["check", "service"],
+            vec!["domains", "list"],
+            vec!["mcp", "configure"],
+            vec!["mcp", "list_tools"],
+            vec!["credential-helper", "list"],
+            vec!["credential-helper", "install", "pnpm"],
+            vec!["credential-helper", "uninstall", "docker"],
+            vec!["credential-helper", "docker", "store"],
+            vec!["credential-helper", "docker", "erase"],
+            vec!["credential-helper", "docker", "list"],
+            vec!["credential-helper", "docker", "future-operation"],
+            vec!["policy", "license", "get"],
+            vec!["future-command"],
+            vec!["repositories"],
+            vec!["repositories", "future-command"],
+            vec!["whoami", "--", "anything"],
+        ] {
+            assert!(
+                invocation_is_secretless(
+                    &script_path,
+                    script.as_bytes(),
+                    &invocation(args(&values)),
+                ),
+                "cloudsmith {values:?}",
+            );
+        }
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(vec![OsString::from_vec(vec![0xff])]),
+        ));
+
+        for values in [
+            vec!["whoami"],
+            vec!["-F", "json", "-Pprod", "repositories", "list"],
+            vec!["check", "rates"],
+            vec!["list", "packages", "workspace/repo"],
+            vec!["entitlements", "list", "workspace/repo"],
+            vec!["metadata", "add", "workspace/repo/package"],
+            vec!["metrics", "packages", "workspace/repo"],
+            vec!["policy", "deny", "get", "workspace", "policy"],
+            vec!["push", "npm", "workspace/repo", "package.tgz"],
+            vec!["repositories", "gpg", "get", "workspace/repo"],
+            vec!["repositories", "privileges", "set", "workspace/repo"],
+            vec!["tokens", "refresh"],
+            vec!["upstream", "python", "list", "workspace/repo"],
+            vec!["mcp", "start"],
+            vec!["credential-helper", "cargo"],
+            vec!["credential-helper", "docker"],
+            vec!["credential-helper", "docker", "get"],
+            vec!["credential-helper", "generic"],
+            vec!["credential-helper", "pnpm"],
+            vec!["domains", "list", "--workspace", "workspace"],
+        ] {
+            assert!(
+                !invocation_is_secretless(
+                    &script_path,
+                    script.as_bytes(),
+                    &invocation(args(&values)),
+                ),
+                "cloudsmith {values:?}",
+            );
+        }
+
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&["repositories", "list", "--api-key=explicit"])),
+        ));
+        unsafe { std::env::set_var("CLOUDSMITH_API_KEY", "") };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&["whoami"])),
+        ));
+        unsafe { std::env::remove_var("CLOUDSMITH_API_KEY") };
+
+        fs::write(
+            &credentials,
+            "[default]\napi_key = default-key\n[profile:prod]\napi_key = prod-key\n",
+        )
+        .unwrap();
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&[
+                "--credentials-file",
+                credentials.to_str().unwrap(),
+                "--profile",
+                "prod",
+                "whoami",
+            ])),
+        ));
+        fs::write(
+            &environment_credentials,
+            "[default]\napi_key = environment-key\n",
+        )
+        .unwrap();
+        unsafe { std::env::set_var("CLOUDSMITH_CREDENTIALS_FILE", &environment_credentials) };
+        assert!(invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&["whoami"])),
+        ));
+        fs::write(&credentials, "[profile:other]\napi_key = other-key\n").unwrap();
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&[
+                "--credentials-file",
+                credentials.to_str().unwrap(),
+                "--profile",
+                "prod",
+                "whoami",
+            ])),
+        ));
+        unsafe { std::env::remove_var("CLOUDSMITH_CREDENTIALS_FILE") };
+
+        fs::write(&config, "[profile:prod]\nworkspace = configured\n").unwrap();
+        assert!(!invocation_is_secretless(
+            &script_path,
+            script.as_bytes(),
+            &invocation(args(&[
+                "--config-file",
+                config.to_str().unwrap(),
+                "--profile=prod",
+                "domains",
                 "list",
             ])),
         ));

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,6 +18,7 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
+    if gateID == "cloudsmith-cli" { return cloudsmithRequestClassification(arguments) }
     if gateID == "composer" { return composerRequestClassification(arguments) }
     if gateID == "transifex-cli" { return transifexRequestClassification(arguments) }
     if gateID == "travis" { return travisRequestClassification(arguments) }
@@ -1565,6 +1566,149 @@ private let civoCommandPolicy = SecretGateCommandPolicy(
     secretDump: "apikey show,database credential,instance show,instance password,instance console status,kubernetes show,kubernetes config,objectstore credential secret,objectstore credential export"
 )
 
+// Reviewed against cloudsmith-cli v1.26.0 (aac8c040). Unknown command paths
+// stay Unknown so temporary authority cannot broaden when the CLI grows.
+private func cloudsmithRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    guard let parsed = cloudsmithCommandWords(arguments) else { return .unknown }
+    let words = parsed.map { $0.lowercased() }
+    guard let root = words.first else {
+        return .unknown
+    }
+    let action = words.dropFirst().first
+    let showsEntitlementTokens = arguments.contains("--show-tokens")
+
+    switch root {
+    case "help", "version": return .readOnly
+    case "docs": return .unknown // launches a browser
+    case "authenticate", "auth", "login", "token": return .secretDump
+    case "logout": return .mutating
+    case "copy", "cp", "delete", "rm", "move", "mv", "promote", "resync": return .mutating
+    case "dependencies", "deps", "download", "status", "vulnerabilities", "whoami": return .readOnly
+    case "check": return action.map { $0 == "service" || $0 == "rates" || $0 == "limits" ? .readOnly : .unknown } ?? .unknown
+    case "domains", "domain": return ["list", "ls"].contains(action) ? .readOnly : .unknown
+    case "entitlements", "ents":
+        guard let action else { return .unknown }
+        let known = ["create", "new", "delete", "rm", "list", "ls", "refresh", "restrict", "sync", "update", "set"]
+        guard known.contains(action) else { return .unknown }
+        if showsEntitlementTokens { return .secretDump }
+        return ["list", "ls"].contains(action) ? .readOnly : .mutating
+    case "list", "ls":
+        guard let action else { return .unknown }
+        if ["dependencies", "deps", "distros", "packages", "pkgs", "repos"].contains(action) { return .readOnly }
+        if ["entitlements", "ents"].contains(action) { return showsEntitlementTokens ? .secretDump : .readOnly }
+        return .unknown
+    case "mcp":
+        if action == "configure" { return .mutating }
+        if ["list_groups", "list_tools"].contains(action) { return .readOnly }
+        return .unknown
+    case "metadata": return cloudsmithSimpleEffect(action, reads: ["list", "ls"], writes: ["add", "remove", "rm", "update"])
+    case "metrics": return ["entitlements", "ents", "tokens", "packages", "pkgs"].contains(action) ? .readOnly : .unknown
+    case "policy": return cloudsmithPolicyEffect(words)
+    case "push", "upload", "deploy": return cloudsmithPushFormats.contains(action ?? "") ? .mutating : .unknown
+    case "quarantine", "block": return ["add", "remove", "rm", "restore"].contains(action) ? .mutating : .unknown
+    case "quota": return ["history", "limits"].contains(action) ? .readOnly : .unknown
+    case "repositories", "repos": return cloudsmithRepositoryEffect(words)
+    case "tags", "tag": return cloudsmithSimpleEffect(action, reads: ["list", "ls"], writes: ["add", "clear", "remove", "rm", "replace"])
+    case "tokens": return ["create", "list", "ls", "refresh"].contains(action) ? .secretDump : .unknown
+    case "upstream": return cloudsmithUpstreamEffect(words)
+    case "credential-helper": return cloudsmithCredentialHelperEffect(words)
+    default: return .unknown
+    }
+}
+
+private func cloudsmithCommandWords(_ arguments: [String]) -> [String]? {
+    let valued = Set([
+        "--credentials-file", "-P", "--profile", "-k", "--api-key", "-C", "--config-file",
+        "-F", "--output-format", "--api-host", "--api-proxy", "--api-user-agent", "--api-headers",
+        "--allowed-api-host-suffixes", "--allowed-api-proxy-suffixes", "--oidc-audience", "-w",
+        "--workspace", "--org", "--organization", "--oidc-org", "-o", "--owner",
+        "--oidc-service-slug", "--oidc-detector-order", "--rate-limit-warning", "--error-retry-max",
+        "--error-retry-backoff", "--error-retry-codes",
+    ])
+    let booleans = Set(["-d", "--debug", "-v", "--verbose", "-S", "--without-api-ssl-verify", "-R", "--without-rate-limit", "--oidc-discovery-disabled"])
+    let longValued = valued.filter { $0.hasPrefix("--") }
+    let shortValued = valued.filter { $0.hasPrefix("-") && !$0.hasPrefix("--") }
+    var words: [String] = []
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if ["--help", "-h"].contains(argument) { return ["help"] }
+        if ["--version", "-V"].contains(argument) { return ["version"] }
+        if valued.contains(argument) {
+            guard index + 1 < arguments.count else { return nil }
+            index += 2
+        } else if longValued.contains(where: { argument.hasPrefix("\($0)=") })
+            || shortValued.contains(where: { argument.hasPrefix($0) && argument.count > $0.count })
+            || booleans.contains(argument)
+            || booleans.contains(where: { argument.hasPrefix("\($0)=") })
+        {
+            index += 1
+        } else {
+            words.append(argument)
+            index += 1
+        }
+    }
+    return words
+}
+
+private func cloudsmithSimpleEffect(
+    _ action: String?, reads: Set<String>, writes: Set<String>
+) -> SecretGateRequestClassification {
+    guard let action else { return .unknown }
+    if reads.contains(action) { return .readOnly }
+    if writes.contains(action) { return .mutating }
+    return .unknown
+}
+
+private func cloudsmithPolicyEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 3 else { return .unknown }
+    switch words[1] {
+    case "deny": return cloudsmithSimpleEffect(words[2], reads: ["get", "list", "ls"], writes: ["create", "new", "delete", "rm", "update", "set"])
+    case "license", "vulnerability": return cloudsmithSimpleEffect(words[2], reads: ["list", "ls"], writes: ["create", "new", "delete", "rm", "update"])
+    default: return .unknown
+    }
+}
+
+private func cloudsmithRepositoryEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 2 else { return .unknown }
+    if ["get", "list", "ls"].contains(words[1]) { return .readOnly }
+    if ["create", "new", "delete", "rm", "update"].contains(words[1]) { return .mutating }
+    guard words.count >= 3 else { return .unknown }
+    if words[1] == "gpg" {
+        return cloudsmithSimpleEffect(words[2], reads: ["get", "list", "ls"], writes: ["regenerate", "regen", "upload", "set"])
+    }
+    if ["privileges", "privilege"].contains(words[1]) {
+        return cloudsmithSimpleEffect(words[2], reads: ["list", "ls", "get"], writes: ["replace", "revoke", "set"])
+    }
+    return .unknown
+}
+
+private func cloudsmithUpstreamEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 3, cloudsmithUpstreamFormats.contains(words[1]) else { return .unknown }
+    return cloudsmithSimpleEffect(words[2], reads: ["list", "ls"], writes: ["create", "new", "delete", "rm", "update"])
+}
+
+private func cloudsmithCredentialHelperEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 2 else { return .unknown }
+    if ["cargo", "generic", "pnpm"].contains(words[1]) { return .secretDump }
+    if words[1] == "docker" {
+        if words.count == 2 || words[2] == "get" { return .secretDump }
+        if ["store", "erase"].contains(words[2]) { return .mutating }
+        return words[2] == "list" ? .readOnly : .unknown
+    }
+    if words[1] == "list" { return .readOnly }
+    if ["install", "uninstall"].contains(words[1]) { return .mutating }
+    return .unknown
+}
+
+private let cloudsmithPushFormats = SecretGateCommandPolicy.commands("""
+alpine,cargo,cocoapods,composer,conan,conda,cran,dart,deb,docker,generic,go,helm,hex,huggingface,luarocks,maven,mcp,nix,npm,nuget,p2,python,raw,rpm,ruby,swift,terraform,vagrant,vsx
+""")
+
+private let cloudsmithUpstreamFormats = SecretGateCommandPolicy.commands("""
+alpine,cargo,conda,cran,dart,deb,docker,generic,go,helm,hex,huggingface,maven,nix,npm,nuget,python,rpm,ruby,swift
+""")
+
 private func k6RequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
     // Mirrors the wrapper's positive catalog so future forms stay Unknown.
     if arguments.contains(where: { $0 == "--help" || $0 == "-h" })
@@ -2031,7 +2175,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "checkov": .init("", ""),
     "circleci": .init("", ""),
     "civo": .init("", ""),
-    "cloudsmith-cli": .init("whoami,repos list,packages list,packages search", "push,packages delete,repos create,repos delete"),
+    "cloudsmith-cli": .init("", ""),
     "composer": .init("", ""),
     "doctl": .init("account get,compute droplet list,compute droplet get,kubernetes cluster list,kubernetes cluster get", "compute droplet create,compute droplet delete,kubernetes cluster create,kubernetes cluster delete", secretDump: "auth token"),
     "flyctl": .init("status,apps list,machine list,machine status,secrets list,auth whoami", "deploy,scale,apps create,apps destroy,machine run,machine destroy,secrets set,secrets unset,secrets import,auth logout", secretDump: "auth token"),

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretGateCommandPolicy.swift
@@ -18,6 +18,7 @@ public func genericSecretGateRequestClassification(
     gateID: String,
     arguments: [String]
 ) -> SecretGateRequestClassification {
+    if gateID == "cloudsmith-cli" { return cloudsmithRequestClassification(arguments) }
     let words = arguments.map { $0.lowercased() }
     guard !words.isEmpty else { return .unknown }
     if gateID == "stripe" { return stripeRequestClassification(words) }
@@ -109,6 +110,148 @@ private func stripeRequestClassification(_ arguments: [String]) -> SecretGateReq
     return .unknown
 }
 
+// Reviewed against cloudsmith-cli v1.26.0 (aac8c040). Unknown command paths
+// stay Unknown so temporary authority cannot broaden when the CLI grows.
+private func cloudsmithRequestClassification(_ arguments: [String]) -> SecretGateRequestClassification {
+    guard let parsed = cloudsmithCommandWords(arguments) else { return .unknown }
+    let words = parsed.map { $0.lowercased() }
+    guard let root = words.first else {
+        return .unknown
+    }
+    let action = words.dropFirst().first
+    let showsEntitlementTokens = arguments.contains("--show-tokens")
+
+    switch root {
+    case "help", "version": return .readOnly
+    case "docs": return .unknown // launches a browser
+    case "authenticate", "auth", "login", "token": return .secretDump
+    case "logout": return .mutating
+    case "copy", "cp", "delete", "rm", "move", "mv", "promote", "resync": return .mutating
+    case "dependencies", "deps", "download", "status", "vulnerabilities", "whoami": return .readOnly
+    case "check": return action.map { $0 == "service" || $0 == "rates" || $0 == "limits" ? .readOnly : .unknown } ?? .unknown
+    case "domains", "domain": return ["list", "ls"].contains(action) ? .readOnly : .unknown
+    case "entitlements", "ents":
+        guard let action else { return .unknown }
+        let known = ["create", "new", "delete", "rm", "list", "ls", "refresh", "restrict", "sync", "update", "set"]
+        guard known.contains(action) else { return .unknown }
+        if showsEntitlementTokens { return .secretDump }
+        return ["list", "ls"].contains(action) ? .readOnly : .mutating
+    case "list", "ls":
+        guard let action else { return .unknown }
+        if ["dependencies", "deps", "distros", "packages", "pkgs", "repos"].contains(action) { return .readOnly }
+        if ["entitlements", "ents"].contains(action) { return showsEntitlementTokens ? .secretDump : .readOnly }
+        return .unknown
+    case "mcp":
+        if action == "configure" { return .mutating }
+        if ["list_groups", "list_tools"].contains(action) { return .readOnly }
+        return .unknown
+    case "metadata": return cloudsmithSimpleEffect(action, reads: ["list", "ls"], writes: ["add", "remove", "rm", "update"])
+    case "metrics": return ["entitlements", "ents", "tokens", "packages", "pkgs"].contains(action) ? .readOnly : .unknown
+    case "policy": return cloudsmithPolicyEffect(words)
+    case "push", "upload", "deploy": return cloudsmithPushFormats.contains(action ?? "") ? .mutating : .unknown
+    case "quarantine", "block": return ["add", "remove", "rm", "restore"].contains(action) ? .mutating : .unknown
+    case "quota": return ["history", "limits"].contains(action) ? .readOnly : .unknown
+    case "repositories", "repos": return cloudsmithRepositoryEffect(words)
+    case "tags", "tag": return cloudsmithSimpleEffect(action, reads: ["list", "ls"], writes: ["add", "clear", "remove", "rm", "replace"])
+    case "tokens": return ["create", "list", "ls", "refresh"].contains(action) ? .secretDump : .unknown
+    case "upstream": return cloudsmithUpstreamEffect(words)
+    case "credential-helper": return cloudsmithCredentialHelperEffect(words)
+    default: return .unknown
+    }
+}
+
+private func cloudsmithCommandWords(_ arguments: [String]) -> [String]? {
+    let valued = Set([
+        "--credentials-file", "-P", "--profile", "-k", "--api-key", "-C", "--config-file",
+        "-F", "--output-format", "--api-host", "--api-proxy", "--api-user-agent", "--api-headers",
+        "--allowed-api-host-suffixes", "--allowed-api-proxy-suffixes", "--oidc-audience", "-w",
+        "--workspace", "--org", "--organization", "--oidc-org", "-o", "--owner",
+        "--oidc-service-slug", "--oidc-detector-order", "--rate-limit-warning", "--error-retry-max",
+        "--error-retry-backoff", "--error-retry-codes",
+    ])
+    let booleans = Set(["-d", "--debug", "-v", "--verbose", "-S", "--without-api-ssl-verify", "-R", "--without-rate-limit", "--oidc-discovery-disabled"])
+    let longValued = valued.filter { $0.hasPrefix("--") }
+    let shortValued = valued.filter { $0.hasPrefix("-") && !$0.hasPrefix("--") }
+    var words: [String] = []
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if ["--help", "-h"].contains(argument) { return ["help"] }
+        if ["--version", "-V"].contains(argument) { return ["version"] }
+        if valued.contains(argument) {
+            guard index + 1 < arguments.count else { return nil }
+            index += 2
+        } else if longValued.contains(where: { argument.hasPrefix("\($0)=") })
+            || shortValued.contains(where: { argument.hasPrefix($0) && argument.count > $0.count })
+            || booleans.contains(argument)
+            || booleans.contains(where: { argument.hasPrefix("\($0)=") })
+        {
+            index += 1
+        } else {
+            words.append(argument)
+            index += 1
+        }
+    }
+    return words
+}
+
+private func cloudsmithSimpleEffect(
+    _ action: String?, reads: Set<String>, writes: Set<String>
+) -> SecretGateRequestClassification {
+    guard let action else { return .unknown }
+    if reads.contains(action) { return .readOnly }
+    if writes.contains(action) { return .mutating }
+    return .unknown
+}
+
+private func cloudsmithPolicyEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 3 else { return .unknown }
+    switch words[1] {
+    case "deny": return cloudsmithSimpleEffect(words[2], reads: ["get", "list", "ls"], writes: ["create", "new", "delete", "rm", "update", "set"])
+    case "license", "vulnerability": return cloudsmithSimpleEffect(words[2], reads: ["list", "ls"], writes: ["create", "new", "delete", "rm", "update"])
+    default: return .unknown
+    }
+}
+
+private func cloudsmithRepositoryEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 2 else { return .unknown }
+    if ["get", "list", "ls"].contains(words[1]) { return .readOnly }
+    if ["create", "new", "delete", "rm", "update"].contains(words[1]) { return .mutating }
+    guard words.count >= 3 else { return .unknown }
+    if words[1] == "gpg" {
+        return cloudsmithSimpleEffect(words[2], reads: ["get", "list", "ls"], writes: ["regenerate", "regen", "upload", "set"])
+    }
+    if ["privileges", "privilege"].contains(words[1]) {
+        return cloudsmithSimpleEffect(words[2], reads: ["list", "ls", "get"], writes: ["replace", "revoke", "set"])
+    }
+    return .unknown
+}
+
+private func cloudsmithUpstreamEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 3, cloudsmithUpstreamFormats.contains(words[1]) else { return .unknown }
+    return cloudsmithSimpleEffect(words[2], reads: ["list", "ls"], writes: ["create", "new", "delete", "rm", "update"])
+}
+
+private func cloudsmithCredentialHelperEffect(_ words: [String]) -> SecretGateRequestClassification {
+    guard words.count >= 2 else { return .unknown }
+    if ["cargo", "generic", "pnpm"].contains(words[1]) { return .secretDump }
+    if words[1] == "docker" {
+        return words.count == 2 || words[2] == "get" ? .secretDump
+            : ["store", "erase", "list"].contains(words[2]) ? .readOnly : .unknown
+    }
+    if words[1] == "list" { return .readOnly }
+    if ["install", "uninstall"].contains(words[1]) { return .mutating }
+    return .unknown
+}
+
+private let cloudsmithPushFormats = SecretGateCommandPolicy.commands("""
+alpine,cargo,cocoapods,composer,conan,conda,cran,dart,deb,docker,generic,go,helm,hex,huggingface,luarocks,maven,mcp,nix,npm,nuget,p2,python,raw,rpm,ruby,swift,terraform,vagrant,vsx
+""")
+
+private let cloudsmithUpstreamFormats = SecretGateCommandPolicy.commands("""
+alpine,cargo,conda,cran,dart,deb,docker,generic,go,helm,hex,huggingface,maven,nix,npm,nuget,python,rpm,ruby,swift
+""")
+
 // Reviewed against Stripe CLI v1.50.6's generated command map. New roots and
 // operation names remain Unknown until their authority is reviewed.
 private let stripeResourceRoots = SecretGateCommandPolicy.commands("""
@@ -133,7 +276,7 @@ private let secretGateCommandPolicies: [String: SecretGateCommandPolicy] = [
     "checkov": .init("frameworks", "submit"),
     "circleci": .init("project list,pipeline list,config validate", "pipeline run,context create,context delete,context store-secret"),
     "civo": .init("instance list,instance show,kubernetes list,kubernetes show", "instance create,instance remove,kubernetes create,kubernetes remove", secretDump: "apikey show"),
-    "cloudsmith-cli": .init("whoami,repos list,packages list,packages search", "push,packages delete,repos create,repos delete"),
+    "cloudsmith-cli": .init("", ""),
     "composer": .init("show,search,outdated,audit,diagnose", "install,update,require,remove,publish", secretDump: "config --auth,config --global --auth"),
     "doctl": .init("account get,compute droplet list,compute droplet get,kubernetes cluster list,kubernetes cluster get", "compute droplet create,compute droplet delete,kubernetes cluster create,kubernetes cluster delete"),
     "flyctl": .init("status,apps list,machine list,machine status,secrets list,auth whoami", "deploy,scale,apps create,apps destroy,machine run,machine destroy,secrets set,secrets unset,secrets import", secretDump: "auth token"),

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -795,7 +795,7 @@ import Testing
         ["whoami"],
         ["-F", "json", "-Pprod", "repositories", "list"],
         ["credential-helper", "list"],
-        ["credential-helper", "docker", "store"],
+        ["credential-helper", "docker", "list"],
         ["mcp", "list_tools"],
     ]
     for arguments in readOnly {
@@ -815,6 +815,8 @@ import Testing
         ["tags", "replace", "workspace/repo/package"],
         ["upstream", "ruby", "delete", "workspace/repo/upstream"],
         ["credential-helper", "install", "pnpm"],
+        ["credential-helper", "docker", "store"],
+        ["credential-helper", "docker", "erase"],
         ["mcp", "configure"],
         ["logout"],
     ]

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretGateCommandPolicyTests.swift
@@ -12,7 +12,7 @@ import Testing
         "checkov": ["frameworks"],
         "circleci": ["pipeline", "list"],
         "civo": ["instance", "list"],
-        "cloudsmith-cli": ["packages", "list"],
+        "cloudsmith-cli": ["list", "packages"],
         "composer": ["audit"],
         "doctl": ["account", "get"],
         "flyctl": ["apps", "list"],
@@ -111,6 +111,88 @@ import Testing
     #expect(genericSecretGateRequestClassification(gateID: "stripe", arguments: ["projects", "add", "database"]) == .unknown)
     #expect(genericSecretGateRequestClassification(gateID: "stripe", arguments: ["customers", "future-operation"]) == .unknown)
     #expect(genericSecretGateRequestClassification(gateID: "stripe", arguments: ["future-resource", "list"]) == .unknown)
+}
+
+@Test func cloudsmithPolicyClassifiesReviewedCommandEffects() {
+    let readOnly = [
+        ["-V"],
+        ["help"],
+        ["check", "service"],
+        ["check", "rates"],
+        ["dependencies", "workspace/repo/package"],
+        ["domains", "list"],
+        ["download", "workspace/repo", "package"],
+        ["list", "packages", "workspace/repo"],
+        ["entitlements", "list", "workspace/repo"],
+        ["metadata", "list", "workspace/repo/package"],
+        ["metrics", "packages", "workspace/repo"],
+        ["policy", "deny", "get", "workspace", "policy"],
+        ["quota", "history", "workspace"],
+        ["repositories", "gpg", "get", "workspace/repo"],
+        ["repositories", "privileges", "list", "workspace/repo"],
+        ["tags", "list", "workspace/repo/package"],
+        ["upstream", "python", "list", "workspace/repo"],
+        ["vulnerabilities", "workspace/repo/package"],
+        ["whoami"],
+        ["-F", "json", "-Pprod", "repositories", "list"],
+        ["credential-helper", "list"],
+        ["credential-helper", "docker", "store"],
+        ["mcp", "list_tools"],
+    ]
+    for arguments in readOnly {
+        #expect(genericSecretGateRequestClassification(gateID: "cloudsmith-cli", arguments: arguments) == .readOnly)
+    }
+
+    let mutating = [
+        ["copy", "workspace/repo/package", "workspace/other"],
+        ["delete", "workspace/repo/package"],
+        ["entitlements", "refresh", "workspace/repo/token"],
+        ["metadata", "add", "workspace/repo/package"],
+        ["policy", "license", "create", "workspace"],
+        ["push", "npm", "workspace/repo", "package.tgz"],
+        ["push", "npm", "--api-key", "-h", "workspace/repo", "package.tgz"],
+        ["quarantine", "add", "workspace/repo/package"],
+        ["repositories", "privileges", "set", "workspace/repo"],
+        ["tags", "replace", "workspace/repo/package"],
+        ["upstream", "ruby", "delete", "workspace/repo/upstream"],
+        ["credential-helper", "install", "pnpm"],
+        ["mcp", "configure"],
+        ["logout"],
+    ]
+    for arguments in mutating {
+        #expect(genericSecretGateRequestClassification(gateID: "cloudsmith-cli", arguments: arguments) == .mutating)
+    }
+
+    let secretDump = [
+        ["authenticate", "--request-api-key"],
+        ["login"],
+        ["tokens", "list"],
+        ["tokens", "create"],
+        ["entitlements", "list", "workspace/repo", "--show-tokens"],
+        ["entitlements", "refresh", "workspace/repo/token", "--show-tokens"],
+        ["credential-helper", "cargo"],
+        ["credential-helper", "docker"],
+        ["credential-helper", "docker", "get"],
+        ["credential-helper", "generic"],
+        ["credential-helper", "pnpm"],
+    ]
+    for arguments in secretDump {
+        #expect(genericSecretGateRequestClassification(gateID: "cloudsmith-cli", arguments: arguments) == .secretDump)
+    }
+
+    for arguments in [
+        ["docs"],
+        ["mcp", "start"],
+        ["future-command"],
+        ["repositories", "future-command"],
+        ["push", "future-format"],
+        ["policy", "license", "get"],
+        ["credential-helper", "docker", "future-operation"],
+        ["--credentials-file"],
+        ["-v"],
+    ] {
+        #expect(genericSecretGateRequestClassification(gateID: "cloudsmith-cli", arguments: arguments) == .unknown)
+    }
 }
 
 @Test func npmPolicyUsesSpecificSubcommandsBeforeBroadFallbacks() {


### PR DESCRIPTION
## Summary

- route `CLOUDSMITH_API_KEY` only to reviewed Cloudsmith API commands and dynamic MCP execution
- keep local/public/auth-management and credential-helper management paths tokenless
- preserve alternate explicit-key and profile-aware credentials-file compatibility without exposing credential values
- classify reviewed Cloudsmith command effects precisely in the macOS Authorization Gate

The command catalogue and option behavior were audited against official `cloudsmith-cli` v1.26.0 at commit `aac8c040611e15dc32ab373b400ad105abdbaffc`.

Credential-independent execution authorization remains out of scope. This applies the positive Secret routing boundary already established by ADR 0032, so no domain-language or architecture change is required.

## Verification

- `cargo test cloudsmith_requests_its_key_only_for_reviewed_api_commands --lib`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --filter SecretGateCommandPolicyTests`
- `swift test --package-path src/menu-helper --disable-automatic-resolution`
- `scripts/test-menu-helper-self-checks.sh`
- `scripts/test-launcher-bundle-runner.sh`
- `scripts/test-varlock-plugin-helper.sh`
- `cargo fmt --all -- --check`
- `git diff --check`