### PR TITLE
Report locked Secrets as unavailable instead of missing

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -38,6 +38,38 @@ is inactive or its displays sleep. The originating process must remain alive,
 and Secret Availability still applies. AWS MFA entry remains Mac-local and
 requires an active session and awake displays.
 
+### Remote work from a locked Mac
+
+iPhone Approval does not unlock the Mac's Keychain. A Secret configured as
+**When Unlocked** stays unavailable while the Mac is locked, even if you can
+approve on your phone. Automic Vault may reject the request before it reaches
+Approval, so you receive no phone notification. A missing notification alone
+does not establish a relay or phone problem.
+
+To let a remote agent use a particular Secret while the Mac is locked:
+
+1. Unlock the Mac and open Automic Vault with `av open`.
+2. Open **Secrets**, select the Secret, and enable **Available While Locked**.
+   Repeat for each Secret the operation needs. For GitHub, check the relevant
+   `GH_TOKEN_…` account and host entries.
+3. Keep iPhone Approval enabled if you want to approve remotely, then retry a
+   read such as `gh auth status` from the same remote agent while the Mac is locked.
+
+This choice makes all Values of that Secret available after the first unlock
+following a restart. Enable it only for Secrets needed by your remote workflow.
+The Secret Gate still verifies and authorizes every operation; policy may allow
+a recognized read without prompting, and a request that needs Approval goes to
+an eligible iPhone. The Mac and originating process must keep running.
+
+Unlock the Mac for login or credential changes that fail with Keychain error
+`-25308`. Saving Secrets requires a complete inventory, which may be unavailable
+while locked even when a particular Secret allows use while locked. Some app
+versions also report an unavailable GitHub Secret as an "invalid token"; retry
+while unlocked before treating this as an expired or revoked GitHub token.
+
+See the canonical [Secret Availability](domain-language.md#secret-availability)
+definition for the storage and authorization boundaries.
+
 ## iPhone Approval
 
 iPhone Approval is optional and enabled per Mac. Once enabled, every human
@@ -59,6 +91,9 @@ To enroll:
    notifications.
 3. On the Mac, open **Settings → iPhone Approval** and click
    **Enable iPhone Approval**.
+
+If you will use an agent while the Mac is locked, also configure
+[Secret Availability for remote work](#remote-work-from-a-locked-mac).
 
 Routine requests can offer **Approve Once** in an authenticated notification.
 Requests with Unknown operation risk, Secret Disclosure, Unconstrained Secret

--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -52,5 +52,5 @@ the Mac is unlocked. The Secret Gate still authorizes each operation.
 
 If `gh auth status` reports an invalid token only while locked, or login fails
 with Keychain error `-25308`, follow the
-[locked-Mac setup and troubleshooting guide](https://github.com/automic-vault/automic-vault/blob/main/docs/authorization.md#remote-work-from-a-locked-mac).
+[locked-Mac setup and troubleshooting guide](../../../docs/authorization.md#remote-work-from-a-locked-mac).
 Login and credential changes can still require an unlocked Mac.

--- a/src/isotopes/hardeners/gh_cli.md
+++ b/src/isotopes/hardeners/gh_cli.md
@@ -43,3 +43,14 @@ Write Access authorizes recognized remote writes, but Secret Disclosure through
   git-credential`; the hardened `gh` helper path requests the token through
   Automic Vault.
 - `av harden gh-cli` remains accepted as a compatibility alias.
+
+## Using GitHub while the Mac is locked
+
+iPhone Approval cannot unlock a Secret configured as When Unlocked. For a remote
+agent, enable **Available While Locked** on the relevant GitHub Secrets while
+the Mac is unlocked. The Secret Gate still authorizes each operation.
+
+If `gh auth status` reports an invalid token only while locked, or login fails
+with Keychain error `-25308`, follow the
+[locked-Mac setup and troubleshooting guide](https://github.com/automic-vault/automic-vault/blob/main/docs/authorization.md#remote-work-from-a-locked-mac).
+Login and credential changes can still require an unlocked Mac.

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -5457,7 +5457,7 @@ private final class ApprovalServer: @unchecked Sendable {
         switch loadStoredSecretsResult(directAccessRules: directAccessRules) {
         case .success(let loaded): storedSecrets = loaded
         case .failure(let status):
-            reply(peer, to: message, ok: false, error: "stored Secrets are unavailable: \(status)")
+            reply(peer, to: message, ok: false, error: SecretValueCustodyError.inventoryUnavailable(status).localizedDescription)
             return
         }
         let storedSecret = storedSecrets.first { $0.account == key }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1652,9 +1652,10 @@ public func loadStoredSecretsResult(
 
 public func loadStoredSecretsForUseResult(
     service: String = automicVaultKeychainService,
-    directAccessRules: [DirectAccessRule] = []
+    directAccessRules: [DirectAccessRule] = [],
+    requiredNames: [String] = []
 ) -> StoredSecretsLoad {
-    retryLockedSecretInventory { accessibility in
+    retryLockedSecretInventory(requiredNames: requiredNames) { accessibility in
         loadStoredSecretsResult(
             service: service,
             directAccessRules: directAccessRules,
@@ -1664,11 +1665,18 @@ public func loadStoredSecretsForUseResult(
 }
 
 func retryLockedSecretInventory(
+    requiredNames: [String] = [],
     _ load: (StoredSecretAccessibility?) -> StoredSecretsLoad
 ) -> StoredSecretsLoad {
     let result = load(nil)
     if case .failure(errSecInteractionNotAllowed) = result {
-        return load(.afterFirstUnlock)
+        let available = load(.afterFirstUnlock)
+        if case .success(let secrets) = available,
+           !Set(requiredNames).isSubset(of: Set(secrets.map(\.account))) {
+            // A filtered inventory cannot establish that an omitted Secret is absent.
+            return result
+        }
+        return available
     }
     return result
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -14,6 +14,8 @@ public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable 
         switch self {
         case .repairFailed(let status):
             "secret repair must complete before this request: \(status)"
+        case .inventoryUnavailable(let status) where status == errSecInteractionNotAllowed:
+            "Stored Secrets are unavailable from Keychain. Unlock the Mac and retry. (\(status))"
         case .inventoryUnavailable(let status):
             "failed to inspect stored Secrets: \(status)"
         case .secretMissing(let name):
@@ -78,7 +80,7 @@ struct SelectedSecretValueSourceIdentity: Hashable, Sendable {
 protocol SecretValueCustodyAdapter: Sendable {
     func repairPendingMutation() -> OSStatus
     func pendingMutationNames() -> Set<String>?
-    func inventory() -> StoredSecretsLoad
+    func inventory(requiredNames: [String]) -> StoredSecretsLoad
     func load(_ value: StoredSecretValue) -> StoredSecretValueLoad
 }
 
@@ -91,8 +93,8 @@ private struct KeychainSecretValueCustodyAdapter: SecretValueCustodyAdapter {
         MenubarHelperCore.pendingSecretMutationNames()
     }
 
-    func inventory() -> StoredSecretsLoad {
-        loadStoredSecretsForUseResult()
+    func inventory(requiredNames: [String]) -> StoredSecretsLoad {
+        loadStoredSecretsForUseResult(requiredNames: requiredNames)
     }
 
     func load(_ value: StoredSecretValue) -> StoredSecretValueLoad {
@@ -121,7 +123,7 @@ public struct SecretValueCustody: Sendable {
             }
         }
         let secrets: [StoredSecret]
-        switch adapter.inventory() {
+        switch adapter.inventory(requiredNames: names) {
         case .success(let inventory):
             secrets = inventory
         case .failure(let status):

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
@@ -30,7 +30,7 @@ private struct InMemorySecretValueCustodyAdapter: SecretValueCustodyAdapter {
 
     func repairPendingMutation() -> OSStatus { repairStatus }
     func pendingMutationNames() -> Set<String>? { pendingNames }
-    func inventory() -> StoredSecretsLoad { inventoryResult }
+    func inventory(requiredNames: [String]) -> StoredSecretsLoad { inventoryResult }
     func load(_ value: StoredSecretValue) -> StoredSecretValueLoad {
         loadedValues[value.keychainAccount] ?? .notFound
     }
@@ -161,11 +161,68 @@ private struct InMemorySecretValueCustodyAdapter: SecretValueCustodyAdapter {
     }
 }
 
-private func storedValue(source: StoredSecretValueSource, account: String) -> StoredSecretValue {
+private func storedValue(
+    source: StoredSecretValueSource,
+    account: String,
+    accessibility: StoredSecretAccessibility = .whenUnlocked
+) -> StoredSecretValue {
     StoredSecretValue(
         source: source,
         keychainAccount: account,
-        accessibility: .whenUnlocked,
+        accessibility: accessibility,
         keychainProperties: []
     )
+}
+
+private struct LockedInventoryCustodyAdapter: SecretValueCustodyAdapter {
+    let available: [StoredSecret]
+
+    func repairPendingMutation() -> OSStatus { errSecSuccess }
+    func pendingMutationNames() -> Set<String>? { [] }
+    func inventory(requiredNames: [String]) -> StoredSecretsLoad {
+        retryLockedSecretInventory(requiredNames: requiredNames) { accessibility in
+            accessibility == nil ? .failure(errSecInteractionNotAllowed) : .success(available)
+        }
+    }
+    func load(_ value: StoredSecretValue) -> StoredSecretValueLoad { .success("test-secret") }
+}
+
+@Test(arguments: [false, true])
+func lockedSecretIsUnavailableRatherThanMissing(hasOtherAvailableSecret: Bool) throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let other = StoredSecret(account: "OTHER_TOKEN", accessibility: .afterFirstUnlock, values: [
+        storedValue(source: .global, account: "OTHER_TOKEN", accessibility: .afterFirstUnlock),
+    ])
+    let custody = SecretValueCustody(adapter: LockedInventoryCustodyAdapter(
+        available: hasOtherAvailableSecret ? [other] : []
+    ))
+
+    #expect(throws: SecretValueCustodyError.inventoryUnavailable(errSecInteractionNotAllowed)) {
+        let selected = try custody.bind(names: ["GH_TOKEN_GITHUB_COM"], cwd: cwd)
+        _ = try custody.load(selected, names: ["GH_TOKEN_GITHUB_COM"])
+    }
+}
+
+@Test func availableWhileLockedSecretRemainsUsable() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let secret = StoredSecret(account: "GH_TOKEN_GITHUB_COM", accessibility: .afterFirstUnlock, values: [
+        storedValue(source: .global, account: "GH_TOKEN_GITHUB_COM", accessibility: .afterFirstUnlock),
+    ])
+    let custody = SecretValueCustody(adapter: LockedInventoryCustodyAdapter(available: [secret]))
+    let selected = try custody.bind(names: [secret.account], cwd: cwd)
+
+    #expect(try custody.load(selected, names: [secret.account]) == [secret.account: "test-secret"])
+    #expect(throws: SecretValueCustodyError.inventoryUnavailable(errSecInteractionNotAllowed)) {
+        _ = try custody.bind(names: [secret.account, "LOCKED_TOKEN"], cwd: cwd)
+    }
+}
+
+@Test func completeInventoryStillReportsAnAbsentSecretAsMissing() throws {
+    let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
+    let custody = SecretValueCustody(adapter: InMemorySecretValueCustodyAdapter(secrets: [], loadedValues: [:]))
+    let selected = try custody.bind(names: ["ABSENT_TOKEN"], cwd: cwd)
+
+    #expect(throws: SecretValueCustodyError.secretMissing("ABSENT_TOKEN")) {
+        _ = try custody.load(selected, names: ["ABSENT_TOKEN"])
+    }
 }


### PR DESCRIPTION
When a locked Mac cannot load the complete Secret inventory, the retry returns only Secrets configured as Available While Locked. A requested Secret omitted from that filtered inventory was reported as missing, causing `gh auth status` to report an invalid token before reaching Approval.

Preserve the original Keychain availability error whenever the filtered retry cannot account for every requested Secret. Read and save inventory failures now advise unlocking the Mac and retrying. Available While Locked Secrets continue through normal authorization; When Unlocked Secrets remain unavailable while locked, and mutation checks still require the complete inventory.

The authorization guide and bundled GitHub hardener reference now explain remote setup, why a locked Secret can prevent a phone notification, and why login or credential changes may still require an unlocked Mac.

Validation: reproduced the incorrect missing-Secret error before the fix; regression checks cover empty and mixed filtered inventories, usable available Secrets, multi-Secret requests, and genuinely absent Secrets. The full Swift suite and all 28 menu helper self-checks pass. The gh provider-error propagation test also passes.

Refs #308. This requires an Automic Vault app update; no additional gh Isotope revision is needed.
