### PR TITLE
Support multiline and exact stdin input in av save

### DIFF
--- a/docs/project-secrets.md
+++ b/docs/project-secrets.md
@@ -19,6 +19,31 @@ The Project Directory selects a value and grants no authority. The same
 name-based policy covers all Values of that Secret. A read failure for the
 selected Value ends the request without trying another value.
 
+## Multiline and exact input
+
+`av save NAME` prompts for one hidden line. For a multiline Secret Value such as
+a PEM, use:
+
+```sh
+$ av save --multiline --project-directory=. DEPLOY_PRIVATE_KEY
+```
+
+Input stays hidden. Press Ctrl-D after the final newline to finish. To finish
+without a final newline, press Ctrl-D twice. Every received newline and space
+is part of the Value; nothing is trimmed. Ctrl-C cancels without saving.
+Terminal input still follows the terminal's line editing, line-length limits,
+and newline processing.
+
+For exact input from a pipe or redirected descriptor, use `av save --stdin NAME`.
+This reads to EOF without trimming or newline conversion and refuses terminal
+stdin. Both flags work with Global Values and `--project-directory` and cannot
+be combined. Values must be nonempty UTF-8 without NUL bytes, at most 1 MiB.
+
+Both input modes use the existing save Approval and Authorization Record path.
+They do not retrieve existing Secrets or authorize later Secret Use. Keep the
+producer's Secret output out of command arguments, environment variables,
+logs, and plaintext files.
+
 ## dotenvx
 
 For dotenvx, store the decryption key in Automic Vault and remove `.env.keys`:

--- a/src/approval_service.rs
+++ b/src/approval_service.rs
@@ -1,4 +1,11 @@
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
+
+// Field names are static protocol metadata; rejected values must never enter diagnostics.
+pub(crate) fn xpc_string(field: &'static [u8], value: &str) -> Result<CString, String> {
+    let field =
+        CStr::from_bytes_with_nul(field).map_err(|_| "invalid XPC field name".to_string())?;
+    CString::new(value).map_err(|_| format!("XPC field {} contains NUL", field.to_string_lossy()))
+}
 
 #[cfg(target_os = "macos")]
 unsafe extern "C" {
@@ -53,6 +60,23 @@ fn unavailable_message_for_sandbox(sandbox_denied: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn xpc_string_errors_name_fields_without_disclosing_values() {
+        for field in [&b"value\0"[..], &b"args\0"[..], &b"target\0"[..]] {
+            let name = CStr::from_bytes_with_nul(field).unwrap().to_str().unwrap();
+            assert_eq!(
+                xpc_string(field, "sensitive-before\0sensitive-after").unwrap_err(),
+                format!("XPC field {name} contains NUL")
+            );
+        }
+        assert_eq!(
+            xpc_string(b"value\0", " line\r\nline\n ")
+                .unwrap()
+                .to_bytes(),
+            b" line\r\nline\n "
+        );
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -1315,18 +1315,16 @@ fn xpc_approve_request(
         fn av_xpc_connection_set_empty_event_handler(connection: XpcObject);
     }
 
-    unsafe fn set_string(dict: XpcObject, key: &[u8], value: &str) -> Result<(), String> {
-        let value =
-            CString::new(value).map_err(|_| format!("XPC field contains NUL: {value:?}"))?;
+    unsafe fn set_string(dict: XpcObject, key: &'static [u8], value: &str) -> Result<(), String> {
+        let value = crate::approval_service::xpc_string(key, value)?;
         unsafe { xpc_dictionary_set_string(dict, key.as_ptr().cast(), value.as_ptr()) };
         Ok(())
     }
 
-    unsafe fn string_array(values: &[String]) -> Result<XpcObject, String> {
+    unsafe fn string_array(field: &'static [u8], values: &[String]) -> Result<XpcObject, String> {
         let array = unsafe { xpc_array_create_empty() };
         for value in values {
-            let value = CString::new(value.as_str())
-                .map_err(|_| format!("XPC array contains NUL: {value:?}"))?;
+            let value = crate::approval_service::xpc_string(field, value)?;
             let string = unsafe { xpc_string_create(value.as_ptr()) };
             unsafe {
                 xpc_array_append_value(array, string);
@@ -1435,15 +1433,15 @@ fn xpc_approve_request(
             request.allow_missing_keys,
         );
 
-        let keys = string_array(&request.keys)?;
+        let keys = string_array(b"keys\0", &request.keys)?;
         xpc_dictionary_set_value(message, b"keys\0".as_ptr().cast(), keys);
         xpc_release(keys);
 
-        let args = string_array(&request.args)?;
+        let args = string_array(b"args\0", &request.args)?;
         xpc_dictionary_set_value(message, b"args\0".as_ptr().cast(), args);
         xpc_release(args);
 
-        let conflicts = string_array(&request.env_conflicts)?;
+        let conflicts = string_array(b"env_conflicts\0", &request.env_conflicts)?;
         xpc_dictionary_set_value(message, b"env_conflicts\0".as_ptr().cast(), conflicts);
         xpc_release(conflicts);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -46,7 +46,7 @@ commands:
   $ av inject -- <command>                # run an approved script
   $ av proxy +KEY... [--] <command>       # proxy secret references for a command
   $ av list                               # list saved secret names
-  $ av save [--project-directory=DIR] KEY # store a global or Project Value
+  $ av save [options] KEY                 # store a global or Project Value
   $ av harden <tool> [-y|--yes]           # harden a tool; migrate credentials
   $ av unharden brew [-y|--yes]           # temporarily restore Homebrew for cask migration
   $ av gpg-sign [GPG options]             # authorize and sign a Git payload
@@ -543,7 +543,7 @@ where
             };
             open::run(stderr, secret_gate.as_deref())
         }
-        Some("save") => save::run(rest, stderr),
+        Some("save") => save::run(rest, stdout, stderr),
         _ => {
             let _ = writeln!(stderr, "{USAGE}");
             2

--- a/src/cli/save.rs
+++ b/src/cli/save.rs
@@ -207,7 +207,7 @@ fn read_secret_from_tty(key: &str, input: Input) -> Result<Zeroizing<String>, St
 
     let mut bytes = Zeroizing::new(Vec::new());
     let mut chunk = Zeroizing::new([0u8; 4096]);
-    let result = loop {
+    let result: Result<(), String> = loop {
         if INPUT_SIGNAL.load(Ordering::Relaxed) != 0 {
             break Err("Secret input canceled".into());
         }
@@ -241,20 +241,14 @@ fn read_secret_from_tty(key: &str, input: Input) -> Result<Zeroizing<String>, St
             continue;
         }
         match tty.read(&mut *chunk) {
-            Ok(0) => break decode_secret(&bytes),
+            Ok(0) => break Ok(()),
             Ok(count) => {
                 bytes.extend_from_slice(&chunk[..count]);
                 if bytes.len() > MAX_SECRET_BYTES {
                     break Err("Secret Value exceeds 1 MiB".into());
                 }
-                if input == Input::Line {
-                    while bytes
-                        .last()
-                        .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
-                    {
-                        bytes.pop();
-                    }
-                    break decode_secret(&bytes);
+                if input == Input::Line && bytes.ends_with(b"\n") {
+                    break Ok(());
                 }
             }
             Err(error)
@@ -270,10 +264,18 @@ fn read_secret_from_tty(key: &str, input: Input) -> Result<Zeroizing<String>, St
     writeln!(tty).ok();
     drop(signals);
     if INPUT_SIGNAL.load(Ordering::Relaxed) != 0 {
-        Err("Secret input canceled".into())
-    } else {
-        result
+        return Err("Secret input canceled".into());
     }
+    result?;
+    if input == Input::Line {
+        while bytes
+            .last()
+            .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
+        {
+            bytes.pop();
+        }
+    }
+    decode_secret(&bytes)
 }
 
 struct EchoRestore {

--- a/src/cli/save.rs
+++ b/src/cli/save.rs
@@ -1,13 +1,33 @@
 use std::ffi::OsString;
 use std::fs::OpenOptions;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{IsTerminal, Read, Write};
 use std::os::fd::AsRawFd;
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::Path;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use zeroize::Zeroizing;
 
 use super::inject;
 
-pub(crate) fn run(args: Vec<OsString>, stderr: &mut dyn Write) -> i32 {
+const MAX_SECRET_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Input {
+    Line,
+    Multiline,
+    Stdin,
+}
+
+pub(crate) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    if args.len() == 1 && (args[0] == "--help" || args[0] == "-h") {
+        let _ = writeln!(
+            stdout,
+            "{}\n\nDefault: hidden single-line terminal input.\n--multiline: hidden terminal input until Ctrl-D; preserve received whitespace.\n--stdin: read redirected stdin to EOF without trimming or newline conversion.\nInput must be nonempty UTF-8 without NUL, at most 1 MiB. Saving requires Approval.",
+            usage()
+        );
+        return 0;
+    }
     match run_inner(args) {
         Ok(()) => 0,
         Err(err) => {
@@ -18,21 +38,42 @@ pub(crate) fn run(args: Vec<OsString>, stderr: &mut dyn Write) -> i32 {
 }
 
 fn run_inner(args: Vec<OsString>) -> Result<(), String> {
-    let (key, project_directory) = parse_args(args)?;
+    let (key, project_directory, input) = parse_args(args)?;
     let key = key
         .to_str()
         .ok_or_else(|| "save key must be valid UTF-8".to_string())?;
     inject::validate_key_name(key)?;
-    let value = read_secret_from_tty(key)?;
+    let value = if input == Input::Stdin {
+        let stdin = std::io::stdin();
+        if stdin.is_terminal() {
+            return Err(
+                "--stdin requires redirected input; use --multiline for hidden terminal input"
+                    .into(),
+            );
+        }
+        read_secret_to_end(stdin.lock())?
+    } else {
+        read_secret_from_tty(key, input)?
+    };
     save_value(key, &value, project_directory.as_deref())
 }
 
-fn parse_args(args: Vec<OsString>) -> Result<(OsString, Option<String>), String> {
+fn parse_args(args: Vec<OsString>) -> Result<(OsString, Option<String>, Input), String> {
     let mut key = None;
     let mut project_directory = None;
+    let mut input = Input::Line;
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
-        if arg == "--project-directory" {
+        if arg == "--multiline" || arg == "--stdin" {
+            if input != Input::Line {
+                return Err("specify only one of --multiline or --stdin".into());
+            }
+            input = if arg == "--multiline" {
+                Input::Multiline
+            } else {
+                Input::Stdin
+            };
+        } else if arg == "--project-directory" {
             let path = args.next().ok_or_else(usage)?;
             if project_directory.is_some() {
                 return Err("--project-directory may be specified only once".into());
@@ -50,11 +91,11 @@ fn parse_args(args: Vec<OsString>) -> Result<(OsString, Option<String>), String>
             return Err(usage());
         }
     }
-    Ok((key.ok_or_else(usage)?, project_directory))
+    Ok((key.ok_or_else(usage)?, project_directory, input))
 }
 
 fn usage() -> String {
-    "usage: av save [--project-directory=DIR] KEY".into()
+    "usage: av save [--multiline | --stdin] [--project-directory=DIR] KEY".into()
 }
 
 fn canonical_project_directory(path: &Path) -> Result<String, String> {
@@ -97,60 +138,208 @@ fn save_value(key: &str, value: &str, project_directory: Option<&str>) -> Result
     if value.is_empty() {
         return Err("empty key value".into());
     }
+    if value.contains('\0') {
+        return Err("Secret Value must not contain NUL".into());
+    }
+    if value.len() > MAX_SECRET_BYTES {
+        return Err("Secret Value exceeds 1 MiB".into());
+    }
     match project_directory {
         Some(path) => crate::secrets::store_project_secret(key, value, path),
         None => crate::secrets::store_secret(key, value),
     }
 }
 
-fn read_secret_from_tty(key: &str) -> Result<String, String> {
+fn read_secret_to_end(reader: impl Read) -> Result<Zeroizing<String>, String> {
+    let mut bytes = Zeroizing::new(Vec::new());
+    reader
+        .take(MAX_SECRET_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "failed to read Secret Value".to_string())?;
+    decode_secret(&bytes)
+}
+
+fn decode_secret(bytes: &[u8]) -> Result<Zeroizing<String>, String> {
+    if bytes.len() > MAX_SECRET_BYTES {
+        return Err("Secret Value exceeds 1 MiB".into());
+    }
+    let value =
+        std::str::from_utf8(bytes).map_err(|_| "Secret Value must be valid UTF-8".to_string())?;
+    Ok(Zeroizing::new(value.to_owned()))
+}
+
+fn read_secret_from_tty(key: &str, input: Input) -> Result<Zeroizing<String>, String> {
     let mut tty = OpenOptions::new()
         .read(true)
         .write(true)
+        .custom_flags(libc::O_NONBLOCK)
         .open("/dev/tty")
         .map_err(|err| format!("failed to open /dev/tty: {err}"))?;
-    write!(tty, "Value for {key}: ").map_err(|err| format!("failed to prompt: {err}"))?;
-    tty.flush()
-        .map_err(|err| format!("failed to flush prompt: {err}"))?;
-
     let fd = tty.as_raw_fd();
+    if fd as usize >= libc::FD_SETSIZE {
+        return Err("terminal descriptor exceeds select limit".into());
+    }
     let mut original = unsafe { std::mem::zeroed::<libc::termios>() };
     if unsafe { libc::tcgetattr(fd, &mut original) } != 0 {
         return Err(std::io::Error::last_os_error().to_string());
     }
+    let signals = InputSignals::install()?;
+    let mut restore = EchoRestore {
+        fd,
+        original,
+        restored: false,
+    };
     let mut hidden = original;
-    hidden.c_lflag &= !libc::ECHO;
+    hidden.c_lflag &= !(libc::ECHO | libc::ECHONL);
+    hidden.c_lflag |= libc::ICANON | libc::ISIG;
     if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &hidden) } != 0 {
         return Err(std::io::Error::last_os_error().to_string());
     }
-    let restore = EchoRestore { fd, original };
-
-    let mut reader = BufReader::new(
-        tty.try_clone()
-            .map_err(|err| format!("failed to read from /dev/tty: {err}"))?,
-    );
-    let mut value = String::new();
-    reader
-        .read_line(&mut value)
-        .map_err(|err| format!("failed to read key value: {err}"))?;
-    drop(restore);
-    writeln!(tty).ok();
-
-    while value.ends_with('\n') || value.ends_with('\r') {
-        value.pop();
+    // Prompt only after echo is disabled so pasted input cannot race setup.
+    if input == Input::Multiline {
+        writeln!(tty, "Enter value for {key}. Ctrl-D ends input (twice without a final newline); Ctrl-C cancels.")
+            .map_err(|err| format!("failed to prompt: {err}"))?;
+    } else {
+        write!(tty, "Value for {key}: ").map_err(|err| format!("failed to prompt: {err}"))?;
     }
-    Ok(value)
+    tty.flush()
+        .map_err(|err| format!("failed to flush prompt: {err}"))?;
+
+    let mut bytes = Zeroizing::new(Vec::new());
+    let mut chunk = Zeroizing::new([0u8; 4096]);
+    let result = loop {
+        if INPUT_SIGNAL.load(Ordering::Relaxed) != 0 {
+            break Err("Secret input canceled".into());
+        }
+        // Use select: macOS poll can report POLLHUP for a live /dev/tty.
+        // Nonblocking read and a bounded wait also close the signal-before-read race.
+        let mut readable = unsafe { std::mem::zeroed::<libc::fd_set>() };
+        let mut timeout = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 100_000,
+        };
+        unsafe {
+            libc::FD_ZERO(&mut readable);
+            libc::FD_SET(fd, &mut readable);
+        }
+        let ready = unsafe {
+            libc::select(
+                fd + 1,
+                &mut readable,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut timeout,
+            )
+        };
+        if ready < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            break Err("failed to wait for Secret input".into());
+        }
+        if ready == 0 {
+            continue;
+        }
+        match tty.read(&mut *chunk) {
+            Ok(0) => break decode_secret(&bytes),
+            Ok(count) => {
+                bytes.extend_from_slice(&chunk[..count]);
+                if bytes.len() > MAX_SECRET_BYTES {
+                    break Err("Secret Value exceeds 1 MiB".into());
+                }
+                if input == Input::Line {
+                    while bytes
+                        .last()
+                        .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
+                    {
+                        bytes.pop();
+                    }
+                    break decode_secret(&bytes);
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+                ) => {}
+            Err(_) => break Err("failed to read Secret Value".into()),
+        }
+    };
+    // Restore the terminal before restoring signal dispositions or requesting Approval.
+    restore.restore()?;
+    writeln!(tty).ok();
+    drop(signals);
+    if INPUT_SIGNAL.load(Ordering::Relaxed) != 0 {
+        Err("Secret input canceled".into())
+    } else {
+        result
+    }
 }
 
 struct EchoRestore {
     fd: i32,
     original: libc::termios,
+    restored: bool,
+}
+
+impl EchoRestore {
+    fn restore(&mut self) -> Result<(), String> {
+        if !self.restored {
+            // Discard unread input so canceled/pasted Secret text cannot reach the shell.
+            if unsafe { libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.original) } != 0 {
+                return Err("failed to restore terminal settings".into());
+            }
+            self.restored = true;
+        }
+        Ok(())
+    }
 }
 
 impl Drop for EchoRestore {
     fn drop(&mut self) {
-        unsafe {
-            libc::tcsetattr(self.fd, libc::TCSANOW, &self.original);
+        let _ = self.restore();
+    }
+}
+
+static INPUT_SIGNAL: AtomicI32 = AtomicI32::new(0);
+const INPUT_SIGNALS: [i32; 7] = [
+    libc::SIGINT,
+    libc::SIGTERM,
+    libc::SIGHUP,
+    libc::SIGQUIT,
+    libc::SIGTSTP,
+    libc::SIGTTIN,
+    libc::SIGTTOU,
+];
+
+extern "C" fn cancel_input(signal: i32) {
+    INPUT_SIGNAL.store(signal, Ordering::Relaxed);
+}
+
+struct InputSignals(Vec<(i32, libc::sigaction)>);
+
+impl InputSignals {
+    fn install() -> Result<Self, String> {
+        INPUT_SIGNAL.store(0, Ordering::Relaxed);
+        let mut guard = Self(Vec::new());
+        for signal in INPUT_SIGNALS {
+            let mut action = unsafe { std::mem::zeroed::<libc::sigaction>() };
+            let mut original = unsafe { std::mem::zeroed::<libc::sigaction>() };
+            action.sa_sigaction = cancel_input as *const () as usize;
+            unsafe { libc::sigemptyset(&mut action.sa_mask) };
+            if unsafe { libc::sigaction(signal, &action, &mut original) } != 0 {
+                return Err("failed to protect terminal input from interruption".into());
+            }
+            guard.0.push((signal, original));
+        }
+        Ok(guard)
+    }
+}
+
+impl Drop for InputSignals {
+    fn drop(&mut self) {
+        for (signal, original) in self.0.iter().rev() {
+            unsafe { libc::sigaction(*signal, original, std::ptr::null_mut()) };
         }
     }
 }
@@ -158,6 +347,49 @@ impl Drop for EchoRestore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn eof_input_preserves_exact_text_and_rejects_unsupported_values() {
+        for value in [
+            "  token  ",
+            "line\nline",
+            "line\nline\n",
+            "line\r\nline\r\n",
+            "é🔑\n",
+        ] {
+            let read = read_secret_to_end(value.as_bytes()).unwrap();
+            assert_eq!(read.as_bytes(), value.as_bytes());
+        }
+        assert_eq!(
+            read_secret_to_end(&b"sensitive\xff"[..]).unwrap_err(),
+            "Secret Value must be valid UTF-8"
+        );
+        assert_eq!(
+            read_secret_to_end(&vec![b'x'; MAX_SECRET_BYTES + 1][..]).unwrap_err(),
+            "Secret Value exceeds 1 MiB"
+        );
+        assert_eq!(
+            save_value("SAVED_KEY", "sensitive\0value", None).unwrap_err(),
+            "Secret Value must not contain NUL"
+        );
+    }
+
+    #[test]
+    fn input_modes_are_explicit_and_mutually_exclusive() {
+        for (flag, expected) in [("--multiline", Input::Multiline), ("--stdin", Input::Stdin)] {
+            let (_, _, mode) = parse_args(vec![flag.into(), "SAVED_KEY".into()]).unwrap();
+            assert_eq!(mode, expected);
+            assert!(parse_args(vec![flag.into(), flag.into(), "SAVED_KEY".into()]).is_err());
+        }
+        assert!(
+            parse_args(vec![
+                "--stdin".into(),
+                "SAVED_KEY".into(),
+                "--multiline".into()
+            ])
+            .is_err()
+        );
+    }
 
     #[test]
     fn saves_value_to_test_keychain() {
@@ -191,12 +423,13 @@ mod tests {
     #[test]
     fn parses_and_canonicalizes_project_directory() {
         let directory = std::env::temp_dir();
-        let (key, project) = parse_args(vec![
+        let (key, project, input) = parse_args(vec![
             OsString::from(format!("--project-directory={}", directory.display())),
             OsString::from("SAVED_KEY"),
         ])
         .unwrap();
         assert_eq!(key, "SAVED_KEY");
+        assert_eq!(input, Input::Line);
         assert_eq!(
             project,
             Some(

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -917,8 +917,7 @@ fn xpc_request_with_project_directory(
     }
 
     unsafe fn set_string(dict: XpcObject, key: &[u8], value: &str) -> Result<(), String> {
-        let value =
-            CString::new(value).map_err(|_| format!("XPC field contains NUL: {value:?}"))?;
+        let value = CString::new(value).map_err(|_| "XPC field contains NUL".to_string())?;
         unsafe { xpc_dictionary_set_string(dict, key.as_ptr().cast(), value.as_ptr()) };
         Ok(())
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -916,8 +916,8 @@ fn xpc_request_with_project_directory(
         fn av_xpc_connection_set_empty_event_handler(connection: XpcObject);
     }
 
-    unsafe fn set_string(dict: XpcObject, key: &[u8], value: &str) -> Result<(), String> {
-        let value = CString::new(value).map_err(|_| "XPC field contains NUL".to_string())?;
+    unsafe fn set_string(dict: XpcObject, key: &'static [u8], value: &str) -> Result<(), String> {
+        let value = crate::approval_service::xpc_string(key, value)?;
         unsafe { xpc_dictionary_set_string(dict, key.as_ptr().cast(), value.as_ptr()) };
         Ok(())
     }

--- a/tests/save_cli.rs
+++ b/tests/save_cli.rs
@@ -313,6 +313,19 @@ fn terminal_modes_preserve_input_restore_echo_and_cancel_without_saving() {
         b"  synthetic-test-only  "
     );
 
+    let mut tty = Terminal::spawn(&fixture, &["SAVED_KEY"]);
+    tty.ready();
+    tty.send(b"  synthetic-test-only");
+    tty.send(b"\x04");
+    std::thread::sleep(Duration::from_millis(50));
+    assert!(tty.child.try_wait().unwrap().is_none());
+    tty.send(b"  \n");
+    tty.finish(true);
+    assert_eq!(
+        fs::read(fixture.saved()).unwrap(),
+        b"  synthetic-test-only  "
+    );
+
     for signal in [
         None,
         Some(libc::SIGTERM),

--- a/tests/save_cli.rs
+++ b/tests/save_cli.rs
@@ -263,6 +263,8 @@ impl Terminal {
             assert!(Instant::now() < deadline, "save did not exit");
             std::thread::sleep(Duration::from_millis(10));
         }
+        // macOS revokes the slave when the controlling session exits. The master
+        // still exposes its termios; tcgetattr(slave) fails after child exit.
         let mut restored = unsafe { std::mem::zeroed::<libc::termios>() };
         assert_eq!(
             unsafe { libc::tcgetattr(self.master.as_ref().unwrap().as_raw_fd(), &mut restored) },

--- a/tests/save_cli.rs
+++ b/tests/save_cli.rs
@@ -1,0 +1,354 @@
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+struct Fixture(std::path::PathBuf);
+
+impl Fixture {
+    fn new() -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "av-save-cli-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(root.join("keychain")).unwrap();
+        Self(root)
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_av"));
+        command
+            .arg("save")
+            .env("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", self.0.join("keychain"));
+        command
+    }
+
+    fn saved(&self) -> std::path::PathBuf {
+        self.0.join("keychain/SAVED_KEY")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn stdin_preserves_pem_bytes_and_project_values() {
+    let fixture = Fixture::new();
+    let pem = "-----BEGIN PRIVATE KEY-----\nsynthetic-test-only\n-----END PRIVATE KEY-----";
+    for value in [
+        pem.to_owned(),
+        format!("{pem}\n"),
+        format!("{pem}\n").replace('\n', "\r\n"),
+        "  é🔑  \n\n".into(),
+    ] {
+        let mut child = fixture
+            .command()
+            .args(["--stdin", "SAVED_KEY"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(value.as_bytes())
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success(), "{:?}", output);
+        assert!(output.stdout.is_empty() && output.stderr.is_empty());
+        assert_eq!(fs::read(fixture.saved()).unwrap(), value.as_bytes());
+    }
+    let project = fixture.0.join("project");
+    fs::create_dir(&project).unwrap();
+    let mut child = fixture
+        .command()
+        .args(["--stdin", "--project-directory"])
+        .arg(&project)
+        .arg("SAVED_KEY")
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"project\r\nvalue\r\n")
+        .unwrap();
+    assert!(child.wait().unwrap().success());
+    let encoded_path: String = fs::canonicalize(project)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    assert_eq!(
+        fs::read(
+            fixture
+                .0
+                .join("keychain/.project-values")
+                .join(encoded_path)
+                .join("SAVED_KEY")
+        )
+        .unwrap(),
+        b"project\r\nvalue\r\n"
+    );
+    assert_eq!(fs::read(fixture.saved()).unwrap(), "  é🔑  \n\n".as_bytes());
+}
+
+#[test]
+fn invalid_stdin_never_saves_or_echoes_input() {
+    let fixture = Fixture::new();
+    fs::write(fixture.saved(), "original").unwrap();
+    for (value, error) in [
+        (Vec::new(), "empty key value"),
+        (
+            b"sensitive-before\0sensitive-after".to_vec(),
+            "must not contain NUL",
+        ),
+        (
+            b"sensitive-before\xffsensitive-after".to_vec(),
+            "must be valid UTF-8",
+        ),
+        (vec![b'x'; 1024 * 1024 + 1], "exceeds 1 MiB"),
+    ] {
+        let mut child = fixture
+            .command()
+            .args(["--stdin", "SAVED_KEY"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child.stdin.take().unwrap().write_all(&value).unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains(error), "{stderr}");
+        assert!(!stderr.contains("sensitive"));
+        assert_eq!(fs::read(fixture.saved()).unwrap(), b"original");
+    }
+}
+
+struct Terminal {
+    child: Child,
+    master: Option<File>,
+    slave: File,
+    output: Vec<u8>,
+    original: libc::termios,
+}
+
+impl Terminal {
+    fn spawn(fixture: &Fixture, args: &[&str]) -> Self {
+        let (mut master, mut slave) = (-1, -1);
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+        let master = unsafe { File::from_raw_fd(master) };
+        let slave = unsafe { File::from_raw_fd(slave) };
+        for file in [&master, &slave] {
+            assert_eq!(
+                unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) },
+                0
+            );
+        }
+        assert_eq!(
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) },
+            0
+        );
+        let mut original = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { libc::tcgetattr(slave.as_raw_fd(), &mut original) },
+            0
+        );
+        let mut command = fixture.command();
+        command
+            .args(args)
+            .stdin(slave.try_clone().unwrap())
+            .stdout(slave.try_clone().unwrap())
+            .stderr(slave.try_clone().unwrap());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 || libc::ioctl(0, libc::TIOCSCTTY as libc::c_ulong, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        Self {
+            child: command.spawn().unwrap(),
+            master: Some(master),
+            slave,
+            output: Vec::new(),
+            original,
+        }
+    }
+
+    fn drain(&mut self) {
+        let mut chunk = [0; 4096];
+        loop {
+            match self.master.as_mut().unwrap().read(&mut chunk) {
+                Ok(0) => break,
+                Ok(count) => self.output.extend_from_slice(&chunk[..count]),
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        || error.raw_os_error() == Some(libc::EIO) =>
+                {
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(error) => panic!("{error}"),
+            }
+        }
+    }
+
+    fn ready(&mut self) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            self.drain();
+            let output = String::from_utf8_lossy(&self.output);
+            if output.contains("Ctrl-C cancels.") || output.contains("Value for SAVED_KEY: ") {
+                break;
+            }
+            assert!(Instant::now() < deadline, "prompt timed out: {output}");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let mut attributes = unsafe { std::mem::zeroed::<libc::termios>() };
+        assert_eq!(
+            unsafe { libc::tcgetattr(self.slave.as_raw_fd(), &mut attributes) },
+            0
+        );
+        assert_eq!(attributes.c_lflag & (libc::ECHO | libc::ECHONL), 0);
+    }
+
+    fn send(&mut self, bytes: &[u8]) {
+        self.master.as_mut().unwrap().write_all(bytes).unwrap();
+    }
+
+    fn finish(&mut self, success: bool) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            self.drain();
+            if let Some(status) = self.child.try_wait().unwrap() {
+                self.drain();
+                assert_eq!(
+                    status.success(),
+                    success,
+                    "{}",
+                    String::from_utf8_lossy(&self.output)
+                );
+                break;
+            }
+            assert!(Instant::now() < deadline, "save did not exit");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let mut restored = unsafe { std::mem::zeroed::<libc::termios>() };
+        assert_eq!(
+            unsafe { libc::tcgetattr(self.master.as_ref().unwrap().as_raw_fd(), &mut restored) },
+            0
+        );
+        assert_eq!(restored.c_lflag, self.original.c_lflag);
+        assert_eq!(restored.c_iflag, self.original.c_iflag);
+        assert_eq!(restored.c_cc, self.original.c_cc);
+        assert!(!String::from_utf8_lossy(&self.output).contains("synthetic-test-only"));
+    }
+}
+
+impl Drop for Terminal {
+    fn drop(&mut self) {
+        drop(self.master.take());
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn terminal_modes_preserve_input_restore_echo_and_cancel_without_saving() {
+    let fixture = Fixture::new();
+    for final_newline in [true, false] {
+        let mut tty = Terminal::spawn(&fixture, &["--multiline", "SAVED_KEY"]);
+        tty.ready();
+        let mut value =
+            b"-----BEGIN PRIVATE KEY-----\nsynthetic-test-only\n-----END PRIVATE KEY-----".to_vec();
+        if final_newline {
+            value.push(b'\n');
+        }
+        tty.send(&value);
+        tty.send(b"\x04");
+        if !final_newline {
+            // Separate the flush from the subsequent zero-byte EOF read.
+            std::thread::sleep(Duration::from_millis(50));
+            tty.send(b"\x04");
+        }
+        tty.finish(true);
+        assert_eq!(fs::read(fixture.saved()).unwrap(), value);
+    }
+    let mut tty = Terminal::spawn(&fixture, &["SAVED_KEY"]);
+    tty.ready();
+    tty.send(b"  synthetic-test-only  \n");
+    tty.finish(true);
+    assert_eq!(
+        fs::read(fixture.saved()).unwrap(),
+        b"  synthetic-test-only  "
+    );
+
+    for signal in [
+        None,
+        Some(libc::SIGTERM),
+        Some(libc::SIGHUP),
+        Some(libc::SIGTSTP),
+    ] {
+        let mut tty = Terminal::spawn(&fixture, &["--multiline", "SAVED_KEY"]);
+        tty.ready();
+        tty.send(b"synthetic-test-only\nunfinished-secret");
+        if let Some(signal) = signal {
+            assert_eq!(unsafe { libc::kill(tty.child.id() as i32, signal) }, 0);
+        } else {
+            tty.send(b"\x03");
+        }
+        tty.finish(false);
+        assert_eq!(
+            fs::read(fixture.saved()).unwrap(),
+            b"  synthetic-test-only  "
+        );
+    }
+    for value in [
+        &b""[..],
+        &b"synthetic-test-only\0value\n"[..],
+        &b"synthetic-test-only\xff\n"[..],
+    ] {
+        let mut tty = Terminal::spawn(&fixture, &["--multiline", "SAVED_KEY"]);
+        tty.ready();
+        tty.send(value);
+        tty.send(b"\x04");
+        tty.finish(false);
+        assert_eq!(
+            fs::read(fixture.saved()).unwrap(),
+            b"  synthetic-test-only  "
+        );
+    }
+    let mut tty = Terminal::spawn(&fixture, &["--stdin", "SAVED_KEY"]);
+    tty.finish(false);
+    assert!(String::from_utf8_lossy(&tty.output).contains("requires redirected input"));
+}


### PR DESCRIPTION
`av save` currently accepts one terminal line and removes its line ending, so it cannot import multiline PEMs with their exact whitespace. Add `--multiline` for hidden terminal input terminated by Ctrl-D and `--stdin` for redirected UTF-8 input read to EOF without trimming or newline conversion. Both support Project Values and retain the existing save Approval and Authorization Record path.

Reject empty, NUL-containing, invalid UTF-8, and oversized input without printing the value or changing an existing Secret. Input is limited to 1 MiB. Restore terminal settings and discard pending input on completion or cancellation, and report only static field names in XPC NUL errors across save and inject. Document terminal processing limits and the distinction between multiline entry and exact stdin import.

Validation:
- Formatting and whitespace checks pass.
- Full Rust suite passes (`cargo test --locked --all-targets --all-features`).
- Six save unit tests and the XPC diagnostic redaction regression pass.
- Three CLI integration tests pass, covering PEMs with and without final newlines, CRLF, Unicode, Project Values, invalid input, hidden terminal input, EOF, mid-line Ctrl-D, and cancellation using a macOS pseudo-terminal.
- Optimized CLI integration tests pass (`cargo test --locked --profile test-release --test save_cli`).
- Tests use synthetic values and the existing isolated test store; the signed save Approval path is unchanged.

Addresses the input-preservation portion of #309. Descriptor delivery shipped separately in #316; backup/recovery and legacy migration remain separate work.
