### PR TITLE
Add SSH Agent setting with shared credential and Launcher authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,8 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "signature",
+ "ssh-key",
  "subtle",
  "tokio",
  "toml",
@@ -294,6 +296,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
 
 [[package]]
 name = "bit-vec"
@@ -468,6 +481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +521,17 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
 
 [[package]]
 name = "chacha20"
@@ -1640,6 +1673,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -2070,6 +2104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2244,17 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "polyval"
@@ -2372,7 +2426,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -2562,6 +2616,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2",
  "signature",
  "spki",
  "subtle",
@@ -2922,6 +2977,56 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20 0.9.1",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "bcrypt-pbkdf",
+ "ed25519-dalek",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ pgp = { version = "0.20", default-features = false }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+ssh-key = { version = "0.6.7", features = ["ed25519", "p256", "p384", "p521", "encryption"] }
+signature = "2.2"
 subtle = "2.6"
 tokio = { version = "1.53", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0.9"

--- a/docs/adr/0043-ssh-agent-gate.md
+++ b/docs/adr/0043-ssh-agent-gate.md
@@ -20,7 +20,11 @@ Approval surface. Disabling immediately prevents new Secret Application.
 
 The signed bundled `av ssh-agent` serves a mode-0600 Unix socket in a private
 mode-0700 directory. It implements bounded identity enumeration and SSH user
-authentication signing from RFC 9987. Unsupported operations, including adding
+authentication signing from RFC 9987, including OpenSSH's
+`publickey-hostbound-v00@openssh.com` format. The additional server host key or
+host certificate is structurally validated and included in the authorized payload
+digest and signature. This does not introduce destination policy: server trust
+remains the SSH client's responsibility. Unsupported operations, including adding
 keys, PKCS#11 loading, arbitrary signing and unrecognized flags, fail closed.
 Use RustCrypto's SSH key implementation for OpenSSH decoding, decryption and
 signatures for Ed25519 and ECDSA keys. RSA is rejected because the available

--- a/docs/adr/0043-ssh-agent-gate.md
+++ b/docs/adr/0043-ssh-agent-gate.md
@@ -47,6 +47,12 @@ its parent from gaining a different Launcher's authority by executing an
 allow-listed app after preparing a request. Kernels that cannot provide original
 parent execution versions leave the feature unavailable; Settings explains this.
 The long-running helper never supplies Launcher attribution.
+A root-owned `/usr/bin/login` may be traversed as a system relay, because Terminal
+uses it to start the user's shell. Both original execution links must verify, the
+live relay must satisfy `anchor apple and identifier com.apple.login`, and its
+parent must have the child's UID and audit session. The relay supplies no Launcher
+authority. Its PID version comes from kernel process information when its audit
+token is inaccessible; the relay's unknown audit session is not used for attribution.
 A Verified Launcher is required even for manual Approval. The signing Target
 remains the signed `av` helper, which alone receives usable credential bytes.
 The peer and Keychain configuration are rechecked before release. Each use must

--- a/docs/adr/0043-ssh-agent-gate.md
+++ b/docs/adr/0043-ssh-agent-gate.md
@@ -64,6 +64,9 @@ persist and verify an Authorization Record before credential bytes leave custody
 No transient decision reuse, script authority, Temporary Access Grants or
 Retained Launcher Provenance applies. Policy offers Approval Required and Allow
 Authentication; authentication can enable remote writes.
+Both approval and denial reuse are disabled: the long-running Gate Client serves
+unrelated SSH clients and Launchers, so a process-scoped denial quarantine would
+incorrectly suppress their subsequent Approval requests.
 
 ## Consequences
 

--- a/docs/adr/0043-ssh-agent-gate.md
+++ b/docs/adr/0043-ssh-agent-gate.md
@@ -23,13 +23,30 @@ mode-0700 directory. It implements bounded identity enumeration and SSH user
 authentication signing from RFC 9987. Unsupported operations, including adding
 keys, PKCS#11 loading, arbitrary signing and unrecognized flags, fail closed.
 Use RustCrypto's SSH key implementation for OpenSSH decoding, decryption and
-signatures; never invoke the ambient system agent or write usable keys to disk.
+signatures for Ed25519 and ECDSA keys. RSA is rejected because the available
+RustCrypto RSA implementation has the unpatched
+[RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071.html) timing
+advisory; another reviewed implementation is required before enabling RSA.
+Never invoke the ambient system agent or write usable keys to disk.
 
 For each signature the helper passes the connected socket over authenticated
 XPC, binding the exact bounded payload digest, public key and signature flags.
-The menu app obtains the socket peer's kernel audit token and verifies its PID
-version, start time, user and audit session against the still-live process.
-Launcher attribution starts from that peer, never the long-running helper.
+The menu app obtains the socket peer's kernel audit token, matches the socket's
+recorded executable UUID, and verifies that the live process owns the exact
+connected endpoint through kernel descriptor information. `LOCAL_PEERTOKEN`
+alone is insufficient: macOS resolves the most recent accessor's current task,
+including after exec or PID reuse. UUID is corroborating data, not code identity.
+Each request retains and revalidates the peer's PID version, start time, user,
+audit session, arguments and working directory.
+
+Launcher attribution follows only live original ancestors. Each parent must
+match the child's kernel-recorded parent unique ID and original parent PID
+version. The peer cannot represent itself as a Launcher, and session-leader or
+retained-provenance fallback is unavailable. This prevents a socket sender or
+its parent from gaining a different Launcher's authority by executing an
+allow-listed app after preparing a request. Kernels that cannot provide original
+parent execution versions leave the feature unavailable; Settings explains this.
+The long-running helper never supplies Launcher attribution.
 A Verified Launcher is required even for manual Approval. The signing Target
 remains the signed `av` helper, which alone receives usable credential bytes.
 The peer and Keychain configuration are rechecked before release. Each use must
@@ -45,8 +62,8 @@ never loads private material. Private-key copies outside Automic Vault and keys
 already loaded into other agents remain independent access paths. Settings must
 explain these limits and never silently delete originals or clear another agent.
 
-The socket establishes the local connecting process, not the origin of every
-byte it forwards. Forwarded or shared connections inherit that local client's
+The socket establishes a live local accessor and its original ancestry, not the
+origin of every byte it forwards. Forwarded or shared connections inherit that local client's
 attribution. Hostnames and remote command arguments are context, not verified
 destination restrictions. A subsequent destination policy requires an additional
 review of OpenSSH session binding and forwarding, not trust in client labels.

--- a/docs/adr/0043-ssh-agent-gate.md
+++ b/docs/adr/0043-ssh-agent-gate.md
@@ -1,0 +1,55 @@
+# ADR 0043: Gate SSH authentication through a local SSH agent
+
+Status: accepted
+
+## Context
+
+An encrypted SSH key with a Keychain passphrase protects the file at rest, but
+an ordinary agent can make its signing authority ambient to same-user software.
+Issue #217 requests Launcher-based authorization, with destination policy left
+for later. Unlike GPG signing, SSH uses the same credential for all Launchers.
+
+## Decision
+
+Add an off-by-default SSH Agent setting and a built-in SSH Agent Gate. Keep one
+OpenSSH private key and optional passphrase together in `AV_SSH_CREDENTIAL` in
+the Data Protection Keychain. Select only its Global Value. Persist the enabled
+state and corresponding public key in a separate Keychain configuration item.
+Changing credentials or enabling the integration uses the existing authority
+Approval surface. Disabling immediately prevents new Secret Application.
+
+The signed bundled `av ssh-agent` serves a mode-0600 Unix socket in a private
+mode-0700 directory. It implements bounded identity enumeration and SSH user
+authentication signing from RFC 9987. Unsupported operations, including adding
+keys, PKCS#11 loading, arbitrary signing and unrecognized flags, fail closed.
+Use RustCrypto's SSH key implementation for OpenSSH decoding, decryption and
+signatures; never invoke the ambient system agent or write usable keys to disk.
+
+For each signature the helper passes the connected socket over authenticated
+XPC, binding the exact bounded payload digest, public key and signature flags.
+The menu app obtains the socket peer's kernel audit token and verifies its PID
+version, start time, user and audit session against the still-live process.
+Launcher attribution starts from that peer, never the long-running helper.
+A Verified Launcher is required even for manual Approval. The signing Target
+remains the signed `av` helper, which alone receives usable credential bytes.
+The peer and Keychain configuration are rechecked before release. Each use must
+persist and verify an Authorization Record before credential bytes leave custody.
+No transient decision reuse, script authority, Temporary Access Grants or
+Retained Launcher Provenance applies. Policy offers Approval Required and Allow
+Authentication; authentication can enable remote writes.
+
+## Consequences
+
+Public keys are deliberately enumerable without Approval, but enumerating them
+never loads private material. Private-key copies outside Automic Vault and keys
+already loaded into other agents remain independent access paths. Settings must
+explain these limits and never silently delete originals or clear another agent.
+
+The socket establishes the local connecting process, not the origin of every
+byte it forwards. Forwarded or shared connections inherit that local client's
+attribution. Hostnames and remote command arguments are context, not verified
+destination restrictions. A subsequent destination policy requires an additional
+review of OpenSSH session binding and forwarding, not trust in client labels.
+
+References: [SSH agent protocol](https://www.rfc-editor.org/rfc/rfc9987.html),
+[OpenSSH extensions](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.agent).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,18 @@ confined to the adjacent signed `av` process and the Keychain-owning menu app,
 which stores it after deriving its public key.
 See [ADR 0019](adr/0019-gpg-signing-gate.md).
 
+The optional SSH Agent Gate uses a Unix socket served by the bundled signed
+`av ssh-agent` Target. The helper passes a duplicate of each connected socket
+over authenticated XPC. The Mac derives the local peer's execution identity from
+its kernel audit token, resolves that peer's Verified Launcher, and binds the
+bounded SSH authentication payload digest before authorizing. It rechecks the
+peer and credential configuration before releasing the single Global Value of
+`AV_SSH_CREDENTIAL`. The helper signs in memory and returns only the signature.
+Private keys are never added to the system agent. There is no decision reuse,
+Blessing, Temporary Access Grant, or retained provenance at this gate. Settings
+stores its enabled state and public key in the Data Protection Keychain.
+See [ADR 0043](adr/0043-ssh-agent-gate.md).
+
 ### Launcher Packaging
 
 Launcher Bundles let one unsigned Mach-O command-line tool participate as a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -408,6 +408,12 @@ observe a Secret after Application. These findings inform Approval; they do not
 create authority, replace Target verification, or imply that a Target will keep
 a Secret confidential.
 
+Execution Chain labels may identify an invocation such as `npm` from mutable
+process arguments. They retain the interpreter's executable path and runtime
+posture and do not establish the invoked code's identity. SSH Approvals identify
+the local SSH client separately from the `av` signing Target and describe the
+operation as authentication, which may permit remote writes.
+
 For `av proxy`, the CLI remains the Gate Client and the signed proxy helper is
 the immediate Secret Target. The launched executable is bound as the Proxy
 Session Target and receives bearer Secret References. Its PID version, start

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,9 @@ The optional SSH Agent Gate uses a Unix socket served by the bundled signed
 over authenticated XPC. The Mac derives the local peer's execution identity from
 its kernel audit token, recorded executable UUID and live endpoint ownership,
 then resolves a Verified Launcher through kernel-bound original parent
-executions. The peer cannot be its own Launcher. Unsupported kernels and changed
+executions. Terminal's root-owned Apple `login` relay may be traversed only with
+both original execution links verified and matching user/audit-session endpoints.
+The relay grants no authority. The peer cannot be its own Launcher. Unsupported kernels and changed
 ancestry deny use. The bounded SSH authentication payload digest is bound before
 authorizing. It rechecks the
 peer and credential configuration before releasing the single Global Value of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,8 +159,11 @@ See [ADR 0019](adr/0019-gpg-signing-gate.md).
 The optional SSH Agent Gate uses a Unix socket served by the bundled signed
 `av ssh-agent` Target. The helper passes a duplicate of each connected socket
 over authenticated XPC. The Mac derives the local peer's execution identity from
-its kernel audit token, resolves that peer's Verified Launcher, and binds the
-bounded SSH authentication payload digest before authorizing. It rechecks the
+its kernel audit token, recorded executable UUID and live endpoint ownership,
+then resolves a Verified Launcher through kernel-bound original parent
+executions. The peer cannot be its own Launcher. Unsupported kernels and changed
+ancestry deny use. The bounded SSH authentication payload digest is bound before
+authorizing. It rechecks the
 peer and credential configuration before releasing the single Global Value of
 `AV_SSH_CREDENTIAL`. The helper signs in memory and returns only the signature.
 Private keys are never added to the system agent. There is no decision reuse,

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -88,6 +88,9 @@ its optional passphrase in one protected Secret, `AV_SSH_CREDENTIAL`.
 
 Each request binds the live local socket peer, its Verified Launcher, the signed
 `av` Gate Client and signing Target, and the exact authentication payload.
+The Verified Launcher must be a live original ancestor: the socket peer cannot
+represent itself as a Launcher. Every parent execution must match the kernel's
+original-parent evidence; unavailable or changed ancestry denies use.
 The gate defaults to **Approval Required** and offers **Allow Authentication**
 for recognized SSH authentication signatures. This delegates authentication,
 including access that may permit remote writes; it is not Read Only authority.

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -78,6 +78,24 @@ this gate is signing, it exposes only **Approval Required** and **Allow
 Signing**. Allow Signing is the GPG-specific presentation of Local Write. The
 gate defaults to Approval Required.
 
+### SSH Agent Gate
+
+The built-in Tool-specific Secret Gate for SSH authentication signatures through
+Automic Vault's optional SSH agent. One SSH Credential is used for every
+Verified Launcher; there are no Launcher-specific credential selectors or
+Project Values at this gate. The credential contains an OpenSSH private key and
+its optional passphrase in one protected Secret, `AV_SSH_CREDENTIAL`.
+
+Each request binds the live local socket peer, its Verified Launcher, the signed
+`av` Gate Client and signing Target, and the exact authentication payload.
+The gate defaults to **Approval Required** and offers **Allow Authentication**
+for recognized SSH authentication signatures. This delegates authentication,
+including access that may permit remote writes; it is not Read Only authority.
+Public-key enumeration does not apply a Secret. Agent key mutation and arbitrary
+signing are unsupported. No destination-specific authority is claimed. A local
+client that forwards or shares its connection can carry other software's
+requests under its Launcher attribution.
+
 ### Proxy Session
 
 A live, memory-only Secret Proxy Gate context bound to one complete command and

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -55,6 +55,10 @@ Automic Vault decides whether a complete operation may use it.
   authorizes private-key use and may select an alternate credential for exact
   Verified Launchers.
 
+- The optional SSH agent authorizes each authentication signature using one
+  credential shared across Verified Launchers. SSH clients receive signatures,
+  never the private key. Destination-specific restrictions are not provided.
+
 ## Claim boundaries
 
 User-facing copy must preserve these limits:

--- a/scripts/test-ssh-agent-peer.sh
+++ b/scripts/test-ssh-agent-peer.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+repo=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$(mktemp -d /tmp/av-ssh-peer-test.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+cat > "$scratch/check.c" <<'C'
+#include "CProcessInfo.h"
+#include <assert.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+int main(int argc, char **argv) {
+ char args[65536]; ssize_t count=av_process_arguments_data(getpid(),args,sizeof(args));
+ assert(count>0); char *cursor=args;
+ for(int i=0;i<argc;i++) { assert(strcmp(cursor,argv[i])==0); cursor+=strlen(cursor)+1; }
+ assert(cursor==args+count);
+ assert(av_process_arguments_data(getpid(),args,4)==-1);
+ char dir[]="/tmp/av-ssh-peer-XXXXXX"; assert(mkdtemp(dir));
+ struct sockaddr_un addr={.sun_family=AF_UNIX};
+ snprintf(addr.sun_path,sizeof(addr.sun_path),"%s/socket",dir);
+ int server=socket(AF_UNIX,SOCK_STREAM,0); assert(server>=0);
+ assert(bind(server,(void*)&addr,sizeof(addr))==0); assert(listen(server,1)==0);
+ int channel[2], report[2]; assert(pipe(channel)==0); assert(pipe(report)==0);
+ pid_t child=fork(); assert(child>=0);
+ if(child==0) {
+   close(channel[1]); close(report[0]);
+   int client=socket(AF_UNIX,SOCK_STREAM,0); assert(connect(client,(void*)&addr,sizeof(addr))==0);
+   pid_t nested=fork(); assert(nested>=0);
+   if(nested==0) { close(client); pause(); _exit(0); }
+   assert(write(report[1],&nested,sizeof(nested))==sizeof(nested));
+   char b; read(channel[0],&b,1); execl("/bin/sleep","sleep","60",NULL); _exit(1);
+ }
+ close(channel[0]); int fd=accept(server,NULL,NULL); assert(fd>=0);
+ AVProcessIdentity peer={0}; assert(av_socket_peer_identity(fd,&peer)); assert(peer.pid==child);
+ AVProcessIdentity parent={0}; assert(av_original_parent_identity(&peer,&parent)); assert(parent.pid==getpid());
+ AVProcessIdentity changed=peer; changed.pidversion++;
+ assert(!av_original_parent_identity(&changed,&parent));
+ assert(peer.pidversion>0); char cwd[4096]; assert(av_process_cwd(child,cwd,sizeof(cwd))); assert(cwd[0]=='/');
+ close(report[1]); pid_t nested=0;
+ assert(read(report[0],&nested,sizeof(nested))==sizeof(nested)); close(report[0]);
+ AVProcessIdentity grandchild={0}; assert(av_process_identity(nested,&grandchild));
+ assert(av_original_parent_identity(&grandchild,&parent)); assert(parent.pid==child);
+ int version=peer.pidversion;
+ write(channel[1],"x",1);
+ AVProcessIdentity current={0};
+ for(int i=0;i<200;i++) {
+   assert(av_process_identity(child,&current));
+   if(current.pidversion!=version) break;
+   usleep(10000);
+ }
+ assert(current.pidversion!=version);
+ assert(!av_socket_peer_identity(fd,&peer)); // Same PID after exec is a different execution.
+ assert(!av_original_parent_identity(&grandchild,&parent)); // An exec cannot impersonate a child's original Launcher.
+ kill(nested,SIGTERM); kill(child,SIGTERM);waitpid(child,NULL,0);
+ assert(!av_socket_peer_identity(fd,&peer)); assert(!av_socket_peer_identity(channel[1],&peer));
+ close(fd);close(channel[1]);
+ // Inspect a signed Apple process as well as the synthetic fork fixture.
+ int native_input[2]; assert(pipe(native_input)==0);
+ pid_t native=fork(); assert(native>=0);
+ if(native==0) {
+   close(native_input[1]); assert(dup2(native_input[0],STDIN_FILENO)>=0);
+   execl("/usr/bin/nc","nc","-U",addr.sun_path,NULL); _exit(1);
+ }
+ close(native_input[0]); int native_fd=accept(server,NULL,NULL); assert(native_fd>=0);
+ assert(av_socket_peer_identity(native_fd,&peer)); assert(peer.pid==native);
+ assert(av_original_parent_identity(&peer,&parent)); assert(parent.pid==getpid());
+ kill(native,SIGTERM);waitpid(native,NULL,0);close(native_fd);close(native_input[1]);
+ close(server);unlink(addr.sun_path);rmdir(dir);puts("SSH socket peer checks passed");
+}
+C
+clang -Wall -Wextra -Werror \
+  -I"$repo/src/menu-helper/Sources/CProcessInfo/include" \
+  "$scratch/check.c" "$repo/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c" \
+  -lbsm -o "$scratch/check"
+"$scratch/check" 'a b' $'a\nb' ''

--- a/scripts/test-ssh-agent-peer.sh
+++ b/scripts/test-ssh-agent-peer.sh
@@ -15,6 +15,21 @@ cat > "$scratch/check.c" <<'C'
 #include <stdio.h>
 #include <string.h>
 int main(int argc, char **argv) {
+ if(argc==3 && strcmp(argv[1],"--login-child")==0) {
+   AVProcessIdentity child={0}, parent={0}, login={0};
+   assert(av_process_identity(atoi(argv[2]),&child));
+   assert(!av_original_parent_identity(&child,&parent));
+   assert(av_original_login_parent_identity(&child,&parent));
+   assert(av_process_identity(child.ppid,&login));
+   assert(parent.pid==login.ppid && parent.euid==child.euid && parent.audit_session_id==child.audit_session_id);
+   AVProcessIdentity changed=child; changed.pidversion++;
+   assert(!av_original_login_parent_identity(&changed,&parent));
+   changed=child; changed.audit_session_id++;
+   assert(!av_original_login_parent_identity(&changed,&parent));
+   changed=child; changed.euid++;
+   assert(!av_original_login_parent_identity(&changed,&parent));
+   puts("SSH original login relay checks passed"); return 0;
+ }
  char args[65536]; ssize_t count=av_process_arguments_data(getpid(),args,sizeof(args));
  assert(count>0); char *cursor=args;
  for(int i=0;i<argc;i++) { assert(strcmp(cursor,argv[i])==0); cursor+=strlen(cursor)+1; }
@@ -38,6 +53,7 @@ int main(int argc, char **argv) {
  close(channel[0]); int fd=accept(server,NULL,NULL); assert(fd>=0);
  AVProcessIdentity peer={0}; assert(av_socket_peer_identity(fd,&peer)); assert(peer.pid==child);
  AVProcessIdentity parent={0}; assert(av_original_parent_identity(&peer,&parent)); assert(parent.pid==getpid());
+ assert(!av_original_login_parent_identity(&peer,&parent));
  AVProcessIdentity changed=peer; changed.pidversion++;
  assert(!av_original_parent_identity(&changed,&parent));
  assert(peer.pidversion>0); char cwd[4096]; assert(av_process_cwd(child,cwd,sizeof(cwd))); assert(cwd[0]=='/');
@@ -78,3 +94,6 @@ clang -Wall -Wextra -Werror \
   "$scratch/check.c" "$repo/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c" \
   -lbsm -o "$scratch/check"
 "$scratch/check" 'a b' $'a\nb' ''
+if [[ -n "${AV_SSH_LOGIN_CHILD_PID:-}" ]]; then
+  "$scratch/check" --login-child "$AV_SSH_LOGIN_CHILD_PID"
+fi

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -1266,10 +1266,78 @@ pub(super) fn approve_gpg_signing(
     Err("GPG signing approval is only available on macOS".into())
 }
 
+pub(super) fn approve_ssh_agent(
+    args: Vec<String>,
+    socket: i32,
+    signing: bool,
+) -> Result<SecretValues, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let request = ApprovalRequest {
+            op: if signing {
+                "ssh-sign"
+            } else {
+                "ssh-identities"
+            },
+            keys: Vec::new(),
+            target: std::env::current_exe()
+                .and_then(std::fs::canonicalize)
+                .map_err(|e| e.to_string())?
+                .to_string_lossy()
+                .into_owned(),
+            args,
+            cwd: "/".into(),
+            replace_existing_env: false,
+            allow_missing_keys: false,
+            env_conflicts: Vec::new(),
+            shebang_script: None,
+            script_data: None,
+            snapshot_incompatible_interpreter: None,
+            tool: Some("ssh-agent"),
+            docker_server_url: None,
+            terraform_hostname: None,
+            aliyun_profile: None,
+            oxide_scope: None,
+            fastly_scope: None,
+            sqlcmd_scope: None,
+            goat_scope: None,
+            ordercli_scope: None,
+            openhue_scope: None,
+            uaa_scope: None,
+            railway_scope: None,
+            kubectl_scope: None,
+            wakatime_api_url: None,
+        };
+        xpc_approve_request_with_socket(
+            &request,
+            &[if signing {
+                "AV_SSH_CREDENTIAL".into()
+            } else {
+                "public_key".into()
+            }],
+            Some(socket),
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (args, socket, signing);
+        Err("SSH Agent requires macOS".into())
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn xpc_approve_request(
     request: &ApprovalRequest,
     response_keys: &[String],
+) -> Result<SecretValues, String> {
+    xpc_approve_request_with_socket(request, response_keys, None)
+}
+
+#[cfg(target_os = "macos")]
+fn xpc_approve_request_with_socket(
+    request: &ApprovalRequest,
+    response_keys: &[String],
+    socket: Option<i32>,
 ) -> Result<SecretValues, String> {
     use std::os::raw::{c_char, c_int, c_void};
 
@@ -1291,6 +1359,7 @@ fn xpc_approve_request(
             message: XpcObject,
         ) -> XpcObject;
         fn xpc_dictionary_create_empty() -> XpcObject;
+        fn xpc_dictionary_set_fd(dict: XpcObject, key: *const c_char, fd: c_int);
         fn xpc_dictionary_set_bool(xdict: XpcObject, key: *const c_char, value: bool);
         fn xpc_dictionary_get_bool(xdict: XpcObject, key: *const c_char) -> bool;
         fn xpc_dictionary_set_string(xdict: XpcObject, key: *const c_char, value: *const c_char);
@@ -1365,6 +1434,9 @@ fn xpc_approve_request(
     }
 
     unsafe {
+        if let Some(fd) = socket {
+            xpc_dictionary_set_fd(message, c"ssh_socket".as_ptr(), fd);
+        }
         set_string(message, b"op\0", request.op)?;
         set_string(message, b"target\0", &request.target)?;
         set_string(message, b"cwd\0", &request.cwd)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -26,6 +26,7 @@ mod save;
 mod scan;
 mod shell_secrets;
 pub(crate) mod sqlcmd_credential;
+mod ssh_agent;
 pub(crate) mod terraform_credential;
 pub(crate) mod uaa_credential;
 pub(crate) mod wakatime_credential;
@@ -343,6 +344,8 @@ where
             }
         }
         Some("__secret-gates-json") if rest.is_empty() => scan::run_secret_gates_json(stdout),
+        Some("ssh-agent") => ssh_agent::run(rest, stderr),
+        Some("__ssh-public-key") => ssh_agent::public_key(stdout, stderr),
         Some("gpg-sign") => gpg_sign::run(rest, stdout, stderr),
         Some("__gpg-public-key") if rest.is_empty() => gpg_sign::validate(stdout, stderr),
         Some("__gpg-generate-key") if rest.is_empty() => gpg_sign::generate(stdout, stderr),

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -634,7 +634,7 @@ mod tests {
             .iter()
             .map(|gate| gate["id"].as_str().unwrap())
             .collect::<std::collections::BTreeSet<_>>();
-        let standalone_gate_ids = std::collections::BTreeSet::from(["gpg-signing"]);
+        let standalone_gate_ids = std::collections::BTreeSet::from(["gpg-signing", "ssh-agent"]);
         assert_eq!(
             catalog_gate_ids
                 .difference(&hardener_gate_ids)

--- a/src/cli/ssh_agent.rs
+++ b/src/cli/ssh_agent.rs
@@ -101,7 +101,11 @@ fn serve(path: &Path) -> Result<(), String> {
         .filter(|p| p.is_absolute())
         .ok_or("Socket path must be absolute")?;
     // Never follow a substituted private directory or lock file.
-    match std::fs::DirBuilder::new().recursive(true).mode(0o700).create(parent) {
+    match std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(parent)
+    {
         Ok(()) => (),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
         Err(e) => return Err(e.to_string()),

--- a/src/cli/ssh_agent.rs
+++ b/src/cli/ssh_agent.rs
@@ -1,0 +1,433 @@
+//! Narrow SSH agent: public enumeration and RFC 4252 userauth signatures only.
+use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+
+use signature::Signer;
+use ssh_key::{Algorithm, PrivateKey, PublicKey};
+use zeroize::{Zeroize, Zeroizing};
+
+const MAX_PACKET: usize = 256 * 1024;
+const MAX_CREDENTIAL: u64 = 1024 * 1024;
+const FAILURE: &[u8] = &[5];
+
+#[derive(serde::Deserialize)]
+struct Credential {
+    private_key: String,
+    passphrase: String,
+}
+impl Drop for Credential {
+    fn drop(&mut self) {
+        self.private_key.zeroize();
+        self.passphrase.zeroize();
+    }
+}
+
+fn decode_credential(value: &str) -> Result<PrivateKey, String> {
+    if value.len() as u64 > MAX_CREDENTIAL {
+        return Err("SSH credential exceeds 1 MiB".into());
+    }
+    let credential: Credential =
+        serde_json::from_str(value).map_err(|_| "Invalid SSH credential")?;
+    let key = PrivateKey::from_openssh(&credential.private_key)
+        .map_err(|_| "Invalid OpenSSH private key")?;
+    if matches!(key.kdf(), ssh_key::Kdf::Bcrypt { rounds, .. } if *rounds > 1024) {
+        return Err("SSH key decryption exceeds the supported KDF cost (1024 rounds)".into());
+    }
+    let key = if key.is_encrypted() {
+        key.decrypt(&credential.passphrase)
+            .map_err(|_| "Could not decrypt the SSH private key")?
+    } else {
+        key
+    };
+    match key.algorithm() {
+        Algorithm::Ed25519 | Algorithm::Ecdsa { .. } => Ok(key),
+        _ => Err("Use an Ed25519 or ECDSA OpenSSH private key".into()),
+    }
+}
+
+pub(super) fn public_key(stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    let result = (|| {
+        let mut input = Zeroizing::new(String::new());
+        std::io::stdin()
+            .take(MAX_CREDENTIAL + 1)
+            .read_to_string(&mut input)
+            .map_err(|e| e.to_string())?;
+        if input.len() as u64 > MAX_CREDENTIAL {
+            return Err("SSH credential exceeds 1 MiB".into());
+        }
+        let key = decode_credential(&input)?;
+        let public = key.public_key().to_openssh().map_err(|e| e.to_string())?;
+        stdout
+            .write_all(public.as_bytes())
+            .map_err(|e| e.to_string())
+    })();
+    report(result, stderr)
+}
+
+pub(super) fn run(args: Vec<OsString>, stderr: &mut dyn Write) -> i32 {
+    report(
+        (|| {
+            if args.len() != 1 {
+                return Err("usage: av ssh-agent SOCKET_PATH".into());
+            }
+            serve(Path::new(&args[0]))
+        })(),
+        stderr,
+    )
+}
+
+fn report(result: Result<(), String>, stderr: &mut dyn Write) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            let _ = writeln!(stderr, "av ssh-agent: {error}");
+            1
+        }
+    }
+}
+
+fn serve(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .filter(|p| p.is_absolute())
+        .ok_or("Socket path must be absolute")?;
+    // Never follow a substituted private directory or lock file.
+    match std::fs::DirBuilder::new().mode(0o700).create(parent) {
+        Ok(()) => (),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
+        Err(e) => return Err(e.to_string()),
+    }
+    let meta = std::fs::symlink_metadata(parent).map_err(|e| e.to_string())?;
+    if !meta.is_dir() || meta.uid() != unsafe { libc::geteuid() } || meta.mode() & 0o077 != 0 {
+        return Err("SSH agent directory must be owned by you with mode 0700".into());
+    }
+    let lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(parent.join("lock"))
+        .map_err(|e| e.to_string())?;
+    let meta = lock.metadata().map_err(|e| e.to_string())?;
+    if !meta.is_file() || meta.uid() != unsafe { libc::geteuid() } || meta.mode() & 0o077 != 0 {
+        return Err("Unsafe SSH agent lock file".into());
+    }
+    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err("SSH agent is already running".into());
+    }
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        if !meta.file_type().is_socket() || meta.uid() != unsafe { libc::geteuid() } {
+            return Err("Refusing to replace an unrelated socket path".into());
+        }
+        std::fs::remove_file(path).map_err(|e| e.to_string())?;
+    }
+    let listener = UnixListener::bind(path).map_err(|e| e.to_string())?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| e.to_string())?;
+    listener.set_nonblocking(true).map_err(|e| e.to_string())?;
+    let parent_pid = unsafe { libc::getppid() };
+    let clients = Arc::new(AtomicUsize::new(0));
+    while unsafe { libc::getppid() } == parent_pid {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                // ponytail: 16 simultaneous clients; use an async listener if demand grows.
+                if clients.load(Ordering::Relaxed) >= 16 {
+                    continue;
+                }
+                clients.fetch_add(1, Ordering::Relaxed);
+                let clients = clients.clone();
+                std::thread::spawn(move || {
+                    let _ = connection(stream);
+                    clients.fetch_sub(1, Ordering::Relaxed);
+                });
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100))
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    let _ = std::fs::remove_file(path);
+    Ok(())
+}
+use std::os::unix::fs::DirBuilderExt;
+
+fn connection(mut stream: UnixStream) -> Result<(), String> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(120)))
+        .map_err(|e| e.to_string())?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(10)))
+        .map_err(|e| e.to_string())?;
+    loop {
+        let mut length = [0; 4];
+        if stream.read_exact(&mut length).is_err() {
+            return Ok(());
+        }
+        let length = u32::from_be_bytes(length) as usize;
+        if length == 0 || length > MAX_PACKET {
+            return Err("Invalid SSH agent packet length".into());
+        }
+        let mut packet = vec![0; length];
+        stream.read_exact(&mut packet).map_err(|e| e.to_string())?;
+        let response = respond(&packet, |args, signing| {
+            super::inject::approve_ssh_agent(args, stream.as_raw_fd(), signing)
+        })
+        .unwrap_or_else(|_| FAILURE.to_vec());
+        stream
+            .write_all(&(response.len() as u32).to_be_bytes())
+            .map_err(|e| e.to_string())?;
+        stream.write_all(&response).map_err(|e| e.to_string())?;
+    }
+}
+
+fn string(out: &mut Vec<u8>, value: &[u8]) {
+    out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    out.extend_from_slice(value);
+}
+fn take<'a>(input: &mut &'a [u8], size: usize) -> Result<&'a [u8], String> {
+    if size > input.len() {
+        return Err("Truncated SSH message".into());
+    }
+    let (value, rest) = input.split_at(size);
+    *input = rest;
+    Ok(value)
+}
+fn uint(input: &mut &[u8]) -> Result<u32, String> {
+    Ok(u32::from_be_bytes(take(input, 4)?.try_into().unwrap()))
+}
+fn field<'a>(input: &mut &'a [u8]) -> Result<&'a [u8], String> {
+    let size = uint(input)? as usize;
+    take(input, size)
+}
+fn digest(value: &[u8]) -> String {
+    ring::digest::digest(&ring::digest::SHA256, value)
+        .as_ref()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+// Limit this gate to SSH public-key authentication, never generic SSHSIG signing.
+fn authentication(payload: &[u8], key: &[u8], algorithm: &str) -> Result<(), String> {
+    let mut input = payload;
+    if !(16..=64).contains(&field(&mut input)?.len())
+        || take(&mut input, 1)? != [50]
+        || field(&mut input)?.is_empty()
+        || field(&mut input)? != b"ssh-connection"
+        || field(&mut input)? != b"publickey"
+        || take(&mut input, 1)? != [1]
+        || field(&mut input)? != algorithm.as_bytes()
+        || field(&mut input)? != key
+        || !input.is_empty()
+    {
+        return Err("Only SSH public-key authentication is supported".into());
+    }
+    Ok(())
+}
+
+fn respond(
+    packet: &[u8],
+    mut authorize: impl FnMut(
+        Vec<String>,
+        bool,
+    ) -> Result<std::collections::BTreeMap<String, String>, String>,
+) -> Result<Vec<u8>, String> {
+    if packet.len() > MAX_PACKET {
+        return Err("SSH message too large".into());
+    }
+    if packet == [11] {
+        let values = authorize(vec![], false)?;
+        let public = values
+            .get("public_key")
+            .ok_or("SSH agent is not configured")?;
+        let key = PublicKey::from_openssh(public).map_err(|_| "Invalid public key")?;
+        let mut response = vec![12];
+        response.extend_from_slice(&1u32.to_be_bytes());
+        string(&mut response, &key.to_bytes().map_err(|e| e.to_string())?);
+        string(&mut response, b"Automic Vault");
+        return Ok(response);
+    }
+    if packet.first() != Some(&13) {
+        return Ok(FAILURE.to_vec());
+    }
+    let mut input = &packet[1..];
+    let key_blob = field(&mut input)?;
+    let payload = field(&mut input)?;
+    let flags = uint(&mut input)?;
+    if !input.is_empty() {
+        return Err("Trailing SSH message data".into());
+    }
+    let public = PublicKey::from_bytes(key_blob).map_err(|_| "Invalid SSH public key")?;
+    let algorithm = match (public.algorithm(), flags) {
+        (Algorithm::Ed25519, 0) => "ssh-ed25519".to_string(),
+        (Algorithm::Ecdsa { .. }, 0) => public.algorithm().to_string(),
+        _ => return Err("Unsupported SSH signature algorithm or flags".into()),
+    };
+    authentication(payload, key_blob, &algorithm)?;
+    let mut values = authorize(
+        vec![
+            format!("payload-sha256={}", digest(payload)),
+            format!("public-key-sha256={}", digest(key_blob)),
+            format!("signature-flags={flags}"),
+        ],
+        true,
+    )?;
+    let credential = Zeroizing::new(values.remove("AV_SSH_CREDENTIAL").unwrap_or_default());
+    values.values_mut().for_each(Zeroize::zeroize);
+    let key = decode_credential(&credential)?;
+    if key.public_key().key_data() != public.key_data() {
+        return Err("SSH credential changed".into());
+    }
+    let signature: ssh_key::Signature = key.try_sign(payload).map_err(|_| "SSH signing failed")?;
+    if signature.algorithm().to_string() != algorithm {
+        return Err("Unexpected SSH signature algorithm".into());
+    }
+    let mut blob = Vec::new();
+    string(&mut blob, algorithm.as_bytes());
+    string(&mut blob, signature.as_bytes());
+    let mut response = vec![14];
+    string(&mut response, &blob);
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use signature::Verifier;
+    fn request(key: &PrivateKey) -> (Vec<u8>, Vec<u8>) {
+        let blob = key.public_key().to_bytes().unwrap();
+        let mut payload = Vec::new();
+        string(&mut payload, &[7; 32]);
+        payload.push(50);
+        string(&mut payload, b"git");
+        string(&mut payload, b"ssh-connection");
+        string(&mut payload, b"publickey");
+        payload.push(1);
+        string(&mut payload, key.algorithm().as_str().as_bytes());
+        string(&mut payload, &blob);
+        let mut packet = vec![13];
+        string(&mut packet, &blob);
+        string(&mut packet, &payload);
+        packet.extend_from_slice(&0u32.to_be_bytes());
+        (packet, payload)
+    }
+    #[test]
+    fn authentication_signature_binds_payload_and_key_and_verifies() {
+        let key = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();
+        let (packet, payload) = request(&key);
+        let value = serde_json::json!({"private_key": key.to_openssh(Default::default()).unwrap().as_str(), "passphrase": ""}).to_string();
+        let response = respond(&packet, |args, signing| {
+            assert!(signing);
+            assert_eq!(args[0], format!("payload-sha256={}", digest(&payload)));
+            assert_eq!(
+                args[1],
+                format!(
+                    "public-key-sha256={}",
+                    digest(&key.public_key().to_bytes().unwrap())
+                )
+            );
+            Ok([("AV_SSH_CREDENTIAL".into(), value.clone())].into())
+        })
+        .unwrap();
+        assert_eq!(response[0], 14);
+        let mut input = &response[1..];
+        let mut blob = field(&mut input).unwrap();
+        assert_eq!(field(&mut blob).unwrap(), b"ssh-ed25519");
+        let signature =
+            ssh_key::Signature::new(Algorithm::Ed25519, field(&mut blob).unwrap().to_vec())
+                .unwrap();
+        Verifier::verify(key.public_key(), &payload, &signature).unwrap();
+        assert!(respond(&packet, |_, _| Err("denied".into())).is_err());
+    }
+    #[test]
+    fn all_supported_keys_sign_and_mismatched_credentials_fail() {
+        for algorithm in [
+            Algorithm::Ed25519,
+            Algorithm::Ecdsa {
+                curve: ssh_key::EcdsaCurve::NistP256,
+            },
+            Algorithm::Ecdsa {
+                curve: ssh_key::EcdsaCurve::NistP384,
+            },
+            Algorithm::Ecdsa {
+                curve: ssh_key::EcdsaCurve::NistP521,
+            },
+        ] {
+            let key = PrivateKey::random(&mut rand::rngs::OsRng, algorithm.clone()).unwrap();
+            let (packet, payload) = request(&key);
+            let value = serde_json::json!({"private_key": key.to_openssh(Default::default()).unwrap().as_str(), "passphrase": ""}).to_string();
+            let response = respond(&packet, |_, _| {
+                Ok([("AV_SSH_CREDENTIAL".into(), value.clone())].into())
+            })
+            .unwrap();
+            let mut input = &response[1..];
+            let mut blob = field(&mut input).unwrap();
+            assert_eq!(field(&mut blob).unwrap(), algorithm.as_str().as_bytes());
+            let signature =
+                ssh_key::Signature::new(algorithm, field(&mut blob).unwrap().to_vec()).unwrap();
+            Verifier::verify(key.public_key(), &payload, &signature).unwrap();
+            let different = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();
+            let wrong = serde_json::json!({"private_key": different.to_openssh(Default::default()).unwrap().as_str(), "passphrase": ""}).to_string();
+            assert!(
+                respond(&packet, |_, _| Ok([(
+                    "AV_SSH_CREDENTIAL".into(),
+                    wrong.clone()
+                )]
+                .into()))
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn listing_never_requests_private_material() {
+        let key = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();
+        let response = respond(&[11], |args, signing| {
+            assert!(args.is_empty());
+            assert!(!signing);
+            Ok([("public_key".into(), key.public_key().to_openssh().unwrap())].into())
+        })
+        .unwrap();
+        assert_eq!(response[0], 12);
+        let mut input = &response[1..];
+        assert_eq!(uint(&mut input).unwrap(), 1);
+        assert_eq!(
+            field(&mut input).unwrap(),
+            key.public_key().to_bytes().unwrap()
+        );
+        assert_eq!(field(&mut input).unwrap(), b"Automic Vault");
+        assert!(input.is_empty());
+    }
+
+    #[test]
+    fn malformed_and_unsupported_requests_never_authorize() {
+        let key = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();
+        let (packet, _) = request(&key);
+        for end in 0..packet.len() {
+            let _ = respond(&packet[..end], |_, _| {
+                panic!("truncated message authorized")
+            });
+        }
+        let mut trailing = packet.clone();
+        trailing.push(0);
+        assert!(respond(&trailing, |_, _| panic!()).is_err());
+        let mut flags = packet;
+        *flags.last_mut().unwrap() = 1;
+        assert!(respond(&flags, |_, _| panic!()).is_err());
+        for opcode in [17, 18, 19, 20, 22, 23, 25, 26, 27] {
+            assert_eq!(respond(&[opcode], |_, _| panic!()).unwrap(), FAILURE);
+        }
+        assert!(authentication(b"SSHSIG arbitrary signing", b"", "ssh-ed25519").is_err());
+    }
+}

--- a/src/cli/ssh_agent.rs
+++ b/src/cli/ssh_agent.rs
@@ -231,13 +231,34 @@ fn authentication(payload: &[u8], key: &[u8], algorithm: &str) -> Result<(), Str
         || take(&mut input, 1)? != [50]
         || field(&mut input)?.is_empty()
         || field(&mut input)? != b"ssh-connection"
-        || field(&mut input)? != b"publickey"
-        || take(&mut input, 1)? != [1]
-        || field(&mut input)? != algorithm.as_bytes()
-        || field(&mut input)? != key
-        || !input.is_empty()
     {
         return Err("Only SSH public-key authentication is supported".into());
+    }
+    let host_bound = match field(&mut input)? {
+        b"publickey" => false,
+        b"publickey-hostbound-v00@openssh.com" => true,
+        _ => return Err("Unsupported SSH authentication method".into()),
+    };
+    if take(&mut input, 1)? != [1]
+        || field(&mut input)? != algorithm.as_bytes()
+        || field(&mut input)? != key
+    {
+        return Err("Invalid SSH authentication request".into());
+    }
+    if host_bound {
+        let host = field(&mut input)?;
+        // Structural validation only; destination policy remains the SSH client's responsibility.
+        if PublicKey::from_bytes(host).is_err()
+            && !matches!(
+                ssh_key::Certificate::from_bytes(host).map(|cert| cert.cert_type()),
+                Ok(ssh_key::certificate::CertType::Host)
+            )
+        {
+            return Err("Invalid SSH server host key".into());
+        }
+    }
+    if !input.is_empty() {
+        return Err("Trailing SSH authentication data".into());
     }
     Ok(())
 }
@@ -333,22 +354,108 @@ mod tests {
     }
 
     fn request(key: &PrivateKey) -> (Vec<u8>, Vec<u8>) {
+        request_with_host(key, None)
+    }
+    fn request_with_host(key: &PrivateKey, host: Option<&[u8]>) -> (Vec<u8>, Vec<u8>) {
         let blob = key.public_key().to_bytes().unwrap();
         let mut payload = Vec::new();
         string(&mut payload, &[7; 32]);
         payload.push(50);
         string(&mut payload, b"git");
         string(&mut payload, b"ssh-connection");
-        string(&mut payload, b"publickey");
+        string(
+            &mut payload,
+            if host.is_some() {
+                b"publickey-hostbound-v00@openssh.com"
+            } else {
+                b"publickey"
+            },
+        );
         payload.push(1);
         string(&mut payload, key.algorithm().as_str().as_bytes());
         string(&mut payload, &blob);
+        if let Some(host) = host {
+            string(&mut payload, host);
+        }
         let mut packet = vec![13];
         string(&mut packet, &blob);
         string(&mut packet, &payload);
         packet.extend_from_slice(&0u32.to_be_bytes());
         (packet, payload)
     }
+    #[test]
+    fn host_bound_authentication_signs_the_complete_payload() {
+        let key = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();
+        let host = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();
+        let host_blob = host.public_key().to_bytes().unwrap();
+        let (packet, payload) = request_with_host(&key, Some(&host_blob));
+        let value = serde_json::json!({"private_key": key.to_openssh(Default::default()).unwrap().as_str(), "passphrase": ""}).to_string();
+        let response = respond(&packet, |args, signing| {
+            assert!(signing);
+            assert_eq!(args[0], format!("payload-sha256={}", digest(&payload)));
+            Ok([("AV_SSH_CREDENTIAL".into(), value.clone())].into())
+        })
+        .unwrap();
+        assert_eq!(response[0], 14);
+        let mut input = &response[1..];
+        let mut blob = field(&mut input).unwrap();
+        assert_eq!(field(&mut blob).unwrap(), b"ssh-ed25519");
+        let signature =
+            ssh_key::Signature::new(Algorithm::Ed25519, field(&mut blob).unwrap().to_vec())
+                .unwrap();
+        Verifier::verify(key.public_key(), &payload, &signature).unwrap();
+        let (_, changed_host) =
+            request_with_host(&key, Some(&key.public_key().to_bytes().unwrap()));
+        assert!(Verifier::verify(key.public_key(), &changed_host, &signature).is_err());
+        for host in [b"".as_slice(), b"invalid host key"] {
+            let (packet, _) = request_with_host(&key, Some(host));
+            assert!(respond(&packet, |_, _| panic!("malformed host key authorized")).is_err());
+        }
+        for cert_type in [
+            ssh_key::certificate::CertType::Host,
+            ssh_key::certificate::CertType::User,
+        ] {
+            let mut builder =
+                ssh_key::certificate::Builder::new(vec![0; 16], host.public_key(), 0, 60).unwrap();
+            builder
+                .cert_type(cert_type)
+                .unwrap()
+                .valid_principal("fixture")
+                .unwrap();
+            let certificate = builder.sign(&host).unwrap().to_bytes().unwrap();
+            let (_, payload) = request_with_host(&key, Some(&certificate));
+            assert_eq!(
+                authentication(
+                    &payload,
+                    &key.public_key().to_bytes().unwrap(),
+                    "ssh-ed25519"
+                )
+                .is_ok(),
+                cert_type == ssh_key::certificate::CertType::Host
+            );
+        }
+        for end in 0..payload.len() {
+            assert!(
+                authentication(
+                    &payload[..end],
+                    &key.public_key().to_bytes().unwrap(),
+                    "ssh-ed25519"
+                )
+                .is_err()
+            );
+        }
+        let mut trailing = payload;
+        trailing.push(0);
+        assert!(
+            authentication(
+                &trailing,
+                &key.public_key().to_bytes().unwrap(),
+                "ssh-ed25519"
+            )
+            .is_err()
+        );
+    }
+
     #[test]
     fn authentication_signature_binds_payload_and_key_and_verifies() {
         let key = PrivateKey::random(&mut rand::rngs::OsRng, Algorithm::Ed25519).unwrap();

--- a/src/cli/ssh_agent.rs
+++ b/src/cli/ssh_agent.rs
@@ -101,7 +101,7 @@ fn serve(path: &Path) -> Result<(), String> {
         .filter(|p| p.is_absolute())
         .ok_or("Socket path must be absolute")?;
     // Never follow a substituted private directory or lock file.
-    match std::fs::DirBuilder::new().mode(0o700).create(parent) {
+    match std::fs::DirBuilder::new().recursive(true).mode(0o700).create(parent) {
         Ok(()) => (),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
         Err(e) => return Err(e.to_string()),

--- a/src/cli/ssh_agent.rs
+++ b/src/cli/ssh_agent.rs
@@ -167,6 +167,8 @@ fn serve(path: &Path) -> Result<(), String> {
 use std::os::unix::fs::DirBuilderExt;
 
 fn connection(mut stream: UnixStream) -> Result<(), String> {
+    // Darwin accepts inherit O_NONBLOCK; wait for each request using the bounded timeout.
+    stream.set_nonblocking(false).map_err(|e| e.to_string())?;
     stream
         .set_read_timeout(Some(Duration::from_secs(120)))
         .map_err(|e| e.to_string())?;
@@ -309,6 +311,27 @@ fn respond(
 mod tests {
     use super::*;
     use signature::Verifier;
+
+    #[test]
+    fn connection_survives_a_pause_after_an_unsupported_request() {
+        let (server, mut client) = UnixStream::pair().unwrap();
+        // Darwin accepts inherit the listener's nonblocking mode.
+        server.set_nonblocking(true).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let worker = std::thread::spawn(|| connection(server));
+        for _ in 0..2 {
+            client.write_all(&[0, 0, 0, 1, 27]).unwrap();
+            let mut response = [0; 5];
+            client.read_exact(&mut response).unwrap();
+            assert_eq!(response, [0, 0, 0, 1, 5]);
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        drop(client);
+        worker.join().unwrap().unwrap();
+    }
+
     fn request(key: &PrivateKey) -> (Vec<u8>, Vec<u8>) {
         let blob = key.public_key().to_bytes().unwrap();
         let mut payload = Vec::new();

--- a/src/isotopes/hardeners/mod.rs
+++ b/src/isotopes/hardeners/mod.rs
@@ -347,7 +347,8 @@ pub(crate) fn metadata() -> Vec<HardenerMetadata> {
 
 pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
     let mut gates = vec![
-        gpg_signing_gate(),
+        signing_gate("gpg-signing", "gpg-sign", "AV_GPG_*"),
+        signing_gate("ssh-agent", "ssh-sign", "AV_SSH_CREDENTIAL"),
         aliyun_cli::secret_gate(),
         aws_cli::secret_gate(),
         docker::secret_gate(),
@@ -376,18 +377,18 @@ pub(crate) fn secret_gates() -> Vec<SecretGateDescriptor> {
     gates
 }
 
-fn gpg_signing_gate() -> SecretGateDescriptor {
-    let keys = vec!["AV_GPG_*".to_string()];
+fn signing_gate(id: &'static str, operation: &'static str, secret: &str) -> SecretGateDescriptor {
+    let keys = vec![secret.to_string()];
     let target_path = std::env::current_exe()
         .and_then(std::fs::canonicalize)
         .unwrap_or_else(|_| "/Applications/Automic Vault.app/Contents/MacOS/av".into())
         .to_string_lossy()
         .into_owned();
     SecretGateDescriptor {
-        id: "gpg-signing",
+        id,
         key_patterns: keys.clone(),
         routes: vec![SecretGateRoute {
-            operation: "gpg-sign",
+            operation,
             script_path: None,
             target_path,
             caller_identifiers: vec!["com.automicvault.av"],

--- a/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
+++ b/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
@@ -181,3 +181,109 @@ bool av_process_environment_value(pid_t pid, const char *key, char *out, size_t 
     free(buffer);
     return true;
 }
+
+// XNU's stable 56-byte PROC_PIDUNIQIDENTIFIERINFO ABI (flavor 17).
+// The original-parent version was reserved on older kernels; zero fails closed.
+// https://github.com/apple-oss-distributions/xnu/blob/main/bsd/sys/proc_info_private.h
+struct av_unique_info {
+    uint8_t uuid[16];
+    uint64_t unique_id, parent_unique_id;
+    int32_t version, original_parent_version;
+    uint64_t reserved[2];
+};
+_Static_assert(sizeof(struct av_unique_info) == 56, "process execution ABI");
+
+static bool unique_info(pid_t pid, struct av_unique_info *info) {
+    return proc_pidinfo(pid, 17, 0, info, sizeof(*info)) == sizeof(*info);
+}
+
+bool av_original_parent_tracking_available(void) {
+    struct av_unique_info info = {0};
+    return unique_info(getpid(), &info) && info.original_parent_version > 0;
+}
+
+bool av_original_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out) {
+    struct av_unique_info original = {0}, parent = {0};
+    return child->ppid > 1 && unique_info(child->pid, &original) &&
+        original.version == child->pidversion && original.original_parent_version > 0 &&
+        av_process_identity(child->ppid, parent_out) && unique_info(child->ppid, &parent) &&
+        original.parent_unique_id == parent.unique_id &&
+        original.original_parent_version == parent.version && parent.version == parent_out->pidversion &&
+        child->euid == parent_out->euid && child->audit_session_id == parent_out->audit_session_id;
+}
+
+// LOCAL_PEERTOKEN resolves the most recent socket accessor's *current* task.
+// Also require its recorded executable UUID and ownership of the exact peer endpoint.
+bool av_socket_peer_identity(int fd, AVProcessIdentity *identity_out) {
+    audit_token_t token = {0};
+    uint8_t uuid[16] = {0}, zero_uuid[16] = {0};
+    socklen_t token_size = sizeof(token), uuid_size = sizeof(uuid);
+    struct av_unique_info before = {0}, after = {0};
+    struct socket_fdinfo local = {0};
+    if (getsockopt(fd, SOL_LOCAL, LOCAL_PEERTOKEN, &token, &token_size) != 0 ||
+        token_size != sizeof(token) || audit_token_to_euid(token) != geteuid() ||
+        getsockopt(fd, SOL_LOCAL, LOCAL_PEERUUID, uuid, &uuid_size) != 0 || uuid_size != sizeof(uuid) ||
+        memcmp(uuid, zero_uuid, sizeof(uuid)) == 0 ||
+        !av_process_identity(audit_token_to_pid(token), identity_out) ||
+        !unique_info(identity_out->pid, &before) || memcmp(uuid, before.uuid, sizeof(uuid)) != 0 ||
+        before.version != audit_token_to_pidversion(token) ||
+        identity_out->pidversion != before.version || identity_out->euid != audit_token_to_euid(token) ||
+        identity_out->audit_session_id != (uint32_t)audit_token_to_asid(token) ||
+        proc_pidfdinfo(getpid(), fd, PROC_PIDFDSOCKETINFO, &local, sizeof(local)) != sizeof(local) ||
+        local.psi.soi_kind != SOCKINFO_UN || local.psi.soi_type != SOCK_STREAM ||
+        local.psi.soi_proto.pri_un.unsi_conn_so == 0) return false;
+    // Bound inspection rather than allocating from an untrusted descriptor count.
+    struct proc_fdinfo descriptors[4096];
+    int bytes = proc_pidinfo(identity_out->pid, PROC_PIDLISTFDS, 0, descriptors, sizeof(descriptors));
+    if (bytes <= 0 || bytes >= (int)sizeof(descriptors) || bytes % sizeof(descriptors[0]) != 0) return false;
+    bool owns_peer = false;
+    for (size_t i = 0; i < (size_t)bytes / sizeof(descriptors[0]); i++) {
+        if (descriptors[i].proc_fdtype != PROX_FDTYPE_SOCKET) continue;
+        struct socket_fdinfo peer = {0};
+        if (proc_pidfdinfo(identity_out->pid, descriptors[i].proc_fd, PROC_PIDFDSOCKETINFO,
+                          &peer, sizeof(peer)) != sizeof(peer)) continue;
+        if (peer.psi.soi_kind == SOCKINFO_UN && peer.psi.soi_type == SOCK_STREAM &&
+            peer.psi.soi_so == local.psi.soi_proto.pri_un.unsi_conn_so &&
+            peer.psi.soi_proto.pri_un.unsi_conn_so == local.psi.soi_so) {
+            owns_peer = true;
+            break;
+        }
+    }
+    return owns_peer && unique_info(identity_out->pid, &after) &&
+        before.unique_id == after.unique_id && before.version == after.version &&
+        memcmp(before.uuid, after.uuid, sizeof(uuid)) == 0;
+}
+
+bool av_process_cwd(pid_t pid, char *out, size_t out_len) {
+    struct proc_vnodepathinfo info = {0};
+    if (proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info, sizeof(info)) != sizeof(info) ||
+        info.pvi_cdir.vip_path[0] != '/' || strlen(info.pvi_cdir.vip_path) >= out_len) return false;
+    strlcpy(out, info.pvi_cdir.vip_path, out_len);
+    return true;
+}
+
+// Preserve every argument boundary, including empty strings and embedded newlines.
+ssize_t av_process_arguments_data(pid_t pid, char *out, size_t out_len) {
+    if (out_len <= sizeof(int)) return -1;
+    size_t len = out_len;
+    int mib[] = { CTL_KERN, KERN_PROCARGS2, pid };
+    if (sysctl(mib, 3, out, &len, NULL, 0) != 0 || len <= sizeof(int)) return -1;
+    int argc = 0;
+    memcpy(&argc, out, sizeof(argc));
+    if (argc <= 0) return -1;
+    char *cursor = out + sizeof(argc), *end = out + len;
+    size_t path_len = strnlen(cursor, (size_t)(end - cursor));
+    if (path_len == (size_t)(end - cursor)) return -1;
+    cursor += path_len + 1;
+    while (cursor < end && *cursor == 0) cursor++;
+    char *start = cursor;
+    for (int i = 0; i < argc; i++) {
+        if (cursor >= end) return -1;
+        size_t size = strnlen(cursor, (size_t)(end - cursor));
+        if (size == (size_t)(end - cursor)) return -1;
+        cursor += size + 1;
+    }
+    size_t bytes = (size_t)(cursor - start);
+    memmove(out, start, bytes);
+    return (ssize_t)bytes;
+}

--- a/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
+++ b/src/menu-helper/Sources/CProcessInfo/CProcessInfo.c
@@ -202,13 +202,30 @@ bool av_original_parent_tracking_available(void) {
     return unique_info(getpid(), &info) && info.original_parent_version > 0;
 }
 
-bool av_original_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out) {
+static bool original_parent_execution(const AVProcessIdentity *child, AVProcessIdentity *parent_out) {
     struct av_unique_info original = {0}, parent = {0};
-    return child->ppid > 1 && unique_info(child->pid, &original) &&
+    if (!(child->ppid > 1 && unique_info(child->pid, &original) &&
         original.version == child->pidversion && original.original_parent_version > 0 &&
         av_process_identity(child->ppid, parent_out) && unique_info(child->ppid, &parent) &&
         original.parent_unique_id == parent.unique_id &&
-        original.original_parent_version == parent.version && parent.version == parent_out->pidversion &&
+        original.original_parent_version == parent.version)) return false;
+    // task_name_for_pid cannot expose root login's audit token to the user's app.
+    // Its kernel execution version remains available through proc_pidinfo.
+    if (parent_out->pidversion == 0 && parent_out->euid == 0 &&
+        strcmp(parent_out->path, "/usr/bin/login") == 0) parent_out->pidversion = parent.version;
+    return parent.version == parent_out->pidversion;
+}
+
+bool av_original_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out) {
+    return original_parent_execution(child, parent_out) &&
+        child->euid == parent_out->euid && child->audit_session_id == parent_out->audit_session_id;
+}
+
+bool av_original_login_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out) {
+    AVProcessIdentity login = {0};
+    return original_parent_execution(child, &login) && login.euid == 0 &&
+        strcmp(login.path, "/usr/bin/login") == 0 &&
+        original_parent_execution(&login, parent_out) &&
         child->euid == parent_out->euid && child->audit_session_id == parent_out->audit_session_id;
 }
 

--- a/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
+++ b/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
@@ -22,6 +22,9 @@ typedef struct {
 
 bool av_original_parent_tracking_available(void);
 bool av_original_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out);
+// Verifies both execution links and endpoint UID/session. Caller must verify the live
+// Apple signature of /usr/bin/login at child->ppid before using the returned parent.
+bool av_original_login_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out);
 bool av_socket_peer_identity(int fd, AVProcessIdentity *identity_out);
 ssize_t av_process_arguments_data(pid_t pid, char *out, size_t out_len);
 bool av_process_cwd(pid_t pid, char *out, size_t out_len);

--- a/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
+++ b/src/menu-helper/Sources/CProcessInfo/include/CProcessInfo.h
@@ -20,6 +20,11 @@ typedef struct {
     char path[PROC_PIDPATHINFO_MAXSIZE];
 } AVProcessIdentity;
 
+bool av_original_parent_tracking_available(void);
+bool av_original_parent_identity(const AVProcessIdentity *child, AVProcessIdentity *parent_out);
+bool av_socket_peer_identity(int fd, AVProcessIdentity *identity_out);
+ssize_t av_process_arguments_data(pid_t pid, char *out, size_t out_len);
+bool av_process_cwd(pid_t pid, char *out, size_t out_len);
 bool av_peer_pid(int fd, pid_t *pid_out);
 bool av_process_identity(pid_t pid, AVProcessIdentity *identity_out);
 bool av_process_arguments(pid_t pid, char *out, size_t out_len);

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -344,6 +344,12 @@ final class DashboardModel: ObservableObject {
                     detail: "Store GPG signing credentials, configure Git, and select Verified Launchers that use an alternate key."
                 ),
                 DashboardItem(
+                    id: "ssh-agent",
+                    title: "SSH Agent",
+                    subtitle: "Authorize SSH authentication",
+                    detail: "Use one protected SSH credential for every Verified Launcher."
+                ),
+                DashboardItem(
                     id: "secret-name-access",
                     title: "Secret Name Access",
                     subtitle: "Verified Launchers allowed to run av list",
@@ -1794,6 +1800,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
         "detached-process-access",
         "verified-launcher-helpers",
         "gpg-signing",
+        "ssh-agent",
         "secret-name-access",
         "about",
     ],
@@ -2222,6 +2229,8 @@ private struct DashboardDetailView: View {
                         .padding(.top, 32)
                         .padding(.bottom, 28)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                } else if model.selectedItem?.id == "ssh-agent" {
+                    SSHAgentSettingsView(onCredentialSaved: model.reload, onOpenGate: { model.showSecretGate(id: "ssh-agent") })
                 } else if model.selectedItem?.id == "gpg-signing" {
                     GPGSigningSettingsView(onCredentialSaved: model.reload)
                         .padding(.horizontal, 22)
@@ -4329,6 +4338,184 @@ private struct VerifiedLauncherHelpersSettingsView: View {
     }
 }
 
+private struct SSHAgentSettingsView: View {
+    let onCredentialSaved: () -> Void
+    let onOpenGate: () -> Void
+    @StateObject private var approval = AuthorityApprovalState()
+    @ObservedObject private var runtime = SSHAgentRuntime.shared
+    @State private var config = loadSSHAgentConfiguration()
+    @State private var importing = false
+    @State private var status = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("SSH Agent").font(.system(size: 24, weight: .semibold))
+            Text("Authorize SSH authentication with one credential shared across Verified Launchers.")
+                .foregroundStyle(.secondary)
+            Toggle("Enable SSH Agent", isOn: Binding(get: { config.enabled }, set: { setEnabled($0) }))
+                .disabled(config.publicKey.isEmpty || approval.isPending("enable") || (!SSHAgentRuntime.isSupported && !config.enabled))
+            if !SSHAgentRuntime.isSupported {
+                Text("This macOS version cannot provide the original process ancestry required by SSH Agent.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            Text("Every signature requires Approval until you change the SSH Agent Authorization Gate’s Access Level. Allow Authentication can grant remote access, including writes.")
+                .font(.caption).foregroundStyle(.secondary)
+            Button(config.publicKey.isEmpty ? "Import SSH Credential…" : "Replace SSH Credential…") {
+                importing = true
+            }
+            if !config.publicKey.isEmpty {
+                Text("Public key").font(.headline)
+                Text(config.publicKey).font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled).fixedSize(horizontal: false, vertical: true)
+                Button("Copy Public Key") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(config.publicKey, forType: .string)
+                }
+                Button("Open Authorization Gate") { onOpenGate() }
+            }
+            Divider()
+            Button("Configure OpenSSH") {
+                do {
+                    try configureOpenSSHAgent(enabled: true)
+                    status = "Configured ~/.ssh/config to use the Automic Vault SSH agent."
+                } catch { status = error.localizedDescription }
+            }.disabled(!config.enabled)
+            Button("Remove OpenSSH Configuration") {
+                do {
+                    try configureOpenSSHAgent(enabled: false)
+                    status = "Removed Automic Vault’s SSH configuration block."
+                } catch { status = error.localizedDescription }
+            }
+            Text("Other agent clients can use SSH_AUTH_SOCK=\(sshAgentSocketURL().path). Disabling the agent leaves OpenSSH configured to fail closed until you remove its configuration.")
+                .font(.caption).foregroundStyle(.secondary).textSelection(.enabled)
+            InfoBlock(title: "Existing access paths", text: "Importing does not delete your original private key, its Keychain passphrase, or keys loaded in another agent. These remain independent access paths. After verifying the new setup, remove the old copies and agent entries yourself. Explicit IdentityFile settings may still select other keys.")
+            InfoBlock(title: "Local Launcher boundary", text: "Destination-specific restrictions are not provided. Clients need a live Verified Launcher ancestor; a client cannot act as its own Launcher. Shared or forwarded connections carry requests under that ancestor’s attribution. OpenSSH configuration disables forwarding by default.")
+            if !runtime.status.isEmpty { InfoBlock(title: "SSH Agent", text: runtime.status) }
+            if !status.isEmpty { InfoBlock(title: "Status", text: status) }
+        }
+        .sheet(isPresented: $importing) {
+            SSHCredentialSheetView { publicKey in
+                config = loadSSHAgentConfiguration()
+                status = "Saved SSH credential in the Data Protection Keychain."
+                onCredentialSaved()
+            }
+        }
+        .onDisappear { approval.cancelAll() }
+    }
+
+    private func setEnabled(_ enabled: Bool) {
+        if !enabled { persistEnabled(false); return }
+        let reviewed = loadSSHAgentConfiguration()
+        approval.request("enable", title: "Enable SSH Agent?",
+                         detail: "Make this SSH credential available through its Authorization Gate: \(reviewed.publicKey). Every Verified Launcher uses the same credential. Existing gate policy applies.") { allowed in
+            guard allowed else { return }
+            guard loadSSHAgentConfiguration() == reviewed else {
+                status = "The SSH credential changed while awaiting Approval. Review it and try again."
+                return
+            }
+            persistEnabled(true)
+        }
+    }
+
+    private func persistEnabled(_ enabled: Bool) {
+        var next = loadSSHAgentConfiguration()
+        next.enabled = enabled
+        next.generation = UUID()
+        let result = saveSSHAgentConfiguration(next)
+        guard result == errSecSuccess else { status = "Could not save SSH Agent setting: \(result)"; return }
+        config = next
+        NotificationCenter.default.post(name: .sshAgentConfigurationChanged, object: nil)
+    }
+}
+
+private struct SSHCredentialSheetView: View {
+    let onSaved: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var approval = AuthorityApprovalState()
+    @State private var privateKey = ""
+    @State private var passphrase = ""
+    @State private var busy = false
+    @State private var error = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Text("OpenSSH private key").font(.caption)
+                TextEditor(text: $privateKey)
+                    .font(.system(.caption, design: .monospaced)).frame(minHeight: 130)
+                    .accessibilityLabel("SSH private key")
+                SecureField("Passphrase (leave empty if none)", text: $passphrase)
+                Text("Paste a complete OPENSSH PRIVATE KEY block. Ed25519 and ECDSA authentication are supported. Stored private keys are never displayed. Replacing the credential cannot recover the previous private key.")
+                    .font(.caption).foregroundStyle(.secondary)
+                if !error.isEmpty { Text(error).foregroundStyle(.red) }
+            }.formStyle(.grouped).disabled(busy)
+                .navigationTitle("Import SSH Credential")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }.disabled(busy)
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(busy ? "Saving…" : "Save") { submit() }
+                            .disabled(privateKey.isEmpty || busy)
+                    }
+                }
+        }.frame(width: 560, height: 420)
+            .interactiveDismissDisabled(busy)
+            .onDisappear { privateKey = ""; passphrase = ""; approval.cancelAll() }
+    }
+
+    private func submit() {
+        busy = true
+        let credential = ["private_key": privateKey, "passphrase": passphrase]
+        let executable = Bundle.main.executableURL
+        Task {
+            do {
+                let publicKey = try await validateSSHCredential(credential, executable: executable)
+                approval.request("save", title: "Store this SSH credential?",
+                                 detail: "Replace the shared SSH credential for every Verified Launcher. Public key: \(publicKey)") { allowed in
+                    guard allowed else { busy = false; return }
+                    do {
+                        let data = try JSONEncoder().encode(credential)
+                        // Disable first: a partial write cannot combine an old public key with new private material.
+                        var config = loadSSHAgentConfiguration()
+                        let enabled = config.enabled
+                        config.enabled = false
+                        config.generation = UUID()
+                        var result = saveSSHAgentConfiguration(config)
+                        guard result == errSecSuccess else { throw SSHAgentError.failed("Keychain error \(result)") }
+                        result = saveStoredSecret(account: sshCredentialSecretName,
+                                                  value: String(decoding: data, as: UTF8.self))
+                        guard result == errSecSuccess else { throw SSHAgentError.failed("Keychain error \(result)") }
+                        config.publicKey = publicKey
+                        config.enabled = enabled
+                        result = saveSSHAgentConfiguration(config)
+                        guard result == errSecSuccess else { throw SSHAgentError.failed("Keychain error \(result)") }
+                        privateKey = ""; passphrase = ""
+                        NotificationCenter.default.post(name: .sshAgentConfigurationChanged, object: nil)
+                        onSaved(publicKey)
+                        dismiss()
+                    } catch {
+                        self.error = error.localizedDescription; busy = false
+                        NotificationCenter.default.post(name: .sshAgentConfigurationChanged, object: nil)
+                    }
+                }
+            } catch { self.error = error.localizedDescription; busy = false }
+        }
+    }
+}
+
+@concurrent
+private func validateSSHCredential(_ credential: [String: String], executable: URL?) async throws -> String {
+    let input = try JSONEncoder().encode(credential)
+    guard input.count <= 1024 * 1024 else { throw SSHAgentError.failed("SSH credential exceeds 1 MiB") }
+    let output = try runBundledCredentialCommand(arguments: ["__ssh-public-key"],
+        input: input, mainExecutableURL: executable)
+    guard let publicKey = String(data: output, encoding: .utf8), !publicKey.isEmpty else {
+        throw SSHAgentError.failed("Could not derive the SSH public key")
+    }
+    return publicKey
+}
+
 private struct GPGSigningSettingsView: View {
     @StateObject private var approval = AuthorityApprovalState()
     let onCredentialSaved: () -> Void
@@ -4722,7 +4909,7 @@ private func generateAndSaveAlternateGPGCredential(
     mainExecutableURL: URL?
 ) async throws -> String {
     let request = try JSONEncoder().encode(["name": name, "email": email])
-    let privateKeyData = try runBundledGPGCommand(
+    let privateKeyData = try runBundledCredentialCommand(
         arguments: ["__gpg-generate-key"],
         input: request,
         mainExecutableURL: mainExecutableURL
@@ -4742,7 +4929,7 @@ private func deriveGPGPublicKey(
     privateKey: String,
     mainExecutableURL: URL?
 ) throws -> String {
-    let output = try runBundledGPGCommand(
+    let output = try runBundledCredentialCommand(
         arguments: ["__gpg-public-key"],
         input: Data(privateKey.utf8),
         mainExecutableURL: mainExecutableURL
@@ -4753,12 +4940,7 @@ private func deriveGPGPublicKey(
     return publicKey
 }
 
-private func runBundledGPGCommand(
-    arguments: [String],
-    input inputData: Data,
-    mainExecutableURL: URL?
-) throws -> Data {
-    let process = Process()
+func validatedBundledAVURL(mainExecutableURL: URL?) throws -> URL {
     let executable = try bundledExecutableURL(
         named: "av",
         beside: mainExecutableURL
@@ -4782,6 +4964,16 @@ private func runBundledGPGCommand(
           let teamIdentifier = selfTeamIdentifier(),
           signing[kSecCodeInfoTeamIdentifier] as? String == teamIdentifier
     else { throw GPGSigningConfigurationError.bundledExecutableUnavailable(executable.path) }
+    return executable
+}
+
+func runBundledCredentialCommand(
+    arguments: [String],
+    input inputData: Data,
+    mainExecutableURL: URL?
+) throws -> Data {
+    let process = Process()
+    let executable = try validatedBundledAVURL(mainExecutableURL: mainExecutableURL)
     process.executableURL = executable
     process.arguments = arguments
     let inputPipe = Pipe()

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2231,6 +2231,10 @@ private struct DashboardDetailView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else if model.selectedItem?.id == "ssh-agent" {
                     SSHAgentSettingsView(onCredentialSaved: model.reload, onOpenGate: { model.showSecretGate(id: "ssh-agent") })
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 } else if model.selectedItem?.id == "gpg-signing" {
                     GPGSigningSettingsView(onCredentialSaved: model.reload)
                         .padding(.horizontal, 22)

--- a/src/menu-helper/Sources/MenubarHelper/SSHAgentRuntime.swift
+++ b/src/menu-helper/Sources/MenubarHelper/SSHAgentRuntime.swift
@@ -1,0 +1,65 @@
+import AppKit
+import CProcessInfo
+import MenubarHelperCore
+
+extension Notification.Name {
+    static let sshAgentConfigurationChanged = Notification.Name("SSHAgentConfigurationChanged")
+}
+
+@MainActor
+final class SSHAgentRuntime: NSObject, ObservableObject {
+    static let shared = SSHAgentRuntime()
+    static var isSupported: Bool { av_original_parent_tracking_available() }
+    @Published private(set) var status = ""
+    private var process: Process?
+
+    func startObserving() {
+        NotificationCenter.default.removeObserver(self)
+        NotificationCenter.default.addObserver(self, selector: #selector(refresh),
+                                              name: .sshAgentConfigurationChanged, object: nil)
+        refresh()
+    }
+
+    func stop() {
+        NotificationCenter.default.removeObserver(self)
+        if let process, process.isRunning { process.terminate(); process.waitUntilExit() }
+        process = nil
+    }
+
+    @objc private func refresh() {
+        guard loadSSHAgentConfiguration().enabled else {
+            if let process, process.isRunning { process.terminate(); process.waitUntilExit() }
+            process = nil
+            status = ""
+            return
+        }
+        guard Self.isSupported else {
+            status = "This Mac cannot verify original process ancestry. SSH Agent remains unavailable."
+            return
+        }
+        guard process?.isRunning != true else { return }
+        status = ""
+        do {
+            let child = Process()
+            child.executableURL = try validatedBundledAVURL(mainExecutableURL: Bundle.main.executableURL)
+            child.arguments = ["ssh-agent", sshAgentSocketURL().path]
+            child.standardInput = FileHandle.nullDevice
+            child.standardOutput = FileHandle.nullDevice
+            child.environment = ["PATH": "/usr/bin:/bin", "HOME": FileManager.default.homeDirectoryForCurrentUser.path]
+            let errors = Pipe()
+            child.standardError = errors
+            child.terminationHandler = { [weak self] child in
+                let detail = String(decoding: errors.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                Task { @MainActor in
+                    guard let self, self.process?.processIdentifier == child.processIdentifier else { return }
+                    self.status = detail.isEmpty ? "SSH Agent stopped. Disable and re-enable it to retry." : detail
+                }
+            }
+            try child.run()
+            process = child
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1727,7 +1727,7 @@ private func automaticAccessRecord(_ record: AccessRequestRecord) -> AutoApprova
         accessRequestID: record.id,
         date: record.date,
         launcher: record.launcher ?? "Launcher unavailable",
-        launcherIconPath: "",
+        launcherIconPath: record.launcherIconPath ?? "",
         tool: record.tool,
         displayCommand: record.commandForDisplay,
         keys: record.keys,
@@ -1765,6 +1765,7 @@ private func accessRequestRecord(
         approvalSource: approvalSource,
         reason: reason,
         launcher: launcher.map { approvalPromptRequester(launcher: $0, fallback: $0.path).name },
+        launcherIconPath: launcher.map { approvalPromptRequester(launcher: $0, fallback: $0.path).iconPath },
         callerPath: callerPath,
         target: request.target,
         targetRuntimeProtection: automaticTargetRuntimeProtection(
@@ -1861,6 +1862,13 @@ private func exactAuthorizationCommand(_ request: ApprovalRequest, scriptPath: S
 }
 
 private func authorizationHistoryCommand(_ request: ApprovalRequest, scriptPath: String? = nil) -> String {
+    if let peer = request.sshPeer {
+        let tool = pathString(peer.identity)
+        return prettyShellCommand(
+            target: tool,
+            args: redactedAuthorizationArguments(tool: tool, arguments: Array(peer.arguments.dropFirst()))
+        )
+    }
     let parts = authorizationCommandParts(request, scriptPath: scriptPath)
     return prettyShellCommand(
         target: parts.tool,
@@ -13228,6 +13236,9 @@ private func runApprovalSelfCheck() -> Int32 {
     guard approvalCommandPath(sshRequest) == pathString(selfIdentity),
           sshRequest.target == "/usr/local/bin/av",
           approvalPromptCommand(sshRequest) == "\(shellQuote(pathString(selfIdentity))) pangolin true",
+          authorizationHistoryCommand(sshRequest) == prettyShellCommand(
+              target: pathString(selfIdentity), args: ["pangolin", "true"]
+          ),
           approvalProcessInvocationName(path: nodePath, arguments: ["npm i", "", ""]) == "npm",
           approvalProcessInvocationName(path: nodePath, arguments: ["npm", "install"]) == "npm",
           approvalProcessInvocationName(path: nodePath, arguments: [nodePath, "/opt/npm/bin/npm-cli.js", "i"]) == "npm",
@@ -15604,6 +15615,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
         approvalSource: "Auto",
         reason: "Read Only from app policy",
         launcher: "Codex",
+        launcherIconPath: "/Applications/Codex.app",
         callerPath: "/usr/local/bin/av",
         target: "/bin/zsh",
         cwd: "/tmp",
@@ -15620,6 +15632,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
             approvalSource: source,
             reason: recordedApproval.reason,
             launcher: recordedApproval.launcher,
+            launcherIconPath: recordedApproval.launcherIconPath,
             callerPath: recordedApproval.callerPath,
             target: recordedApproval.target,
             cwd: recordedApproval.cwd,
@@ -15628,6 +15641,9 @@ private func runMenuStatusSelfCheck() -> Int32 {
         )
     }
     let policyDenial = retrospectiveRecord("Denied")
+    guard automaticAccessRecord(policyDenial).launcherIconPath == "/Applications/Codex.app",
+          restoredApproval.launcherIconPath == "/Applications/Codex.app"
+    else { return 1 }
     let grantController = TemporaryAccessGrantController()
     let grantWallNow = Date(timeIntervalSince1970: 20_000)
     let grantMonotonicNow: TimeInterval = 100

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -82,6 +82,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return formatter
     }()
     private var approval: ApprovalServer?
+    private let sshAgent = SSHAgentRuntime.shared
     private var scanWorkItem: DispatchWorkItem?
     private var scanBurstStartedAt: TimeInterval?
     private var pendingFullScan = false
@@ -359,6 +360,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             try approval.start()
             self.approval = approval
+            sshAgent.startObserving()
             scheduleScan(after: 0)
             scanQueue.async { [weak self] in
                 let metadata = loadDetectorMetadata(avExecutableURL: avExecutableURL())
@@ -384,6 +386,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func stopServices() {
+        sshAgent.stop()
         temporaryAccessGrants.cancelAll()
         refreshTemporaryAccessGrants()
         temporaryAccessGrantTimer?.invalidate()
@@ -1967,6 +1970,79 @@ func avExecutableURL() -> URL {
     return URL(fileURLWithPath: "/usr/local/bin/av")
 }
 
+private func sshAgentPeerArguments(_ pid: pid_t) -> [String]? {
+    var buffer = [CChar](repeating: 0, count: 64 * 1024)
+    let count = av_process_arguments_data(pid, &buffer, buffer.count)
+    guard count > 0,
+          let text = String(bytes: buffer.prefix(count).map { UInt8(bitPattern: $0) }, encoding: .utf8)
+    else { return nil }
+    return text.split(separator: "\0", omittingEmptySubsequences: false).dropLast().map(String.init)
+}
+
+private func sshAgentPeerCWD(_ pid: pid_t) -> String? {
+    var buffer = [CChar](repeating: 0, count: 4096)
+    guard av_process_cwd(pid, &buffer, buffer.count) else { return nil }
+    return String(decoding: buffer.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
+}
+
+// An SSH client cannot stand in as its own Launcher. Every ancestor must be the
+// same execution that parented its child, preventing an exec into an allowed app.
+private func sshAgentLaunchers(for identity: AVProcessIdentity) -> [LauncherIdentity] {
+    var child = identity
+    for _ in 0..<32 {
+        var parent = AVProcessIdentity()
+        guard av_original_parent_identity(&child, &parent) else { return [] }
+        let candidates = launcherIdentities(pid: parent.pid, identity: parent)
+            .filter { $0.runtimeProtection.allowsSecretGateAccess }
+        if !candidates.isEmpty { return candidates }
+        child = parent
+    }
+    return []
+}
+
+/// Retains the kernel socket evidence through Approval and release.
+private final class SSHAgentPeer: Sendable {
+    let socket: FileHandle
+    let identity: AVProcessIdentity
+    let configuration: SSHAgentConfiguration
+    let launchers: [LauncherIdentity]
+    let arguments: [String]
+    let cwd: String
+    let helperIdentity: AVProcessIdentity
+
+    init(socket: FileHandle, identity: AVProcessIdentity, configuration: SSHAgentConfiguration,
+         launchers: [LauncherIdentity], arguments: [String], cwd: String,
+         helperIdentity: AVProcessIdentity) {
+        self.socket = socket
+        self.identity = identity
+        self.configuration = configuration
+        self.launchers = launchers
+        self.arguments = arguments
+        self.cwd = cwd
+        self.helperIdentity = helperIdentity
+    }
+
+    func validate() throws {
+        var current = AVProcessIdentity()
+        var helper = AVProcessIdentity()
+        guard av_process_identity(helperIdentity.pid, &helper), sameProcessIdentity(helperIdentity, helper),
+              let signing = liveSigningInfo(pid: helper.pid),
+              signing.mainExecutable == pathString(helperIdentity),
+              signing.identifier == "com.automicvault.av", signing.runtimeProtection == .hardened,
+              av_socket_peer_identity(socket.fileDescriptor, &current),
+              sameProcessIdentity(identity, current), pathString(identity) == pathString(current),
+              sshAgentPeerArguments(current.pid) == arguments, sshAgentPeerCWD(current.pid) == cwd,
+              loadSSHAgentConfiguration() == configuration, configuration.enabled,
+              launcherBundleIntegrityError(for: current) == nil
+        else { throw AppError("SSH agent connection or configuration changed") }
+        let live = sshAgentLaunchers(for: current)
+        guard !launchers.isEmpty, launchers.allSatisfy({ expected in
+            live.contains { $0.designatedRequirement == expected.designatedRequirement
+                && $0.runtimeProtection == expected.runtimeProtection }
+        }) else { throw AppError("SSH Verified Launcher changed before signing") }
+    }
+}
+
 private struct ApprovalRequest {
     let op: String
     let keys: [String]
@@ -1985,6 +2061,7 @@ private struct ApprovalRequest {
     let credentialScope: String?
     let credentialParent: CredentialHelperParent?
     let selectedSecretValues: SelectedSecretValues
+    let sshPeer: SSHAgentPeer?
 
     init(
         op: String,
@@ -2003,7 +2080,8 @@ private struct ApprovalRequest {
         detail: String?,
         credentialScope: String? = nil,
         credentialParent: CredentialHelperParent? = nil,
-        selectedSecretValues: SelectedSecretValues = SelectedSecretValues(values: [:])
+        selectedSecretValues: SelectedSecretValues = SelectedSecretValues(values: [:]),
+        sshPeer: SSHAgentPeer? = nil
     ) {
         self.op = op
         self.keys = keys
@@ -2022,6 +2100,7 @@ private struct ApprovalRequest {
         self.credentialScope = credentialScope
         self.credentialParent = credentialParent
         self.selectedSecretValues = selectedSecretValues
+        self.sshPeer = sshPeer
     }
 
     func selecting(_ values: SelectedSecretValues) -> ApprovalRequest {
@@ -2042,7 +2121,8 @@ private struct ApprovalRequest {
             detail: detail,
             credentialScope: credentialScope,
             credentialParent: credentialParent,
-            selectedSecretValues: values
+            selectedSecretValues: values,
+            sshPeer: sshPeer
         )
     }
 
@@ -2064,7 +2144,8 @@ private struct ApprovalRequest {
             detail: detail,
             credentialScope: credentialScope,
             credentialParent: credentialParent,
-            selectedSecretValues: selectedSecretValues
+            selectedSecretValues: selectedSecretValues,
+            sshPeer: sshPeer
         )
     }
 
@@ -2109,7 +2190,7 @@ private struct ApprovalRequest {
                 )
             },
             selectedSecretValues: selectedSecretValues,
-            policy: awsRequestMayUseLongLivedCredentials(self)
+            policy: op == "ssh-sign" || awsRequestMayUseLongLivedCredentials(self)
                 ? .freshApprovalRequired
                 : .reusable
         )
@@ -2999,6 +3080,7 @@ private func temporaryAccessGrantCandidate(
         agentTaskContext: agentTaskContext
     ) == nil,
     let gate, let launcher, let agentTaskContext,
+    gate.id != "ssh-agent",
     let runtimeRequirement = launcher.runtimeProtection.secretGateAdmissionRequirement
     else {
         return nil
@@ -3432,7 +3514,15 @@ private final class ApprovalServer: @unchecked Sendable {
                 return
             }
             reply(peer, to: message, ok: true, error: nil, value: "1")
-        case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing):
+        case .sshIdentities where isTrustedAvCaller(path: callerPath, signing: signing):
+            let config = loadSSHAgentConfiguration()
+            guard config.enabled, !config.publicKey.isEmpty else {
+                reply(peer, to: message, ok: false, error: "SSH Agent is disabled or unconfigured")
+                return
+            }
+            reply(peer, to: message, ok: true, error: nil, secrets: ["public_key": config.publicKey])
+        case .gpgSign where isTrustedAvCaller(path: callerPath, signing: signing),
+             .sshSign where isTrustedAvCaller(path: callerPath, signing: signing):
             handleInject(
                 message,
                 on: peer,
@@ -3749,7 +3839,15 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: "invalid approval request")
             return
         }
-        var launchers = launcherIdentities(for: identity)
+        do {
+            parsedRequest = try sshAgentRequest(from: message, request: parsedRequest,
+                                              helperIdentity: identity, helperPath: callerPath)
+        } catch {
+            reply(peer, to: message, ok: false, error: error.localizedDescription)
+            return
+        }
+        let originIdentity = parsedRequest.sshPeer?.identity ?? identity
+        var launchers = parsedRequest.sshPeer?.launchers ?? launcherIdentities(for: identity)
         if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {
             launchers.append(launcher)
         }
@@ -3901,8 +3999,13 @@ private final class ApprovalServer: @unchecked Sendable {
             }
             let selected = try secretValueCustody.bind(
                 names: selectionNames,
-                cwd: kubectlRequest.cwd
+                cwd: kubectlRequest.cwd,
+                globalOnly: kubectlRequest.sshPeer != nil
             )
+            if kubectlRequest.sshPeer != nil,
+               selected.source(for: sshCredentialSecretName) != .global {
+                throw AppError("SSH Agent requires the Global Value of its credential")
+            }
             // ponytail: Global Values only until OAuth refresh mutations bind the selected source.
             if isTrustedWranglerCaller(path: callerPath, signing: signing),
                !wranglerCredentialSelectionIsSupported(selected) {
@@ -3920,19 +4023,19 @@ private final class ApprovalServer: @unchecked Sendable {
             reply(peer, to: message, ok: false, error: error.localizedDescription)
             return
         }
-        let scriptApproval = scriptApproval(for: request)
-        let processChains = retainedProcessChains(for: identity)
+        let scriptApproval = request.sshPeer == nil ? scriptApproval(for: request) : nil
+        let processChains = request.sshPeer == nil ? retainedProcessChains(for: identity) : []
         let keepsDetachedProcessAccess = UserDefaults.standard.bool(
             forKey: keepLauncherAccessForDetachedProcessesDefaultsKey
         )
-        let ancestorFallbackPath = launcherFallbackPath(for: identity)
+        let ancestorFallbackPath = launcherFallbackPath(for: originIdentity)
         let launcherFallbackPath = ancestorFallbackPath ?? callerPath
         let launcher = executionOrigin(
             among: launchers,
             callerPID: pid,
             ancestorFallbackPath: ancestorFallbackPath
         )
-        let activeBlessing = activeBlessedScript(pid: pid, identity: identity)
+        let activeBlessing = request.sshPeer == nil ? activeBlessedScript(pid: pid, identity: identity) : nil
         if let script = activeBlessing {
             if handleBlessedCapability(
                 script,
@@ -4047,6 +4150,10 @@ private final class ApprovalServer: @unchecked Sendable {
             signing: signing,
             descriptors: secretGateDescriptors
         )
+        if request.sshPeer != nil, configuredGate?.id != "ssh-agent" {
+            reply(peer, to: message, ok: false, error: "SSH Agent Gate is unavailable")
+            return
+        }
         let authorizationGate = configuredGate.map {
             RetainedAuthorizationGate.secretGate($0.id)
         } ?? .directSecret
@@ -4082,7 +4189,7 @@ private final class ApprovalServer: @unchecked Sendable {
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
         }
-        let currentAgentTaskContext = agentTaskContext(pid: pid)
+        let currentAgentTaskContext = request.sshPeer == nil ? agentTaskContext(pid: pid) : nil
         let retainedProcessExplanation: String?
         if !keepsDetachedProcessAccess,
            retainedBlessingMatch != nil,
@@ -4397,6 +4504,7 @@ private final class ApprovalServer: @unchecked Sendable {
                    isAllowedCaller(path: currentCallerPath, signing: currentSigning),
                    let configuredGate,
                    let classification,
+                   request.sshPeer == nil,
                    let currentAgentTaskContext = agentTaskContext(pid: pid),
                    self.handleTemporaryAccessGrant(
                        request: request,
@@ -6429,6 +6537,60 @@ private final class ApprovalServer: @unchecked Sendable {
         )
     }
 
+    private func sshAgentRequest(
+        from message: xpc_object_t, request: ApprovalRequest,
+        helperIdentity: AVProcessIdentity, helperPath: String
+    ) throws -> ApprovalRequest {
+        guard request.op == "ssh-sign" else {
+            guard request.tool != "ssh-agent" else { throw AppError("SSH requires the agent protocol") }
+            return request
+        }
+        guard request.tool == "ssh-agent", request.target == helperPath,
+              request.keys.isEmpty, validSSHSigningArguments(request.args),
+              !request.replaceExistingEnv, !request.allowMissingKeys,
+              request.envConflicts.isEmpty, request.shebangScript == nil, request.scriptData == nil,
+              request.snapshotIncompatibleInterpreter == nil,
+              let signing = liveSigningInfo(pid: helperIdentity.pid),
+              signing.mainExecutable == helperPath, signing.runtimeProtection == .hardened,
+              signing.identifier == "com.automicvault.av",
+              xpc_dictionary_get_value(message, "ssh_socket") != nil
+        else { throw AppError("Invalid SSH agent signing request") }
+        let fd = xpc_dictionary_dup_fd(message, "ssh_socket")
+        guard fd >= 0 else { throw AppError("SSH socket evidence is unavailable") }
+        let socket = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        var origin = AVProcessIdentity()
+        guard av_socket_peer_identity(fd, &origin), origin.euid == helperIdentity.euid,
+              origin.audit_session_id == helperIdentity.audit_session_id,
+              launcherBundleIntegrityError(for: origin) == nil,
+              let arguments = sshAgentPeerArguments(origin.pid), !arguments.isEmpty
+        else { throw AppError("SSH socket peer cannot be verified") }
+        let config = loadSSHAgentConfiguration()
+        let publicFields = config.publicKey.split(separator: " ")
+        guard config.enabled, publicFields.count >= 2,
+              let publicBytes = Data(base64Encoded: String(publicFields[1])),
+              request.args[1] == "public-key-sha256=" + SHA256.hash(data: publicBytes)
+                .map({ String(format: "%02x", $0) }).joined()
+        else { throw AppError("SSH Agent is disabled or the requested key does not match") }
+        let launchers = sshAgentLaunchers(for: origin)
+        guard !launchers.isEmpty else { throw AppError("SSH authentication requires a live Verified Launcher ancestor with verifiable original process ancestry") }
+        guard let cwd = sshAgentPeerCWD(origin.pid) else {
+            throw AppError("SSH peer working directory is unavailable")
+        }
+        let originPeer = SSHAgentPeer(socket: socket, identity: origin, configuration: config,
+                                     launchers: launchers, arguments: arguments, cwd: cwd,
+                                     helperIdentity: helperIdentity)
+        try originPeer.validate()
+        return ApprovalRequest(
+            op: "ssh-sign", keys: [sshCredentialSecretName], target: helperPath,
+            args: request.args + ["socket-peer=\(pathString(origin))"] + arguments,
+            cwd: cwd, replaceExistingEnv: false, allowMissingKeys: false,
+            envConflicts: [], shebangScript: nil, scriptData: nil, tool: "ssh-agent",
+            title: "Authenticate with your SSH credential?",
+            detail: "The SSH Agent will sign this authentication request using your shared SSH credential. This can grant remote access, including writes. Destination restrictions are not configured. Shared or forwarded connections inherit the local client’s Launcher attribution.",
+            sshPeer: originPeer
+        )
+    }
+
     private func dockerCredentialRequest(
         from message: xpc_object_t,
         request: ApprovalRequest,
@@ -7799,12 +7961,21 @@ private final class ApprovalServer: @unchecked Sendable {
         activateAfterRecording: () -> Void = {},
         release: (ApprovedPayload) -> Void
     ) throws -> Bool {
+        try request.sshPeer?.validate()
         let transaction = try prepareApprovedFulfillment(
             for: request,
             awsRegistration: awsRegistration
         )
+        try request.sshPeer?.validate()
         return transaction.commit(
-            record: { onAccessRequest(record) },
+            record: {
+                do {
+                    try request.sshPeer?.validate()
+                    guard onAccessRequest(record) else { return false }
+                    try request.sshPeer?.validate()
+                    return true
+                } catch { return false }
+            },
             activate: { material in
                 if let registration = material.awsRegistration {
                     installAWSRegistration(registration, pid: pid, identity: identity)
@@ -7812,6 +7983,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 activateAfterRecording()
             },
             observe: { material in
+                guard request.sshPeer == nil else { return }
                 recordLiveSecretUse(
                     request: request,
                     payload: material.payload,
@@ -8127,7 +8299,7 @@ private final class ApprovalServer: @unchecked Sendable {
             return nil
         }
         let op = String(cString: opPointer)
-        guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign"
+        guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign" || op == "ssh-sign"
             || op == "docker-get" || op == "goat-get" || op == "ordercli-get" || op == "openhue-get" || op == "plumber-get" || op == "uaa-get" || op == "railway-get"
             || op == "oxide-get" || op == "fastly-get" || op == "sqlcmd-get" || op == "terraform-get" || op == "aliyun-get" || op == "wakatime-get"
             || op == "rclone-get" || op == "kubectl-get"
@@ -8529,6 +8701,8 @@ private func classifySecretGateRequest(
     request: ApprovalRequest
 ) -> SecretGateRequestClassification {
     switch gateID {
+    case "ssh-agent":
+        return .mutating
     case "gpg-signing":
         return .localWrite
     case "wrangler":
@@ -10450,7 +10624,7 @@ private func approvalProcessSecurity(
 ) -> ApprovalProcessSecurity {
     let automicVaultTeamIdentifier = selfTeamIdentifier()
     var identities = approvalProcessIdentities(
-        gateClientPID: gateClientPID,
+        gateClientPID: request.sshPeer?.identity.pid ?? gateClientPID,
         launcherPID: launcher?.pid
     )
     if let launcher,
@@ -10467,10 +10641,13 @@ private func approvalProcessSecurity(
         ))
     }
     if !identities.contains(where: { $0.pid == gateClientPID }) {
+        var helper = AVProcessIdentity()
+        let execution = av_process_identity(gateClientPID, &helper)
+            ? approvalProcessExecution(pid: gateClientPID, identity: helper) : nil
         identities.insert(ApprovalProcessIdentity(
             pid: gateClientPID,
             path: gateClientPath,
-            execution: nil
+            execution: execution
         ), at: 0)
     }
 
@@ -11295,6 +11472,14 @@ private func showApprovalAlert(
     compact: Bool = false
 ) -> ApprovalDecision {
     guard cancellation?.isCanceled != true else { return .canceled }
+    let sshTimer = request.sshPeer.map { peer in
+        let timer = Timer(timeInterval: 1, repeats: true) { _ in
+            do { try peer.validate() } catch { cancellation?.cancel() }
+        }
+        RunLoop.main.add(timer, forMode: .modalPanel)
+        return timer
+    }
+    defer { sshTimer?.invalidate() }
     let receivedAt = Date()
     let requester = approvalPromptRequester(launcher: launcher, fallback: launcherFallbackPath)
     let processSecurity = approvalProcessSecurity(
@@ -11488,6 +11673,9 @@ private func prettyShellCommand(target: String, args: [String]) -> String {
 }
 
 private func approvalPromptCommand(_ request: ApprovalRequest, scriptPath: String? = nil) -> String {
+    if let peer = request.sshPeer {
+        return ([pathString(peer.identity)] + peer.arguments.dropFirst()).map(shellQuote).joined(separator: " ")
+    }
     let parts = authorizationCommandParts(request, scriptPath: scriptPath)
     let resolvedScript = scriptPath ?? resolvedShebangScriptPath(request)
     let invokedScript = resolvedScript.flatMap { path in

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2202,9 +2202,10 @@ private struct ApprovalRequest {
                 )
             },
             selectedSecretValues: selectedSecretValues,
-            policy: op == "ssh-sign" || awsRequestMayUseLongLivedCredentials(self)
-                ? .freshApprovalRequired
-                : .reusable
+            // The SSH helper is shared by unrelated clients and Launchers. Even
+            // denial reuse would quarantine every client using that helper.
+            policy: op == "ssh-sign" ? .disabled
+                : awsRequestMayUseLongLivedCredentials(self) ? .freshApprovalRequired : .reusable
         )
     }
 }
@@ -13202,7 +13203,7 @@ private func runApprovalSelfCheck() -> Int32 {
         ])
     )
     let sshRequest = ApprovalRequest(
-        op: "inject", keys: [sshCredentialSecretName], target: "/usr/local/bin/av",
+        op: "ssh-sign", keys: [sshCredentialSecretName], target: "/usr/local/bin/av",
         args: ["ssh-agent"], cwd: "/tmp", replaceExistingEnv: false,
         allowMissingKeys: false, envConflicts: [], shebangScript: nil,
         scriptData: nil, tool: "ssh-agent", title: nil, detail: nil,
@@ -13213,6 +13214,17 @@ private func runApprovalSelfCheck() -> Int32 {
         )
     )
     let nodePath = "/opt/homebrew/bin/node"
+    let sshReuseRequest = sshRequest.decisionReuseRequest(
+        clientIdentity: selfIdentity, callerPath: sshRequest.target, signing: helperSigning
+    )
+    var sshReuseCache = AuthorizationDecisionReuseCache()
+    for outcome in [AuthorizationDecisionReuseOutcome.denied, .approved, .alwaysApproved] {
+        sshReuseCache.remember(outcome, for: sshReuseRequest)
+        guard sshReuseCache.decision(for: sshReuseRequest) == nil else {
+            print("SSH requests must never reuse approval or denial")
+            return 1
+        }
+    }
     guard approvalCommandPath(sshRequest) == pathString(selfIdentity),
           sshRequest.target == "/usr/local/bin/av",
           approvalPromptCommand(sshRequest) == "\(shellQuote(pathString(selfIdentity))) pangolin true",

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1991,7 +1991,18 @@ private func sshAgentLaunchers(for identity: AVProcessIdentity) -> [LauncherIden
     var child = identity
     for _ in 0..<32 {
         var parent = AVProcessIdentity()
-        guard av_original_parent_identity(&child, &parent) else { return [] }
+        if !av_original_parent_identity(&child, &parent) {
+            // Terminal uses a root-owned login relay; it supplies no Launcher authority.
+            var code: SecCode?
+            var requirement: SecRequirement?
+            guard av_original_login_parent_identity(&child, &parent),
+                  SecCodeCopyGuestWithAttributes(nil, [kSecGuestAttributePid: child.ppid] as CFDictionary, [], &code) == errSecSuccess,
+                  let code,
+                  SecRequirementCreateWithString("anchor apple and identifier com.apple.login" as CFString, [], &requirement) == errSecSuccess,
+                  let requirement,
+                  SecCodeCheckValidity(code, [], requirement) == errSecSuccess
+            else { return [] }
+        }
         let candidates = launcherIdentities(pid: parent.pid, identity: parent)
             .filter { $0.runtimeProtection.allowsSecretGateAccess }
         if !candidates.isEmpty { return candidates }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -1869,7 +1869,8 @@ private func authorizationHistoryCommand(_ request: ApprovalRequest, scriptPath:
 }
 
 private func approvalCommandPath(_ request: ApprovalRequest) -> String {
-    resolvedShebangScriptPath(request) ?? request.target
+    if let peer = request.sshPeer { return pathString(peer.identity) }
+    return resolvedShebangScriptPath(request) ?? request.target
 }
 
 private func resolvedShebangScriptPath(_ request: ApprovalRequest) -> String? {
@@ -1970,7 +1971,7 @@ func avExecutableURL() -> URL {
     return URL(fileURLWithPath: "/usr/local/bin/av")
 }
 
-private func sshAgentPeerArguments(_ pid: pid_t) -> [String]? {
+private func processArgumentVector(_ pid: pid_t) -> [String]? {
     var buffer = [CChar](repeating: 0, count: 64 * 1024)
     let count = av_process_arguments_data(pid, &buffer, buffer.count)
     guard count > 0,
@@ -2042,7 +2043,7 @@ private final class SSHAgentPeer: Sendable {
               signing.identifier == "com.automicvault.av", signing.runtimeProtection == .hardened,
               av_socket_peer_identity(socket.fileDescriptor, &current),
               sameProcessIdentity(identity, current), pathString(identity) == pathString(current),
-              sshAgentPeerArguments(current.pid) == arguments, sshAgentPeerCWD(current.pid) == cwd,
+              processArgumentVector(current.pid) == arguments, sshAgentPeerCWD(current.pid) == cwd,
               loadSSHAgentConfiguration() == configuration, configuration.enabled,
               launcherBundleIntegrityError(for: current) == nil
         else { throw AppError("SSH agent connection or configuration changed") }
@@ -6573,7 +6574,7 @@ private final class ApprovalServer: @unchecked Sendable {
         guard av_socket_peer_identity(fd, &origin), origin.euid == helperIdentity.euid,
               origin.audit_session_id == helperIdentity.audit_session_id,
               launcherBundleIntegrityError(for: origin) == nil,
-              let arguments = sshAgentPeerArguments(origin.pid), !arguments.isEmpty
+              let arguments = processArgumentVector(origin.pid), !arguments.isEmpty
         else { throw AppError("SSH socket peer cannot be verified") }
         let config = loadSSHAgentConfiguration()
         let publicFields = config.publicKey.split(separator: " ")
@@ -10500,9 +10501,26 @@ private struct ApprovalProcessSecurityNode: Identifiable {
     let posture: ApprovalProcessPosture
     let explanation: String
     let isAutomicVaultSigned: Bool
+    var invocationName: String? = nil
 
     var id: String { "\(pid ?? -1):\(path)" }
-    var name: String { URL(fileURLWithPath: path).lastPathComponent }
+    var executableName: String { URL(fileURLWithPath: path).lastPathComponent }
+    var name: String { invocationName ?? executableName }
+}
+
+// Diagnostic display only: argv (including npm's rewritten process title) is
+// mutable. It must never replace the executable identity or its runtime posture.
+private func approvalProcessInvocationName(path: String, arguments: [String]) -> String? {
+    guard ["node", "nodejs"].contains(URL(fileURLWithPath: path).lastPathComponent),
+          let first = arguments.first
+    else { return nil }
+    if first == "npm" || first.hasPrefix("npm ") { return "npm" }
+    if let script = arguments.dropFirst().first,
+       URL(fileURLWithPath: script).lastPathComponent == "npm-cli.js"
+    {
+        return "npm"
+    }
+    return nil
 }
 
 private struct ApprovalProcessSecurity {
@@ -10677,8 +10695,16 @@ private func approvalProcessSecurity(
         if isLauncher { roles.append("Verified Launcher") }
         if isTarget { roles.append(request.keys.isEmpty ? "Target" : "Secret recipient") }
         if isGateClient { roles.append("Verified Gate Client") }
+        if identity.pid == request.sshPeer?.identity.pid { roles.append("SSH client") }
         if roles.isEmpty { roles.append("Intermediary") }
 
+        let invocationName = identity.execution.flatMap { execution -> String? in
+            guard !isLauncher, approvalProcessExecutionIsLive(execution),
+                  let arguments = processArgumentVector(identity.pid),
+                  approvalProcessExecutionIsLive(execution)
+            else { return nil }
+            return approvalProcessInvocationName(path: identity.path, arguments: arguments)
+        }
         let signing = identity.execution.flatMap { execution -> LiveSigningInfo? in
             guard approvalProcessExecutionIsLive(execution) else { return nil }
             let signing = liveSigningInfo(pid: identity.pid)
@@ -10699,7 +10725,8 @@ private func approvalProcessSecurity(
             isAutomicVaultSigned: isAutomicVaultSigned(
                 signing,
                 teamIdentifier: automicVaultTeamIdentifier
-            )
+            ),
+            invocationName: invocationName
         )
     }
 
@@ -11527,7 +11554,8 @@ private func showApprovalAlert(
             launcher: launcher,
             processSecurity: processSecurity,
             receivedAt: receivedAt
-        )
+        ),
+        sshSigningTargetPath: request.sshPeer.map { _ in escapedSecurityPath(request.target) }
     )
     let usesIPhoneApproval = PhoneApprovalCoordinator.shared.isEnabled
     let usesTouchIDApproval = TouchIDApproval.isEnabled
@@ -11829,6 +11857,15 @@ private struct ApprovalPromptContent {
     let blessing: BlessedScriptPromptContext?
     let processSecurity: ApprovalProcessSecurity
     let sections: [ApprovalPromptSection]
+    var sshSigningTargetPath: String? = nil
+
+    var operationTitle: String? {
+        sshSigningTargetPath == nil ? operation : "SSH Authentication"
+    }
+
+    var writeAccessUnavailableReason: String? {
+        sshSigningTargetPath == nil ? temporaryGrantUnavailableReason : nil
+    }
 }
 
 private extension ApprovalProcessPosture {
@@ -11857,6 +11894,9 @@ private extension ApprovalProcessSecurityNode {
         [
             "\(displayRoles): \(name.isEmpty ? path : name)",
             "Path: \(escapedSecurityPath(path))",
+            invocationName.map { _ in
+                "Invoked via \(executableName); name reported by mutable process arguments, not verified code identity"
+            },
             pid.map { "PID: \($0)" },
             "Status: \(posture.presentation.title)",
             explanation,
@@ -12073,12 +12113,18 @@ private struct ApprovalPromptProcessNodeView: View {
             .overlay {
                 Capsule().stroke(.white.opacity(0.1), lineWidth: 1)
             }
+            if node.invocationName != nil {
+                Text("via \(node.executableName)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             ApprovalPromptPathView(path: escapedSecurityPath(node.path))
         }
         .frame(width: 150)
+        .help(node.details)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(
-            "\(node.displayRoles), \(node.name), \(presentation.title)\(node.isAutomicVaultSigned ? ", signed by Automic Vault" : "")"
+            "\(node.displayRoles), \(node.name)\(node.invocationName == nil ? "" : " via \(node.executableName)"), \(presentation.title)\(node.isAutomicVaultSigned ? ", signed by Automic Vault" : "")"
         )
     }
 }
@@ -12260,7 +12306,7 @@ private struct ApprovalPromptView: View {
             .defaultScrollAnchor(.top)
             .layoutPriority(1)
 
-            if let reason = content.temporaryGrantUnavailableReason {
+            if let reason = content.writeAccessUnavailableReason {
                 Text(reason)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -12438,7 +12484,7 @@ private struct ApprovalPromptCommandView: View {
                     }
                 }
                 VStack(alignment: .leading, spacing: 8) {
-                    if let operation = content.operation {
+                    if let operation = content.operationTitle {
                         ApprovalPromptInlineMeta(
                             label: "Operation",
                             value: operation,
@@ -12463,10 +12509,17 @@ private struct ApprovalPromptCommandView: View {
                         systemImage: "folder"
                     )
                     ApprovalPromptInlineMeta(
-                        label: "Full Path",
+                        label: content.sshSigningTargetPath == nil ? "Full Path" : "SSH Client",
                         value: content.commandPath,
                         systemImage: "terminal"
                     )
+                    if let target = content.sshSigningTargetPath {
+                        ApprovalPromptInlineMeta(
+                            label: "Signing Target",
+                            value: target,
+                            systemImage: "key.horizontal"
+                        )
+                    }
                     if let blessing = content.blessing {
                         ApprovalPromptInlineMeta(
                             label: "Capabilities",
@@ -13148,6 +13201,33 @@ private func runApprovalSelfCheck() -> Int32 {
             ),
         ])
     )
+    let sshRequest = ApprovalRequest(
+        op: "inject", keys: [sshCredentialSecretName], target: "/usr/local/bin/av",
+        args: ["ssh-agent"], cwd: "/tmp", replaceExistingEnv: false,
+        allowMissingKeys: false, envConflicts: [], shebangScript: nil,
+        scriptData: nil, tool: "ssh-agent", title: nil, detail: nil,
+        sshPeer: SSHAgentPeer(
+            socket: .nullDevice, identity: selfIdentity, configuration: SSHAgentConfiguration(),
+            launchers: [], arguments: [pathString(selfIdentity), "pangolin", "true"],
+            cwd: "/tmp", helperIdentity: selfIdentity
+        )
+    )
+    let nodePath = "/opt/homebrew/bin/node"
+    guard approvalCommandPath(sshRequest) == pathString(selfIdentity),
+          sshRequest.target == "/usr/local/bin/av",
+          approvalPromptCommand(sshRequest) == "\(shellQuote(pathString(selfIdentity))) pangolin true",
+          approvalProcessInvocationName(path: nodePath, arguments: ["npm i", "", ""]) == "npm",
+          approvalProcessInvocationName(path: nodePath, arguments: ["npm", "install"]) == "npm",
+          approvalProcessInvocationName(path: nodePath, arguments: [nodePath, "/opt/npm/bin/npm-cli.js", "i"]) == "npm",
+          approvalProcessInvocationName(path: nodePath, arguments: [nodePath, "postinstall.cjs"]) == nil,
+          approvalProcessInvocationName(path: nodePath, arguments: [nodePath, "-e", "npm-cli.js"]) == nil,
+          approvalProcessInvocationName(path: nodePath, arguments: ["npm-imposter"]) == nil,
+          approvalProcessInvocationName(path: "/usr/bin/ssh", arguments: ["npm i"]) == nil,
+          approvalProcessInvocationName(path: nodePath, arguments: []) == nil
+    else {
+        print("SSH command and npm invocation presentation self-check failed")
+        return 1
+    }
     guard processEnvironmentValueSelfCheck() else {
         print("bounded peer environment self-check failed")
         return 2
@@ -13346,6 +13426,28 @@ private func runApprovalSelfCheck() -> Int32 {
         processSecurity: promptProcessSecurity,
         sections: []
     )
+    var sshPromptContent = promptContent
+    sshPromptContent.sshSigningTargetPath = sshRequest.target
+    let npmNode = ApprovalProcessSecurityNode(
+        pid: 42, path: nodePath, roles: ["Intermediary"], posture: .doesNotMeetRequirements,
+        explanation: "Hardened Runtime is not enabled; Executes mutable JavaScript and dependencies",
+        isAutomicVaultSigned: false, invocationName: "npm"
+    )
+    guard sshPromptContent.operationTitle == "SSH Authentication",
+          sshPromptContent.writeAccessUnavailableReason == nil,
+          promptContent.operationTitle == promptContent.operation,
+          promptContent.writeAccessUnavailableReason == promptContent.temporaryGrantUnavailableReason,
+          npmNode.name == "npm", npmNode.executableName == "node",
+          npmNode.details.contains(nodePath),
+          npmNode.details.contains("not verified code identity"),
+          npmNode.posture == .doesNotMeetRequirements,
+          !npmNode.isLauncher, !npmNode.isTarget,
+          NSHostingView(rootView: ApprovalPromptCommandView(content: sshPromptContent)).fittingSize.height > 0,
+          NSHostingView(rootView: ApprovalPromptProcessNodeView(node: npmNode)).fittingSize.height > 0
+    else {
+        print("SSH Approval presentation self-check failed")
+        return 1
+    }
     let collapsedPrompt = NSHostingView(
         rootView: ApprovalPromptView(
             content: promptContent,

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -20,6 +20,8 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case keys
     case authorize
     case gpgSign = "gpg-sign"
+    case sshSign = "ssh-sign"
+    case sshIdentities = "ssh-identities"
     case proxyStart = "proxy-start"
     case awsCredentials = "aws-credentials"
     case dockerGet = "docker-get"

--- a/src/menu-helper/Sources/MenubarHelperCore/AuthorizationDecisionReuse.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/AuthorizationDecisionReuse.swift
@@ -48,6 +48,7 @@ public struct AuthorizationCredentialHelperParent: Hashable, Sendable {
 public enum AuthorizationDecisionReusePolicy: Hashable, Sendable {
     case reusable
     case freshApprovalRequired
+    case disabled
 }
 
 public enum AuthorizationDecisionReuseOutcome: Equatable, Sendable {
@@ -152,6 +153,7 @@ public struct AuthorizationDecisionReuseCache: Sendable {
         now: Date = Date()
     ) -> AuthorizationDecisionReuseOutcome? {
         prune(now: now)
+        guard request.policy != .disabled else { return nil }
         if expirations[.denial(request.client)] != nil { return .denied }
         guard request.policy == .reusable else { return nil }
         return expirations[.approval(request)] == nil ? nil : .approved
@@ -163,6 +165,7 @@ public struct AuthorizationDecisionReuseCache: Sendable {
         now: Date = Date()
     ) {
         prune(now: now)
+        guard request.policy != .disabled else { return }
         let key: Key
         switch outcome {
         case .canceled, .interrupted, .temporaryAccessGrant:

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -790,6 +790,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
     public let approvalSource: String?
     public let reason: String
     public let launcher: String?
+    public let launcherIconPath: String?
     public let callerPath: String
     public let target: String
     public let targetRuntimeProtection: String?
@@ -808,6 +809,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         approvalSource: String? = nil,
         reason: String,
         launcher: String?,
+        launcherIconPath: String? = nil,
         callerPath: String,
         target: String,
         targetRuntimeProtection: String? = nil,
@@ -825,6 +827,7 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         self.approvalSource = approvalSource
         self.reason = reason
         self.launcher = launcher
+        self.launcherIconPath = launcherIconPath
         self.callerPath = callerPath
         self.target = target
         self.targetRuntimeProtection = targetRuntimeProtection

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -610,12 +610,14 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     public var defaultPolicyLabel: String {
         appPolicies.isEmpty ? "All Verified Launchers" : "All Other Verified Launchers"
     }
-    public var displayName: String { id == "node" ? "npm" : id }
+    public var displayName: String { id == "ssh-agent" ? "SSH Agent" : id == "node" ? "npm" : id }
     public var authorizationGateName: String {
-        id == "node" ? "npm Authorization Gate" : "\(id.uppercased()) Authorization Gate"
+        if id == "ssh-agent" { return "SSH Agent Authorization Gate" }
+        return id == "node" ? "npm Authorization Gate" : "\(id.uppercased()) Authorization Gate"
     }
 
     public var availableProtections: [SecretGateProtection] {
+        if id == "ssh-agent" { return [.noAccess, .fullExceptSecretDumps] }
         if id == "gpg-signing" {
             return [.noAccess, .readOnlyAndLocalWrites]
         }
@@ -638,11 +640,14 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     }
 
     public var initialProtection: SecretGateProtection {
-        if id == "gpg-signing" || id == "kubectl" { return .noAccess }
+        if id == "ssh-agent" || id == "gpg-signing" || id == "kubectl" { return .noAccess }
         return id == "brew" ? .readOnlyAndUpdates : .readOnly
     }
 
     public func normalizedProtection(_ protection: SecretGateProtection) -> SecretGateProtection {
+        if id == "ssh-agent" {
+            return protection.allows(.mutating) ? .fullExceptSecretDumps : .noAccess
+        }
         if id == "gpg-signing" {
             return protection.allows(.localWrite) ? .readOnlyAndLocalWrites : .noAccess
         }
@@ -663,6 +668,9 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
 
     public func protectionTitle(_ protection: SecretGateProtection) -> String {
         let protection = normalizedProtection(protection)
+        if id == "ssh-agent" {
+            return protection == .fullExceptSecretDumps ? "Allow Authentication" : "Approval Required"
+        }
         if id == "gpg-signing" {
             return protection == .readOnlyAndLocalWrites ? "Allow Signing" : "Approval Required"
         }
@@ -671,6 +679,11 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
 
     public func protectionSubtitle(_ protection: SecretGateProtection) -> String {
         let protection = normalizedProtection(protection)
+        if id == "ssh-agent" {
+            return protection == .fullExceptSecretDumps
+                ? "Recognized SSH authentication signatures are automically authorized"
+                : "Every SSH authentication signature requires Approval"
+        }
         if id == "gpg-signing" {
             return protection == .readOnlyAndLocalWrites
                 ? "Recognized GPG signing requests are automically authorized"
@@ -1081,6 +1094,7 @@ public func dashboardSecretGateDescriptors(
     }
     return activeHardenerGates + catalog.filter {
         !hardenerGateIDs.contains($0.id)
+            && ($0.id != "ssh-agent" || storedSecretNames.contains(sshCredentialSecretName))
             && ($0.id != "gpg-signing"
                 || storedSecretNames.contains(gpgDefaultPrivateKeySecretName)
                 || storedSecretNames.contains(gpgAlternatePrivateKeySecretName))
@@ -1867,10 +1881,11 @@ public enum StoredSecretSelectionError: Error, LocalizedError, Equatable {
 public func resolveStoredSecretValues(
     names: [String],
     cwd: String,
-    secrets: [StoredSecret]
+    secrets: [StoredSecret],
+    globalOnly: Bool = false
 ) throws -> [String: StoredSecretValue] {
     guard !names.isEmpty else { return [:] }
-    let rank = Dictionary(
+    let rank = globalOnly ? [:] : Dictionary(
         uniqueKeysWithValues: try physicalDirectoryAncestors(cwd).enumerated().map { ($1, $0) }
     )
     let byName = Dictionary(uniqueKeysWithValues: secrets.map { ($0.account, $0) })

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -610,7 +610,7 @@ public struct SecretGate: Equatable, Identifiable, Sendable {
     public var defaultPolicyLabel: String {
         appPolicies.isEmpty ? "All Verified Launchers" : "All Other Verified Launchers"
     }
-    public var displayName: String { id == "ssh-agent" ? "SSH Agent" : id == "node" ? "npm" : id }
+    public var displayName: String { id == "node" ? "npm" : id }
     public var authorizationGateName: String {
         if id == "ssh-agent" { return "SSH Agent Authorization Gate" }
         return id == "node" ? "npm Authorization Gate" : "\(id.uppercased()) Authorization Gate"

--- a/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/GPGSigning.swift
@@ -265,7 +265,7 @@ public enum GPGSigningConfigurationError: LocalizedError {
         switch self {
         case .programUnavailable(let path): "The bundled Git signing adapter is unavailable at \(path)."
         case .bundledExecutableUnavailable(let path): "The bundled Automic Vault executable is unavailable or invalid at \(path)."
-        case .credentialFailed(let detail): "Could not process the GPG credential\(detail.isEmpty ? "." : ": \(detail)")"
+        case .credentialFailed(let detail): "Could not process the credential\(detail.isEmpty ? "." : ": \(detail)")"
         case .gitFailed(let detail): "Git configuration failed\(detail.isEmpty ? "." : ": \(detail)")"
         }
     }

--- a/src/menu-helper/Sources/MenubarHelperCore/SSHAgent.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SSHAgent.swift
@@ -63,6 +63,7 @@ public func sshAgentConfig(_ existing: String, socketPath: String?) throws -> St
               !remaining[end.upperBound...].contains(sshConfigEnd)
         else { throw SSHAgentError.invalidConfiguration }
         remaining = String(remaining[end.upperBound...])
+        if remaining.hasPrefix("\n") { remaining.removeFirst() }
     }
     guard let socketPath else { return remaining }
     guard socketPath.hasPrefix("/"), !socketPath.contains(where: { "\n\r\"\\$%".contains($0) })
@@ -74,7 +75,7 @@ public func sshAgentConfig(_ existing: String, socketPath: String?) throws -> St
       ForwardAgent no
       AddKeysToAgent no
       UseKeychain no
-    """ + "\n" + sshConfigEnd + remaining
+    """ + "\n" + sshConfigEnd + (remaining.isEmpty ? "" : "\n" + remaining)
 }
 
 public func configureOpenSSHAgent(enabled: Bool, home: URL = FileManager.default.homeDirectoryForCurrentUser) throws {

--- a/src/menu-helper/Sources/MenubarHelperCore/SSHAgent.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SSHAgent.swift
@@ -30,8 +30,13 @@ public func saveSSHAgentConfiguration(_ config: SSHAgentConfiguration) -> OSStat
                            account: "configuration", accessibility: .afterFirstUnlock)
 }
 
-public func sshAgentSocketURL(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
-    home.appendingPathComponent(".automic-vault-ssh/agent.sock")
+public func sshAgentSocketURL(
+    home: URL = FileManager.default.homeDirectoryForCurrentUser,
+    xdgDataHome: String? = ProcessInfo.processInfo.environment["XDG_DATA_HOME"]
+) -> URL {
+    let directory = xdgDataHome.flatMap { $0.hasPrefix("/") ? URL(fileURLWithPath: $0) : nil }
+        ?? home.appendingPathComponent(".local/share")
+    return directory.appendingPathComponent("automic-vault/ssh-agent.sock")
 }
 
 public func validSSHSigningArguments(_ arguments: [String]) -> Bool {

--- a/src/menu-helper/Sources/MenubarHelperCore/SSHAgent.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SSHAgent.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Darwin
+import Security
+
+public let sshCredentialSecretName = "AV_SSH_CREDENTIAL"
+public let sshAgentConfigurationService = "com.automicvault.ssh-agent-configuration"
+
+public struct SSHAgentConfiguration: Codable, Equatable, Sendable {
+    public var generation: UUID = UUID()
+    public var enabled: Bool
+    public var publicKey: String
+    public init(enabled: Bool = false, publicKey: String = "") {
+        self.enabled = enabled
+        self.publicKey = publicKey
+    }
+}
+
+public func loadSSHAgentConfiguration() -> SSHAgentConfiguration {
+    guard case .success(let data) = loadKeychainDataResult(
+        service: sshAgentConfigurationService, account: "configuration"
+    ), let config = try? JSONDecoder().decode(SSHAgentConfiguration.self, from: data)
+    else { return SSHAgentConfiguration() }
+    return config
+}
+
+@discardableResult
+public func saveSSHAgentConfiguration(_ config: SSHAgentConfiguration) -> OSStatus {
+    guard let data = try? JSONEncoder().encode(config) else { return errSecParam }
+    return saveKeychainData(data, service: sshAgentConfigurationService,
+                           account: "configuration", accessibility: .afterFirstUnlock)
+}
+
+public func sshAgentSocketURL(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+    home.appendingPathComponent(".automic-vault-ssh/agent.sock")
+}
+
+public func validSSHSigningArguments(_ arguments: [String]) -> Bool {
+    guard arguments.count == 3 else { return false }
+    for (value, prefix) in zip(arguments.prefix(2), ["payload-sha256=", "public-key-sha256="]) {
+        guard value.hasPrefix(prefix) else { return false }
+        let digest = value.dropFirst(prefix.count)
+        guard digest.utf8.count == 64,
+              digest.utf8.allSatisfy({ 48...57 ~= $0 || 97...102 ~= $0 }) else { return false }
+    }
+    return arguments[2] == "signature-flags=0"
+}
+
+private let sshConfigStart = "# BEGIN Automic Vault SSH Agent\n"
+private let sshConfigEnd = "# END Automic Vault SSH Agent\n"
+
+/// OpenSSH uses the first value encountered. Keep the managed block before user configuration.
+public func sshAgentConfig(_ existing: String, socketPath: String?) throws -> String {
+    var remaining = existing
+    if remaining.contains(sshConfigStart) || remaining.contains(sshConfigEnd) {
+        guard remaining.hasPrefix(sshConfigStart),
+              let end = remaining.range(of: sshConfigEnd),
+              !remaining[end.upperBound...].contains(sshConfigStart),
+              !remaining[end.upperBound...].contains(sshConfigEnd)
+        else { throw SSHAgentError.invalidConfiguration }
+        remaining = String(remaining[end.upperBound...])
+    }
+    guard let socketPath else { return remaining }
+    guard socketPath.hasPrefix("/"), !socketPath.contains(where: { "\n\r\"\\$%".contains($0) })
+    else { throw SSHAgentError.invalidConfiguration }
+    return sshConfigStart + """
+    Host *
+      IdentityAgent "\(socketPath)"
+      IdentityFile none
+      ForwardAgent no
+      AddKeysToAgent no
+      UseKeychain no
+    """ + "\n" + sshConfigEnd + remaining
+}
+
+public func configureOpenSSHAgent(enabled: Bool, home: URL = FileManager.default.homeDirectoryForCurrentUser) throws {
+    let directory = home.appendingPathComponent(".ssh")
+    let file = directory.appendingPathComponent("config")
+    let fm = FileManager.default
+    if !fm.fileExists(atPath: directory.path) {
+        try fm.createDirectory(at: directory, withIntermediateDirectories: false,
+                               attributes: [.posixPermissions: 0o700])
+    }
+    let attributes = try fm.attributesOfItem(atPath: directory.path)
+    guard attributes[.type] as? FileAttributeType == .typeDirectory,
+          (attributes[.ownerAccountID] as? NSNumber)?.uint32Value == getuid() else {
+        throw SSHAgentError.invalidConfiguration
+    }
+    // Keep even the atomic replacement's temporary file private.
+    try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    let existing: String
+    if let attributes = try? fm.attributesOfItem(atPath: file.path) {
+        guard attributes[.type] as? FileAttributeType == .typeRegular,
+              (attributes[.ownerAccountID] as? NSNumber)?.uint32Value == getuid() else {
+            throw SSHAgentError.invalidConfiguration
+        }
+        existing = try String(contentsOf: file, encoding: .utf8)
+    } else { existing = "" }
+    let updated = try sshAgentConfig(existing, socketPath: enabled ? sshAgentSocketURL(home: home).path : nil)
+    try updated.write(to: file, atomically: true, encoding: .utf8)
+    try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+}
+
+public enum SSHAgentError: LocalizedError {
+    case invalidConfiguration
+    case failed(String)
+    public var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration: "The SSH configuration cannot be safely updated. Check its path and Automic Vault block."
+        case .failed(let message): message
+        }
+    }
+}

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -111,7 +111,7 @@ public struct SecretValueCustody: Sendable {
         self.adapter = adapter
     }
 
-    public func bind(names: [String], cwd: String) throws -> SelectedSecretValues {
+    public func bind(names: [String], cwd: String, globalOnly: Bool = false) throws -> SelectedSecretValues {
         guard !names.isEmpty else { return SelectedSecretValues(values: [:]) }
         let repairStatus = adapter.repairPendingMutation()
         if repairStatus != errSecSuccess {
@@ -128,7 +128,7 @@ public struct SecretValueCustody: Sendable {
             throw SecretValueCustodyError.inventoryUnavailable(status)
         }
         return SelectedSecretValues(
-            values: try resolveStoredSecretValues(names: names, cwd: cwd, secrets: secrets)
+            values: try resolveStoredSecretValues(names: names, cwd: cwd, secrets: secrets, globalOnly: globalOnly)
         )
     }
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationCommandRedactorTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationCommandRedactorTests.swift
@@ -103,6 +103,7 @@ import Testing
         decision: "Approved",
         reason: "Approved in prompt",
         launcher: "Terminal",
+        launcherIconPath: "/System/Applications/Utilities/Terminal.app",
         callerPath: "/usr/local/bin/av",
         target: "/usr/bin/curl",
         targetRuntimeProtection: "Hardened Runtime",
@@ -115,6 +116,7 @@ import Testing
     #expect(decoded.command == "curl --api-key api-secret")
     #expect(decoded.commandForDisplay == "curl --api-key <redacted>")
     #expect(decoded.targetRuntimeProtection == "Hardened Runtime")
+    #expect(decoded.launcherIconPath == "/System/Applications/Utilities/Terminal.app")
     #expect(!decoded.commandForDisplay.contains("api-secret"))
 }
 
@@ -140,5 +142,6 @@ import Testing
     #expect(record.command == "gh api --header Authorization:secret-value")
     #expect(record.commandForDisplay == "gh <arguments hidden>")
     #expect(record.targetRuntimeProtection == nil)
+    #expect(record.launcherIconPath == nil)
     #expect(!record.commandForDisplay.contains("secret-value"))
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationDecisionReuseTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationDecisionReuseTests.swift
@@ -51,6 +51,27 @@ func authorizationDecisionReuseBindsEveryRequestField(_ mutation: RequestMutatio
     #expect(cache.decision(for: request, now: Date(timeIntervalSince1970: 101)) == nil)
 }
 
+@Test func authorizationDecisionReuseDisabledIsolatesRequestsSharingAHelper() {
+    let request = reuseRequest(policy: .disabled)
+    let otherRequest = reuseRequest(.arguments, policy: .disabled)
+    let now = Date(timeIntervalSince1970: 100)
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(.denied, for: request, now: now)
+    #expect(cache.decision(for: request, now: now) == nil)
+    #expect(cache.decision(for: otherRequest, now: now) == nil)
+    #expect(cache.decision(for: reuseRequest(), now: now) == nil)
+
+    cache.remember(.approved, for: request, now: now)
+    cache.remember(.alwaysApproved, for: request, now: now)
+    #expect(cache.decision(for: request, now: now) == nil)
+
+    // A shared helper's existing denial must not suppress a fresh SSH request.
+    cache.remember(.denied, for: reuseRequest(), now: now)
+    #expect(cache.decision(for: request, now: now) == nil)
+    // Fresh approval alone deliberately retains denial quarantine for other gates.
+    #expect(cache.decision(for: reuseRequest(policy: .freshApprovalRequired), now: now) == .denied)
+}
+
 @Test func authorizationDecisionReuseDenialQuarantinesTheLiveGateClient() {
     let denied = reuseRequest()
     let differentRequest = reuseRequest(.arguments)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SSHAgentTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SSHAgentTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+struct SSHAgentTests {
+    @Test func signingRequestRequiresTwoDigestsAndKnownFlags() {
+        let args = ["payload-sha256=" + String(repeating: "a", count: 64),
+                    "public-key-sha256=" + String(repeating: "0", count: 64), "signature-flags=0"]
+        #expect(validSSHSigningArguments(args))
+        #expect(!validSSHSigningArguments(Array(args.dropLast())))
+        #expect(!validSSHSigningArguments(args + ["extra"]))
+        #expect(!validSSHSigningArguments([args[0], args[1], "signature-flags=1"]))
+        #expect(!validSSHSigningArguments([args[0] + "f", args[1], args[2]]))
+        #expect(!validSSHSigningArguments([args[0].uppercased(), args[1], args[2]]))
+    }
+
+    @Test func agentPolicyStartsWithApprovalAndHasNoReadOnlyAuthority() {
+        let gate = SecretGate(id: "ssh-agent", keyPatterns: [sshCredentialSecretName],
+                              routes: [], defaultProtection: .noAccess, appPolicies: [])
+        #expect(gate.initialProtection == .noAccess)
+        #expect(gate.availableProtections == [.noAccess, .fullExceptSecretDumps])
+        #expect(gate.normalizedProtection(.readOnly) == .noAccess)
+        #expect(gate.normalizedProtection(.readOnlyAndLocalWrites) == .noAccess)
+        #expect(gate.protectionTitle(.fullExceptSecretDumps) == "Allow Authentication")
+        #expect(SSHAgentConfiguration().enabled == false)
+    }
+
+    @Test func agentSelectsTheGlobalCredentialEvenWithARootProjectValue() throws {
+        let global = StoredSecretValue(source: .global, keychainAccount: sshCredentialSecretName, accessibility: .whenUnlocked, keychainProperties: [])
+        let project = StoredSecretValue(source: .projectDirectory("/"), keychainAccount: "project", accessibility: .whenUnlocked, keychainProperties: [])
+        let secret = StoredSecret(account: sshCredentialSecretName, values: [global, project])
+        let selected = try resolveStoredSecretValues(names: [sshCredentialSecretName], cwd: "/",
+                                                    secrets: [secret], globalOnly: true)
+        #expect(selected[sshCredentialSecretName]?.source == .global)
+        let ordinary = try resolveStoredSecretValues(names: [sshCredentialSecretName], cwd: "/", secrets: [secret])
+        #expect(ordinary[sshCredentialSecretName]?.source == .projectDirectory("/"))
+    }
+
+    @Test func configurationIsReversibleAndRejectsAmbiguousBlocks() throws {
+        let original = "Host work\n  HostName work.example\n  User alice\n"
+        let configured = try sshAgentConfig(original, socketPath: "/Users/alice/.automic-vault-ssh/agent.sock")
+        #expect(configured.hasPrefix("# BEGIN Automic Vault SSH Agent\nHost *\n"))
+        #expect(configured.contains("  IdentityFile none\n"))
+        #expect(configured.contains("  UseKeychain no\n"))
+        #expect(try sshAgentConfig(configured, socketPath: nil) == original)
+        #expect(try sshAgentConfig(configured, socketPath: "/Users/alice/.automic-vault-ssh/agent.sock") == configured)
+        #expect(throws: SSHAgentError.self) { try sshAgentConfig(original + configured, socketPath: nil) }
+        #expect(throws: SSHAgentError.self) { try sshAgentConfig(original, socketPath: "/tmp/a\nProxyCommand bad") }
+        #expect(throws: SSHAgentError.self) { try sshAgentConfig(original, socketPath: "/tmp/%h") }
+    }
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SSHAgentTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SSHAgentTests.swift
@@ -38,12 +38,19 @@ struct SSHAgentTests {
 
     @Test func configurationIsReversibleAndRejectsAmbiguousBlocks() throws {
         let original = "Host work\n  HostName work.example\n  User alice\n"
-        let configured = try sshAgentConfig(original, socketPath: "/Users/alice/.automic-vault-ssh/agent.sock")
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let socketPath = sshAgentSocketURL(home: home, xdgDataHome: nil).path
+        #expect(socketPath == "/Users/alice/.local/share/automic-vault/ssh-agent.sock")
+        #expect(sshAgentSocketURL(home: home, xdgDataHome: "").path == socketPath)
+        #expect(sshAgentSocketURL(home: home, xdgDataHome: "relative/path").path == socketPath)
+        #expect(sshAgentSocketURL(home: home, xdgDataHome: "/custom/data").path == "/custom/data/automic-vault/ssh-agent.sock")
+        let configured = try sshAgentConfig(original, socketPath: socketPath)
         #expect(configured.hasPrefix("# BEGIN Automic Vault SSH Agent\nHost *\n"))
+        #expect(configured.contains("  IdentityAgent \"\(socketPath)\"\n"))
         #expect(configured.contains("  IdentityFile none\n"))
         #expect(configured.contains("  UseKeychain no\n"))
         #expect(try sshAgentConfig(configured, socketPath: nil) == original)
-        #expect(try sshAgentConfig(configured, socketPath: "/Users/alice/.automic-vault-ssh/agent.sock") == configured)
+        #expect(try sshAgentConfig(configured, socketPath: socketPath) == configured)
         #expect(throws: SSHAgentError.self) { try sshAgentConfig(original + configured, socketPath: nil) }
         #expect(throws: SSHAgentError.self) { try sshAgentConfig(original, socketPath: "/tmp/a\nProxyCommand bad") }
         #expect(throws: SSHAgentError.self) { try sshAgentConfig(original, socketPath: "/tmp/%h") }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SSHAgentTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SSHAgentTests.swift
@@ -49,8 +49,16 @@ struct SSHAgentTests {
         #expect(configured.contains("  IdentityAgent \"\(socketPath)\"\n"))
         #expect(configured.contains("  IdentityFile none\n"))
         #expect(configured.contains("  UseKeychain no\n"))
+        #expect(configured.contains("# END Automic Vault SSH Agent\n\n" + original))
         #expect(try sshAgentConfig(configured, socketPath: nil) == original)
         #expect(try sshAgentConfig(configured, socketPath: socketPath) == configured)
+        let empty = try sshAgentConfig("", socketPath: socketPath)
+        #expect(empty.hasSuffix("# END Automic Vault SSH Agent\n"))
+        #expect(try sshAgentConfig(empty, socketPath: nil) == "")
+        let leadingBlank = try sshAgentConfig("\n" + original, socketPath: socketPath)
+        #expect(try sshAgentConfig(leadingBlank, socketPath: nil) == "\n" + original)
+        let legacy = configured.replacingOccurrences(of: "# END Automic Vault SSH Agent\n\n", with: "# END Automic Vault SSH Agent\n")
+        #expect(try sshAgentConfig(legacy, socketPath: socketPath) == configured)
         #expect(throws: SSHAgentError.self) { try sshAgentConfig(original + configured, socketPath: nil) }
         #expect(throws: SSHAgentError.self) { try sshAgentConfig(original, socketPath: "/tmp/a\nProxyCommand bad") }
         #expect(throws: SSHAgentError.self) { try sshAgentConfig(original, socketPath: "/tmp/%h") }

--- a/tests/ssh_agent.rs
+++ b/tests/ssh_agent.rs
@@ -1,0 +1,73 @@
+#![cfg(target_os = "macos")]
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn imports_encrypted_openssh_keys_and_rejects_wrong_passphrases() {
+    let directory = std::env::temp_dir().join(format!(
+        "av-ssh-import-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir(&directory).unwrap();
+    for algorithm in ["ed25519", "ecdsa", "rsa"] {
+        let key = directory.join(algorithm);
+        assert!(
+            Command::new("/usr/bin/ssh-keygen")
+                .args([
+                    "-q",
+                    "-t",
+                    algorithm,
+                    "-N",
+                    "fixture-passphrase",
+                    "-C",
+                    "fixture"
+                ])
+                .arg("-f")
+                .arg(&key)
+                .status()
+                .unwrap()
+                .success()
+        );
+        for passphrase in ["fixture-passphrase", "wrong-passphrase"] {
+            let credential = serde_json::json!({
+                "private_key": std::fs::read_to_string(&key).unwrap(), "passphrase": passphrase
+            });
+            let mut child = Command::new(env!("CARGO_BIN_EXE_av"))
+                .arg("__ssh-public-key")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(credential.to_string().as_bytes())
+                .unwrap();
+            let output = child.wait_with_output().unwrap();
+            if passphrase == "fixture-passphrase" && algorithm != "rsa" {
+                assert!(
+                    output.status.success(),
+                    "{}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                assert_eq!(
+                    String::from_utf8(output.stdout).unwrap().trim(),
+                    std::fs::read_to_string(key.with_extension("pub"))
+                        .unwrap()
+                        .trim()
+                );
+            } else {
+                assert!(!output.status.success());
+                assert!(output.stdout.is_empty());
+                assert!(!String::from_utf8_lossy(&output.stderr).contains(passphrase));
+            }
+        }
+    }
+    std::fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
Adds an off-by-default SSH Agent setting that authorizes SSH authentication through the SSH Agent Authorization Gate. Every Verified Launcher uses the same Global Value of the SSH credential; there are no Launcher-specific credential overrides.

Settings can import an OpenSSH private key, display its public key, and configure OpenSSH to use the bundled agent. Each signature requires Approval unless the Launcher's Access Level allows authentication.

### Security boundaries

- Implements public-key enumeration and SSH authentication signatures for Ed25519 and ECDSA. Rejects arbitrary signing, key mutation, unsupported operations, and RSA (the available implementation has an unpatched timing advisory).
- Binds each request to its exact payload and public key, verifies the live socket peer and original Launcher ancestry, and revalidates before releasing credential material. Requires an Authorization Record for every use; temporary grants and transient decision reuse do not apply.
- Requires a live Verified Launcher ancestor and kernel support for original parent execution versions. Fails closed when either is unavailable.
- Destination restrictions are deferred. Shared or forwarded connections inherit the local client's attribution. Existing private-key copies and other agents remain independent access paths.

See ADR 0043 for the authority model and macOS peer-verification constraints.

### Validation

- Rust library suite: 1,063 passed, 1 ignored.
- Swift suite: 296 passed.
- App self-checks: 28 passed.
- OpenSSH encrypted-key interoperability test passed.
- Native socket tests passed, including exec transitions, changed parent execution, dead peers, and argument boundaries.
- No live SSH server login was tested.

Closes #217.
