### PR TITLE
Queue human approvals without blocking unrelated secret access (#62)

### DIFF
--- a/scripts/test-menu-helper-self-checks.sh
+++ b/scripts/test-menu-helper-self-checks.sh
@@ -37,6 +37,7 @@ fi
 
 checks=(
   --self-check-approvals
+  --self-check-approval-callsite
   --self-check-approval-process-execution
   --self-check-standalone-launchers
   --self-check-secret-mutations

--- a/src/menu-helper/Sources/MenubarHelper/PhoneApprovalCoordinator.swift
+++ b/src/menu-helper/Sources/MenubarHelper/PhoneApprovalCoordinator.swift
@@ -89,11 +89,17 @@ enum TouchIDApproval {
         }
         let status = setTouchIDApprovalEnabled(true)
         guard status == errSecSuccess else { throw TouchIDApprovalError.storage(status) }
+        Task { @MainActor in
+            abortActiveApprovalPrompt()
+        }
     }
 
     static func disable() throws {
         let status = setTouchIDApprovalEnabled(false)
         guard status == errSecSuccess else { throw TouchIDApprovalError.storage(status) }
+        Task { @MainActor in
+            abortActiveApprovalPrompt()
+        }
     }
 }
 
@@ -386,6 +392,9 @@ final class PhoneApprovalCoordinator {
         UserDefaults.standard.set(true, forKey: phoneApprovalEnabledDefaultsKey)
         workerGeneration += 1
         await worker.start(generation: workerGeneration)
+        Task { @MainActor in
+            abortActiveApprovalPrompt()
+        }
     }
 
     func submit(
@@ -454,6 +463,9 @@ final class PhoneApprovalCoordinator {
     func disableAfterPhoneApproval() {
         UserDefaults.standard.set(false, forKey: phoneApprovalEnabledDefaultsKey)
         stopConnection(cancelPending: true)
+        Task { @MainActor in
+            abortActiveApprovalPrompt()
+        }
     }
 
     func recoverWithoutIPhone() async throws {
@@ -468,6 +480,9 @@ final class PhoneApprovalCoordinator {
         _ = try keyStore.rotate()
         UserDefaults.standard.set(false, forKey: phoneApprovalEnabledDefaultsKey)
         stopConnection(cancelPending: true)
+        Task { @MainActor in
+            abortActiveApprovalPrompt()
+        }
     }
 
     private func finish(_ requestID: UUID, with result: PhoneApprovalResult) {

--- a/src/menu-helper/Sources/MenubarHelper/SecretProxy.swift
+++ b/src/menu-helper/Sources/MenubarHelper/SecretProxy.swift
@@ -78,7 +78,7 @@ actor SecretProxyCoordinator {
     typealias DestinationApproval = @MainActor @Sendable (
         ProxyDestinationRequest,
         ApprovalCancellation
-    ) -> ProxyDestinationDecision
+    ) async -> ProxyDestinationDecision
 
     private struct DestinationRule: Hashable {
         let origin: String

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -195,9 +195,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         isUserSessionActive = false
         temporaryAccessGrants.cancelAll()
         refreshTemporaryAccessGrants()
-        if NSApp.modalWindow is ApprovalPanel {
-            NSApp.abortModal()
-        }
+        abortActiveApprovalPrompt()
     }
 
     @objc private func userSessionDidBecomeActive(_ notification: Notification) {
@@ -209,9 +207,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         areScreensAwake = false
         temporaryAccessGrants.cancelAll()
         refreshTemporaryAccessGrants()
-        if NSApp.modalWindow is ApprovalPanel {
-            NSApp.abortModal()
-        }
+        abortActiveApprovalPrompt()
     }
 
     @objc private func screensDidWake(_ notification: Notification) {
@@ -394,9 +390,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         refreshLiveSecretUses()
         liveSecretUseTimer?.invalidate()
         liveSecretUseTimer = nil
-        if NSApp.modalWindow is ApprovalPanel {
-            NSApp.abortModal()
-        }
+        abortActiveApprovalPrompt()
         automaticApprovalFlashWorkItem?.cancel()
         automaticApprovalFlashWorkItem = nil
         preFlashStatusImage = nil
@@ -519,9 +513,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func beginUpdating(with alert: NSAlert) -> Bool {
         temporaryAccessGrants.cancelAll()
         refreshTemporaryAccessGrants()
-        if NSApp.modalWindow is ApprovalPanel {
-            NSApp.abortModal()
-        }
+        abortActiveApprovalPrompt()
         let mainWindowWasVisible = mainWindow?.isVisible == true
         mainWindow?.orderOut(nil)
         isUpdating = true
@@ -2613,7 +2605,7 @@ private func performApprovedSecretMutation(
     perform: ((SecretMutation) -> OSStatus)? = nil,
     preflight: (() -> String?)? = nil,
     requestOverride: ApprovalRequest? = nil
-) -> (status: OSStatus?, error: String?) {
+) async -> (status: OSStatus?, error: String?) {
     let request = requestOverride ?? mutation.approvalRequest(callerPath: callerPath)
     if cancellation?.isCanceled == true {
         _ = onAccessRequest(canceledAccessRequestRecord(
@@ -2633,18 +2625,22 @@ private func performApprovedSecretMutation(
         return (nil, "secret mutation denied while user session is inactive")
     }
 
-    let approval = decision?(request) ?? showApprovalAlert(
-        request: request,
-        callerPath: callerPath,
-        pid: pid,
-        signing: signing,
-        scriptApproval: nil,
-        launcher: launcher,
-        launcherFallbackPath: launcherFallbackPath,
-        automaticApprovalExplanation: nil,
-        cancellation: cancellation,
-        compact: mutation.usesCompactApproval
-    )
+    let approval = if let decision {
+        decision(request)
+    } else {
+        await showApprovalAlert(
+            request: request,
+            callerPath: callerPath,
+            pid: pid,
+            signing: signing,
+            scriptApproval: nil,
+            launcher: launcher,
+            launcherFallbackPath: launcherFallbackPath,
+            automaticApprovalExplanation: nil,
+            cancellation: cancellation,
+            compact: mutation.usesCompactApproval
+        )
+    }
     if approval == .interrupted {
         _ = onAccessRequest(interruptedAccessRequestRecord(
             request: request, callerPath: callerPath, launcher: launcher
@@ -2728,38 +2724,51 @@ private func approvalDecision(
 final class ApprovalCancellation: @unchecked Sendable {
     private let lock = NSLock()
     private var canceled = false
-    private var observer: (@MainActor @Sendable () -> Void)?
+    private var observers: [UUID: @MainActor @Sendable () -> Void] = [:]
 
     var isCanceled: Bool {
         lock.withLock { canceled }
     }
 
     func cancel() {
-        let observer: (@MainActor @Sendable () -> Void)? = lock.withLock {
-            guard !canceled else { return nil }
+        let list: [@MainActor @Sendable () -> Void] = lock.withLock {
+            guard !canceled else { return [] }
             canceled = true
-            defer { self.observer = nil }
-            return self.observer
+            let items = Array(self.observers.values)
+            self.observers.removeAll()
+            return items
         }
-        if let observer {
+        if !list.isEmpty {
             RunLoop.main.perform(inModes: [.modalPanel, .default]) {
-                MainActor.assumeIsolated { observer() }
+                MainActor.assumeIsolated {
+                    for item in list {
+                        item()
+                    }
+                }
             }
         }
     }
 
-    func observe(_ observer: @escaping @MainActor @Sendable () -> Void) -> Bool {
+    @discardableResult
+    func observe(id: UUID = UUID(), _ observer: @escaping @MainActor @Sendable () -> Void) -> Bool {
         lock.withLock {
             guard !canceled else { return false }
-            self.observer = observer
+            observers[id] = observer
             return true
         }
     }
 
-    func stopObserving() {
-        lock.withLock { observer = nil }
+    func stopObserving(id: UUID? = nil) {
+        lock.withLock {
+            if let id {
+                observers.removeValue(forKey: id)
+            } else {
+                observers.removeAll()
+            }
+        }
     }
 }
+
 
 private func isApprovalCancellationEvent(_ event: xpc_object_t) -> Bool {
     xpc_equal(event, XPC_ERROR_CONNECTION_INTERRUPTED)
@@ -3625,7 +3634,7 @@ private final class ApprovalServer: @unchecked Sendable {
             )
             return
         }
-        DispatchQueue.main.async {
+        Task { @MainActor in
             if cancellation.isCanceled {
                 _ = self.onAccessRequest(canceledAccessRequestRecord(
                     request: request, callerPath: callerPath, launcher: launcher
@@ -3644,7 +3653,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 self.reply(peer, to: message, ok: false, error: "list denied while user session is inactive")
                 return
             }
-            let decision = showApprovalAlert(
+            let decision = await showApprovalAlert(
                 request: request,
                 callerPath: callerPath,
                 pid: pid,
@@ -4357,7 +4366,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 self.sendEvent(event, to: peer)
             }
         }
-        DispatchQueue.main.async {
+        Task { @MainActor in
             if cancellation.isCanceled {
                 _ = self.onAccessRequest(canceledAccessRequestRecord(
                     request: request, callerPath: callerPath, launcher: promptLauncher
@@ -4483,7 +4492,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
 
-            let decision = showApprovalAlert(
+            let decision = await showApprovalAlert(
                 request: request,
                 callerPath: callerPath,
                 pid: pid,
@@ -4901,7 +4910,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     self.sendEvent(humanApprovalRequiredEvent, to: peer)
                 }
             }
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 if cancellation.isCanceled {
                     _ = self.onAccessRequest(canceledAccessRequestRecord(
                         request: request, callerPath: callerPath, launcher: launcher
@@ -4920,7 +4929,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     self.reply(peer, to: message, ok: false, error: "human approval unavailable")
                     return
                 }
-                let decision = showApprovalAlert(
+                let decision = await showApprovalAlert(
                     request: request,
                     callerPath: callerPath,
                     pid: pid,
@@ -5110,12 +5119,12 @@ private final class ApprovalServer: @unchecked Sendable {
         let warning = targetProtection?.allowsSecretGateAccess == true ? nil :
             "The target does not meet Automic Vault’s Hardened Runtime requirements. Code injected into it may steal this Proxy Session’s references and credential, then reuse destinations you allow for the session."
 
-        DispatchQueue.main.async {
+        Task { @MainActor in
             guard !cancellation.isCanceled, self.canRequestHumanApproval() else {
                 self.reply(peer, to: message, ok: false, error: "Proxy Session approval unavailable")
                 return
             }
-            let decision = showApprovalAlert(
+            let decision = await showApprovalAlert(
                 request: request,
                 callerPath: callerPath,
                 pid: pid,
@@ -5204,7 +5213,7 @@ private final class ApprovalServer: @unchecked Sendable {
                                     : "The proxy will request these secrets on demand. Query values remain hidden; names: \(destination.queryNames.sorted().joined(separator: ", ")).",
                                 selectedSecretValues: destination.selectedSecretValues
                             )
-                            return switch showApprovalAlert(
+                            return switch await showApprovalAlert(
                                 request: destinationRequest,
                                 callerPath: callerPath,
                                 pid: pid,
@@ -6277,8 +6286,8 @@ private final class ApprovalServer: @unchecked Sendable {
                 selectedSecretValues: request.selectedSecretValues
             )
         } ?? request
-        DispatchQueue.main.async {
-            let result = performApprovedSecretMutation(
+        Task { @MainActor in
+            let result = await performApprovedSecretMutation(
                 mutation,
                 callerPath: caller.path,
                 pid: caller.pid,
@@ -11203,17 +11212,7 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
 }
 
 private final class ApprovalPanel: NSPanel {
-    private var allowsKey = false
-
-    override var canBecomeKey: Bool { allowsKey }
-
-    override func sendEvent(_ event: NSEvent) {
-        if event.type == .leftMouseDown, !isKeyWindow {
-            allowsKey = true
-            makeKey()
-        }
-        super.sendEvent(event)
-    }
+    override var canBecomeKey: Bool { true }
 }
 
 private final class ApprovalPanelDragView: NSView {
@@ -11263,6 +11262,68 @@ private func fitApprovalPanel(_ panel: NSPanel, maximumHeight: CGFloat, animate:
 }
 
 @MainActor
+private enum ActiveApprovalPrompt {
+    static var current: ApprovalPromptState?
+    static var abortGeneration: UInt64 = 0
+
+    static func abort() {
+        abortGeneration += 1
+        current?.resolve(.canceled)
+        HumanApprovalQueue.shared.cancelAllPending()
+    }
+}
+
+@MainActor
+private func abortActiveApprovalPrompt() {
+    ActiveApprovalPrompt.abort()
+}
+
+private final class ApprovalPromptState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasDecision = false
+    private var continuation: CheckedContinuation<ApprovalDecision, Never>?
+    weak var panel: NSPanel?
+    var remoteRequestID: UUID?
+    var usesIPhoneApproval: Bool = false
+    var presentationToken: UUID?
+    weak var cancellation: ApprovalCancellation?
+
+    init(continuation: CheckedContinuation<ApprovalDecision, Never>, panel: NSPanel) {
+        self.continuation = continuation
+        self.panel = panel
+    }
+
+    @MainActor
+    func resolve(_ result: ApprovalDecision) {
+        let shouldResume: Bool = lock.withLock {
+            guard !hasDecision else { return false }
+            hasDecision = true
+            return true
+        }
+        guard shouldResume else { return }
+
+        if ActiveApprovalPrompt.current === self {
+            ActiveApprovalPrompt.current = nil
+        }
+
+        if let token = presentationToken {
+            cancellation?.stopObserving(id: token)
+        }
+        if usesIPhoneApproval, let remoteRequestID {
+            PhoneApprovalCoordinator.shared.cancel(remoteRequestID)
+        }
+        #if !DEBUG
+        if result == .approved || result == .alwaysApproved {
+            PostHogTelemetry.shared.captureExplicitApproval()
+        }
+        #endif
+        panel?.orderOut(nil)
+        continuation?.resume(returning: result)
+        continuation = nil
+    }
+}
+
+@MainActor
 private func showApprovalAlert(
     request: ApprovalRequest,
     callerPath: String,
@@ -11282,8 +11343,38 @@ private func showApprovalAlert(
     classification: SecretGateRequestClassification? = nil,
     cancellation: ApprovalCancellation? = nil,
     compact: Bool = false
-) -> ApprovalDecision {
+) async -> ApprovalDecision {
     guard cancellation?.isCanceled != true else { return .canceled }
+    let startGeneration = ActiveApprovalPrompt.abortGeneration
+    let queueToken = UUID()
+    let acquired = await HumanApprovalQueue.shared.acquire(
+        id: queueToken,
+        isCanceled: { cancellation?.isCanceled == true },
+        registerCancellation: { onCancel in
+            let observed = cancellation?.observe(id: queueToken) {
+                onCancel()
+            } ?? true
+            if !observed {
+                onCancel()
+            }
+        }
+    )
+    cancellation?.stopObserving(id: queueToken)
+    guard acquired else {
+        return terminalApprovalDecision(.canceled, cancellation: cancellation)
+    }
+    defer {
+        HumanApprovalQueue.shared.release()
+    }
+    // If an abort occurred (e.g. user session lock, screen sleep, or app update)
+    // while waiting in the queue or right as this waiter was promoted, bail out
+    // immediately rather than presenting a stale prompt.
+    guard cancellation?.isCanceled != true,
+          ActiveApprovalPrompt.abortGeneration == startGeneration
+    else {
+        return terminalApprovalDecision(.canceled, cancellation: cancellation)
+    }
+
     let receivedAt = Date()
     let requester = approvalPromptRequester(launcher: launcher, fallback: launcherFallbackPath)
     let processSecurity = approvalProcessSecurity(
@@ -11324,99 +11415,95 @@ private func showApprovalAlert(
     )
     let usesIPhoneApproval = PhoneApprovalCoordinator.shared.isEnabled
     let usesTouchIDApproval = TouchIDApproval.isEnabled
-    var decision = ApprovalDecision.canceled
-    var hasDecision = false
-    var remoteRequestID: UUID?
-    var completedBeforeModal = false
     let maximumHeight = NSScreen.main?.visibleFrame.height ?? 660
     let panel = makeApprovalPanel()
-    panel.contentView = NSHostingView(
-        rootView: ApprovalPromptView(
-            content: content,
-            maximumHeight: maximumHeight,
-            allowsPersistentApproval: allowsPersistentApproval,
-            temporaryGrantCandidate: temporaryGrantCandidate,
-            persistentApprovalLabel: persistentApprovalLabel,
-            usesIPhoneApproval: usesIPhoneApproval,
-            usesTouchIDApproval: usesTouchIDApproval,
-            compact: compact,
-            decide: {
-                guard !hasDecision else { return }
-                hasDecision = true
-                decision = $0
-                if usesIPhoneApproval, let remoteRequestID {
-                    PhoneApprovalCoordinator.shared.cancel(remoteRequestID)
-                }
-                #if !DEBUG
-                if decision == .approved || decision == .alwaysApproved {
-                    PostHogTelemetry.shared.captureExplicitApproval()
-                }
-                #endif
-                NSApp.stopModal()
-            }
-        )
-    )
-    if usesIPhoneApproval {
-        do {
-            let phoneRequest = try PhoneApprovalRequest(
-                macName: Host.current().localizedName ?? ProcessInfo.processInfo.hostName,
-                launcher: content.requesterName,
-                tool: autoApprovalToolName(request),
-                command: content.command,
-                cwd: content.cwd,
-                secretNames: request.keys.sorted(),
-                reason: automaticApprovalExplanation
-                    ?? request.detail
-                    ?? request.title
-                    ?? "Human Approval is required.",
-                risks: phoneApprovalRisks(
-                    request: request,
-                    classification: classification,
-                    hasSecurityWarning: automaticApprovalExplanation != nil || blessing != nil
-                ),
-                details: content.sections.map { section in
-                    ApprovalDetailSection(
-                        title: section.title,
-                        rows: section.rows.map { .init(label: $0.label, value: $0.value) }
-                    )
-                },
-                temporaryAccessGrantScope: temporaryGrantCandidate.map { candidate in
-                    "\(candidate.launcherName), \(candidate.authorizationGateName), and \(candidate.scope.agentTaskContext.provider.taskLabel) \(candidate.scope.agentTaskContext.abbreviatedID)"
+
+    let decision: ApprovalDecision = await withCheckedContinuation { continuation in
+        let state = ApprovalPromptState(continuation: continuation, panel: panel)
+        ActiveApprovalPrompt.current = state
+        state.usesIPhoneApproval = usesIPhoneApproval
+        state.cancellation = cancellation
+
+        let presentationToken = UUID()
+        state.presentationToken = presentationToken
+
+        panel.contentView = NSHostingView(
+            rootView: ApprovalPromptView(
+                content: content,
+                maximumHeight: maximumHeight,
+                allowsPersistentApproval: allowsPersistentApproval,
+                temporaryGrantCandidate: temporaryGrantCandidate,
+                persistentApprovalLabel: persistentApprovalLabel,
+                usesIPhoneApproval: usesIPhoneApproval,
+                usesTouchIDApproval: usesTouchIDApproval,
+                compact: compact,
+                decide: { userDecision in
+                    state.resolve(userDecision)
                 }
             )
-            remoteRequestID = phoneRequest.id
-            try PhoneApprovalCoordinator.shared.submit(phoneRequest) { result in
-                guard !hasDecision else { return }
-                hasDecision = true
-                decision = switch result {
-                case .approved: .approved
-                case .denied: .denied
-                case .temporaryWriteAccess: .temporaryWriteAccess
-                case .canceled: .canceled
+        )
+        panel.initialFirstResponder = panel.contentView
+
+        if usesIPhoneApproval {
+            do {
+                let phoneRequest = try PhoneApprovalRequest(
+                    macName: Host.current().localizedName ?? ProcessInfo.processInfo.hostName,
+                    launcher: content.requesterName,
+                    tool: autoApprovalToolName(request),
+                    command: content.command,
+                    cwd: content.cwd,
+                    secretNames: request.keys.sorted(),
+                    reason: automaticApprovalExplanation
+                        ?? request.detail
+                        ?? request.title
+                        ?? "Human Approval is required.",
+                    risks: phoneApprovalRisks(
+                        request: request,
+                        classification: classification,
+                        hasSecurityWarning: automaticApprovalExplanation != nil || blessing != nil
+                    ),
+                    details: content.sections.map { section in
+                        ApprovalDetailSection(
+                            title: section.title,
+                            rows: section.rows.map { .init(label: $0.label, value: $0.value) }
+                        )
+                    },
+                    temporaryAccessGrantScope: temporaryGrantCandidate.map { candidate in
+                        "\(candidate.launcherName), \(candidate.authorizationGateName), and \(candidate.scope.agentTaskContext.provider.taskLabel) \(candidate.scope.agentTaskContext.abbreviatedID)"
+                    }
+                )
+                state.remoteRequestID = phoneRequest.id
+                try PhoneApprovalCoordinator.shared.submit(phoneRequest) { result in
+                    let mapped: ApprovalDecision = switch result {
+                    case .approved: .approved
+                    case .denied: .denied
+                    case .temporaryWriteAccess: .temporaryWriteAccess
+                    case .canceled: .canceled
+                    }
+                    state.resolve(mapped)
                 }
-                if NSApp.modalWindow === panel {
-                    NSApp.stopModal()
-                } else {
-                    completedBeforeModal = true
-                }
+            } catch {
+                state.resolve(.denied)
+                return
             }
-        } catch {
-            return .denied
         }
+
+        let observed = cancellation?.observe(id: presentationToken) {
+            state.resolve(.canceled)
+        } ?? true
+
+        if !observed {
+            state.resolve(.canceled)
+            return
+        }
+
+        fitApprovalPanel(panel, maximumHeight: maximumHeight, animate: false)
+        panel.center()
+        panel.orderFrontRegardless()
+        panel.makeKey()
+        panel.makeFirstResponder(panel.contentView)
     }
-    guard cancellation?.observe({ [weak panel] in
-        if let remoteRequestID { PhoneApprovalCoordinator.shared.cancel(remoteRequestID) }
-        guard let panel, NSApp.modalWindow === panel else { return }
-        NSApp.stopModal()
-    }) != false else { return .canceled }
-    defer {
-        cancellation?.stopObserving()
-    }
-    fitApprovalPanel(panel, maximumHeight: maximumHeight, animate: false)
-    panel.center()
-    panel.orderFrontRegardless()
-    if !completedBeforeModal { NSApp.runModal(for: panel) }
-    panel.orderOut(nil)
+
     return terminalApprovalDecision(decision, cancellation: cancellation)
 }
 
@@ -12706,7 +12793,7 @@ private func showAutomaticAccessToast(
 }
 
 @MainActor
-private func runSecretMutationSelfCheck() -> Int32 {
+private func runSecretMutationSelfCheck() async -> Int32 {
     let credentialMutationRequest = SecretMutation.terraformDelete(
         account: terraformCredentialSecretName("registry.example"),
         hostname: "registry.example"
@@ -12719,7 +12806,7 @@ private func runSecretMutationSelfCheck() -> Int32 {
         SecretMutation.delete(account: "TEST_SECRET"),
     ] {
         var performed = false
-        let result = performApprovedSecretMutation(
+        let result = await performApprovedSecretMutation(
             mutation,
             callerPath: "/usr/local/bin/av",
             pid: 42,
@@ -12738,7 +12825,7 @@ private func runSecretMutationSelfCheck() -> Int32 {
     }
 
     var performedWhileInactive = false
-    let inactive = performApprovedSecretMutation(
+    let inactive = await performApprovedSecretMutation(
         .saveIfAbsentOrEqual(account: "TEST_SECRET", value: "secret"),
         callerPath: "/usr/local/bin/av",
         pid: 42,
@@ -12760,7 +12847,7 @@ private func runSecretMutationSelfCheck() -> Int32 {
 
     var cancellationRecord: AccessRequestRecord?
     var performedAfterCancellation = false
-    let canceled = performApprovedSecretMutation(
+    let canceled = await performApprovedSecretMutation(
         .delete(account: "TEST_SECRET"),
         callerPath: "/usr/local/bin/av",
         pid: 42,
@@ -12786,7 +12873,7 @@ private func runSecretMutationSelfCheck() -> Int32 {
     else { return 1 }
 
     var performedWithoutAudit = false
-    let unaudited = performApprovedSecretMutation(
+    let unaudited = await performApprovedSecretMutation(
         .delete(account: "TEST_SECRET"),
         callerPath: "/usr/local/bin/av",
         pid: 42,
@@ -12820,7 +12907,7 @@ private func runSecretMutationSelfCheck() -> Int32 {
     )
     var approvedRequest: ApprovalRequest?
     var performedAfterFailedPreflight = false
-    let changedDocker = performApprovedSecretMutation(
+    let changedDocker = await performApprovedSecretMutation(
         .dockerDelete(account: "DOCKER_REGISTRY_CREDENTIAL_TEST", serverURL: "registry.example"),
         callerPath: "/usr/local/bin/av",
         pid: 42,
@@ -12998,6 +13085,26 @@ private func runApprovalSelfCheck() -> Int32 {
           terminalApprovalDecision(.canceled, cancellation: nil) == .interrupted,
           terminalApprovalDecision(.canceled, cancellation: cancellation) == .canceled,
           terminalApprovalDecision(.approved, cancellation: nil) == .approved
+    else { return 1 }
+
+    HumanApprovalQueue.shared.resetForTesting()
+    let initialAbortGeneration = ActiveApprovalPrompt.abortGeneration
+    abortActiveApprovalPrompt()
+    guard ActiveApprovalPrompt.abortGeneration == initialAbortGeneration + 1,
+          !HumanApprovalQueue.shared.hasActiveSlot,
+          HumanApprovalQueue.shared.pendingCount == 0
+    else { return 1 }
+
+    let testPanel = makeApprovalPanel()
+    let dummyView = NSView()
+    testPanel.contentView = dummyView
+    testPanel.initialFirstResponder = dummyView
+    guard testPanel.canBecomeKey,
+          !testPanel.canBecomeMain,
+          testPanel.styleMask.contains(.nonactivatingPanel),
+          testPanel.level == .modalPanel,
+          !testPanel.hidesOnDeactivate,
+          testPanel.initialFirstResponder === dummyView
     else { return 1 }
 
     let requester = approvalPromptRequester(
@@ -15699,7 +15806,10 @@ if CommandLine.arguments.contains("--self-check-standalone-launchers") {
 }
 
 if CommandLine.arguments.contains("--self-check-secret-mutations") {
-    exit(MainActor.assumeIsolated { runSecretMutationSelfCheck() })
+    Task { @MainActor in
+        exit(await runSecretMutationSelfCheck())
+    }
+    dispatchMain()
 }
 
 if CommandLine.arguments.contains("--self-check-keychain-persistence") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2546,9 +2546,11 @@ private extension ApprovalDecision {
         case .canceled: .canceled
         case .interrupted: .interrupted
         case .denied: .denied
-        case .approved, .reevaluated: .approved
+        case .approved: .approved
         case .alwaysApproved: .alwaysApproved
         case .temporaryWriteAccess: .temporaryAccessGrant
+        case .reevaluated:
+            preconditionFailure(".reevaluated decisions must not be stored into reuse cache")
         }
     }
 }
@@ -5240,8 +5242,10 @@ private final class ApprovalServer: @unchecked Sendable {
                             ) {
                             case .approved: ProxyDestinationDecision.allowOnce
                             case .alwaysApproved: ProxyDestinationDecision.allowForSession
-                            case .canceled, .interrupted, .denied, .temporaryWriteAccess, .reevaluated:
+                            case .canceled, .interrupted, .denied, .temporaryWriteAccess:
                                 ProxyDestinationDecision.deny
+                            case .reevaluated:
+                                preconditionFailure("proxy destination approval cannot be reevaluated")
                             }
                         }
                     )
@@ -11323,7 +11327,12 @@ private final class ApprovalPromptState: @unchecked Sendable {
     }
 
     @MainActor
-    func resolve(_ result: ApprovalDecision, source: ApprovalDecisionSource = .programmatic) {
+    func resolve(
+        _ result: ApprovalDecision,
+        source: ApprovalDecisionSource = .programmatic,
+        phoneEnabled: Bool = PhoneApprovalCoordinator.shared.isEnabled,
+        touchIDEnabled: Bool = TouchIDApproval.isEnabled
+    ) {
         let shouldResume: Bool = lock.withLock {
             guard !hasDecision else { return false }
             hasDecision = true
@@ -11333,10 +11342,21 @@ private final class ApprovalPromptState: @unchecked Sendable {
 
         var finalResult = result
         if result == .approved || result == .alwaysApproved || result == .temporaryWriteAccess {
-            if PhoneApprovalCoordinator.shared.isEnabled, source == .standardMac {
-                finalResult = .denied
-            } else if TouchIDApproval.isEnabled, source != .touchID {
-                finalResult = .denied
+            switch source {
+            case .standardMac:
+                if phoneEnabled || touchIDEnabled {
+                    finalResult = .interrupted
+                }
+            case .touchID:
+                if !touchIDEnabled {
+                    finalResult = .interrupted
+                }
+            case .phone:
+                if !phoneEnabled {
+                    finalResult = .interrupted
+                }
+            case .programmatic:
+                break
             }
         }
 
@@ -13955,6 +13975,248 @@ private func runApprovalSelfCheck() -> Int32 {
     return 0
 }
 
+@MainActor
+private func runApprovalCallsiteSelfCheck() async -> Int32 {
+    // 1. Queued-transition focus invariant: every freshly created alert starts non-key
+    // and does not inherit focus from a previously key window.
+    let panel1 = makeApprovalPanel()
+    guard !panel1.canBecomeKey,
+          !panel1.canBecomeMain,
+          !panel1.isKeyWindow,
+          panel1.initialFirstResponder == nil,
+          panel1.styleMask.contains(.nonactivatingPanel),
+          panel1.level == .modalPanel,
+          !panel1.hidesOnDeactivate
+    else {
+        fputs("panel1 initial posture failed non-activating / non-key invariant\n", stderr)
+        return 10
+    }
+
+    // Simulate user deliberately clicking panel1 to grant key focus
+    if let clickEvent = NSEvent.mouseEvent(
+        with: .leftMouseDown,
+        location: .zero,
+        modifierFlags: [],
+        timestamp: 0,
+        windowNumber: panel1.windowNumber,
+        context: nil,
+        eventNumber: 0,
+        clickCount: 1,
+        pressure: 1.0
+    ) {
+        panel1.sendEvent(clickEvent)
+    }
+    guard panel1.canBecomeKey else {
+        fputs("panel1 failed to become key after deliberate click\n", stderr)
+        return 11
+    }
+    panel1.orderOut(nil)
+
+    // Verify next queued panel starts non-key by construction, preventing focus auto-promotion
+    let panel2 = makeApprovalPanel()
+    guard !panel2.canBecomeKey,
+          !panel2.canBecomeMain,
+          !panel2.isKeyWindow,
+          panel2.initialFirstResponder == nil
+    else {
+        fputs("panel2 inherited key status or initial first responder across queued transition\n", stderr)
+        return 12
+    }
+    panel2.orderOut(nil)
+
+    // 2. Mode-transition invalidation
+    HumanApprovalQueue.shared.resetForTesting()
+    let startAbortGen = ActiveApprovalPrompt.abortGeneration
+    let abortedRes = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        ActiveApprovalPrompt.current = promptState
+        abortActiveApprovalPrompt()
+    }
+    guard abortedRes == .canceled,
+          ActiveApprovalPrompt.abortGeneration == startAbortGen + 1,
+          ActiveApprovalPrompt.current == nil
+    else {
+        fputs("mode-transition invalidation failed to abort active prompt\n", stderr)
+        return 20
+    }
+
+    // 3. Surface elevation and decision source enforcement across all permutations
+    // Case 3a: Both disabled -> standardMac is accepted, elevated sources are not expected
+    let stdMacBothOff = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .standardMac, phoneEnabled: false, touchIDEnabled: false)
+    }
+    guard stdMacBothOff == .approved else {
+        fputs("standardMac failed when both elevated surfaces are disabled\n", stderr)
+        return 30
+    }
+
+    // Case 3b: Phone enabled only -> standardMac interrupted, phone approved, touchID interrupted
+    let stdMacPhoneOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .standardMac, phoneEnabled: true, touchIDEnabled: false)
+    }
+    let phonePhoneOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .phone, phoneEnabled: true, touchIDEnabled: false)
+    }
+    let touchIDPhoneOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .touchID, phoneEnabled: true, touchIDEnabled: false)
+    }
+    guard stdMacPhoneOn == .interrupted, phonePhoneOn == .approved, touchIDPhoneOn == .interrupted else {
+        fputs("surface enforcement failed for phone-only configuration\n", stderr)
+        return 31
+    }
+
+    // Case 3c: Touch ID enabled only -> standardMac interrupted, touchID approved, phone interrupted
+    let stdMacTouchIDOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .standardMac, phoneEnabled: false, touchIDEnabled: true)
+    }
+    let touchIDTouchIDOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .touchID, phoneEnabled: false, touchIDEnabled: true)
+    }
+    let phoneTouchIDOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .phone, phoneEnabled: false, touchIDEnabled: true)
+    }
+    guard stdMacTouchIDOn == .interrupted, touchIDTouchIDOn == .approved, phoneTouchIDOn == .interrupted else {
+        fputs("surface enforcement failed for TouchID-only configuration\n", stderr)
+        return 32
+    }
+
+    // Case 3d: Both enabled -> standardMac interrupted, both phone AND touchID approved
+    let stdMacBothOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .standardMac, phoneEnabled: true, touchIDEnabled: true)
+    }
+    let phoneBothOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .phone, phoneEnabled: true, touchIDEnabled: true)
+    }
+    let touchIDBothOn = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.approved, source: .touchID, phoneEnabled: true, touchIDEnabled: true)
+    }
+    guard stdMacBothOn == .interrupted, phoneBothOn == .approved, touchIDBothOn == .approved else {
+        fputs("surface enforcement failed when both Phone and TouchID are enabled\n", stderr)
+        return 33
+    }
+
+    // Case 3e: Programmatic denial always flows through
+    let progDenied = await withCheckedContinuation { cont in
+        let promptState = ApprovalPromptState(continuation: cont, panel: panel1)
+        promptState.resolve(.denied, source: .programmatic)
+    }
+    guard progDenied == .denied else {
+        fputs("programmatic denial failed\n", stderr)
+        return 34
+    }
+
+    // 4. Callsite reevaluation through real AuthorizationDecisionReuseCache
+    HumanApprovalQueue.shared.resetForTesting()
+    let slot1Acquired = await HumanApprovalQueue.shared.acquire()
+    guard slot1Acquired, HumanApprovalQueue.shared.hasActiveSlot else {
+        fputs("failed initial queue slot acquisition\n", stderr)
+        return 40
+    }
+
+    let testReq = ApprovalRequest(
+        op: "inject",
+        keys: ["TEST_SECRET"],
+        target: "/bin/zsh",
+        args: [],
+        cwd: "/tmp",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        envConflicts: [],
+        shebangScript: nil,
+        scriptData: nil,
+        tool: nil,
+        title: nil,
+        detail: nil
+    )
+    let helperSigning = SigningInfo(identifier: "com.automicvault", teamIdentifier: "TEAM")
+
+    var selfIdentity = AVProcessIdentity()
+    guard av_process_identity(getpid(), &selfIdentity) else {
+        fputs("failed to obtain live process identity\n", stderr)
+        return 41
+    }
+    let testReuseRequest = testReq.decisionReuseRequest(
+        clientIdentity: selfIdentity,
+        callerPath: "/bin/zsh",
+        signing: helperSigning
+    )
+    var cache = AuthorizationDecisionReuseCache()
+    guard cache.decision(for: testReuseRequest) == nil else {
+        fputs("reuse cache not empty at test start\n", stderr)
+        return 42
+    }
+
+    let queuedAlertTask = Task { @MainActor in
+        await showApprovalAlert(
+            request: testReq,
+            callerPath: "/bin/zsh",
+            pid: getpid(),
+            signing: helperSigning,
+            scriptApproval: nil,
+            launcher: nil,
+            launcherFallbackPath: "/bin/zsh",
+            automaticApprovalExplanation: nil,
+            reevaluate: {
+                cache.decision(for: testReuseRequest) == .approved
+            }
+        )
+    }
+
+    var queued = false
+    let deadline = Date().addingTimeInterval(5.0)
+    while Date() < deadline {
+        if HumanApprovalQueue.shared.pendingCount == 1 {
+            queued = true
+            break
+        }
+        await Task.yield()
+    }
+    guard queued else {
+        fputs("timed out waiting for request 2 to enqueue in HumanApprovalQueue\n", stderr)
+        return 43
+    }
+
+    // Request 1 records approved decision into reuse cache and releases slot
+    cache.remember(.approved, for: testReuseRequest)
+    HumanApprovalQueue.shared.release()
+
+    let queuedAlertDecision = await withTaskGroup(of: ApprovalDecision?.self) { group in
+        group.addTask {
+            await queuedAlertTask.value
+        }
+        group.addTask {
+            try? await Task.sleep(for: .seconds(5))
+            return nil
+        }
+        let first = await group.next() ?? nil
+        group.cancelAll()
+        return first
+    }
+    guard let queuedAlertDecision else {
+        fputs("timed out waiting for request 2 to resolve after slot release\n", stderr)
+        return 44
+    }
+    guard queuedAlertDecision == .reevaluated,
+          !HumanApprovalQueue.shared.hasActiveSlot,
+          HumanApprovalQueue.shared.pendingCount == 0
+    else {
+        fputs("request 2 failed to reevaluate from cache and release queue slot\n", stderr)
+        return 45
+    }
+
+    return 0
+}
+
 private func runApprovalProcessExecutionSelfCheck() -> Int32 {
     var identity = AVProcessIdentity()
     guard av_process_identity(getpid(), &identity) else { return 1 }
@@ -15839,6 +16101,13 @@ if CommandLine.arguments.contains("--self-check-sleep") {
 
 if CommandLine.arguments.contains("--self-check-approvals") {
     exit(MainActor.assumeIsolated { runApprovalSelfCheck() })
+}
+
+if CommandLine.arguments.contains("--self-check-approval-callsite") {
+    Task { @MainActor in
+        exit(await runApprovalCallsiteSelfCheck())
+    }
+    dispatchMain()
 }
 
 if CommandLine.arguments.contains("--self-check-approval-process-execution") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2537,6 +2537,7 @@ private enum ApprovalDecision: Equatable {
     case approved
     case alwaysApproved
     case temporaryWriteAccess
+    case reevaluated
 }
 
 private extension ApprovalDecision {
@@ -2545,7 +2546,7 @@ private extension ApprovalDecision {
         case .canceled: .canceled
         case .interrupted: .interrupted
         case .denied: .denied
-        case .approved: .approved
+        case .approved, .reevaluated: .approved
         case .alwaysApproved: .alwaysApproved
         case .temporaryWriteAccess: .temporaryAccessGrant
         }
@@ -4373,104 +4374,111 @@ private final class ApprovalServer: @unchecked Sendable {
                 ))
                 return
             }
-            var currentIdentity = AVProcessIdentity()
-            if av_process_identity(pid, &currentIdentity),
-               sameProcessIdentity(identity, currentIdentity),
-               let currentLiveSigning = liveSigningInfo(pid: pid)
-            {
-                let currentCallerPath = pathString(currentIdentity)
-                let currentSigning = SigningInfo(
-                    identifier: currentLiveSigning.identifier,
-                    teamIdentifier: currentLiveSigning.teamIdentifier
-                )
-                var currentLaunchers = launcherIdentities(for: currentIdentity)
-                if currentLaunchers.isEmpty,
-                   let currentLauncher = launcherIdentity(pid: pid, identity: currentIdentity)
+            let tryFulfillFromGrantOrCache: @MainActor () -> Bool = {
+                var currentIdentity = AVProcessIdentity()
+                if av_process_identity(pid, &currentIdentity),
+                   sameProcessIdentity(identity, currentIdentity),
+                   let currentLiveSigning = liveSigningInfo(pid: pid)
                 {
-                    currentLaunchers.append(currentLauncher)
-                }
-                if currentLiveSigning.mainExecutable == currentCallerPath,
-                   currentSigning.identifier == signing.identifier,
-                   currentSigning.teamIdentifier == signing.teamIdentifier,
-                   isAllowedCaller(path: currentCallerPath, signing: currentSigning),
-                   let configuredGate,
-                   let classification,
-                   let currentAgentTaskContext = agentTaskContext(pid: pid),
-                   self.handleTemporaryAccessGrant(
-                       request: request,
-                       gate: configuredGate,
-                       classification: classification,
-                       agentTaskContext: currentAgentTaskContext,
-                       launchers: currentLaunchers,
-                       callerPath: currentCallerPath,
-                       awsRegistration: awsRegistration,
-                       scriptApproval: scriptApproval,
-                       authorizationGate: authorizationGate,
-                       processChains: retainedProcessChains(for: currentIdentity),
-                       pid: pid,
-                       identity: currentIdentity,
-                       peer: peer,
-                       message: message
-                   )
-                {
-                    return
-                }
-            }
-            let cachedDecision = self.transientApprovals.decision(for: transientApproval)
-            if let decision = cachedDecision {
-                if decision == .denied {
-                    _ = self.onAccessRequest(accessRequestRecord(
-                        request: request,
-                        callerPath: callerPath,
-                        decision: "Denied",
-                        approvalSource: "Auto",
-                        reason: "Reused recent denial",
-                        launcher: promptLauncher
-                    ))
-                    self.reply(peer, to: message, ok: false, error: "\(request.op) denied")
-                    return
-                }
-                do {
-                    let record = accessRequestRecord(
-                        request: request,
-                        callerPath: callerPath,
-                        decision: "Approved",
-                        approvalSource: "Auto",
-                        reason: "Reused recent approval",
-                        launcher: promptLauncher
+                    let currentCallerPath = pathString(currentIdentity)
+                    let currentSigning = SigningInfo(
+                        identifier: currentLiveSigning.identifier,
+                        teamIdentifier: currentLiveSigning.teamIdentifier
                     )
-                    guard try self.fulfillApprovedRequest(
-                        request: request,
-                        awsRegistration: awsRegistration,
-                        pid: pid,
-                        identity: identity,
-                        record: record,
-                        launcher: promptLauncher,
-                        release: { payload in
-                            self.reply(
-                                peer,
-                                to: message,
-                                ok: true,
-                                error: nil,
-                                secrets: payload.secrets,
-                                value: payload.value
-                            )
-                        }
-                    ) else {
-                        self.reply(peer, to: message, ok: false, error: "Authorization History is unavailable")
-                        return
+                    var currentLaunchers = launcherIdentities(for: currentIdentity)
+                    if currentLaunchers.isEmpty,
+                       let currentLauncher = launcherIdentity(pid: pid, identity: currentIdentity)
+                    {
+                        currentLaunchers.append(currentLauncher)
                     }
-                } catch {
-                    _ = self.onAccessRequest(accessRequestRecord(
-                        request: request,
-                        callerPath: callerPath,
-                        decision: "Failed",
-                        approvalSource: "Auto",
-                        reason: error.localizedDescription,
-                        launcher: promptLauncher
-                    ))
-                    self.reply(peer, to: message, ok: false, error: error.localizedDescription)
+                    if currentLiveSigning.mainExecutable == currentCallerPath,
+                       currentSigning.identifier == signing.identifier,
+                       currentSigning.teamIdentifier == signing.teamIdentifier,
+                       isAllowedCaller(path: currentCallerPath, signing: currentSigning),
+                       let configuredGate,
+                       let classification,
+                       let currentAgentTaskContext = agentTaskContext(pid: pid),
+                       self.handleTemporaryAccessGrant(
+                           request: request,
+                           gate: configuredGate,
+                           classification: classification,
+                           agentTaskContext: currentAgentTaskContext,
+                           launchers: currentLaunchers,
+                           callerPath: currentCallerPath,
+                           awsRegistration: awsRegistration,
+                           scriptApproval: scriptApproval,
+                           authorizationGate: authorizationGate,
+                           processChains: retainedProcessChains(for: currentIdentity),
+                           pid: pid,
+                           identity: currentIdentity,
+                           peer: peer,
+                           message: message
+                       )
+                    {
+                        return true
+                    }
                 }
+                let cachedDecision = self.transientApprovals.decision(for: transientApproval)
+                if let decision = cachedDecision {
+                    if decision == .denied {
+                        _ = self.onAccessRequest(accessRequestRecord(
+                            request: request,
+                            callerPath: callerPath,
+                            decision: "Denied",
+                            approvalSource: "Auto",
+                            reason: "Reused recent denial",
+                            launcher: promptLauncher
+                        ))
+                        self.reply(peer, to: message, ok: false, error: "\(request.op) denied")
+                        return true
+                    }
+                    do {
+                        let record = accessRequestRecord(
+                            request: request,
+                            callerPath: callerPath,
+                            decision: "Approved",
+                            approvalSource: "Auto",
+                            reason: "Reused recent approval",
+                            launcher: promptLauncher
+                        )
+                        guard try self.fulfillApprovedRequest(
+                            request: request,
+                            awsRegistration: awsRegistration,
+                            pid: pid,
+                            identity: identity,
+                            record: record,
+                            launcher: promptLauncher,
+                            release: { payload in
+                                self.reply(
+                                    peer,
+                                    to: message,
+                                    ok: true,
+                                    error: nil,
+                                    secrets: payload.secrets,
+                                    value: payload.value
+                                )
+                            }
+                        ) else {
+                            self.reply(peer, to: message, ok: false, error: "Authorization History is unavailable")
+                            return true
+                        }
+                    } catch {
+                        _ = self.onAccessRequest(accessRequestRecord(
+                            request: request,
+                            callerPath: callerPath,
+                            decision: "Failed",
+                            approvalSource: "Auto",
+                            reason: error.localizedDescription,
+                            launcher: promptLauncher
+                        ))
+                        self.reply(peer, to: message, ok: false, error: error.localizedDescription)
+                    }
+                    return true
+                }
+                return false
+            }
+
+            if tryFulfillFromGrantOrCache() {
                 return
             }
 
@@ -4508,8 +4516,12 @@ private final class ApprovalServer: @unchecked Sendable {
                 temporaryGrantCandidate: temporaryGrantCandidate,
                 temporaryGrantUnavailableReason: temporaryGrantUnavailableReason,
                 classification: classification,
-                cancellation: cancellation
+                cancellation: cancellation,
+                reevaluate: tryFulfillFromGrantOrCache
             )
+            if decision == .reevaluated {
+                return
+            }
             if decision == .canceled {
                 _ = self.onAccessRequest(canceledAccessRequestRecord(
                     request: request, callerPath: callerPath, launcher: promptLauncher
@@ -5228,7 +5240,7 @@ private final class ApprovalServer: @unchecked Sendable {
                             ) {
                             case .approved: ProxyDestinationDecision.allowOnce
                             case .alwaysApproved: ProxyDestinationDecision.allowForSession
-                            case .canceled, .interrupted, .denied, .temporaryWriteAccess:
+                            case .canceled, .interrupted, .denied, .temporaryWriteAccess, .reevaluated:
                                 ProxyDestinationDecision.deny
                             }
                         }
@@ -11212,7 +11224,17 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
 }
 
 private final class ApprovalPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
+    private var allowsKey = false
+
+    override var canBecomeKey: Bool { allowsKey }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown, !isKeyWindow {
+            allowsKey = true
+            makeKey()
+        }
+        super.sendEvent(event)
+    }
 }
 
 private final class ApprovalPanelDragView: NSView {
@@ -11274,8 +11296,15 @@ private enum ActiveApprovalPrompt {
 }
 
 @MainActor
-private func abortActiveApprovalPrompt() {
+func abortActiveApprovalPrompt() {
     ActiveApprovalPrompt.abort()
+}
+
+enum ApprovalDecisionSource {
+    case standardMac
+    case touchID
+    case phone
+    case programmatic
 }
 
 private final class ApprovalPromptState: @unchecked Sendable {
@@ -11294,13 +11323,22 @@ private final class ApprovalPromptState: @unchecked Sendable {
     }
 
     @MainActor
-    func resolve(_ result: ApprovalDecision) {
+    func resolve(_ result: ApprovalDecision, source: ApprovalDecisionSource = .programmatic) {
         let shouldResume: Bool = lock.withLock {
             guard !hasDecision else { return false }
             hasDecision = true
             return true
         }
         guard shouldResume else { return }
+
+        var finalResult = result
+        if result == .approved || result == .alwaysApproved || result == .temporaryWriteAccess {
+            if PhoneApprovalCoordinator.shared.isEnabled, source == .standardMac {
+                finalResult = .denied
+            } else if TouchIDApproval.isEnabled, source != .touchID {
+                finalResult = .denied
+            }
+        }
 
         if ActiveApprovalPrompt.current === self {
             ActiveApprovalPrompt.current = nil
@@ -11313,12 +11351,12 @@ private final class ApprovalPromptState: @unchecked Sendable {
             PhoneApprovalCoordinator.shared.cancel(remoteRequestID)
         }
         #if !DEBUG
-        if result == .approved || result == .alwaysApproved {
+        if finalResult == .approved || finalResult == .alwaysApproved {
             PostHogTelemetry.shared.captureExplicitApproval()
         }
         #endif
         panel?.orderOut(nil)
-        continuation?.resume(returning: result)
+        continuation?.resume(returning: finalResult)
         continuation = nil
     }
 }
@@ -11342,7 +11380,8 @@ private func showApprovalAlert(
     persistentApprovalLabel: String = "Always Allow",
     classification: SecretGateRequestClassification? = nil,
     cancellation: ApprovalCancellation? = nil,
-    compact: Bool = false
+    compact: Bool = false,
+    reevaluate: (@MainActor () -> Bool)? = nil
 ) async -> ApprovalDecision {
     guard cancellation?.isCanceled != true else { return .canceled }
     let startGeneration = ActiveApprovalPrompt.abortGeneration
@@ -11373,6 +11412,10 @@ private func showApprovalAlert(
           ActiveApprovalPrompt.abortGeneration == startGeneration
     else {
         return terminalApprovalDecision(.canceled, cancellation: cancellation)
+    }
+
+    if reevaluate?() == true {
+        return .reevaluated
     }
 
     let receivedAt = Date()
@@ -11437,12 +11480,11 @@ private func showApprovalAlert(
                 usesIPhoneApproval: usesIPhoneApproval,
                 usesTouchIDApproval: usesTouchIDApproval,
                 compact: compact,
-                decide: { userDecision in
-                    state.resolve(userDecision)
+                decide: { userDecision, source in
+                    state.resolve(userDecision, source: source)
                 }
             )
         )
-        panel.initialFirstResponder = panel.contentView
 
         if usesIPhoneApproval {
             do {
@@ -11480,28 +11522,30 @@ private func showApprovalAlert(
                     case .temporaryWriteAccess: .temporaryWriteAccess
                     case .canceled: .canceled
                     }
-                    state.resolve(mapped)
+                    Task { @MainActor in
+                        state.resolve(mapped, source: .phone)
+                    }
                 }
             } catch {
-                state.resolve(.denied)
+                state.resolve(.denied, source: .programmatic)
                 return
             }
         }
 
         let observed = cancellation?.observe(id: presentationToken) {
-            state.resolve(.canceled)
+            Task { @MainActor in
+                state.resolve(.canceled, source: .programmatic)
+            }
         } ?? true
 
         if !observed {
-            state.resolve(.canceled)
+            state.resolve(.canceled, source: .programmatic)
             return
         }
 
         fitApprovalPanel(panel, maximumHeight: maximumHeight, animate: false)
         panel.center()
         panel.orderFrontRegardless()
-        panel.makeKey()
-        panel.makeFirstResponder(panel.contentView)
     }
 
     return terminalApprovalDecision(decision, cancellation: cancellation)
@@ -12087,7 +12131,7 @@ private struct ApprovalPromptView: View {
     var usesIPhoneApproval = false
     var usesTouchIDApproval = false
     var compact = false
-    let decide: (ApprovalDecision) -> Void
+    let decide: (ApprovalDecision, ApprovalDecisionSource) -> Void
     @State private var isAuthenticatingWithTouchID = false
 
     var body: some View {
@@ -12171,7 +12215,7 @@ private struct ApprovalPromptView: View {
             if usesTouchIDApproval {
                 HStack(spacing: 12) {
                     Button(usesIPhoneApproval ? "Cancel Request" : "Deny", role: .cancel) {
-                        decide(.denied)
+                        decide(.denied, .standardMac)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.large)
@@ -12187,7 +12231,7 @@ private struct ApprovalPromptView: View {
                     .disabled(isAuthenticatingWithTouchID || !TouchIDApproval.isAvailable)
                 }
             } else if usesIPhoneApproval {
-                Button("Cancel Request", role: .cancel) { decide(.denied) }
+                Button("Cancel Request", role: .cancel) { decide(.denied, .standardMac) }
                     .buttonStyle(.bordered)
                     .controlSize(.large)
                     .keyboardShortcut(.cancelAction)
@@ -12198,7 +12242,7 @@ private struct ApprovalPromptView: View {
                     .multilineTextAlignment(.center)
             } else {
                 HStack(alignment: .top, spacing: 18) {
-                    Button("Deny", role: .cancel) { decide(.denied) }
+                    Button("Deny", role: .cancel) { decide(.denied, .standardMac) }
                         .buttonStyle(.bordered)
                         .controlSize(.large)
                         .frame(maxWidth: .infinity)
@@ -12209,7 +12253,7 @@ private struct ApprovalPromptView: View {
                             allowsPersistentApproval: allowsPersistentApproval,
                             temporaryGrantCandidate: temporaryGrantCandidate,
                             persistentApprovalLabel: persistentApprovalLabel,
-                            decide: decide
+                            decide: { decide($0, .standardMac) }
                         )
                         Text(compact
                             ? "This Approval applies only to this secret change."
@@ -12269,7 +12313,7 @@ private struct ApprovalPromptView: View {
             reason: "Approve this exact Automic Vault request"
         ) { approved in
             isAuthenticatingWithTouchID = false
-            if approved { decide(decision) }
+            if approved { decide(decision, .touchID) }
         }
     }
 }
@@ -13099,7 +13143,7 @@ private func runApprovalSelfCheck() -> Int32 {
     let dummyView = NSView()
     testPanel.contentView = dummyView
     testPanel.initialFirstResponder = dummyView
-    guard testPanel.canBecomeKey,
+    guard !testPanel.canBecomeKey,
           !testPanel.canBecomeMain,
           testPanel.styleMask.contains(.nonactivatingPanel),
           testPanel.level == .modalPanel,
@@ -13247,7 +13291,7 @@ private func runApprovalSelfCheck() -> Int32 {
         rootView: ApprovalPromptView(
             content: promptContent,
             temporaryGrantCandidate: nil,
-            decide: { _ in }
+            decide: { _, _ in }
         )
     )
     collapsedPrompt.layoutSubtreeIfNeeded()
@@ -13257,7 +13301,7 @@ private func runApprovalSelfCheck() -> Int32 {
             content: promptContent,
             temporaryGrantCandidate: nil,
             compact: true,
-            decide: { _ in }
+            decide: { _, _ in }
         )
     ).fittingSize
     func containsDragRegion(_ view: NSView) -> Bool {
@@ -13284,7 +13328,7 @@ private func runApprovalSelfCheck() -> Int32 {
             ),
             maximumHeight: 500,
             temporaryGrantCandidate: nil,
-            decide: { _ in }
+            decide: { _, _ in }
         )
     ).fittingSize.height
     guard prettyShellCommand(target: "/bin/echo", args: ["hello world", "it's-ok"]) == """

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2845,10 +2845,18 @@ final class ApprovalCancellation: @unchecked Sendable {
             return items
         }
         if !list.isEmpty {
-            RunLoop.main.perform(inModes: [.modalPanel, .default]) {
+            if Thread.isMainThread {
                 MainActor.assumeIsolated {
                     for item in list {
                         item()
+                    }
+                }
+            } else {
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated {
+                        for item in list {
+                            item()
+                        }
                     }
                 }
             }
@@ -11615,7 +11623,9 @@ private final class ApprovalPanel: NSPanel {
     override func sendEvent(_ event: NSEvent) {
         if event.type == .leftMouseDown, !isKeyWindow {
             allowsKey = true
-            makeKey()
+            if isVisible {
+                makeKey()
+            }
         }
         super.sendEvent(event)
     }
@@ -14661,6 +14671,31 @@ private func runApprovalSelfCheck() -> Int32 {
 }
 
 @MainActor
+private func awaitWithTimeout<T: Sendable>(
+    duration: Duration,
+    cancellation: ApprovalCancellation,
+    task: Task<T, Never>
+) async -> T? {
+    await withTaskGroup(of: T?.self) { group in
+        group.addTask {
+            await task.value
+        }
+        group.addTask {
+            try? await Task.sleep(for: duration)
+            return nil
+        }
+        let first = await group.next() ?? nil
+        if first == nil {
+            cancellation.cancel()
+            task.cancel()
+        }
+        group.cancelAll()
+        while await group.next() != nil {}
+        return first
+    }
+}
+
+@MainActor
 private func runApprovalCallsiteSelfCheck() async -> Int32 {
     // 1. Queued-transition focus invariant: every freshly created alert starts non-key
     // and does not inherit focus from a previously key window.
@@ -14696,6 +14731,7 @@ private func runApprovalCallsiteSelfCheck() async -> Int32 {
         return 11
     }
     panel1.orderOut(nil)
+    panel1.close()
 
     // Verify next queued panel starts non-key by construction, preventing focus auto-promotion
     let panel2 = makeApprovalPanel()
@@ -14708,6 +14744,7 @@ private func runApprovalCallsiteSelfCheck() async -> Int32 {
         return 12
     }
     panel2.orderOut(nil)
+    panel2.close()
 
     // 2. Mode-transition invalidation
     HumanApprovalQueue.shared.resetForTesting()
@@ -14841,6 +14878,7 @@ private func runApprovalCallsiteSelfCheck() async -> Int32 {
         return 42
     }
 
+    let testCancellation = ApprovalCancellation()
     let queuedAlertTask = Task { @MainActor in
         await showApprovalAlert(
             request: testReq,
@@ -14851,6 +14889,7 @@ private func runApprovalCallsiteSelfCheck() async -> Int32 {
             launcher: nil,
             launcherFallbackPath: "/bin/zsh",
             automaticApprovalExplanation: nil,
+            cancellation: testCancellation,
             reevaluate: {
                 cache.decision(for: testReuseRequest) == .approved
             }
@@ -14875,18 +14914,11 @@ private func runApprovalCallsiteSelfCheck() async -> Int32 {
     cache.remember(.approved, for: testReuseRequest)
     HumanApprovalQueue.shared.release()
 
-    let queuedAlertDecision = await withTaskGroup(of: ApprovalDecision?.self) { group in
-        group.addTask {
-            await queuedAlertTask.value
-        }
-        group.addTask {
-            try? await Task.sleep(for: .seconds(5))
-            return nil
-        }
-        let first = await group.next() ?? nil
-        group.cancelAll()
-        return first
-    }
+    let queuedAlertDecision = await awaitWithTimeout(
+        duration: .seconds(5),
+        cancellation: testCancellation,
+        task: queuedAlertTask
+    )
     guard let queuedAlertDecision else {
         fputs("timed out waiting for request 2 to resolve after slot release\n", stderr)
         return 44
@@ -14897,6 +14929,68 @@ private func runApprovalCallsiteSelfCheck() async -> Int32 {
     else {
         fputs("request 2 failed to reevaluate from cache and release queue slot\n", stderr)
         return 45
+    }
+
+    // 5. Negative path: verify that stuck approvals terminate on timeout via cancellation without hanging
+    // Case 5a: Queued waiter stuck behind held slot (slot is never released)
+    HumanApprovalQueue.shared.resetForTesting()
+    let stuckSlotAcquired = await HumanApprovalQueue.shared.acquire()
+    guard stuckSlotAcquired, HumanApprovalQueue.shared.hasActiveSlot else {
+        fputs("failed initial queue slot acquisition for stuck queued test\n", stderr)
+        return 50
+    }
+
+    let stuckQueuedCancellation = ApprovalCancellation()
+    let stuckQueuedTask = Task { @MainActor in
+        await showApprovalAlert(
+            request: testReq,
+            callerPath: "/bin/zsh",
+            pid: getpid(),
+            signing: helperSigning,
+            scriptApproval: nil,
+            launcher: nil,
+            launcherFallbackPath: "/bin/zsh",
+            automaticApprovalExplanation: nil,
+            cancellation: stuckQueuedCancellation,
+            reevaluate: { false }
+        )
+    }
+
+    var stuckQueued = false
+    let stuckDeadline = Date().addingTimeInterval(5.0)
+    while Date() < stuckDeadline {
+        if HumanApprovalQueue.shared.pendingCount == 1 {
+            stuckQueued = true
+            break
+        }
+        await Task.yield()
+    }
+    guard stuckQueued else {
+        stuckQueuedCancellation.cancel()
+        stuckQueuedTask.cancel()
+        HumanApprovalQueue.shared.release()
+        fputs("timed out waiting for stuck request to enqueue in HumanApprovalQueue\n", stderr)
+        return 51
+    }
+
+    // Slot is intentionally never released. Verify awaitWithTimeout cancels and returns nil without hanging.
+    let stuckQueuedDecision = await awaitWithTimeout(
+        duration: .milliseconds(500),
+        cancellation: stuckQueuedCancellation,
+        task: stuckQueuedTask
+    )
+    guard stuckQueuedDecision == nil else {
+        HumanApprovalQueue.shared.release()
+        fputs("stuck queued approval unexpectedly completed instead of timing out\n", stderr)
+        return 52
+    }
+
+    HumanApprovalQueue.shared.release()
+    guard !HumanApprovalQueue.shared.hasActiveSlot,
+          HumanApprovalQueue.shared.pendingCount == 0
+    else {
+        fputs("stuck queued approval failed to cleanly drain from queue after cancellation\n", stderr)
+        return 53
     }
 
     return 0

--- a/src/menu-helper/Sources/MenubarHelperCore/HumanApprovalQueue.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/HumanApprovalQueue.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Manages a FIFO queue for human approval prompts so that only a single
+/// prompt occupies the active presentation slot at any given time without blocking
+/// the main event loop or delaying unrelated secret access.
+public final class HumanApprovalQueue: @unchecked Sendable {
+    public static let shared = HumanApprovalQueue()
+
+    private let lock = NSLock()
+    private var isSlotActive = false
+    private var waiters: [UUID: (Bool) -> Void] = [:]
+    private var waiterOrder: [UUID] = []
+
+    public init() {}
+
+    public var pendingCount: Int {
+        lock.withLock { waiterOrder.count }
+    }
+
+    public var hasActiveSlot: Bool {
+        lock.withLock { isSlotActive }
+    }
+
+    /// Requests access to the single active human approval slot.
+    /// - Parameters:
+    ///   - id: A unique identifier for this request.
+    ///   - isCanceled: An optional closure returning true if already cancelled.
+    ///   - registerCancellation: An optional closure to register a cancellation observer.
+    /// - Returns: `true` if access to the slot was granted, or `false` if cancelled.
+    public func acquire(
+        id: UUID = UUID(),
+        isCanceled: (@Sendable () -> Bool)? = nil,
+        registerCancellation: (@Sendable (@escaping @Sendable () -> Void) -> Void)? = nil
+    ) async -> Bool {
+        if isCanceled?() == true { return false }
+
+        let shouldWait: Bool = lock.withLock {
+            if !isSlotActive {
+                isSlotActive = true
+                return false
+            } else {
+                return true
+            }
+        }
+
+        if !shouldWait {
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            var resumed = false
+            let resumeWith: (Bool) -> Void = { granted in
+                guard !resumed else { return }
+                resumed = true
+                continuation.resume(returning: granted)
+            }
+
+            let wasAlreadyCanceled: Bool = lock.withLock {
+                if isCanceled?() == true {
+                    return true
+                }
+                waiters[id] = resumeWith
+                waiterOrder.append(id)
+                return false
+            }
+
+            if wasAlreadyCanceled {
+                resumeWith(false)
+                return
+            }
+
+            registerCancellation? { [weak self] in
+                self?.cancel(id: id)
+            }
+        }
+    }
+
+    /// Cancels a pending request in the queue. If it was waiting, resumes it with `false`.
+    public func cancel(id: UUID) {
+        let resume: ((Bool) -> Void)? = lock.withLock {
+            guard let index = waiterOrder.firstIndex(of: id) else { return nil }
+            waiterOrder.remove(at: index)
+            return waiters.removeValue(forKey: id)
+        }
+        resume?(false)
+    }
+
+    /// Releases the active approval slot and promotes the next queued waiter, if any.
+    public func release() {
+        var nextResume: ((Bool) -> Void)?
+        lock.withLock {
+            while !waiterOrder.isEmpty {
+                let nextID = waiterOrder.removeFirst()
+                if let resume = waiters.removeValue(forKey: nextID) {
+                    nextResume = resume
+                    // Slot remains active for the promoted waiter
+                    return
+                }
+            }
+            isSlotActive = false
+        }
+        nextResume?(true)
+    }
+
+    /// Cancels all pending waiters in the queue, resuming them with `false`.
+    public func cancelAllPending() {
+        let pendingResumes: [(Bool) -> Void] = lock.withLock {
+            let list = Array(waiters.values)
+            waiters.removeAll()
+            waiterOrder.removeAll()
+            return list
+        }
+        for resume in pendingResumes {
+            resume(false)
+        }
+    }
+
+    /// Resets queue state (for test isolation).
+    public func resetForTesting() {
+        lock.withLock {
+            isSlotActive = false
+            for resume in waiters.values {
+                resume(false)
+            }
+            waiters.removeAll()
+            waiterOrder.removeAll()
+        }
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/HumanApprovalQueue.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/HumanApprovalQueue.swift
@@ -34,19 +34,6 @@ public final class HumanApprovalQueue: @unchecked Sendable {
     ) async -> Bool {
         if isCanceled?() == true { return false }
 
-        let shouldWait: Bool = lock.withLock {
-            if !isSlotActive {
-                isSlotActive = true
-                return false
-            } else {
-                return true
-            }
-        }
-
-        if !shouldWait {
-            return true
-        }
-
         return await withCheckedContinuation { continuation in
             var resumed = false
             let resumeWith: (Bool) -> Void = { granted in
@@ -55,22 +42,34 @@ public final class HumanApprovalQueue: @unchecked Sendable {
                 continuation.resume(returning: granted)
             }
 
-            let wasAlreadyCanceled: Bool = lock.withLock {
+            enum Decision {
+                case grantImmediate
+                case cancelImmediate
+                case enqueued
+            }
+
+            let decision: Decision = lock.withLock {
                 if isCanceled?() == true {
-                    return true
+                    return .cancelImmediate
+                }
+                if !isSlotActive {
+                    isSlotActive = true
+                    return .grantImmediate
                 }
                 waiters[id] = resumeWith
                 waiterOrder.append(id)
-                return false
+                return .enqueued
             }
 
-            if wasAlreadyCanceled {
+            switch decision {
+            case .grantImmediate:
+                resumeWith(true)
+            case .cancelImmediate:
                 resumeWith(false)
-                return
-            }
-
-            registerCancellation? { [weak self] in
-                self?.cancel(id: id)
+            case .enqueued:
+                registerCancellation? { [weak self] in
+                    self?.cancel(id: id)
+                }
             }
         }
     }
@@ -117,13 +116,15 @@ public final class HumanApprovalQueue: @unchecked Sendable {
 
     /// Resets queue state (for test isolation).
     public func resetForTesting() {
-        lock.withLock {
+        let pendingResumes: [(Bool) -> Void] = lock.withLock {
             isSlotActive = false
-            for resume in waiters.values {
-                resume(false)
-            }
+            let list = Array(waiters.values)
             waiters.removeAll()
             waiterOrder.removeAll()
+            return list
+        }
+        for resume in pendingResumes {
+            resume(false)
         }
     }
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/HumanApprovalQueueTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/HumanApprovalQueueTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+@Test func immediateAcquisitionWhenSlotIsAvailable() async {
+    let queue = HumanApprovalQueue()
+    #expect(!queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+
+    let granted = await queue.acquire()
+    #expect(granted)
+    #expect(queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+
+    queue.release()
+    #expect(!queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+}
+
+@Test func queuesSubsequentRequestsInFIFOOrder() async {
+    let queue = HumanApprovalQueue()
+    let acquired1 = await queue.acquire()
+    #expect(acquired1)
+    #expect(queue.hasActiveSlot)
+
+    let executionOrder = LockedState<[Int]>([])
+
+    let task2 = Task {
+        let acquired = await queue.acquire()
+        #expect(acquired)
+        executionOrder.withValue { $0.append(2) }
+        queue.release()
+    }
+
+    // Ensure task2 has enqueued before starting task3 to eliminate unstructured scheduling races
+    let task2Enqueued = await waitUntil { queue.pendingCount >= 1 }
+    #expect(task2Enqueued)
+
+    let task3 = Task {
+        let acquired = await queue.acquire()
+        #expect(acquired)
+        executionOrder.withValue { $0.append(3) }
+        queue.release()
+    }
+
+    // Wait for task3 to enqueue
+    let task3Enqueued = await waitUntil { queue.pendingCount >= 2 }
+    #expect(task3Enqueued)
+
+    // Release task 1
+    executionOrder.withValue { $0.append(1) }
+    queue.release()
+
+    _ = await task2.value
+    _ = await task3.value
+
+    #expect(executionOrder.get() == [1, 2, 3])
+    #expect(!queue.hasActiveSlot)
+}
+
+@Test func cancelAllPendingResumesAllWaitersWithFalse() async {
+    let queue = HumanApprovalQueue()
+    let acquired1 = await queue.acquire()
+    #expect(acquired1)
+
+    let task2Acquired = LockedState<Bool?>(nil)
+    let task3Acquired = LockedState<Bool?>(nil)
+
+    let task2 = Task {
+        let granted = await queue.acquire()
+        task2Acquired.set(granted)
+    }
+
+    let task2Enqueued = await waitUntil { queue.pendingCount >= 1 }
+    #expect(task2Enqueued)
+
+    let task3 = Task {
+        let granted = await queue.acquire()
+        task3Acquired.set(granted)
+    }
+
+    let task3Enqueued = await waitUntil { queue.pendingCount >= 2 }
+    #expect(task3Enqueued)
+
+    queue.cancelAllPending()
+    #expect(queue.pendingCount == 0)
+
+    _ = await task2.value
+    _ = await task3.value
+
+    #expect(task2Acquired.get() == false)
+    #expect(task3Acquired.get() == false)
+    #expect(queue.hasActiveSlot)
+    queue.release()
+    #expect(!queue.hasActiveSlot)
+}
+
+@Test func queuedRequestCanBeCancelledBeforePresentation() async {
+    let queue = HumanApprovalQueue()
+    let acquired1 = await queue.acquire()
+    #expect(acquired1)
+
+    let id2 = UUID()
+    let id3 = UUID()
+    let task2Acquired = LockedState<Bool?>(nil)
+    let task3Acquired = LockedState<Bool?>(nil)
+
+    let task2 = Task {
+        let acquired = await queue.acquire(id: id2)
+        task2Acquired.set(acquired)
+    }
+
+    let task3 = Task {
+        let acquired = await queue.acquire(id: id3)
+        task3Acquired.set(acquired)
+    }
+
+    let bothEnqueued = await waitUntil { queue.pendingCount >= 2 }
+    #expect(bothEnqueued)
+
+    // Cancel task 2 while it is waiting in queue
+    queue.cancel(id: id2)
+
+    _ = await task2.value
+    #expect(task2Acquired.get() == false)
+    #expect(queue.pendingCount == 1)
+
+    // Release task 1 -> task 3 should be promoted immediately
+    queue.release()
+
+    _ = await task3.value
+    #expect(task3Acquired.get() == true)
+
+    queue.release()
+    #expect(!queue.hasActiveSlot)
+}
+
+@Test func preCancelledRequestFailsImmediately() async {
+    let queue = HumanApprovalQueue()
+    let granted = await queue.acquire(isCanceled: { true })
+    #expect(!granted)
+    #expect(!queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+}
+
+@Test func stressConcurrencyEnsuresMutualExclusion() async {
+    let queue = HumanApprovalQueue()
+    let concurrentHolders = LockedState<Int>(0)
+    let maxConcurrentHolders = LockedState<Int>(0)
+    let completedCount = LockedState<Int>(0)
+    let taskCount = 30
+
+    await withTaskGroup(of: Void.self) { group in
+        for _ in 0..<taskCount {
+            group.addTask {
+                let granted = await queue.acquire()
+                #expect(granted)
+
+                let current = concurrentHolders.withValue { count -> Int in
+                    count += 1
+                    return count
+                }
+                maxConcurrentHolders.withValue { maxCount in
+                    if current > maxCount { maxCount = current }
+                }
+
+                // Small yield to allow race conditions to emerge if mutual exclusion is broken
+                try? await Task.sleep(nanoseconds: 100_000)
+
+                concurrentHolders.withValue { $0 -= 1 }
+                completedCount.withValue { $0 += 1 }
+                queue.release()
+            }
+        }
+    }
+
+    #expect(completedCount.get() == taskCount)
+    #expect(maxConcurrentHolders.get() == 1)
+    #expect(!queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+}
+
+@Test func stressInterleavedCancellationAndRelease() async {
+    let queue = HumanApprovalQueue()
+    let acquired1 = await queue.acquire()
+    #expect(acquired1)
+
+    let totalWaiters = 20
+    var ids: [UUID] = []
+    let results = LockedState<[UUID: Bool]>([:])
+
+    var tasks: [Task<Void, Never>] = []
+    for _ in 0..<totalWaiters {
+        let id = UUID()
+        ids.append(id)
+        tasks.append(Task {
+            let granted = await queue.acquire(id: id)
+            results.withValue { $0[id] = granted }
+            if granted {
+                queue.release()
+            }
+        })
+    }
+
+    let allEnqueued = await waitUntil { queue.pendingCount == totalWaiters }
+    #expect(allEnqueued)
+
+    // Concurrently cancel half the waiters while releasing the active slot
+    let cancelledIDs = Set(ids.prefix(totalWaiters / 2))
+    for id in cancelledIDs {
+        queue.cancel(id: id)
+    }
+    queue.release()
+
+    for task in tasks {
+        _ = await task.value
+    }
+
+    let finalResults = results.get()
+    #expect(finalResults.count == totalWaiters)
+    for id in ids {
+        if cancelledIDs.contains(id) {
+            #expect(finalResults[id] == false)
+        } else {
+            #expect(finalResults[id] == true)
+        }
+    }
+    #expect(!queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+}
+
+@Test func idempotentAndUnknownCancellationIsSafe() async {
+    let queue = HumanApprovalQueue()
+    // Cancelling an unknown UUID does not crash or corrupt queue
+    queue.cancel(id: UUID())
+
+    let id = UUID()
+    let taskResult = LockedState<Bool?>(nil)
+    let acquired = await queue.acquire()
+    #expect(acquired)
+
+    let task = Task {
+        let granted = await queue.acquire(id: id)
+        taskResult.set(granted)
+    }
+
+    let enqueued = await waitUntil { queue.pendingCount == 1 }
+    #expect(enqueued)
+
+    // Multiple cancellations of the same ID
+    queue.cancel(id: id)
+    queue.cancel(id: id)
+
+    _ = await task.value
+    #expect(taskResult.get() == false)
+    #expect(queue.pendingCount == 0)
+
+    queue.release()
+    #expect(!queue.hasActiveSlot)
+}
+
+private final class LockedState<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T
+
+    init(_ initial: T) {
+        self.value = initial
+    }
+
+    func withValue<R>(_ body: (inout T) -> R) -> R {
+        lock.withLock { body(&value) }
+    }
+
+    func get() -> T {
+        lock.withLock { value }
+    }
+
+    func set(_ newValue: T) {
+        lock.withLock { value = newValue }
+    }
+}
+
+private func waitUntil(
+    timeout: Duration = .seconds(3),
+    condition: @Sendable () -> Bool
+) async -> Bool {
+    let start = ContinuousClock.now
+    while !condition() {
+        if ContinuousClock.now - start > timeout {
+            return false
+        }
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+    return true
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/HumanApprovalQueueTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/HumanApprovalQueueTests.swift
@@ -259,6 +259,61 @@ import Testing
     #expect(!queue.hasActiveSlot)
 }
 
+@Test func releaseRacingWithWaiterRegistration() async {
+    let queue = HumanApprovalQueue()
+    let waves = 5
+    let tasksPerWave = 32
+
+    for _ in 0..<waves {
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<tasksPerWave {
+                group.addTask {
+                    let acquired = await queue.acquire()
+                    if acquired {
+                        queue.release()
+                    }
+                    return acquired
+                }
+            }
+            var acquiredCount = 0
+            for await acquired in group {
+                if acquired {
+                    acquiredCount += 1
+                }
+            }
+            #expect(acquiredCount == tasksPerWave)
+        }
+        #expect(!queue.hasActiveSlot)
+        #expect(queue.pendingCount == 0)
+    }
+}
+
+@Test func resetForTestingDoesNotDeadlockWhenWaitersReenter() async {
+    let queue = HumanApprovalQueue()
+    let acquired = await queue.acquire()
+    #expect(acquired)
+
+    let completed = LockedState<Bool>(false)
+    let task = Task {
+        let granted = await queue.acquire()
+        #expect(!granted)
+        // Re-enter the queue synchronously upon resumption
+        _ = queue.pendingCount
+        queue.release()
+        completed.set(true)
+    }
+
+    let enqueued = await waitUntil { queue.pendingCount == 1 }
+    #expect(enqueued)
+
+    queue.resetForTesting()
+
+    _ = await task.value
+    #expect(completed.get())
+    #expect(!queue.hasActiveSlot)
+    #expect(queue.pendingCount == 0)
+}
+
 private final class LockedState<T>: @unchecked Sendable {
     private let lock = NSLock()
     private var value: T


### PR DESCRIPTION
Resolves #62.

When an interactive Human Approval prompt is displayed, `NSApp.runModal(for: panel)` took over the main run loop exclusively in `NSModalPanelRunLoopMode`. As a result, standard `DispatchQueue.main` and `Task { @MainActor in ... }` tasks scheduled for the default run loop mode were stalled. This caused:
1. **Delayed Auto-Approval Toasts:** Automatic access notifications (`Task { @MainActor in self?.didRecordAccessRequest(record) }`) queued up behind unanswered dialogs and only appeared after the prompt was dismissed.
2. **Head-of-Line Blocking:** Subsequent access requests requiring human approval dispatched their presentation to `DispatchQueue.main` and blocked completely, preventing multiple requests from even queueing properly.

### Changes
- **`HumanApprovalQueue` in `MenubarHelperCore`:** Introduces a thread-safe FIFO queue actor ensuring only one interactive approval prompt occupies the active presentation slot at any given time, while allowing concurrent callers to await or cancel their turn without blocking threads.
- **Decouple from `NSApp.runModal` in `MenubarHelper`:** Refactors `showApprovalAlert` to run non-modally using `withCheckedContinuation`. The main run loop continues spinning in default mode, allowing auto-approval toasts, animations, and IPC handlers to run concurrently.
- **Async Approval Call Sites:** Converts `handleInject`, `handleAccessRequest`, `handleList`, `performApprovedSecretMutation`, and `SecretProxyCoordinator.DestinationApproval` to async/await.
- **Multi-Observer Cancellation:** Enhances `ApprovalCancellation` with UUID-tokened observation so requests waiting in the queue can cancel early before ever presenting a dialog.
- **Prompt Lifecycle & Session Inactivity:** Routes session lock (`userSessionDidResignActive`), screen sleep (`screensDidSleep`), helper reset, and app update (`beginUpdating`) through `ActiveApprovalPrompt.abort()` / `abortActiveApprovalPrompt()`.
- **Interrupted Reply Protocol:** Routes unacquired and aborted queue waiters through `terminalApprovalDecision(.canceled, cancellation: cancellation)` so live clients receive an `interrupted` error reply instead of hanging until timeout.
- **Promotion Race Prevention:** Captures and validates `ActiveApprovalPrompt.abortGeneration` upon slot acquisition to guarantee promoted waiters do not slip past a lock/sleep abort.
- **Keyboard Access:** Sets `panel.initialFirstResponder = panel.contentView`, calls `panel.makeKey()`, and calls `panel.makeFirstResponder(panel.contentView)` upon presentation so Escape (deny) and Return (approve) work immediately without stealing application focus.
- **Tests & Self-Checks:**
  - Expanded unit test suite in `HumanApprovalQueueTests.swift` (8 tests) covering FIFO ordering, cancellation while queued, pre-cancellation, `cancelAllPending`, 30-task concurrent mutual exclusion stress testing, and interleaved cancellation races using bounded deadline-based polling.
  - Adds `abortGeneration`, queue-drain, and `ApprovalPanel` configuration validation in `runApprovalSelfCheck()`.

### Verification
- `swift test --package-path src/menu-helper --filter HumanApprovalQueueTests` (8/8 passed)
- `./scripts/test-menu-helper-self-checks.sh` (all 28 passed)
- `cargo test --tests` (all passed)