### PR TITLE
Fix detector row pills clipping title/severity badge

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -2268,13 +2268,12 @@ private struct DashboardRow: View {
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
+                    .layoutPriority(1)
                 if let status = item.blessingStatus {
                     BlessingStatusPill(status: status)
-                        .fixedSize()
                 }
                 if let kind = item.kind {
                     DetectorKindPill(kind: kind)
-                        .fixedSize()
                 }
                 if item.isHardened, !item.isTriggered {
                     HardenedDetectorPill()
@@ -2283,9 +2282,11 @@ private struct DashboardRow: View {
                 if let severity = item.severity {
                     Text(severity)
                         .font(.system(size: 10, weight: .bold))
+                        .lineLimit(1)
                         .padding(.horizontal, 6)
                         .frame(height: 18)
                         .outlinedPill(detectorSeverityColor(severity))
+                        .layoutPriority(1)
                 }
             }
             Group {


### PR DESCRIPTION

<img width="865" height="592" alt="CleanShot 2026-09-07 at 15 30 27" src="https://github.com/user-attachments/assets/a8df2ef1-d79f-4eb8-9fa5-e9e14b9bc89a" />

## Summary

- Fix triggered detector rows in the menubar sidebar clipping their title and severity badge instead of laying out cleanly
- The kind pill and severity badge were both `.fixedSize()`, so they always claimed full width and left the title to absorb all the squeeze; once a row needed both (any tripped detector), the row overflowed past the sidebar edge instead of truncating
- Let the kind/blessing pills shrink and truncate under pressure, and give the title and severity badge layout priority so they're the last to give up space

## Test plan

- `swift build` in `src/menu-helper` succeeds
