### PR TITLE
Explain when a Blessed Script narrows gate policy (#236)

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -4309,9 +4309,20 @@ private final class ApprovalServer: @unchecked Sendable {
         )
         let promptBlessing: BlessedScriptPromptContext?
         if let activeBlessing {
+            let launcherAllowsOperation = if configuredGate != nil,
+                                             let resolvedPolicy,
+                                             let classification {
+                secretGateProtectionAllows(resolvedPolicy.protection, classification: classification)
+            } else {
+                false
+            }
             promptBlessing = BlessedScriptPromptContext(
                 script: activeBlessing,
-                explanation: "This request exceeds the stored authority. Approval applies only to this request."
+                explanation: activeBlessedScriptPromptExplanation(
+                    script: activeBlessing,
+                    gateID: configuredGate?.id,
+                    launcherAllowsOperation: launcherAllowsOperation
+                )
             )
         } else if let scriptApproval,
                   let script = matchingBlessedScriptExecution(
@@ -13116,6 +13127,38 @@ private func runApprovalSelfCheck() -> Int32 {
     )
     collapsedPrompt.layoutSubtreeIfNeeded()
     let collapsedHeight = collapsedPrompt.fittingSize.height
+    let narrowedPrompt = NSHostingView(
+        rootView: ApprovalPromptView(
+            content: ApprovalPromptContent(
+                requesterName: requester.name,
+                requesterIconPath: requester.iconPath,
+                command: "git commit -S",
+                commandPath: "/usr/local/bin/git",
+                title: "Sign this Git operation?",
+                detail: "Automic Vault will use your default GPG signing credential.",
+                automaticApprovalExplanation: nil,
+                operation: operationClassificationTitle(.localWrite),
+                accessLevel: "Allow Signing",
+                temporaryGrantUnavailableReason: nil,
+                cwd: "/tmp",
+                keys: "AV_GPG_PRIVATE_KEY",
+                blessing: BlessedScriptPromptContext(
+                    script: promptBlessing.script,
+                    explanation: activeBlessedScriptPromptExplanation(
+                        script: promptBlessing.script,
+                        gateID: "gpg-signing",
+                        launcherAllowsOperation: true
+                    )
+                ),
+                processSecurity: promptProcessSecurity,
+                sections: []
+            ),
+            temporaryGrantCandidate: nil,
+            decide: { _ in }
+        )
+    )
+    narrowedPrompt.layoutSubtreeIfNeeded()
+    let narrowedHeight = narrowedPrompt.fittingSize.height
     let compactSize = NSHostingView(
         rootView: ApprovalPromptView(
             content: promptContent,
@@ -13163,6 +13206,21 @@ private func runApprovalSelfCheck() -> Int32 {
           promptBlessing.script.capabilities["gh"] == .readOnly,
           approvalPromptCapabilitySummary(promptBlessing.script)
             == "gh: Read Only • stripe: Write Access",
+          activeBlessedScriptPromptExplanation(
+              script: promptBlessing.script,
+              gateID: "gpg-signing",
+              launcherAllowsOperation: true
+          ) == "The Blessed Script’s declared Capabilities narrow gate policy for this execution and lack a gpg-signing Capability. Approval applies only to this request.",
+          activeBlessedScriptPromptExplanation(
+              script: promptBlessing.script,
+              gateID: "gh",
+              launcherAllowsOperation: true
+          ) == "The Blessed Script’s declared Capabilities narrow gate policy for this execution and exceed the declared gh Capability. Approval applies only to this request.",
+          activeBlessedScriptPromptExplanation(
+              script: promptBlessing.script,
+              gateID: "gpg-signing",
+              launcherAllowsOperation: false
+          ) == "This request exceeds the stored authority. Approval applies only to this request.",
           approvalPromptSecretNames(
               requested: ["PUBLISH_TOKEN", "AWS_ACCESS_KEY_ID"],
               blessed: ["PUBLISH_TOKEN", "AWS_SECRET_ACCESS_KEY"]
@@ -13177,6 +13235,7 @@ private func runApprovalSelfCheck() -> Int32 {
           automaticApprovalExplanation.contains("Approval is required to fail closed"),
           containsDragRegion(collapsedPrompt),
           collapsedHeight > 0,
+          narrowedHeight > 0,
           compactSize.width == 420,
           compactSize.height < collapsedHeight,
           SecretMutation.save(

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -551,3 +551,18 @@ private func saveBlessedScripts(_ scripts: [BlessedScript], service: String, acc
         accessibility: .afterFirstUnlock
     )
 }
+
+public func activeBlessedScriptPromptExplanation(
+    script: BlessedScript,
+    gateID: String?,
+    launcherAllowsOperation: Bool
+) -> String {
+    guard let gateID, launcherAllowsOperation else {
+        return "This request exceeds the stored authority. Approval applies only to this request."
+    }
+    if script.capabilities[gateID] == nil {
+        return "The Blessed Script’s declared Capabilities narrow gate policy for this execution and lack a \(gateID) Capability. Approval applies only to this request."
+    } else {
+        return "The Blessed Script’s declared Capabilities narrow gate policy for this execution and exceed the declared \(gateID) Capability. Approval applies only to this request."
+    }
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -385,3 +385,68 @@ func malformedBlessedScriptManifestsFailClosed(_ source: String) {
         #expect(error.localizedDescription == "invalid av inject shebang")
     }
 }
+
+@Test func blessedScriptNarrowedPolicyExplanationIdentifiesMissingCapability() {
+    let script = BlessedScript(
+        path: "/tmp/deploy.sh",
+        checksum: "checksum",
+        keys: [],
+        target: "/bin/sh",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        capabilities: ["aws": .fullExceptSecretDumps],
+        launchers: []
+    )
+
+    let explanation = activeBlessedScriptPromptExplanation(
+        script: script,
+        gateID: "gpg-signing",
+        launcherAllowsOperation: true
+    )
+    #expect(explanation == "The Blessed Script’s declared Capabilities narrow gate policy for this execution and lack a gpg-signing Capability. Approval applies only to this request.")
+}
+
+@Test func blessedScriptNarrowedPolicyExplanationIdentifiesExceededCapability() {
+    let script = BlessedScript(
+        path: "/tmp/deploy.sh",
+        checksum: "checksum",
+        keys: [],
+        target: "/bin/sh",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        capabilities: ["gh": .readOnly],
+        launchers: []
+    )
+
+    let explanation = activeBlessedScriptPromptExplanation(
+        script: script,
+        gateID: "gh",
+        launcherAllowsOperation: true
+    )
+    #expect(explanation == "The Blessed Script’s declared Capabilities narrow gate policy for this execution and exceed the declared gh Capability. Approval applies only to this request.")
+}
+
+@Test func blessedScriptNarrowedPolicyExplanationFallsBackWhenLauncherDoesNotAllow() {
+    let script = BlessedScript(
+        path: "/tmp/deploy.sh",
+        checksum: "checksum",
+        keys: [],
+        target: "/bin/sh",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        capabilities: ["aws": .fullExceptSecretDumps],
+        launchers: []
+    )
+
+    #expect(activeBlessedScriptPromptExplanation(
+        script: script,
+        gateID: "gpg-signing",
+        launcherAllowsOperation: false
+    ) == "This request exceeds the stored authority. Approval applies only to this request.")
+
+    #expect(activeBlessedScriptPromptExplanation(
+        script: script,
+        gateID: nil,
+        launcherAllowsOperation: true
+    ) == "This request exceeds the stored authority. Approval applies only to this request.")
+}


### PR DESCRIPTION
Resolves #236.

When a Verified Launcher or gate has stored authority (such as Allow Signing at the GPG Signing Gate), running a Blessed Script that declares different Capabilities still requires Approval because authority does not transfer to undeclared or exceeded Capabilities.

Previously, the Approval prompt showed a generic "This request exceeds the stored authority" explanation, leaving the relationship between the base gate policy and the Blessing unclear and the missing or exceeded Capability unnamed.

### Changes
- Introduce `activeBlessedScriptPromptExplanation(script:gateID:launcherAllowsOperation:)` in `BlessedScripts.swift` to identify when declared Capabilities narrow gate policy for the execution and name the missing or exceeded Capability.
- Wire the explanation into `handleInject` and `handleAccessRequest` in `main.swift`.
- Verify the prompt explanation and layout within `runApprovalSelfCheck()`.
- Add unit tests in `BlessedScriptsTests.swift` covering missing capability, exceeded capability, and fallback conditions.

### Verification
- `cargo test --tests` (all pass, 0 failures)
- `swift test --package-path src/menu-helper --filter BlessedScriptsTests` (20/20 passed, 0 failures)