### PR TITLE
Add approved file descriptor delivery to av inject

### DIFF
--- a/docs/adr/0043-file-descriptor-secret-delivery.md
+++ b/docs/adr/0043-file-descriptor-secret-delivery.md
@@ -1,0 +1,48 @@
+# ADR 0043: File Descriptor Secret Delivery
+
+- Status: Accepted
+- Date: 2026-09-08
+
+## Context
+
+Some consumers accept credentials through file descriptors and require exact
+multiline Values without environment injection or named plaintext files.
+Environment injection followed by a pipe would still expose Secrets through the
+intermediate environment. A generic retrieval operation would weaken custody.
+
+## Decision
+
+Add `av inject --mode=fd +FOO:3 +BAR:4 -- COMMAND`. Each Secret has its own
+anonymous pipe. There is no serialization format or Secret transformation.
+
+Use a distinct `inject-fd` XPC operation restricted to the signed `av` Gate
+Client. Older helpers fail closed. Validate all Secret Names, descriptor numbers,
+uniqueness, and complete coverage independently on the CLI and app. The app
+constructs canonical mapping detail rather than trusting client-provided prose.
+That detail participates in the request identity, phone Approval digest, and
+Authorization Record. Preserve the ordinary selected-Value custody transaction
+and require a persisted, verified record before returning any Secret bytes.
+FD replies use XPC data rather than NUL-terminated strings.
+
+Require fresh human Approval for every invocation. Existing Direct Access Rules,
+Blessings, Tool-specific rules, and Temporary Access Grants gain no FD authority.
+Do not offer FD delivery through shebang declarations in this initial version.
+
+The CLI accepts only unused descriptors above stderr. Reserve pipe read ends
+close-on-exec before opening XPC resources and keep write ends close-on-exec.
+After Approval, preload pipes with nonblocking writes and close the writers. If
+any Value does not fit, close all pipes and fail without starting the Target.
+Clear close-on-exec on the selected read ends only when executing the approved
+Target. Continue using `exec` so process attribution and lifetime do not change.
+Remove the requested Secret Names from the Target's environment.
+
+## Consequences
+
+- Exact stored UTF-8 bytes, including multiline PEMs, reach the Target and then
+  EOF. A descriptor can be read repeatedly, but consumed bytes are not replayed.
+- Prebuffering bounds Value size at available kernel pipe capacity. A streaming
+  writer would introduce another Secret-holding process and needs separate review.
+- No Secret enters argv, the supplied environment, a named pipe, or a plaintext
+  file through this delivery path. The Target can still leak bytes or descriptors.
+- This change provides neither encrypted backups nor recovery of bytes changed
+  during an earlier import, and does not claim a 1.x migration or rollback path.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -433,6 +433,27 @@ cannot describe a distinct GPG operation.
 
 The Homebrew migration intentionally broadens persisted `readOnly` rules to allow explicit `brew update`. Homebrew could already update itself and its package metadata as a secondary effect of an authorized inspection command, so the old distinction did not enforce strict read-only execution. The legacy `update` classification covers only `brew update`, a Homebrew Update. The legacy `secretDump` classification covers both Secret Disclosure and AWS Elevated Secret Application. The legacy `mutating` classification can cover local, system, or remote effects. Replacing those values with characteristic sets is a policy-engine migration. It requires a reviewed Tool catalog, compatibility tests, and proof that no existing rule gains authority. Until that migration, the legacy classifier remains the enforcement source and the UI explains its established behavior with the canonical names.
 
+## File descriptor delivery
+
+`av inject --mode=fd +FOO:3 +BAR:4 -- COMMAND` performs Secret Application through
+one anonymous pipe per Secret. The signed `av` Gate Client submits the distinct
+`inject-fd` operation, which older helpers reject. The app validates the complete
+mapping and constructs canonical mapping detail for the immutable request,
+iPhone Approval digest, and persisted Authorization Record. Every invocation
+requires fresh Approval, without Direct Access, Blessing, Tool-specific policy,
+or temporary-grant authorization. The ordinary record-before-release transaction
+and exact Project Value selection still apply.
+
+Only unoccupied descriptors of 3 or higher are accepted. The CLI reserves them
+with close-on-exec before XPC, receives length-delimited UTF-8 Secret bytes,
+prebuffers every pipe using nonblocking writes, and closes every write end before
+executing the Target with the same PID. Failure to buffer a complete Value denies
+execution and closes all pipes. Only the requested read ends have close-on-exec
+cleared for the Target. The requested names are removed from its environment.
+FD mode does not support shebang dispatch, missing Secrets, or environment
+replacement flags. Pipe capacity bounds each Value; this is not a streaming
+export or backup format. See [ADR 0043](adr/0043-file-descriptor-secret-delivery.md).
+
 ## Secret custody and availability
 
 Secret bytes stay in the app's private Keychain access group. Gate policy and Authorization History use separate services. Availability controls whether Keychain may return a Secret while the device is locked. Authorization controls whether the operation may receive it. Both checks must pass.

--- a/docs/direct-secret-access.md
+++ b/docs/direct-secret-access.md
@@ -63,3 +63,33 @@ the Secret also revokes every Direct Access Rule for that Secret Name.
 
 All allowed uses still require a persisted Authorization Record before Automic
 Vault releases the Secret.
+
+## Apply Secrets through file descriptors
+
+For a consumer that reads credentials from file descriptors:
+
+```sh
+av inject --mode=fd +FOO:3 +BAR:4 -- /bin/foo
+```
+
+Each mapping supplies the exact stored UTF-8 bytes through its own anonymous
+pipe, followed by EOF. There is no bundle format, trimming, or added newline.
+The consumer must know which descriptor to read for each Secret. The requested
+Secret Names are removed from its environment, including any existing values.
+Other invocations keep the default environment delivery (`--mode=env`).
+
+FD delivery requires Approval for every invocation, even when a Direct Access
+Rule or Blessing exists. The Approval shows the mappings and selected Global or
+Project Values; Authorization History records them before release. Keep the app
+and CLI updated together: older apps reject this delivery operation.
+
+Descriptors must be distinct, unused, canonical decimal integers of 3 or higher;
+stdin, stdout, and stderr are preserved. Duplicate Secret Names, omitted mappings,
+missing Secrets, `--allow-missing-keys`, `--replace-existing-env`, and FD shebangs
+are rejected. If any Value exceeds the available kernel pipe buffer capacity,
+the command fails without starting the Target. FD delivery preserves bytes already
+stored; it cannot recover whitespace removed by an earlier import.
+
+The Target can copy the bytes or pass its read descriptors to children. Pipes
+avoid a named plaintext file and Secret environment injection; they do not make
+the consumer trustworthy or provide encrypted backup/recovery.

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -341,6 +341,17 @@ Secret Application. The launched Target receives only Secret References. The
 helper applies a Secret to an authorized outbound request and must discard its
 request-scoped copy when that request completes.
 
+### Secret Delivery
+
+The mechanism used to apply a Secret to its Target. `av inject` uses environment
+variables by default. With `--mode=fd`, each requested Secret Name maps to one
+anonymous pipe at an explicit Target file descriptor. The delivery mode and
+complete mapping are part of the Authorization Request and Authorization Record.
+FD delivery requires fresh Approval; existing Direct Access Rules, Blessings,
+and Tool-specific policies do not authorize it. It removes the requested Secret
+Names from the Target's environment. It does not prevent the Target from copying
+Secret bytes or sharing its descriptors after receipt.
+
 ### Secret Disclosure
 
 The intentional return of a raw Secret value to the Launcher, standard output, clipboard, or another general-purpose destination. `gh auth token` is a Secret Disclosure even though it has no remote side effect.

--- a/src/cli/inject.rs
+++ b/src/cli/inject.rs
@@ -8,11 +8,17 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[path = "inject_fd.rs"]
+mod fd;
+
 const USAGE: &str = "\
 Usage: av inject [--replace-existing-env] [--allow-missing-keys] +KEY [+KEY...] [--] COMMAND [args...]
        av inject [--replace-existing-env] [--allow-missing-keys] -- COMMAND [args...]
+       av inject --mode=fd +KEY:FD [+KEY:FD...] -- COMMAND [args...]
 
-Injects named Keychain secrets into COMMAND's environment.";
+Injects named Keychain secrets into COMMAND's environment (default --mode=env).
+FD mode delivers each Secret through an anonymous pipe at FD (3 or higher),
+requires Approval, and removes the named variables from COMMAND's environment.";
 
 const APPROVAL_SERVICE: &str = "com.automicvault.av2.approval";
 const PATH_SCRIPT_INTERPRETERS: &[&str] = &["uv"];
@@ -20,6 +26,7 @@ type SecretValues = BTreeMap<String, String>;
 
 #[derive(Debug, PartialEq, Eq)]
 struct Options {
+    secret_fds: BTreeMap<String, i32>,
     replace_existing_env: bool,
     allow_missing_keys: bool,
     keys: Vec<String>,
@@ -30,6 +37,7 @@ struct Options {
 
 #[derive(Debug, PartialEq, Eq)]
 struct ApprovalRequest {
+    secret_fds: BTreeMap<String, i32>,
     op: &'static str,
     keys: Vec<String>,
     target: String,
@@ -111,13 +119,56 @@ fn dispatch(
 }
 
 fn parse(args: Vec<OsString>) -> Result<Options, String> {
+    let mut mode = None;
+    let mut secret_fds = BTreeMap::new();
     let mut replace_existing_env = false;
     let mut allow_missing_keys = false;
     let mut keys = Vec::new();
     let mut seen_keys = BTreeSet::new();
     let mut iter = args.into_iter();
 
+    let finish = |target,
+                  args,
+                  mut keys: Vec<String>,
+                  secret_fds: BTreeMap<String, i32>,
+                  mode,
+                  replace_existing_env,
+                  allow_missing_keys| {
+        if mode == Some("fd") {
+            if keys.is_empty() || secret_fds.len() != keys.len() {
+                return Err("FD mode requires +KEY:FD for every Secret".into());
+            }
+            if replace_existing_env || allow_missing_keys {
+                return Err(
+                    "FD mode does not accept environment replacement or missing Secrets".into(),
+                );
+            }
+        } else if !secret_fds.is_empty() {
+            return Err("+KEY:FD requires --mode=fd".into());
+        }
+        keys.sort();
+        Ok(Options {
+            secret_fds,
+            replace_existing_env,
+            allow_missing_keys,
+            keys,
+            target,
+            args,
+            shebang_script: None,
+        })
+    };
     while let Some(arg) = iter.next() {
+        if let Some(value) = arg.to_str().and_then(|arg| arg.strip_prefix("--mode=")) {
+            if mode.is_some() {
+                return Err("--mode may be specified only once".into());
+            }
+            mode = Some(match value {
+                "env" => "env",
+                "fd" => "fd",
+                _ => return Err("injection mode must be env or fd".into()),
+            });
+            continue;
+        }
         if arg == "--replace-existing-env" {
             replace_existing_env = true;
             continue;
@@ -139,8 +190,23 @@ fn parse(args: Vec<OsString>) -> Result<Options, String> {
         let value = arg
             .to_str()
             .ok_or_else(|| "inject arguments must be valid UTF-8".to_string())?;
-        if let Some(key) = value.strip_prefix('+') {
+        if let Some(spec) = value.strip_prefix('+') {
+            let (key, descriptor) = match spec.split_once(':') {
+                Some((key, number)) => {
+                    let descriptor = number.parse::<i32>().ok()
+                        .filter(|fd| *fd >= 3 && *fd < i32::MAX && fd.to_string() == number)
+                        .ok_or("file descriptor must be a canonical decimal integer from 3 to 2147483646")?;
+                    (key, Some(descriptor))
+                }
+                None => (spec, None),
+            };
             validate_key_name(key)?;
+            if let Some(descriptor) = descriptor {
+                if secret_fds.values().any(|fd| *fd == descriptor) {
+                    return Err(format!("duplicate file descriptor: {descriptor}"));
+                }
+                secret_fds.insert(key.to_string(), descriptor);
+            }
             if !seen_keys.insert(key.to_string()) {
                 return Err(format!("duplicate key requested: {key}"));
             }
@@ -152,29 +218,29 @@ fn parse(args: Vec<OsString>) -> Result<Options, String> {
             let target = iter
                 .next()
                 .ok_or_else(|| "missing target command".to_string())?;
-            keys.sort();
-            return Ok(Options {
+            return finish(
+                target,
+                iter.collect(),
+                keys,
+                secret_fds,
+                mode,
                 replace_existing_env,
                 allow_missing_keys,
-                keys,
-                target,
-                args: iter.collect(),
-                shebang_script: None,
-            });
+            );
         }
 
         if keys.is_empty() {
             return Err("at least one +KEY must be provided before the target".into());
         }
-        keys.sort();
-        return Ok(Options {
+        return finish(
+            arg,
+            iter.collect(),
+            keys,
+            secret_fds,
+            mode,
             replace_existing_env,
             allow_missing_keys,
-            keys,
-            target: arg,
-            args: iter.collect(),
-            shebang_script: None,
-        });
+        );
     }
 
     if keys.is_empty() {
@@ -187,6 +253,12 @@ fn parse(args: Vec<OsString>) -> Result<Options, String> {
 fn exec(mut options: Options, stderr: &mut dyn Write) -> i32 {
     if unsafe { geteuid() } == 0 {
         let _ = writeln!(stderr, "av inject: must not be run as root");
+        return 1;
+    }
+
+    if !options.secret_fds.is_empty() {
+        let error = fd::exec(&options);
+        let _ = writeln!(stderr, "av inject: {error}");
         return 1;
     }
 
@@ -392,11 +464,19 @@ fn approval_request(
     let env_conflicts = options
         .keys
         .iter()
-        .filter(|key| current_env.contains_key(std::ffi::OsStr::new(key.as_str())))
+        .filter(|key| {
+            options.secret_fds.is_empty()
+                && current_env.contains_key(std::ffi::OsStr::new(key.as_str()))
+        })
         .cloned()
         .collect();
     Ok(ApprovalRequest {
-        op: "inject",
+        secret_fds: options.secret_fds.clone(),
+        op: if options.secret_fds.is_empty() {
+            "inject"
+        } else {
+            "inject-fd"
+        },
         keys: options.keys.clone(),
         target: target.display().to_string(),
         args: options.args.iter().map(os_display).collect(),
@@ -431,6 +511,7 @@ pub(super) fn docker_credential(
 ) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "docker-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -469,6 +550,7 @@ pub(super) fn docker_credential(
 pub(super) fn terraform_credential(key: String, hostname: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "terraform-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -507,6 +589,7 @@ pub(super) fn terraform_credential(key: String, hostname: String) -> Result<Stri
 pub(super) fn aliyun_credential(key: String, profile: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "aliyun-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -545,6 +628,7 @@ pub(super) fn aliyun_credential(key: String, profile: String) -> Result<String, 
 pub(super) fn wakatime_credential(key: String, api_url: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "wakatime-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -583,6 +667,7 @@ pub(super) fn wakatime_credential(key: String, api_url: String) -> Result<String
 pub(super) fn rclone_password(key: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "rclone-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -621,6 +706,7 @@ pub(super) fn rclone_password(key: String) -> Result<String, String> {
 pub(super) fn kubectl_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "kubectl-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -659,6 +745,7 @@ pub(super) fn kubectl_credential(key: String, scope: String) -> Result<String, S
 pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "oxide-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -697,6 +784,7 @@ pub(super) fn oxide_credential(key: String, scope: String) -> Result<String, Str
 pub(super) fn fastly_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "fastly-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -735,6 +823,7 @@ pub(super) fn fastly_credential(key: String, scope: String) -> Result<String, St
 pub(super) fn sqlcmd_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "sqlcmd-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -773,6 +862,7 @@ pub(super) fn sqlcmd_credential(key: String, scope: String) -> Result<String, St
 pub(super) fn goat_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "goat-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -811,6 +901,7 @@ pub(super) fn goat_credential(key: String, scope: String) -> Result<String, Stri
 pub(super) fn railway_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "railway-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -849,6 +940,7 @@ pub(super) fn railway_credential(key: String, scope: String) -> Result<String, S
 pub(super) fn ordercli_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "ordercli-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -887,6 +979,7 @@ pub(super) fn ordercli_credential(key: String, scope: String) -> Result<String, 
 pub(super) fn uaa_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "uaa-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -925,6 +1018,7 @@ pub(super) fn uaa_credential(key: String, scope: String) -> Result<String, Strin
 pub(super) fn openhue_credential(key: String, scope: String) -> Result<String, String> {
     validate_key_name(&key)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "openhue-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -964,6 +1058,7 @@ pub(super) fn plumber_credential(key: String, scope: String) -> Result<String, S
     validate_key_name(&key)?;
     crate::cli::plumber_credential::parse_scope(&scope)?;
     let request = ApprovalRequest {
+        secret_fds: BTreeMap::new(),
         op: "plumber-get",
         keys: vec![key.clone()],
         target: String::new(),
@@ -1226,6 +1321,7 @@ pub(super) fn approve_gpg_signing(
 ) -> Result<SecretValues, String> {
     xpc_approve_request(
         &ApprovalRequest {
+            secret_fds: BTreeMap::new(),
             op: "gpg-sign",
             keys: Vec::new(),
             target,
@@ -1439,6 +1535,17 @@ fn xpc_approve_request(
         xpc_dictionary_set_value(message, b"keys\0".as_ptr().cast(), keys);
         xpc_release(keys);
 
+        if !request.secret_fds.is_empty() {
+            let mappings = request
+                .secret_fds
+                .iter()
+                .map(|(key, fd)| format!("{key}:{fd}"))
+                .collect::<Vec<_>>();
+            let array = string_array(&mappings)?;
+            xpc_dictionary_set_value(message, c"secret_fds".as_ptr(), array);
+            xpc_release(array);
+        }
+
         let args = string_array(&request.args)?;
         xpc_dictionary_set_value(message, b"args\0".as_ptr().cast(), args);
         xpc_release(args);
@@ -1458,7 +1565,7 @@ fn xpc_approve_request(
         return Err("Automic Vault approval did not reply".into());
     }
 
-    let result = unsafe {
+    let result = (|| unsafe {
         if xpc_get_type(reply) == std::ptr::addr_of!(_xpc_type_error).cast() {
             if crate::approval_service_connection_invalid(reply) {
                 Err(crate::approval_service_unavailable_message(&service).into())
@@ -1490,6 +1597,10 @@ fn xpc_approve_request(
                     for key in response_keys {
                         let key_cstr = CString::new(key.as_str())
                             .map_err(|_| format!("invalid key returned by approval: {key:?}"))?;
+                        if request.op == "inject-fd" {
+                            secrets.insert(key.clone(), fd::read_xpc_value(values, &key_cstr)?);
+                            continue;
+                        }
                         let value = xpc_dictionary_get_string(values, key_cstr.as_ptr());
                         if !value.is_null() {
                             secrets.insert(
@@ -1513,7 +1624,7 @@ fn xpc_approve_request(
                 })
             }
         }
-    };
+    })();
     unsafe { xpc_release(reply) };
     result
 }
@@ -1529,6 +1640,47 @@ fn human_approval_message(decision: &[u8]) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fd_mode_validates_complete_unambiguous_mappings() {
+        let options = parse(os(&["--mode=fd", "+FOO:3", "+BAR:4", "--", "/bin/foo"])).unwrap();
+        assert_eq!(options.keys, ["BAR", "FOO"]);
+        assert_eq!(
+            options.secret_fds,
+            BTreeMap::from([("FOO".into(), 3), ("BAR".into(), 4)])
+        );
+        let request = approval_request(&options, Path::new("/bin/foo"), None, None).unwrap();
+        assert_eq!(request.op, "inject-fd");
+        assert_eq!(request.secret_fds, options.secret_fds);
+        assert!(request.env_conflicts.is_empty());
+        for args in [
+            vec!["--mode=fd", "+FOO"],
+            vec!["--mode=fd"],
+            vec!["+FOO:3"],
+            vec!["--mode=fd", "+FOO:3", "+BAR"],
+            vec!["--mode=fd", "+FOO:3", "+BAR:3"],
+            vec!["--mode=fd", "+FOO:3", "+FOO:4"],
+            vec!["--mode=fd", "+FOO:0"],
+            vec!["--mode=fd", "+FOO:1"],
+            vec!["--mode=fd", "+FOO:2"],
+            vec!["--mode=fd", "+FOO:03"],
+            vec!["--mode=fd", "+FOO:+3"],
+            vec!["--mode=fd", "+FOO:2147483647"],
+            vec!["--mode=fd", "+FOO:3:4"],
+            vec!["--mode=fd", "+FOO:3", "--allow-missing-keys"],
+            vec!["--mode=fd", "+FOO:3", "--replace-existing-env"],
+            vec!["--mode=fd", "--mode=env", "+FOO:3"],
+            vec!["--mode=other", "+FOO"],
+        ] {
+            let mut args = os(&args);
+            args.extend(os(&["--", "/bin/foo"]));
+            assert!(parse(args.clone()).is_err(), "{args:?}");
+        }
+        assert_eq!(
+            parse(os(&["--mode=env", "+FOO", "--", "/bin/foo"])).unwrap(),
+            parse(os(&["+FOO", "--", "/bin/foo"])).unwrap()
+        );
+    }
 
     #[test]
     fn reports_only_known_human_approval_decisions() {
@@ -1559,6 +1711,7 @@ mod tests {
         assert_eq!(
             parse(os(&["+B", "+A", "/bin/echo", "hi"])).unwrap(),
             Options {
+                secret_fds: BTreeMap::new(),
                 replace_existing_env: false,
                 allow_missing_keys: false,
                 keys: vec!["A".into(), "B".into()],
@@ -1581,31 +1734,30 @@ mod tests {
 
     #[test]
     fn denied_approval_does_not_load_secrets() {
-        let options = Options {
-            replace_existing_env: false,
-            allow_missing_keys: false,
-            keys: vec!["SOME_SECRET".into()],
-            target: "/bin/echo".into(),
-            args: os(&["hi"]),
-            shebang_script: None,
-        };
-        let mut stderr = Vec::new();
-        let err = prepare_injection(
-            &options,
-            &mut stderr,
-            None,
-            None,
-            |_| Err("user denied injection".into()),
-            |_, _, _| panic!("approval denial must happen before loading secrets"),
-        )
-        .unwrap_err();
+        for args in [
+            os(&["+SOME_SECRET", "--", "/bin/echo", "hi"]),
+            os(&["--mode=fd", "+SOME_SECRET:3", "--", "/bin/echo", "hi"]),
+        ] {
+            let options = parse(args).unwrap();
+            let mut stderr = Vec::new();
+            let err = prepare_injection(
+                &options,
+                &mut stderr,
+                None,
+                None,
+                |_| Err("user denied injection".into()),
+                |_, _, _| panic!("approval denial must happen before loading secrets"),
+            )
+            .unwrap_err();
 
-        assert_eq!(err, "user denied injection");
+            assert_eq!(err, "user denied injection");
+        }
     }
 
     #[test]
     fn builds_approval_request_without_secret_values() {
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: true,
             allow_missing_keys: true,
             keys: vec!["A".into(), "B".into()],
@@ -1636,6 +1788,7 @@ mod tests {
         let _guard = crate::global_test_env_lock().lock().unwrap();
         unsafe { std::env::set_var("SOME_SECRET", "ambient") };
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: false,
             allow_missing_keys: true,
             keys: vec!["SOME_SECRET".into()],
@@ -1656,6 +1809,7 @@ mod tests {
         let _guard = crate::global_test_env_lock().lock().unwrap();
         unsafe { std::env::set_var("NODE_AUTH_TOKEN", "ambient") };
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: false,
             allow_missing_keys: true,
             keys: vec!["NODE_AUTH_TOKEN".into()],
@@ -1686,6 +1840,7 @@ mod tests {
             unsafe { std::env::set_var(key, value) };
         }
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: false,
             allow_missing_keys: true,
             keys: vec!["S3CMD_ENV_ASSIGNMENTS".into()],
@@ -1757,6 +1912,7 @@ mod tests {
     #[test]
     fn build_env_uses_approved_secret_values() {
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: true,
             allow_missing_keys: false,
             keys: vec!["APPROVED_SECRET".into()],
@@ -1815,6 +1971,7 @@ mod tests {
     fn infers_split_shebang_script_argument() {
         let script = temp_script("#!/usr/local/bin/av inject +A /bin/zsh\n");
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: false,
             allow_missing_keys: false,
             keys: vec!["A".into()],
@@ -1833,6 +1990,7 @@ mod tests {
     fn infers_split_shebang_script_after_interpreter_options() {
         let script = temp_script("#!/usr/local/bin/av inject +A /bin/zsh -f\n");
         let options = Options {
+            secret_fds: BTreeMap::new(),
             replace_existing_env: false,
             allow_missing_keys: false,
             keys: vec!["A".into()],

--- a/src/cli/inject_fd.rs
+++ b/src/cli/inject_fd.rs
@@ -1,0 +1,221 @@
+use super::*;
+use std::io;
+use zeroize::Zeroizing;
+
+// The dictionary is owned by the live XPC reply. Data transport preserves NULs
+// and empty Values; environment-mode replies retain their existing string wire format.
+pub(super) unsafe fn read_xpc_value(
+    values: *mut std::ffi::c_void,
+    key: &std::ffi::CStr,
+) -> Result<String, String> {
+    use std::ffi::{c_char, c_void};
+    unsafe extern "C" {
+        static _xpc_type_data: u8;
+        fn xpc_dictionary_get_value(dict: *mut c_void, key: *const c_char) -> *mut c_void;
+        fn xpc_get_type(object: *mut c_void) -> *const c_void;
+        fn xpc_data_get_length(object: *mut c_void) -> usize;
+        fn xpc_data_get_bytes_ptr(object: *mut c_void) -> *const c_void;
+    }
+    unsafe {
+        let data = xpc_dictionary_get_value(values, key.as_ptr());
+        if data.is_null() || xpc_get_type(data) != std::ptr::addr_of!(_xpc_type_data).cast() {
+            return Err("missing or invalid FD Secret payload".into());
+        }
+        let length = xpc_data_get_length(data);
+        if length == 0 {
+            return Ok(String::new());
+        }
+        let bytes = xpc_data_get_bytes_ptr(data);
+        if bytes.is_null() {
+            return Err("invalid FD Secret payload".into());
+        }
+        String::from_utf8(std::slice::from_raw_parts(bytes.cast(), length).to_vec())
+            .map_err(|_| "FD Secret payload is not valid UTF-8".into())
+    }
+}
+
+// Reserve destination descriptors before XPC opens its own files. Keep them
+// close-on-exec until all Secrets have been buffered and authorization succeeds.
+struct SecretPipe {
+    reader: File,
+    writer: File,
+}
+
+fn duplicate(file: &impl AsRawFd, minimum: i32) -> io::Result<File> {
+    let fd = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, minimum) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+fn reserve(mappings: &BTreeMap<String, i32>) -> Result<BTreeMap<String, SecretPipe>, String> {
+    for fd in mappings.values() {
+        if unsafe { libc::fcntl(*fd, libc::F_GETFD) } >= 0
+            || io::Error::last_os_error().raw_os_error() != Some(libc::EBADF)
+        {
+            return Err(format!(
+                "file descriptor {fd} is already open or unavailable"
+            ));
+        }
+    }
+    let minimum = mappings.values().max().copied().unwrap_or(2) + 1;
+    let mut pipes = BTreeMap::new();
+    for (name, destination) in mappings {
+        let make = || -> io::Result<SecretPipe> {
+            let (reader, writer) = io::pipe()?;
+            let high_reader = duplicate(&reader, minimum)?;
+            let high_writer = duplicate(&writer, minimum)?;
+            drop((reader, writer));
+            if unsafe { libc::dup2(high_reader.as_raw_fd(), *destination) } < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let reader = unsafe { File::from_raw_fd(*destination) };
+            if unsafe { libc::fcntl(reader.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) } < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(SecretPipe {
+                reader,
+                writer: high_writer,
+            })
+        };
+        pipes.insert(
+            name.clone(),
+            make().map_err(|err| format!("cannot create Secret pipe: {err}"))?,
+        );
+    }
+    Ok(pipes)
+}
+
+fn fill(
+    pipes: BTreeMap<String, SecretPipe>,
+    mut secrets: SecretValues,
+) -> Result<Vec<File>, String> {
+    let mut readers = Vec::new();
+    for (name, mut pipe) in pipes {
+        let value = Zeroizing::new(match secrets.remove(&name) {
+            Some(value) => value,
+            None => load_test_secret_if_present(&name)?
+                .ok_or_else(|| format!("missing Secret: {name}"))?,
+        });
+        if unsafe { libc::fcntl(pipe.writer.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) } < 0 {
+            return Err(format!(
+                "cannot prepare Secret pipe: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        // ponytail: prebuffering caps Values at the kernel's available pipe
+        // capacity; add a reviewed streaming writer if larger Values are needed.
+        pipe.writer.write_all(value.as_bytes()).map_err(|err| {
+            if err.kind() == io::ErrorKind::WouldBlock {
+                format!("Secret {name} exceeds the anonymous pipe buffer capacity; Target was not started")
+            } else {
+                format!("cannot fill Secret pipe for {name}: {err}")
+            }
+        })?;
+        drop(pipe.writer);
+        readers.push(pipe.reader);
+    }
+    Ok(readers)
+}
+
+pub(super) fn exec(options: &Options) -> String {
+    let prepare = || -> Result<_, String> {
+        if options.shebang_script.is_some() {
+            return Err("FD mode is not supported in av inject shebangs".into());
+        }
+        let pipes = reserve(&options.secret_fds)?;
+        let mut readers = Vec::new();
+        let (target, env) = prepare_injection(
+            options,
+            &mut io::sink(),
+            None,
+            None,
+            approve_injection,
+            |options, _, secrets| {
+                readers = fill(pipes, secrets)?;
+                Ok(secretless_environment(options, false, false))
+            },
+        )?;
+        Ok((target, readers, env))
+    };
+    let (target, readers, env) = match prepare() {
+        Ok(prepared) => prepared,
+        Err(err) => return err,
+    };
+    let mut command = Command::new(&target);
+    command.args(&options.args).env_clear().envs(env);
+    // exec preserves the authorized PID. Closed writers guarantee EOF after
+    // the exact stored bytes; no background process retains a Secret copy.
+    unsafe {
+        command.pre_exec(move || {
+            for reader in &readers {
+                if libc::fcntl(reader.as_raw_fd(), libc::F_SETFD, 0) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            Ok(())
+        });
+    }
+    format!("failed to execute {}: {}", target.display(), command.exec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xpc_data_preserves_exact_values_and_rejects_wrong_types() {
+        use std::ffi::{c_char, c_void};
+        unsafe extern "C" {
+            fn xpc_dictionary_create_empty() -> *mut c_void;
+            fn xpc_dictionary_set_data(
+                dict: *mut c_void,
+                key: *const c_char,
+                bytes: *const c_void,
+                length: usize,
+            );
+            fn xpc_dictionary_set_string(
+                dict: *mut c_void,
+                key: *const c_char,
+                value: *const c_char,
+            );
+            fn xpc_release(object: *mut c_void);
+        }
+        unsafe {
+            let dict = xpc_dictionary_create_empty();
+            assert!(read_xpc_value(dict, c"FOO").is_err());
+            for value in [b"".as_slice(), b"PEM\r\nline\0value\n\n"] {
+                xpc_dictionary_set_data(dict, c"FOO".as_ptr(), value.as_ptr().cast(), value.len());
+                assert_eq!(read_xpc_value(dict, c"FOO").unwrap().as_bytes(), value);
+            }
+            xpc_dictionary_set_string(dict, c"FOO".as_ptr(), c"must-not-leak".as_ptr());
+            assert_eq!(
+                read_xpc_value(dict, c"FOO").unwrap_err(),
+                "missing or invalid FD Secret payload"
+            );
+            xpc_dictionary_set_data(dict, c"FOO".as_ptr(), b"\xff".as_ptr().cast(), 1);
+            assert_eq!(
+                read_xpc_value(dict, c"FOO").unwrap_err(),
+                "FD Secret payload is not valid UTF-8"
+            );
+            xpc_release(dict);
+        }
+    }
+
+    #[test]
+    fn partial_preparation_closes_all_descriptors() {
+        let _guard = crate::global_test_env_lock().lock().unwrap();
+        let mappings = BTreeMap::from([("A".into(), 200), ("B".into(), 201)]);
+        let pipes = reserve(&mappings).unwrap();
+        let secrets = BTreeMap::from([
+            ("A".into(), "small".into()),
+            ("B".into(), "x".repeat(1024 * 1024)),
+        ]);
+        assert!(fill(pipes, secrets).is_err());
+        for fd in mappings.values() {
+            assert_eq!(unsafe { libc::fcntl(*fd, libc::F_GETFD) }, -1);
+            assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::EBADF));
+        }
+    }
+}

--- a/src/cli/inject_fd.rs
+++ b/src/cli/inject_fd.rs
@@ -41,12 +41,19 @@ struct SecretPipe {
     writer: File,
 }
 
-fn duplicate(file: &impl AsRawFd, minimum: i32) -> io::Result<File> {
-    let fd = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, minimum) };
-    if fd < 0 {
-        return Err(io::Error::last_os_error());
+fn duplicate(file: &impl AsRawFd, mappings: &BTreeMap<String, i32>) -> io::Result<File> {
+    let mut minimum = 3;
+    loop {
+        let fd = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, minimum) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let duplicate = unsafe { File::from_raw_fd(fd) };
+        if !mappings.values().any(|destination| *destination == fd) {
+            return Ok(duplicate);
+        }
+        minimum = fd + 1;
     }
-    Ok(unsafe { File::from_raw_fd(fd) })
 }
 
 fn reserve(mappings: &BTreeMap<String, i32>) -> Result<BTreeMap<String, SecretPipe>, String> {
@@ -59,15 +66,14 @@ fn reserve(mappings: &BTreeMap<String, i32>) -> Result<BTreeMap<String, SecretPi
             ));
         }
     }
-    let minimum = mappings.values().max().copied().unwrap_or(2) + 1;
     let mut pipes = BTreeMap::new();
     for (name, destination) in mappings {
         let make = || -> io::Result<SecretPipe> {
             let (reader, writer) = io::pipe()?;
-            let high_reader = duplicate(&reader, minimum)?;
-            let high_writer = duplicate(&writer, minimum)?;
+            let temporary_reader = duplicate(&reader, mappings)?;
+            let temporary_writer = duplicate(&writer, mappings)?;
             drop((reader, writer));
-            if unsafe { libc::dup2(high_reader.as_raw_fd(), *destination) } < 0 {
+            if unsafe { libc::dup2(temporary_reader.as_raw_fd(), *destination) } < 0 {
                 return Err(io::Error::last_os_error());
             }
             let reader = unsafe { File::from_raw_fd(*destination) };
@@ -76,7 +82,7 @@ fn reserve(mappings: &BTreeMap<String, i32>) -> Result<BTreeMap<String, SecretPi
             }
             Ok(SecretPipe {
                 reader,
-                writer: high_writer,
+                writer: temporary_writer,
             })
         };
         pipes.insert(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,6 +44,7 @@ commands:
   $ av bless [--endorse-launcher] <path>  # review a script for secret access
   $ av inject +KEY... [--] <command>      # inject secrets into a command
   $ av inject -- <command>                # run an approved script
+  $ av inject --mode=fd +KEY:FD -- <cmd>  # apply secrets through anonymous pipes
   $ av proxy +KEY... [--] <command>       # proxy secret references for a command
   $ av list                               # list saved secret names
   $ av save [--project-directory=DIR] KEY # store a global or Project Value

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -2109,7 +2109,7 @@ private struct ApprovalRequest {
                 )
             },
             selectedSecretValues: selectedSecretValues,
-            policy: awsRequestMayUseLongLivedCredentials(self)
+            policy: op == "inject-fd" || awsRequestMayUseLongLivedCredentials(self)
                 ? .freshApprovalRequired
                 : .reusable
         )
@@ -3441,6 +3441,11 @@ private final class ApprovalServer: @unchecked Sendable {
                 identity: identity,
                 callerPath: callerPath,
                 signing: signing
+            )
+        case .injectFd where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleInject(
+                message, on: peer, cancellation: cancellation, pid: pid,
+                identity: identity, callerPath: callerPath, signing: signing
             )
         case .inject, .keys, .authorize, .dockerGet, .goatGet, .ordercliGet, .openhueGet, .plumberGet, .uaaGet, .railwayGet,
              .oxideGet, .fastlyGet, .sqlcmdGet, .terraformGet, .aliyunGet, .wakatimeGet, .rcloneGet, .kubectlGet:
@@ -8116,74 +8121,6 @@ private final class ApprovalServer: @unchecked Sendable {
     }
 
 
-    private func approvalRequest(from message: xpc_object_t) -> ApprovalRequest? {
-        guard let opPointer = xpc_dictionary_get_string(message, "op"),
-              let targetPointer = xpc_dictionary_get_string(message, "target"),
-              let cwdPointer = xpc_dictionary_get_string(message, "cwd"),
-              let keys = stringArray(message, "keys"),
-              let args = stringArray(message, "args"),
-              let envConflicts = stringArray(message, "env_conflicts")
-        else {
-            return nil
-        }
-        let op = String(cString: opPointer)
-        guard op == "inject" || op == "keys" || op == "authorize" || op == "gpg-sign"
-            || op == "docker-get" || op == "goat-get" || op == "ordercli-get" || op == "openhue-get" || op == "plumber-get" || op == "uaa-get" || op == "railway-get"
-            || op == "oxide-get" || op == "fastly-get" || op == "sqlcmd-get" || op == "terraform-get" || op == "aliyun-get" || op == "wakatime-get"
-            || op == "rclone-get" || op == "kubectl-get"
-            || op == "proxy-start"
-        else { return nil }
-        let scriptData: Data?
-        if xpc_dictionary_get_value(message, "script_data") != nil {
-            guard let data = xpcData(message, key: "script_data") else { return nil }
-            scriptData = data
-        } else {
-            scriptData = nil
-        }
-
-        return ApprovalRequest(
-            op: op,
-            keys: keys,
-            target: String(cString: targetPointer),
-            args: args,
-            cwd: String(cString: cwdPointer),
-            replaceExistingEnv: xpc_dictionary_get_bool(message, "replace_existing_env"),
-            allowMissingKeys: xpc_dictionary_get_bool(message, "allow_missing_keys"),
-            envConflicts: envConflicts,
-            shebangScript: xpc_dictionary_get_string(message, "shebang_script").map(String.init(cString:)),
-            scriptData: scriptData,
-            snapshotIncompatibleInterpreter: xpc_dictionary_get_string(
-                message,
-                "snapshot_incompatible_interpreter"
-            ).map(String.init(cString:)),
-            tool: xpc_dictionary_get_string(message, "tool").map(String.init(cString:)),
-            title: xpc_dictionary_get_string(message, "title").map(String.init(cString:)),
-            detail: xpc_dictionary_get_string(message, "detail").map(String.init(cString:))
-        )
-    }
-
-    private func stringArray(_ message: xpc_object_t, _ key: String) -> [String]? {
-        guard let value = xpc_dictionary_get_value(message, key),
-              xpc_get_type(value) == XPC_TYPE_ARRAY
-        else {
-            return nil
-        }
-        var strings: [String] = []
-        for index in 0..<xpc_array_get_count(value) {
-            guard let pointer = xpc_array_get_string(value, index) else { return nil }
-            strings.append(String(cString: pointer))
-        }
-        return strings
-    }
-
-    private func xpcData(_ message: xpc_object_t, key: String) -> Data? {
-        var length = 0
-        guard let bytes = xpc_dictionary_get_data(message, key, &length),
-              length <= blessedScriptMaximumBytes
-        else { return nil }
-        return Data(bytes: bytes, count: length)
-    }
-
     private func reply(
         _ peer: xpc_connection_t,
         to message: xpc_object_t,
@@ -8207,8 +8144,14 @@ private final class ApprovalServer: @unchecked Sendable {
             let values = xpc_dictionary_create_empty()
             for (key, value) in secrets {
                 key.withCString { keyPointer in
-                    value.withCString { valuePointer in
-                        xpc_dictionary_set_string(values, keyPointer, valuePointer)
+                    if xpc_dictionary_get_string(message, "op").map(String.init(cString:)) == "inject-fd" {
+                        Data(value.utf8).withUnsafeBytes { bytes in
+                            xpc_dictionary_set_data(values, keyPointer, bytes.baseAddress, bytes.count)
+                        }
+                    } else {
+                        value.withCString { valuePointer in
+                            xpc_dictionary_set_string(values, keyPointer, valuePointer)
+                        }
                     }
                 }
             }
@@ -8261,6 +8204,94 @@ private final class ApprovalServer: @unchecked Sendable {
         xpc_connection_send_message(peer, message)
     }
 }
+
+private func approvalRequest(from message: xpc_object_t) -> ApprovalRequest? {
+    guard let opPointer = xpc_dictionary_get_string(message, "op"),
+          let targetPointer = xpc_dictionary_get_string(message, "target"),
+          let cwdPointer = xpc_dictionary_get_string(message, "cwd"),
+          let keys = stringArray(message, "keys"),
+          let args = stringArray(message, "args"),
+          let envConflicts = stringArray(message, "env_conflicts")
+    else {
+        return nil
+    }
+    let op = String(cString: opPointer)
+    guard op == "inject" || op == "inject-fd" || op == "keys" || op == "authorize" || op == "gpg-sign"
+        || op == "docker-get" || op == "goat-get" || op == "ordercli-get" || op == "openhue-get" || op == "plumber-get" || op == "uaa-get" || op == "railway-get"
+        || op == "oxide-get" || op == "fastly-get" || op == "sqlcmd-get" || op == "terraform-get" || op == "aliyun-get" || op == "wakatime-get"
+        || op == "rclone-get" || op == "kubectl-get"
+        || op == "proxy-start"
+    else { return nil }
+    let scriptData: Data?
+    if xpc_dictionary_get_value(message, "script_data") != nil {
+        guard let data = xpcData(message, key: "script_data") else { return nil }
+        scriptData = data
+    } else {
+        scriptData = nil
+    }
+
+    var title = xpc_dictionary_get_string(message, "title").map(String.init(cString:))
+    var detail = xpc_dictionary_get_string(message, "detail").map(String.init(cString:))
+    if op == "inject-fd" {
+        guard let mappings = stringArray(message, "secret_fds"),
+              let description = fileDescriptorInjectionDetail(keys: keys, mappings: mappings),
+              !xpc_dictionary_get_bool(message, "replace_existing_env"),
+              !xpc_dictionary_get_bool(message, "allow_missing_keys"),
+              envConflicts.isEmpty,
+              xpc_dictionary_get_value(message, "shebang_script") == nil,
+              xpc_dictionary_get_value(message, "script_data") == nil,
+              xpc_dictionary_get_value(message, "snapshot_incompatible_interpreter") == nil,
+              xpc_dictionary_get_value(message, "tool") == nil
+        else { return nil }
+        title = "Apply Secrets through file descriptors?"
+        detail = description
+    } else if xpc_dictionary_get_value(message, "secret_fds") != nil {
+        return nil
+    }
+
+    return ApprovalRequest(
+        op: op,
+        keys: keys,
+        target: String(cString: targetPointer),
+        args: args,
+        cwd: String(cString: cwdPointer),
+        replaceExistingEnv: xpc_dictionary_get_bool(message, "replace_existing_env"),
+        allowMissingKeys: xpc_dictionary_get_bool(message, "allow_missing_keys"),
+        envConflicts: envConflicts,
+        shebangScript: xpc_dictionary_get_string(message, "shebang_script").map(String.init(cString:)),
+        scriptData: scriptData,
+        snapshotIncompatibleInterpreter: xpc_dictionary_get_string(
+            message,
+            "snapshot_incompatible_interpreter"
+        ).map(String.init(cString:)),
+        tool: xpc_dictionary_get_string(message, "tool").map(String.init(cString:)),
+        title: title,
+        detail: detail
+    )
+}
+
+private func stringArray(_ message: xpc_object_t, _ key: String) -> [String]? {
+    guard let value = xpc_dictionary_get_value(message, key),
+          xpc_get_type(value) == XPC_TYPE_ARRAY
+    else {
+        return nil
+    }
+    var strings: [String] = []
+    for index in 0..<xpc_array_get_count(value) {
+        guard let pointer = xpc_array_get_string(value, index) else { return nil }
+        strings.append(String(cString: pointer))
+    }
+    return strings
+}
+
+private func xpcData(_ message: xpc_object_t, key: String) -> Data? {
+    var length = 0
+    guard let bytes = xpc_dictionary_get_data(message, key, &length),
+          length <= blessedScriptMaximumBytes
+    else { return nil }
+    return Data(bytes: bytes, count: length)
+}
+
 
 private func supportsVarlockProtocol(_ version: UInt64) -> Bool {
     version == varlockProtocolVersion
@@ -8429,7 +8460,8 @@ private func secretGateMatches(
     request: ApprovalRequest,
     signing: SigningInfo
 ) -> Bool {
-    gate.routes.contains { route in
+    guard request.op != "inject-fd" else { return false }
+    return gate.routes.contains { route in
         route.operation == request.op
             && route.callerIdentifiers.contains(signing.identifier)
             && normalizedExecutablePath(route.targetPath) == normalizedExecutablePath(request.target)
@@ -11442,7 +11474,7 @@ private func phoneApprovalRisks(
     case .unknown: return [.unknown]
     case .readOnly, .localWrite, .update, .mutating: return [.routine]
     case nil where request.op == "list": return [.secretDisclosure]
-    case nil where request.op == "inject": return [.unconstrainedSecretApplication]
+    case nil where request.op == "inject" || request.op == "inject-fd": return [.unconstrainedSecretApplication]
     case nil: return [.securityWarning]
     }
 }
@@ -11530,6 +11562,13 @@ private func approvalPromptSections(
             ApprovalPromptRow("Signed", "\(signing.identifier) / \(signing.teamIdentifier)"),
         ]),
     ]
+
+    if request.op == "inject-fd" {
+        sections[1] = ApprovalPromptSection("Secret Delivery", "arrow.right", [
+            ApprovalPromptRow("Delivery", request.detail ?? ""),
+            ApprovalPromptRow("Environment", "Requested Secret Names are removed"),
+        ])
+    }
 
     if !request.keys.isEmpty {
         sections.insert(ApprovalPromptSection(
@@ -12898,7 +12937,75 @@ private func runKeychainPersistenceSelfCheck() -> Int32 {
 }
 
 @MainActor
+private func fileDescriptorInjectionSelfCheck() -> Bool {
+    let message = xpc_dictionary_create_empty()
+    func strings(_ key: String, _ values: [String]) {
+        let array = xpc_array_create_empty()
+        for value in values { value.withCString { xpc_array_set_string(array, XPC_ARRAY_APPEND, $0) } }
+        key.withCString { xpc_dictionary_set_value(message, $0, array) }
+    }
+    xpc_dictionary_set_string(message, "op", "inject-fd")
+    xpc_dictionary_set_string(message, "target", "/bin/cat")
+    xpc_dictionary_set_string(message, "cwd", "/tmp")
+    xpc_dictionary_set_string(message, "detail", "untrusted description")
+    xpc_dictionary_set_bool(message, "replace_existing_env", false)
+    xpc_dictionary_set_bool(message, "allow_missing_keys", false)
+    strings("keys", ["FOO", "BAR"])
+    strings("args", [])
+    strings("env_conflicts", [])
+    strings("secret_fds", ["FOO:3", "BAR:4"])
+    guard let request = approvalRequest(from: message),
+          request.detail?.contains("BAR → FD 4, FOO → FD 3") == true,
+          request.title == "Apply Secrets through file descriptors?",
+          phoneApprovalRisks(request: request, classification: nil, hasSecurityWarning: false)
+              == [.unconstrainedSecretApplication]
+    else { return false }
+    var identity = AVProcessIdentity()
+    guard av_process_identity(getpid(), &identity) else { return false }
+    let signing = SigningInfo(identifier: "com.automicvault.av", teamIdentifier: "TEAM")
+    let reuse = request.decisionReuseRequest(clientIdentity: identity, callerPath: "/usr/local/bin/av", signing: signing)
+    var cache = AuthorizationDecisionReuseCache()
+    cache.remember(.approved, for: reuse)
+    guard cache.decision(for: reuse) == nil,
+          request.selecting(SelectedSecretValues(values: [:])).detail == request.detail,
+          accessRequestRecord(request: request, callerPath: "/usr/local/bin/av", decision: "Approved",
+                              approvalSource: "Manual", reason: "test", launcher: nil).detail == request.detail,
+          approvalPromptSections(request: request, callerPath: "/usr/local/bin/av", pid: getpid(),
+                                 signing: signing, scriptApproval: nil, launcher: nil,
+                                 processSecurity: ApprovalProcessSecurity(nodes: []), receivedAt: Date())
+              .contains(where: { $0.title == "Secret Delivery" })
+    else { return false }
+    strings("secret_fds", ["FOO:4", "BAR:3"])
+    guard let swapped = approvalRequest(from: message),
+          swapped.decisionReuseRequest(clientIdentity: identity, callerPath: "/usr/local/bin/av", signing: signing) != reuse
+    else { return false }
+    for mappings in [["FOO:3"], ["FOO:3", "BAR:3"], ["FOO:1", "BAR:4"], ["FOO:3", "BAZ:4"]] {
+        strings("secret_fds", mappings)
+        guard approvalRequest(from: message) == nil else { return false }
+    }
+    strings("secret_fds", ["FOO:3", "BAR:4"])
+    for key in ["replace_existing_env", "allow_missing_keys"] {
+        key.withCString { xpc_dictionary_set_bool(message, $0, true) }
+        guard approvalRequest(from: message) == nil else { return false }
+        key.withCString { xpc_dictionary_set_bool(message, $0, false) }
+    }
+    strings("env_conflicts", ["FOO"])
+    guard approvalRequest(from: message) == nil else { return false }
+    strings("env_conflicts", [])
+    for key in ["shebang_script", "tool", "snapshot_incompatible_interpreter"] {
+        key.withCString { xpc_dictionary_set_string(message, $0, "unexpected") }
+        guard approvalRequest(from: message) == nil else { return false }
+        key.withCString { xpc_dictionary_set_value(message, $0, nil) }
+    }
+    xpc_dictionary_set_string(message, "op", "inject")
+    guard approvalRequest(from: message) == nil else { return false }
+    xpc_dictionary_set_value(message, "secret_fds", nil)
+    return approvalRequest(from: message) != nil
+}
+
+@MainActor
 private func runApprovalSelfCheck() -> Int32 {
+    guard fileDescriptorInjectionSelfCheck() else { return 1 }
     let helperSigning = SigningInfo(identifier: "com.automicvault", teamIdentifier: "TEAM")
     var selfIdentity = AVProcessIdentity()
     guard av_process_identity(getpid(), &selfIdentity), liveSigningInfo(pid: getpid()) != nil else {
@@ -13561,6 +13668,13 @@ private func runApprovalSelfCheck() -> Int32 {
         title: nil,
         detail: nil
     )
+    let fdRequest = ApprovalRequest(
+        op: "inject-fd", keys: directRequest.keys, target: directRequest.target,
+        args: directRequest.args, cwd: directRequest.cwd,
+        replaceExistingEnv: false, allowMissingKeys: false, envConflicts: [],
+        shebangScript: nil, scriptData: nil, tool: nil, title: nil,
+        detail: fileDescriptorInjectionDetail(keys: directRequest.keys, mappings: ["HCLOUD_TOKEN:3"])
+    )
     let directRules = [DirectAccessRule(
         secretName: "HCLOUD_TOKEN",
         launcher: BlessedScriptLauncher(
@@ -13568,7 +13682,11 @@ private func runApprovalSelfCheck() -> Int32 {
             requirement: blockedLauncher.designatedRequirement
         )
     )]
-    guard resolveSecretGatePolicy(gate: policyGate, launchers: []) == nil,
+    guard matchingDirectAccessLauncher(
+              request: fdRequest, configuredGate: nil, trustedAVGateClient: true,
+              launchers: [blockedLauncher], rules: directRules
+          ) == nil,
+          resolveSecretGatePolicy(gate: policyGate, launchers: []) == nil,
           resolveSecretGatePolicy(gate: policyGate, launchers: [blockedLauncher])?.protection == .noAccess,
           resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [blockedLauncher])?.protection == .readOnly,
           resolveSecretGatePolicy(gate: runtimeProtectedGate, launchers: [unhardenedLauncher])?.protection == .noAccess,

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -16,6 +16,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case rcloneHelperVersion = "rclone-helper-version"
     case kubectlHelperVersion = "kubectl-helper-version"
     case inject
+    case injectFd = "inject-fd"
     case varlock
     case keys
     case authorize

--- a/src/menu-helper/Sources/MenubarHelperCore/FileDescriptorInjection.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/FileDescriptorInjection.swift
@@ -1,0 +1,26 @@
+/// Canonical mapping text is bound into the request, phone Approval digest,
+/// decision-reuse identity, and persisted Authorization Record detail.
+public func fileDescriptorInjectionDetail(keys: [String], mappings: [String]) -> String? {
+    guard !keys.isEmpty, Set(keys).count == keys.count, mappings.count == keys.count else { return nil }
+    var names = Set<String>()
+    var descriptors = Set<Int32>()
+    var pairs: [String: Int32] = [:]
+    for mapping in mappings {
+        let parts = mapping.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let first = parts[0].utf8.first,
+              first == 95 || (65...90).contains(first) || (97...122).contains(first),
+              parts[0].utf8.allSatisfy({
+                  $0 == 95 || (65...90).contains($0) || (97...122).contains($0) || (48...57).contains($0)
+              }),
+              let fd = Int32(parts[1]), fd >= 3, fd < Int32.max,
+              String(fd) == parts[1],
+              names.insert(String(parts[0])).inserted,
+              descriptors.insert(fd).inserted
+        else { return nil }
+        pairs[String(parts[0])] = fd
+    }
+    guard names == Set(keys) else { return nil }
+    return "Anonymous pipes: " + pairs.sorted { $0.key < $1.key }.map { "\($0.key) → FD \($0.value)" }.joined(separator: ", ")
+        + ". Exact stored bytes, then EOF. Requested Secret Names are removed from the Target's environment."
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/FileDescriptorInjectionTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/FileDescriptorInjectionTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import MenubarHelperCore
+
+@Test func fdMappingsBindEverySecretToOneDistinctDescriptor() {
+    let detail = fileDescriptorInjectionDetail(keys: ["BAR", "FOO"], mappings: ["FOO:3", "BAR:4"])
+    #expect(detail?.contains("BAR → FD 4, FOO → FD 3") == true)
+    #expect(detail == fileDescriptorInjectionDetail(keys: ["FOO", "BAR"], mappings: ["BAR:4", "FOO:3"]))
+    #expect(detail != fileDescriptorInjectionDetail(keys: ["FOO", "BAR"], mappings: ["BAR:3", "FOO:4"]))
+    for mappings in [
+        ["FOO:3"], ["FOO:3", "FOO:4"], ["FOO:3", "BAR:3"], ["FOO:3", "OTHER:4"],
+        ["FOO:0", "BAR:4"], ["FOO:1", "BAR:4"], ["FOO:2", "BAR:4"],
+        ["FOO:03", "BAR:4"], ["FOO:+3", "BAR:4"], ["FOO:2147483647", "BAR:4"],
+        ["FOO:3:4", "BAR:4"], ["FOO:3", "BAR: 4"],
+    ] {
+        #expect(fileDescriptorInjectionDetail(keys: ["FOO", "BAR"], mappings: mappings) == nil)
+    }
+    #expect(fileDescriptorInjectionDetail(keys: [], mappings: []) == nil)
+    #expect(fileDescriptorInjectionDetail(keys: ["FOO", "FOO"], mappings: ["FOO:3", "FOO:4"]) == nil)
+    #expect(fileDescriptorInjectionDetail(keys: ["BAD\nNAME"], mappings: ["BAD\nNAME:3"]) == nil)
+}

--- a/tests/inject_cli.rs
+++ b/tests/inject_cli.rs
@@ -218,6 +218,41 @@ fn fd_injection_preserves_bytes_eof_and_separates_environment() {
 }
 
 #[test]
+fn fd_injection_can_use_the_highest_descriptor_under_the_process_limit() {
+    let home = temp_home("inject-fd-limit");
+    let keychain = home.join("keychain");
+    fs::create_dir_all(&keychain).unwrap();
+    fs::write(keychain.join("FOO"), "exact value\n").unwrap();
+    fs::write(keychain.join("BAR"), "second").unwrap();
+    let output = Command::new("/bin/sh")
+        .args([
+            "-c",
+            "ulimit -n 32 || exit; exec 3<&- 4<&- 5<&- 31<&-; exec \"$@\"",
+            "inject-fd-limit-test",
+            env!("CARGO_BIN_EXE_av"),
+            "inject",
+            "--mode=fd",
+            "+FOO:31",
+            "+BAR:5",
+            "--",
+            "/bin/cat",
+            "/dev/fd/31",
+            "/dev/fd/5",
+        ])
+        .env("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain)
+        .output()
+        .unwrap();
+    if unsafe { libc::geteuid() } != 0 {
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert_eq!(output.stdout, b"exact value\nsecond");
+        assert!(output.stderr.is_empty(), "{}", stderr(&output));
+    } else {
+        assert!(!output.status.success());
+    }
+    fs::remove_dir_all(home).unwrap();
+}
+
+#[test]
 fn fd_injection_missing_oversized_or_occupied_descriptors_never_start_target() {
     use std::os::unix::process::CommandExt;
     let home = temp_home("inject-fd-errors");

--- a/tests/inject_cli.rs
+++ b/tests/inject_cli.rs
@@ -172,6 +172,91 @@ fn relocated_cli_cannot_enable_the_test_keychain_hook() {
     let _ = fs::remove_dir_all(home);
 }
 
+#[test]
+fn fd_injection_preserves_bytes_eof_and_separates_environment() {
+    let home = temp_home("inject-fd");
+    let keychain = home.join("keychain");
+    fs::create_dir_all(&keychain).unwrap();
+    let pem = b"  -----BEGIN PRIVATE KEY-----\r\nfixture\0bytes\n-----END PRIVATE KEY-----\n\n";
+    fs::write(keychain.join("FOO"), pem).unwrap();
+    fs::write(keychain.join("BAR"), "second").unwrap();
+    let input = home.join("stdin");
+    fs::write(&input, "stdin").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_av"))
+        .args([
+            "inject",
+            "--mode=fd",
+            "+FOO:3",
+            "+BAR:4",
+            "--",
+            "/bin/sh",
+            "-c",
+            "test -z \"${FOO+x}${BAR+x}\" || exit 91; cat <&4; cat <&3; cat <&3; cat",
+        ])
+        .env("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain)
+        .env("FOO", "ambient-foo")
+        .env("BAR", "ambient-bar")
+        .stdin(fs::File::open(input).unwrap())
+        .output()
+        .unwrap();
+    if unsafe { libc::geteuid() } != 0 {
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert_eq!(
+            output.stdout,
+            [b"second".as_slice(), pem, b"stdin"].concat()
+        );
+        assert!(output.stderr.is_empty(), "{}", stderr(&output));
+    } else {
+        assert!(!output.status.success());
+    }
+    fs::remove_dir_all(home).unwrap();
+}
+
+#[test]
+fn fd_injection_missing_oversized_or_occupied_descriptors_never_start_target() {
+    use std::os::unix::process::CommandExt;
+    let home = temp_home("inject-fd-errors");
+    let keychain = home.join("keychain");
+    fs::create_dir_all(&keychain).unwrap();
+    fs::write(keychain.join("LARGE"), vec![b'x'; 1024 * 1024]).unwrap();
+    fs::write(keychain.join("SMALL"), "must-not-leak").unwrap();
+    for (key, occupied, expected) in [
+        ("MISSING", false, "missing Secret"),
+        ("LARGE", false, "exceeds the anonymous pipe buffer capacity"),
+        ("SMALL", true, "already open"),
+    ] {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_av"));
+        command
+            .args([
+                "inject",
+                "--mode=fd",
+                &format!("+{key}:100"),
+                "--",
+                "/bin/echo",
+                "TARGET_RAN",
+            ])
+            .env("AUTOMIC_VAULT_TEST_KEYCHAIN_DIR", &keychain);
+        if occupied {
+            unsafe {
+                command.pre_exec(|| {
+                    if libc::dup2(0, 100) < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+        }
+        let output = command.output().unwrap();
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        assert!(!stderr(&output).contains("must-not-leak"));
+        if unsafe { libc::geteuid() } != 0 {
+            assert!(stderr(&output).contains(expected), "{}", stderr(&output));
+        }
+    }
+    fs::remove_dir_all(home).unwrap();
+}
+
 fn stdout(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }

--- a/tests/inject_cli.rs
+++ b/tests/inject_cli.rs
@@ -182,8 +182,13 @@ fn fd_injection_preserves_bytes_eof_and_separates_environment() {
     fs::write(keychain.join("BAR"), "second").unwrap();
     let input = home.join("stdin");
     fs::write(&input, "stdin").unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_av"))
+    // CI runners can leave these descriptors open. Free them in the child before av starts.
+    let output = Command::new("/bin/sh")
         .args([
+            "-c",
+            "exec 3<&- 4<&-; exec \"$@\"",
+            "inject-fd-test",
+            env!("CARGO_BIN_EXE_av"),
             "inject",
             "--mode=fd",
             "+FOO:3",


### PR DESCRIPTION
Adds file descriptor delivery for consumers that need exact stored Secret bytes without environment injection:

```sh
av inject --mode=fd +FOO:3 +BAR:4 -- /bin/foo
```

Each Secret gets an anonymous pipe with exact stored UTF-8 bytes followed by EOF. Requested names are removed from the Target's environment; stdin, stdout, stderr, and the existing environment delivery mode are preserved.

The distinct `inject-fd` operation requires fresh human Approval and a verified Authorization Record before release. The app validates and records every mapping, includes it in iPhone Approval, and prevents existing Direct Access Rules, Blessings, Tool-specific policies, or cached Approvals from authorizing this delivery mode. Older helpers reject the operation.

Pipes are reserved close-on-exec before XPC and prefilled without blocking. Occupied or duplicate descriptors, missing Secrets, incompatible flags, and Values exceeding available pipe capacity fail without starting the Target. FD shebangs are unsupported initially. ADR 0043 documents these boundaries and the pipe-capacity limit.

Validation:
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo test --profile test-release --all-targets --all-features --locked`
- `swift test --package-path src/menu-helper --disable-automatic-resolution` — 293 passed.
- `scripts/test-menu-helper-self-checks.sh` — 28 passed, including malformed FD requests, canonical mapping display/history, fresh Approval, and Direct Access isolation.

Focused checks exercise real XPC data with embedded NULs, multiline byte preservation, EOF, stdin preservation, ambient-variable removal, descriptor collisions, the highest usable descriptor under a reduced process limit, missing/oversized values, denial before loading, and cleanup after partial preparation.

Related to #309's descriptor-delivery request. Encrypted backup/recovery, import behavior, and 1.x migration/rollback are outside this change.
