### PR TITLE
Document positive Secret routing for env wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,11 @@ Endorsed properties must adopt and link to these definitions rather than keep a
 competing copy. Persisted values, wire fields, and compatibility flags may keep
 legacy names when changing them would break compatibility; user-facing language
 must use the canonical term.
+
+## Environment-wrapper Isotopes
+
+Add or change one environment-wrapper Isotope per pull request. Follow
+[`docs/adr/0032-positive-secret-routing.md`](docs/adr/0032-positive-secret-routing.md):
+review the exact upstream command surface, positively route only invocations
+that may need the protected Secret, and cover both Secret routing and macOS
+operation classification with focused tests.

--- a/docs/adr/0032-positive-secret-routing.md
+++ b/docs/adr/0032-positive-secret-routing.md
@@ -11,23 +11,55 @@ creates a Secret Application request and lets one Approval expose the Secret.
 
 ## Decision
 
-A command-aware wrapper may positively enumerate the Tool operations that can
-legitimately use its protected Secret. Only those invocations request Secret
-Application. Every other invocation executes with that Secret removed from its
-environment and does not enter an Authorization Gate.
+Every environment-wrapper Isotope must positively enumerate the Tool
+invocations that may legitimately use each protected Secret. Only those
+invocations may request Secret Application. Every other invocation executes
+with that Secret removed from its environment and does not enter an
+Authorization Gate.
 
-The npm wrapper follows this rule for exact reviewed npm commands and documented
-aliases that may authenticate to a registry. Unknown commands, commands added by
-a future npm release, npm's dynamic abbreviations, login commands that obtain a
-new credential, and arbitrary package scripts run without `NODE_AUTH_TOKEN`.
+Each catalog is based on a named upstream release or commit and includes exact
+commands, documented aliases, and relevant global options. The review must
+distinguish operations that consume an existing credential from operations that
+establish, replace, remove, or inspect authentication. Empty invocations,
+help/version forms, local-only commands, unknown or future commands, arbitrary
+scripts, and passthrough forms remain tokenless unless the upstream behavior
+shows that they may consume the protected Secret. Parsing fails tokenless when
+arguments are malformed or cannot be represented safely.
+
+When the Tool receives an explicit alternative credential, the wrapper must not
+also request the protected Secret. Tool-specific configuration inspection may
+establish that an alternative credential exists, but it must not print, copy,
+or transmit credential values.
+
+Positive Secret routing happens before Runtime Authorization. The Tool-specific
+policy still classifies every routed operation by its reviewed effects. A routed
+operation whose effects remain uncertain is Unknown and requires Approval.
+Tokenless execution grants no authority and does not replace an Execution Gate.
+
+Each environment-wrapper change includes focused regression coverage for:
+
+- empty, help, version, local-only, unknown, and future command forms;
+- every reviewed credential-consuming command family and documented alias;
+- leading global options, option values that resemble commands, and `--`
+  passthrough;
+- arbitrary script or plugin entry points exposed by the Tool;
+- explicit alternative credentials and configuration profiles when supported;
+- malformed and non-UTF-8 arguments; and
+- unchanged Gate Client and Target identity and integrity requirements.
+
+The Rust routing tests and macOS policy tests must agree on the reviewed command
+surface. A pull request records the upstream version or commit used for the
+review. Changes to credential-independent execution authorization belong in a
+separate Execution Gate decision.
+
 Users may make an explicit `av inject` request when an unsupported operation
-really needs the protected Secret; that request remains subject to the ordinary
-Unknown-operation Approval rule.
+really needs a protected Secret; that request remains subject to the Direct
+Secret Gate.
 
 ## Consequences
 
-Future npm commands fail authentication rather than silently gaining a protected
-credential. The positive catalog must be reviewed when npm adds or changes
-registry-authenticating commands. Unknown Secret Application still cannot be
-automically authorized under ADR 0002 because tokenless routing occurs before a
-Secret Use request exists.
+Future Tool commands fail authentication rather than silently gaining a
+protected credential. Each positive catalog must be reviewed when upstream adds
+or changes credential-consuming commands. Unknown Secret Application still
+cannot be automically authorized under ADR 0002 because tokenless routing occurs
+before a Secret Use request exists.


### PR DESCRIPTION
## Summary

- require one environment-wrapper Isotope per pull request
- turn ADR 0032 into the acceptance checklist for upstream command audits, positive per-Secret routing, alternate credentials, and regression coverage
- keep tokenless execution distinct from credential-independent Execution Gates

## Verification

- `git diff --check`
- verified the contributor link target exists
- reread the canonical domain language, architecture, and positioning documents