### PR TITLE
Fix cursor over detector doc issue links

### DIFF
--- a/src/menu-helper/Sources/MenubarHelper/RenderedMarkdown.swift
+++ b/src/menu-helper/Sources/MenubarHelper/RenderedMarkdown.swift
@@ -22,9 +22,12 @@ struct RenderedMarkdown: View {
             }
 
             if let trailingLink = parsed.trailingLink {
-                // Rendered outside the .textSelection(.enabled) scope above: SwiftUI/AppKit stops
-                // showing the pointing-hand cursor over links once their container is selectable.
+                // .textSelection(.disabled) is explicit, not just "we didn't wrap this one": a
+                // selectable ancestor would otherwise flow its environment value down here too,
+                // and SwiftUI/AppKit stops showing the pointing-hand cursor over links once their
+                // container is selectable.
                 trailingLinkText(trailingLink)
+                    .textSelection(.disabled)
             }
         }
     }

--- a/src/menu-helper/Sources/MenubarHelper/RenderedMarkdown.swift
+++ b/src/menu-helper/Sources/MenubarHelper/RenderedMarkdown.swift
@@ -5,11 +5,33 @@ import SwiftUI
 struct RenderedMarkdown: View {
     let markdown: String
 
+    private var parsedContent: MarkdownBody {
+        markdownExtractingTrailingLinkParagraph(markdownDroppingInitialHeadingMarker(markdown))
+    }
+
     var body: some View {
-        Markdown(markdownDroppingInitialHeadingMarker(markdown))
-            .markdownTheme(.basic.listItem { configuration in
-                configuration.label.markdownMargin(top: .em(0.15))
-            })
-            .textSelection(.enabled)
+        let parsed = parsedContent
+
+        VStack(alignment: .leading, spacing: 8) {
+            if !parsed.text.isEmpty {
+                Markdown(parsed.text)
+                    .markdownTheme(.basic.listItem { configuration in
+                        configuration.label.markdownMargin(top: .em(0.15))
+                    })
+                    .textSelection(.enabled)
+            }
+
+            if let trailingLink = parsed.trailingLink {
+                // Rendered outside the .textSelection(.enabled) scope above: SwiftUI/AppKit stops
+                // showing the pointing-hand cursor over links once their container is selectable.
+                trailingLinkText(trailingLink)
+            }
+        }
+    }
+
+    private func trailingLinkText(_ link: MarkdownTrailingLink) -> Text {
+        var title = AttributedString(link.title)
+        title.link = link.url
+        return Text(title) + Text(link.trailingText)
     }
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/MarkdownDocument.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/MarkdownDocument.swift
@@ -1,7 +1,66 @@
+import Foundation
+
 public func markdownDroppingInitialHeadingMarker(_ markdown: String) -> String {
     guard markdown.hasPrefix("# ") else { return markdown }
     return markdown.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
         .dropFirst()
         .first
         .map(String.init) ?? ""
+}
+
+public struct MarkdownTrailingLink: Equatable, Sendable {
+    public let title: String
+    public let url: URL
+    /// Any punctuation immediately following the link's closing `)`, e.g. a trailing period.
+    public let trailingText: String
+}
+
+public struct MarkdownBody: Equatable, Sendable {
+    public let text: String
+    public let trailingLink: MarkdownTrailingLink?
+}
+
+private let trailingLinkParagraphRegex = try! NSRegularExpression(
+    pattern: #"^\[([^\]]+)\]\(([^\s)]+)\)([\p{P}]{0,2})$"#
+)
+
+/// Splits a standalone `[title](url).`-only paragraph off the end of `markdown`, if present.
+///
+/// A link rendered by MarkdownUI's `Text`-based inline renderer loses its pointing-hand cursor
+/// when the containing view has `.textSelection(.enabled)` applied (an AppKit/SwiftUI limitation).
+/// Every detector doc ends its "not yet hardened" explanation with exactly this kind of paragraph,
+/// so pulling it out lets the caller render it as a plain, non-selectable `Link`/`Text(.link)`
+/// that keeps the correct hover cursor.
+public func markdownExtractingTrailingLinkParagraph(_ markdown: String) -> MarkdownBody {
+    let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    let bodyEndIndex: String.Index
+    let lastParagraph: String
+    if let separatorRange = trimmed.range(of: "\n\n", options: .backwards) {
+        bodyEndIndex = separatorRange.lowerBound
+        lastParagraph = trimmed[separatorRange.upperBound...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    } else {
+        bodyEndIndex = trimmed.startIndex
+        lastParagraph = trimmed
+    }
+
+    guard let trailingLink = trailingLink(matching: lastParagraph) else {
+        return MarkdownBody(text: markdown, trailingLink: nil)
+    }
+
+    return MarkdownBody(text: String(trimmed[trimmed.startIndex..<bodyEndIndex]), trailingLink: trailingLink)
+}
+
+private func trailingLink(matching paragraph: String) -> MarkdownTrailingLink? {
+    let fullRange = NSRange(paragraph.startIndex..., in: paragraph)
+    guard
+        let match = trailingLinkParagraphRegex.firstMatch(in: paragraph, range: fullRange),
+        let titleRange = Range(match.range(at: 1), in: paragraph),
+        let urlRange = Range(match.range(at: 2), in: paragraph),
+        let url = URL(string: String(paragraph[urlRange]))
+    else { return nil }
+
+    let trailingText = Range(match.range(at: 3), in: paragraph).map { String(paragraph[$0]) } ?? ""
+    return MarkdownTrailingLink(title: String(paragraph[titleRange]), url: url, trailingText: trailingText)
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/MarkdownDocumentTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/MarkdownDocumentTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+@Test func markdownDroppingInitialHeadingMarkerStripsLeadingHeading() {
+    #expect(markdownDroppingInitialHeadingMarker("# Title\nBody text") == "Body text")
+}
+
+@Test func markdownDroppingInitialHeadingMarkerLeavesOtherMarkdownAlone() {
+    #expect(markdownDroppingInitialHeadingMarker("Body text") == "Body text")
+}
+
+@Test func extractsTrailingLinkOnlyParagraph() {
+    let markdown = """
+    First paragraph.
+
+    Second paragraph explains things.
+
+    [Open an issue to discuss a safer integration](https://github.com/automic-vault/automic-vault/issues).
+    """
+
+    let result = markdownExtractingTrailingLinkParagraph(markdown)
+
+    #expect(result.text == "First paragraph.\n\nSecond paragraph explains things.")
+    #expect(result.trailingLink?.title == "Open an issue to discuss a safer integration")
+    #expect(result.trailingLink?.url == URL(string: "https://github.com/automic-vault/automic-vault/issues"))
+    #expect(result.trailingLink?.trailingText == ".")
+}
+
+@Test func extractsTrailingLinkWhenItIsTheOnlyParagraph() {
+    let markdown = "[Open an issue](https://example.com/issues)"
+
+    let result = markdownExtractingTrailingLinkParagraph(markdown)
+
+    #expect(result.text == "")
+    #expect(result.trailingLink?.title == "Open an issue")
+    #expect(result.trailingLink?.url == URL(string: "https://example.com/issues"))
+    #expect(result.trailingLink?.trailingText == "")
+}
+
+@Test func leavesMarkdownAloneWhenLastParagraphIsNotJustALink() {
+    let markdown = """
+    Intro.
+
+    See [the issue tracker](https://example.com/issues) for details.
+    """
+
+    let result = markdownExtractingTrailingLinkParagraph(markdown)
+
+    #expect(result.text == markdown)
+    #expect(result.trailingLink == nil)
+}
+
+@Test func leavesPlainMarkdownAlone() {
+    let markdown = "Just some prose with no links at all."
+
+    let result = markdownExtractingTrailingLinkParagraph(markdown)
+
+    #expect(result.text == markdown)
+    #expect(result.trailingLink == nil)
+}


### PR DESCRIPTION
## Summary

- `RenderedMarkdown` wraps detector docs in `.textSelection(.enabled)`, which makes SwiftUI/AppKit show the I-beam cursor over links too, even though they're still clickable. Every detector doc ends its explanation with a standalone `[Open an issue...]` link paragraph, so that paragraph is now split out and rendered outside the selectable scope, where its pointing-hand cursor works normally.
- Added `markdownExtractingTrailingLinkParagraph` to `MenubarHelperCore` so the split logic is unit-testable independent of the SwiftUI view.

## Test plan

- `swift test --filter MarkdownDocumentTests` covers the paragraph-splitting logic (multi-paragraph docs, link-only docs, and docs where the last paragraph isn't just a link).
- Full `swift build`/`swift test` passes for the `menu-helper` package.
- Not verified visually in a running app (no way to drive a native macOS window in this session) — worth a quick hover-over check before merging.
