### PR TITLE
Add explicit script capability inheritance controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ available from the calling context. Make that choice explicit with:
 ```
 
 Use an empty declaration to ensure every later gated operation requires
-Approval, regardless of which Launcher calls the script:
+Approval while Automic Vault can attribute it to the live script execution,
+regardless of which Launcher calls the script:
 
 ```sh
 # --- automic-vault
@@ -218,7 +219,11 @@ The Secret Names in the `av inject` shebang are authorized separately. A script
 with no Secret Names and `capabilities: {}` starts without Approval because it
 receives no Automic Vault authority. This is an authorization ceiling, not a
 sandbox: ordinary commands still run with the user's normal operating-system
-permissions.
+permissions. Restarting Automic Vault or losing observable ancestry ends the
+memory-only ceiling, just as it ends active Blessed Script state.
+
+Compatibility debts reserved for the next major version are tracked in
+[Future Breaking Changes](docs/future-breaking-changes.md).
 
 Editing the script or declaration invalidates the Blessing. A Launcher
 Endorsement lets one Verified Launcher automically authorize that exact

--- a/README.md
+++ b/README.md
@@ -196,6 +196,30 @@ The script declares the Secrets and Tool capabilities it needs:
 # ---
 ```
 
+For compatibility, omitting the manifest inherits automic authority already
+available from the calling context. Make that choice explicit with:
+
+```sh
+# --- automic-vault
+# capabilities: { inherit: true }
+# ---
+```
+
+Use an empty declaration to ensure every later gated operation requires
+Approval, regardless of which Launcher calls the script:
+
+```sh
+# --- automic-vault
+# capabilities: {}
+# ---
+```
+
+The Secret Names in the `av inject` shebang are authorized separately. A script
+with no Secret Names and `capabilities: {}` starts without Approval because it
+receives no Automic Vault authority. This is an authorization ceiling, not a
+sandbox: ordinary commands still run with the user's normal operating-system
+permissions.
+
 Editing the script or declaration invalidates the Blessing. A Launcher
 Endorsement lets one Verified Launcher automically authorize that exact
 Blessing. Use Blessed Scripts for reviewed work that exits, and Tool

--- a/docs/adr/0039-script-capability-inheritance.md
+++ b/docs/adr/0039-script-capability-inheritance.md
@@ -22,6 +22,10 @@ An omitted capabilities manifest retains Capability Inheritance.
 `capabilities: {}` disables Capability Inheritance and establishes an empty
 capability ceiling for the exact script execution.
 
+Blessing records created before Capability Inheritance was stored explicitly
+retain their previous inheritance behavior. Reblessing records the current
+declaration mode.
+
 The empty ceiling blocks automic authorization from outer Blessings, Launcher
 policy, Direct Access Rules, and Temporary Access Grants. It does not block a
 human Approval or constrain ungated process execution. Secret Names in the

--- a/docs/adr/0039-script-capability-inheritance.md
+++ b/docs/adr/0039-script-capability-inheritance.md
@@ -1,0 +1,42 @@
+# ADR 0039: Preserve Script Capability Inheritance Until a Major Version
+
+- Status: Accepted
+- Date: 2026-09-08
+
+## Context
+
+Scripts without a capabilities manifest currently continue beneath authority
+available from their execution context. Users may rely on that behavior. Making
+an omitted manifest mean no inherited authority would be safer, but would break
+existing automation without an explicit migration.
+
+Scripts also need a way to state that no calling Launcher, outer Blessed Script,
+or Temporary Access Grant may automatically authorize their later gated
+operations. Starting a script with that restriction grants no authority and
+therefore does not itself need Approval when the script requests no Secret.
+
+## Decision
+
+An omitted capabilities manifest retains Capability Inheritance.
+`capabilities: { inherit: true }` expresses that behavior explicitly.
+`capabilities: {}` disables Capability Inheritance and establishes an empty
+capability ceiling for the exact script execution.
+
+The empty ceiling blocks automic authorization from outer Blessings, Launcher
+policy, Direct Access Rules, and Temporary Access Grants. It does not block a
+human Approval or constrain ungated process execution. Secret Names in the
+script's own `av inject` shebang remain part of a separate complete Authorization
+Request and must be authorized and recorded before release.
+
+A snapshot-compatible script with no requested Secret Names and an explicit
+empty ceiling may start without Approval. The approval service validates the
+complete declaration and registers the ceiling before allowing execution.
+
+## Consequences
+
+- Existing scripts keep working without modification.
+- Security-sensitive scripts can opt out of ambient automic authority now.
+- Explicit inheritance documents compatibility dependencies before the next
+  major version.
+- A future major version should make omission equivalent to the empty ceiling;
+  the migration is tracked in `docs/future-breaking-changes.md`.

--- a/docs/adr/0039-script-capability-inheritance.md
+++ b/docs/adr/0039-script-capability-inheritance.md
@@ -31,6 +31,8 @@ Request and must be authorized and recorded before release.
 A snapshot-compatible script with no requested Secret Names and an explicit
 empty ceiling may start without Approval. The approval service validates the
 complete declaration and registers the ceiling before allowing execution.
+The ceiling remains memory-only and attributable through live process ancestry;
+an Automic Vault restart or loss of observable ancestry ends it.
 
 ## Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,6 +207,17 @@ between verification and execution, and warns on every run. The Blessing stores
 the override, so existing Blessings must be reviewed again before they can use
 canonical-path execution.
 
+For compatibility, a script with no capabilities manifest uses Capability
+Inheritance. `capabilities: { inherit: true }` makes the same behavior explicit.
+An explicit `capabilities: {}` instead establishes a memory-only empty capability
+ceiling for that exact execution. It blocks automic authorization inherited from
+an outer Blessed Script, Launcher policy, Direct Access Rules, and Temporary
+Access Grants; a later gated request may still receive human Approval. A
+snapshot-compatible script that requests no Secret Names and declares this empty
+ceiling starts without Approval because doing so grants no authority. Scripts
+that request Secret Names still require the ordinary Authorization Decision and
+record before release, and then run beneath the empty ceiling.
+
 ### Distribution
 
 The app, CLI, signed helpers, signed fork Isotope releases and Isotopes tap,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,6 +209,8 @@ canonical-path execution.
 
 For compatibility, a script with no capabilities manifest uses Capability
 Inheritance. `capabilities: { inherit: true }` makes the same behavior explicit.
+Blessing records created before this mode was stored retain their previous
+inheritance behavior until the user reblesses the script.
 An explicit `capabilities: {}` instead establishes a memory-only empty capability
 ceiling for that exact execution. It blocks automic authorization inherited from
 an outer Blessed Script, Launcher policy, Direct Access Rules, and Temporary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,9 @@ Access Grants; a later gated request may still receive human Approval. A
 snapshot-compatible script that requests no Secret Names and declares this empty
 ceiling starts without Approval because doing so grants no authority. Scripts
 that request Secret Names still require the ordinary Authorization Decision and
-record before release, and then run beneath the empty ceiling.
+record before release, and then run beneath the empty ceiling. The ceiling uses
+the same live-ancestry evidence and memory-only lifetime as active Blessed Script
+state; restarting Automic Vault or losing observable ancestry ends it.
 
 ### Distribution
 
@@ -250,9 +252,10 @@ biometric result. Reuse still requires an Authorization Record before Secret
 Application. Operations that may receive long-lived AWS credentials remain
 excluded and require fresh Approval.
 
-An active Blessing is evaluated before a Temporary Access Grant. A matching
-grant may authorize a recognized operation beyond a narrower Blessing only
-inside the grant's exact scope. Matching happens after ordinary Gate Client,
+An active Blessing is evaluated before a Temporary Access Grant. Unless an
+explicit empty capability ceiling is active, a matching grant may authorize a
+recognized operation beyond a narrower Blessing only inside the grant's exact
+scope. Matching happens after ordinary Gate Client,
 Target, request, Secret, gate, Launcher, and runtime verification succeeds.
 Before presenting a queued Approval, the service checks Temporary Access Grants
 again against the still-live Gate Client, current Agent Task Context, and

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -608,8 +608,10 @@ A Script Declaration with no capabilities manifest inherits by default. The
 declaration `capabilities: { inherit: true }` makes that behavior explicit.
 `capabilities: {}` disables Capability Inheritance and declares an empty
 capability ceiling: after any Secret Names requested by the script's own shebang
-are separately authorized, every later gated operation requires Approval.
-Neither form makes the script safe or prevents ordinary ungated execution.
+are separately authorized, every later gated operation attributable to that live
+execution requires Approval. Neither form makes the script safe, prevents
+ordinary ungated execution, or follows a child after its script ancestry becomes
+unobservable.
 
 ### Launcher Endorsement
 

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -597,6 +597,20 @@ Blessing cannot gain this exception during an upgrade.
 
 The maximum Access Level a Blessed Script may receive through one Authorization Gate.
 
+### Capability Inheritance
+
+Compatibility behavior that lets a script continue to use automic authority
+available from its execution context, including an outer Blessed Script, its
+Verified Launcher's Authorization Policy and Direct Access Rules, and a matching
+Temporary Access Grant. Capability Inheritance grants no authority by itself.
+
+A Script Declaration with no capabilities manifest inherits by default. The
+declaration `capabilities: { inherit: true }` makes that behavior explicit.
+`capabilities: {}` disables Capability Inheritance and declares an empty
+capability ceiling: after any Secret Names requested by the script's own shebang
+are separately authorized, every later gated operation requires Approval.
+Neither form makes the script safe or prevents ordinary ungated execution.
+
 ### Launcher Endorsement
 
 Permission for one Verified Launcher to execute an exact Blessing with automic authorization. Launcher Endorsement does not transfer to sibling Launchers or a changed script.

--- a/docs/future-breaking-changes.md
+++ b/docs/future-breaking-changes.md
@@ -22,3 +22,17 @@ capability ceiling now.
 
 Omitting the capabilities manifest should mean `capabilities: {}`. Scripts that
 need ambient authority must declare `capabilities: { inherit: true }` explicitly.
+
+## `av save` single-line input should trim surrounding whitespace
+
+### Current behavior
+
+In single-line mode, `av save` removes the line ending from the entered value but
+preserves other leading and trailing whitespace. Existing Secrets may depend on
+those bytes, so changing this behavior in a minor release could silently alter
+their values.
+
+### Next major version
+
+`av save` should trim whitespace from both ends of values entered in single-line
+mode before validating and storing them.

--- a/docs/future-breaking-changes.md
+++ b/docs/future-breaking-changes.md
@@ -1,0 +1,24 @@
+# Future Breaking Changes
+
+These are compatibility mistakes we intentionally preserve until a major
+version can remove them safely. Each entry states today's behavior and the
+breaking correction so new code can opt in early.
+
+## Script capability declarations should default to no inheritance
+
+### Current behavior
+
+A script with no capabilities manifest inherits automic authority already
+available from its execution context. This includes an outer Blessed Script,
+Verified Launcher policy, Direct Access Rules, and matching Temporary Access
+Grants. Existing scripts may depend on that ambient authority, so changing the
+default in a minor release could break automation.
+
+Use `capabilities: { inherit: true }` to record an intentional dependency on
+this compatibility behavior. Use `capabilities: {}` to opt into the safer empty
+capability ceiling now.
+
+### Next major version
+
+Omitting the capabilities manifest should mean `capabilities: {}`. Scripts that
+need ambient authority must declare `capabilities: { inherit: true }` explicitly.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -47,8 +47,8 @@ Automic Vault decides whether a complete operation may use it.
 - Existing developer commands continue to work above the security boundary.
 - Scripts inherit their existing execution context's automic authority when no
   capability declaration is present. `capabilities: {}` opts into an empty
-  capability ceiling so later gated operations require Approval regardless of
-  the calling Launcher.
+  capability ceiling so later gated operations attributable to that live script
+  execution require Approval regardless of the calling Launcher.
 - An explicitly recognized, vendor-signed CLI sealed inside its vendor's app
   may represent that app as a Verified Launcher; unrelated bundled executables
   do not inherit the app's authority.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -45,6 +45,10 @@ Automic Vault decides whether a complete operation may use it.
   authority. The user may opt to collapse the strip after five seconds to a
   visible warning tab while the menu-bar shield remains orange.
 - Existing developer commands continue to work above the security boundary.
+- Scripts inherit their existing execution context's automic authority when no
+  capability declaration is present. `capabilities: {}` opts into an empty
+  capability ceiling so later gated operations require Approval regardless of
+  the calling Launcher.
 - An explicitly recognized, vendor-signed CLI sealed inside its vendor's app
   may represent that app as a Verified Launcher; unrelated bundled executables
   do not inherit the app's authority.
@@ -73,6 +77,9 @@ User-facing copy must preserve these limits:
   boundary for a Temporary Access Grant.
 - Temporary Access Grants do not cover the Direct Secret Gate, Secret mutation,
   Elevated Secret Application, Secret Disclosure, or Unknown operations.
+- An explicit empty script capability ceiling also blocks matching Temporary
+  Access Grants; it is not an execution sandbox and does not constrain ungated
+  commands.
 - Secret Disclosure remains available as an explicit, more powerful Secret Use.
 - Execution control belongs to the same Developer Authority model even when an
   operation uses no Secret.

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -68,10 +68,14 @@ private func blessedScriptAccessSummary(
     capabilities: [String: SecretGateProtection],
     inheritsCapabilities: Bool
 ) -> String {
-    if inheritsCapabilities { return "Inherited from execution context" }
     let summary = capabilities.sorted { $0.key < $1.key }
         .map { "\($0.key): \($0.value.normalized(forGateID: $0.key).title)" }
         .joined(separator: ", ")
+    if inheritsCapabilities {
+        return summary.isEmpty
+            ? "Inherited from execution context"
+            : "\(summary); additional authority inherited from execution context"
+    }
     return summary.isEmpty ? "None" : summary
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -64,6 +64,24 @@ private extension SecretGateProtection {
     }
 }
 
+private func blessedScriptAccessSummary(
+    capabilities: [String: SecretGateProtection],
+    inheritsCapabilities: Bool
+) -> String {
+    if inheritsCapabilities { return "Inherited from execution context" }
+    let summary = capabilities.sorted { $0.key < $1.key }
+        .map { "\($0.key): \($0.value.normalized(forGateID: $0.key).title)" }
+        .joined(separator: ", ")
+    return summary.isEmpty ? "None" : summary
+}
+
+private func blessedScriptAccessSummary(_ script: BlessedScript) -> String {
+    blessedScriptAccessSummary(
+        capabilities: script.capabilities,
+        inheritsCapabilities: script.usesCapabilityInheritance
+    )
+}
+
 struct BlessedScriptReviewRequest: Sendable {
     let path: String
     let declaration: BlessedScriptDeclaration
@@ -533,6 +551,7 @@ final class DashboardModel: ObservableObject {
             replaceExistingEnv: declaration.replaceExistingEnv,
             allowMissingKeys: declaration.allowMissingKeys,
             allowsCanonicalPathExecution: declaration.snapshotIncompatibleInterpreter != nil,
+            inheritsCapabilities: declaration.manifest.inheritsCapabilities,
             capabilities: declaration.manifest.capabilities,
             launchers: pendingBlessingLaunchers,
             reviewedContents: request.scriptData
@@ -545,7 +564,7 @@ final class DashboardModel: ObservableObject {
                 "Checksum: \(script.checksum)",
                 "Target: \(script.target)",
                 "Secret Names: \(script.keys.joined(separator: ", "))",
-                "Access: \(script.capabilities.sorted { $0.key < $1.key }.map { "\($0.key): \($0.value.title)" }.joined(separator: ", "))",
+                "Access: \(blessedScriptAccessSummary(script))",
                 "Launchers: \(script.launchers.map(\.bundleIdentifier).joined(separator: ", "))",
             ].joined(separator: "\n")
         ) { [weak self] in
@@ -618,6 +637,7 @@ final class DashboardModel: ObservableObject {
                 replaceExistingEnv: script.replaceExistingEnv,
                 allowMissingKeys: script.allowMissingKeys,
                 allowsCanonicalPathExecution: script.allowsCanonicalPathExecution == true,
+                inheritsCapabilities: script.usesCapabilityInheritance,
                 capabilities: script.capabilities,
                 launchers: script.launchers + [launcher],
                 blessedAt: script.blessedAt,
@@ -630,7 +650,7 @@ final class DashboardModel: ObservableObject {
                     "Script: \(script.path)",
                     "Checksum: \(script.checksum)",
                     "Secret Names: \(script.keys.joined(separator: ", "))",
-                    "Access: \(script.capabilities.sorted { $0.key < $1.key }.map { "\($0.key): \($0.value.title)" }.joined(separator: ", "))",
+                    "Access: \(blessedScriptAccessSummary(script))",
                 ].joined(separator: "\n")
             ) {
                 self.finishPolicyUpdate(saveBlessedScript(updated), error: "Could not add Verified Launcher")
@@ -671,6 +691,7 @@ final class DashboardModel: ObservableObject {
             replaceExistingEnv: script.replaceExistingEnv,
             allowMissingKeys: script.allowMissingKeys,
             allowsCanonicalPathExecution: script.allowsCanonicalPathExecution == true,
+            inheritsCapabilities: script.usesCapabilityInheritance,
             capabilities: script.capabilities,
             launchers: launchers,
             blessedAt: script.blessedAt,
@@ -3662,6 +3683,7 @@ private struct BlessedScriptReviewView: View {
                         path: request.path,
                         checksum: request.declaration.checksum,
                         keys: request.declaration.keys,
+                        inheritsCapabilities: request.declaration.manifest.inheritsCapabilities,
                         capabilities: request.declaration.manifest.capabilities
                     )
                     launcherList(model.pendingBlessingLaunchers) {
@@ -3875,6 +3897,7 @@ private struct BlessedScriptDetailView: View {
                 path: script.path,
                 checksum: script.checksum,
                 keys: script.keys,
+                inheritsCapabilities: script.usesCapabilityInheritance,
                 capabilities: script.capabilities
             )
             launcherList(script.launchers) {
@@ -3912,6 +3935,7 @@ private struct BlessedScriptFields: View {
     let path: String
     let checksum: String
     let keys: [String]
+    let inheritsCapabilities: Bool
     let capabilities: [String: SecretGateProtection]
 
     var body: some View {
@@ -3921,9 +3945,10 @@ private struct BlessedScriptFields: View {
             SecretGateField("Secrets", keys.joined(separator: ", "))
             SecretGateField(
                 "Capabilities",
-                capabilities.sorted(by: { $0.key < $1.key })
-                    .map { "\($0.key): \($0.value.normalized(forGateID: $0.key).title)" }
-                    .joined(separator: ", ")
+                blessedScriptAccessSummary(
+                    capabilities: capabilities,
+                    inheritsCapabilities: inheritsCapabilities
+                )
             )
         }
     }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -5332,20 +5332,24 @@ private final class ApprovalServer: @unchecked Sendable {
     private func activeBlessedScripts(pid: pid_t, identity: AVProcessIdentity) -> [BlessedScript] {
         let currentBlessings = loadBlessedScripts()
         blessedExecutionsLock.lock()
-        blessedExecutions = blessedExecutions.filter { key, script in
-            var current = AVProcessIdentity()
-            return currentBlessings.contains(script)
-                && av_process_identity(key.pid, &current)
-                && current.start_usec == key.startUsec
-        }
         let executions = blessedExecutions
+        blessedExecutionsLock.unlock()
+
+        let staleExecutions = executions.compactMap { key, script in
+            currentBlessings.contains(script) && executionIsLive(key) ? nil : key
+        }
+        blessedExecutionsLock.lock()
+        for key in staleExecutions where blessedExecutions[key] == executions[key] {
+            blessedExecutions.removeValue(forKey: key)
+        }
+        let activeExecutions = blessedExecutions
         blessedExecutionsLock.unlock()
 
         var scripts: [BlessedScript] = []
         var currentPID = pid
         var currentIdentity = identity
         for _ in 0..<64 {
-            if let script = executions[BlessedExecutionKey(
+            if let script = activeExecutions[BlessedExecutionKey(
                 pid: currentPID,
                 startUsec: currentIdentity.start_usec
             )] {
@@ -5366,17 +5370,19 @@ private final class ApprovalServer: @unchecked Sendable {
 
     private func activeEmptyCapabilityCeiling(pid: pid_t, identity: AVProcessIdentity) -> Bool {
         blessedExecutionsLock.lock()
-        emptyCapabilityCeilings = emptyCapabilityCeilings.filter { key in
-            var current = AVProcessIdentity()
-            return av_process_identity(key.pid, &current) && current.start_usec == key.startUsec
-        }
         let ceilings = emptyCapabilityCeilings
+        blessedExecutionsLock.unlock()
+
+        let staleCeilings = ceilings.filter { !executionIsLive($0) }
+        blessedExecutionsLock.lock()
+        emptyCapabilityCeilings.subtract(staleCeilings)
+        let activeCeilings = emptyCapabilityCeilings
         blessedExecutionsLock.unlock()
 
         var currentPID = pid
         var currentIdentity = identity
         for _ in 0..<64 {
-            if ceilings.contains(BlessedExecutionKey(
+            if activeCeilings.contains(BlessedExecutionKey(
                 pid: currentPID,
                 startUsec: currentIdentity.start_usec
             )) {
@@ -5387,6 +5393,11 @@ private final class ApprovalServer: @unchecked Sendable {
             guard av_process_identity(currentPID, &currentIdentity) else { return false }
         }
         return false
+    }
+
+    private func executionIsLive(_ key: BlessedExecutionKey) -> Bool {
+        var identity = AVProcessIdentity()
+        return av_process_identity(key.pid, &identity) && identity.start_usec == key.startUsec
     }
 
     private func handleBlessedCapability(
@@ -11302,7 +11313,7 @@ private func scriptStartingWithoutApproval(
 ) -> BlessedScriptDeclaration? {
     guard request.keys.isEmpty,
           let declaration = scriptExecutionDeclaration(for: request),
-          declaration.manifest.capabilities.isEmpty,
+          declaration.manifest.hasEmptyCapabilityCeiling,
           declaration.snapshotIncompatibleInterpreter == nil
     else { return nil }
     return declaration
@@ -13755,6 +13766,13 @@ private func runApprovalSelfCheck() -> Int32 {
     let inheritedScript = scriptStartingWithoutApproval(for: scriptRequest(
         "#!/usr/local/bin/av inject -- /usr/bin/python3\nprint('ok')\n"
     ))
+    let explicitlyInheritedScript = scriptStartingWithoutApproval(for: scriptRequest("""
+    #!/usr/local/bin/av inject -- /usr/bin/python3
+    # --- automic-vault
+    # capabilities: { inherit: true }
+    # ---
+    print("ok")
+    """))
     let emptyCeilingScript = scriptStartingWithoutApproval(for: scriptRequest("""
     #!/usr/local/bin/av inject -- /usr/bin/python3
     # --- automic-vault
@@ -13762,7 +13780,8 @@ private func runApprovalSelfCheck() -> Int32 {
     # ---
     print("ok")
     """))
-    guard inheritedScript?.manifest.inheritsCapabilities == true,
+    guard inheritedScript == nil,
+          explicitlyInheritedScript == nil,
           emptyCeilingScript?.manifest.hasEmptyCapabilityCeiling == true,
           scriptStartingWithoutApproval(for: scriptRequest(
               "#!/usr/local/bin/av inject +TOKEN -- /usr/bin/python3\nprint('ok')\n",

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -12199,6 +12199,7 @@ private struct ApprovalPromptView: View {
 }
 
 private func approvalPromptCapabilitySummary(_ script: BlessedScript) -> String {
+    if script.usesCapabilityInheritance { return "Inherited from execution context" }
     let summary = script.capabilities.sorted(by: { $0.key < $1.key })
         .map { "\($0.key): \($0.value.title)" }
         .joined(separator: " • ")

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3022,6 +3022,17 @@ private struct ScriptApproval {
     let checksum: String
 }
 
+private struct ActiveScriptAuthority {
+    let blessings: [BlessedScript]
+    let hasEmptyCapabilityCeiling: Bool
+
+    var nearestBlessing: BlessedScript? { blessings.first }
+    var allowsAutomaticAuthority: Bool { !hasEmptyCapabilityCeiling }
+    var inheritsLauncherPolicy: Bool {
+        allowsAutomaticAuthority && blessings.allSatisfy(\.usesCapabilityInheritance)
+    }
+}
+
 private func blessedScriptMatches(
     _ script: BlessedScript,
     request: ApprovalRequest,
@@ -3156,6 +3167,7 @@ private final class ApprovalServer: @unchecked Sendable {
     private var retainedProcessProvenance = RetainedProcessProvenanceStore()
     private let blessedExecutionsLock = NSLock()
     private var blessedExecutions: [BlessedExecutionKey: BlessedScript] = [:]
+    private var emptyCapabilityCeilings: Set<BlessedExecutionKey> = []
     private let awsRegistrationsLock = NSLock()
     private var awsRegistrations: [BlessedExecutionKey: AWSRegistration] = [:]
 
@@ -3921,6 +3933,13 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         let scriptApproval = scriptApproval(for: request)
+        if let scriptDeclaration = scriptStartingWithoutApproval(for: request) {
+            if scriptDeclaration.manifest.hasEmptyCapabilityCeiling {
+                registerEmptyCapabilityCeiling(pid: pid, identity: identity)
+            }
+            reply(peer, to: message, ok: true, error: nil, secrets: [:])
+            return
+        }
         let processChains = retainedProcessChains(for: identity)
         let keepsDetachedProcessAccess = UserDefaults.standard.bool(
             forKey: keepLauncherAccessForDetachedProcessesDefaultsKey
@@ -3932,22 +3951,29 @@ private final class ApprovalServer: @unchecked Sendable {
             callerPID: pid,
             ancestorFallbackPath: ancestorFallbackPath
         )
-        let activeBlessing = activeBlessedScript(pid: pid, identity: identity)
-        if let script = activeBlessing {
-            if handleBlessedCapability(
-                script,
-                request: request,
-                signing: signing,
-                descriptors: secretGateDescriptors,
-                launcher: launcher,
-                callerPath: callerPath,
-                awsRegistration: awsRegistration,
-                pid: pid,
-                identity: identity,
-                peer: peer,
-                message: message
-            ) {
-                return
+        let scriptAuthority = ActiveScriptAuthority(
+            blessings: activeBlessedScripts(pid: pid, identity: identity),
+            hasEmptyCapabilityCeiling: activeEmptyCapabilityCeiling(pid: pid, identity: identity)
+        )
+        let activeBlessing = scriptAuthority.nearestBlessing
+        if scriptAuthority.allowsAutomaticAuthority {
+            for script in scriptAuthority.blessings {
+                if handleBlessedCapability(
+                    script,
+                    request: request,
+                    signing: signing,
+                    descriptors: secretGateDescriptors,
+                    launcher: launcher,
+                    callerPath: callerPath,
+                    awsRegistration: awsRegistration,
+                    pid: pid,
+                    identity: identity,
+                    peer: peer,
+                    message: message
+                ) {
+                    return
+                }
+                if !script.usesCapabilityInheritance { break }
             }
         }
         let blessingGate = scriptApproval.map {
@@ -3970,7 +3996,8 @@ private final class ApprovalServer: @unchecked Sendable {
         }
         let effectiveBlessingMatch = currentBlessingMatch
             ?? (keepsDetachedProcessAccess ? retainedBlessingMatch : nil)
-        if let scriptApproval,
+        if scriptAuthority.allowsAutomaticAuthority,
+           let scriptApproval,
            let blessingGate,
            let (script, matchedLauncher) = effectiveBlessingMatch
         {
@@ -4112,7 +4139,9 @@ private final class ApprovalServer: @unchecked Sendable {
             retainedProcessExplanation = nil
         }
         let automaticApprovalExplanation: String?
-        if let resolvedPolicy,
+        if scriptAuthority.hasEmptyCapabilityCeiling {
+            automaticApprovalExplanation = "This script declared an empty capability ceiling, so inherited automatic access cannot authorize this request."
+        } else if let resolvedPolicy,
            let classification,
            let explanation = launcherRuntimeProtectionApprovalExplanation(
                policy: resolvedPolicy,
@@ -4138,7 +4167,8 @@ private final class ApprovalServer: @unchecked Sendable {
         } else {
             automaticApprovalExplanation = nil
         }
-        if let configuredGate,
+        if scriptAuthority.allowsAutomaticAuthority,
+           let configuredGate,
            let classification,
            let currentAgentTaskContext,
            handleTemporaryAccessGrant(
@@ -4160,7 +4190,7 @@ private final class ApprovalServer: @unchecked Sendable {
         {
             return
         }
-        if activeBlessing == nil, let directAccessLauncher {
+        if scriptAuthority.inheritsLauncherPolicy, let directAccessLauncher {
             do {
                 let accessRequestID = UUID()
                 let record = accessRequestRecord(
@@ -4225,7 +4255,7 @@ private final class ApprovalServer: @unchecked Sendable {
             }
             return
         }
-        if activeBlessing == nil,
+        if scriptAuthority.inheritsLauncherPolicy,
            let configuredGate,
            let resolvedPolicy,
            let classification,
@@ -4303,18 +4333,20 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         let promptLauncher = policyLauncher
-        let temporaryGrantCandidate = temporaryAccessGrantCandidate(
+        let temporaryGrantCandidate = scriptAuthority.hasEmptyCapabilityCeiling ? nil : temporaryAccessGrantCandidate(
             gate: configuredGate,
             classification: classification,
             launcher: launcher,
             agentTaskContext: currentAgentTaskContext
         )
-        let temporaryGrantUnavailableReason = temporaryAccessGrantUnavailableReason(
-            hasToolSpecificGate: configuredGate != nil,
-            classification: classification,
-            launcherRuntimeProtection: launcher?.runtimeProtection,
-            agentTaskContext: currentAgentTaskContext
-        )
+        let temporaryGrantUnavailableReason = scriptAuthority.hasEmptyCapabilityCeiling
+            ? "This script declared an empty capability ceiling."
+            : temporaryAccessGrantUnavailableReason(
+                hasToolSpecificGate: configuredGate != nil,
+                classification: classification,
+                launcherRuntimeProtection: launcher?.runtimeProtection,
+                agentTaskContext: currentAgentTaskContext
+            )
         let promptAccessLevel = if let configuredGate, let resolvedPolicy {
             configuredGate.protectionTitle(resolvedPolicy.protection)
         } else {
@@ -4395,6 +4427,7 @@ private final class ApprovalServer: @unchecked Sendable {
                    currentSigning.identifier == signing.identifier,
                    currentSigning.teamIdentifier == signing.teamIdentifier,
                    isAllowedCaller(path: currentCallerPath, signing: currentSigning),
+                   !self.activeEmptyCapabilityCeiling(pid: pid, identity: currentIdentity),
                    let configuredGate,
                    let classification,
                    let currentAgentTaskContext = agentTaskContext(pid: pid),
@@ -5296,7 +5329,7 @@ private final class ApprovalServer: @unchecked Sendable {
         blessedExecutionsLock.unlock()
     }
 
-    private func activeBlessedScript(pid: pid_t, identity: AVProcessIdentity) -> BlessedScript? {
+    private func activeBlessedScripts(pid: pid_t, identity: AVProcessIdentity) -> [BlessedScript] {
         let currentBlessings = loadBlessedScripts()
         blessedExecutionsLock.lock()
         blessedExecutions = blessedExecutions.filter { key, script in
@@ -5308,6 +5341,7 @@ private final class ApprovalServer: @unchecked Sendable {
         let executions = blessedExecutions
         blessedExecutionsLock.unlock()
 
+        var scripts: [BlessedScript] = []
         var currentPID = pid
         var currentIdentity = identity
         for _ in 0..<64 {
@@ -5315,13 +5349,44 @@ private final class ApprovalServer: @unchecked Sendable {
                 pid: currentPID,
                 startUsec: currentIdentity.start_usec
             )] {
-                return script
+                scripts.append(script)
             }
-            guard currentIdentity.ppid > 1 else { return nil }
+            guard currentIdentity.ppid > 1 else { return scripts }
             currentPID = currentIdentity.ppid
-            guard av_process_identity(currentPID, &currentIdentity) else { return nil }
+            guard av_process_identity(currentPID, &currentIdentity) else { return scripts }
         }
-        return nil
+        return scripts
+    }
+
+    private func registerEmptyCapabilityCeiling(pid: pid_t, identity: AVProcessIdentity) {
+        blessedExecutionsLock.lock()
+        emptyCapabilityCeilings.insert(BlessedExecutionKey(pid: pid, startUsec: identity.start_usec))
+        blessedExecutionsLock.unlock()
+    }
+
+    private func activeEmptyCapabilityCeiling(pid: pid_t, identity: AVProcessIdentity) -> Bool {
+        blessedExecutionsLock.lock()
+        emptyCapabilityCeilings = emptyCapabilityCeilings.filter { key in
+            var current = AVProcessIdentity()
+            return av_process_identity(key.pid, &current) && current.start_usec == key.startUsec
+        }
+        let ceilings = emptyCapabilityCeilings
+        blessedExecutionsLock.unlock()
+
+        var currentPID = pid
+        var currentIdentity = identity
+        for _ in 0..<64 {
+            if ceilings.contains(BlessedExecutionKey(
+                pid: currentPID,
+                startUsec: currentIdentity.start_usec
+            )) {
+                return true
+            }
+            guard currentIdentity.ppid > 1 else { return false }
+            currentPID = currentIdentity.ppid
+            guard av_process_identity(currentPID, &currentIdentity) else { return false }
+        }
+        return false
     }
 
     private func handleBlessedCapability(
@@ -7808,6 +7873,9 @@ private final class ApprovalServer: @unchecked Sendable {
             activate: { material in
                 if let registration = material.awsRegistration {
                     installAWSRegistration(registration, pid: pid, identity: identity)
+                }
+                if scriptExecutionDeclaration(for: request)?.manifest.hasEmptyCapabilityCeiling == true {
+                    registerEmptyCapabilityCeiling(pid: pid, identity: identity)
                 }
                 activateAfterRecording()
             },
@@ -11213,6 +11281,33 @@ private func scriptApproval(for request: ApprovalRequest) -> ScriptApproval? {
     return ScriptApproval(path: path, checksum: checksum)
 }
 
+private func scriptExecutionDeclaration(for request: ApprovalRequest) -> BlessedScriptDeclaration? {
+    guard request.op == "inject",
+          request.shebangScript != nil,
+          let data = request.scriptData,
+          let declaration = try? blessedScriptDeclaration(data: data),
+          declaration.matchesExecution(
+              keys: request.keys,
+              target: request.target,
+              replaceExistingEnv: request.replaceExistingEnv,
+              allowMissingKeys: request.allowMissingKeys,
+              snapshotIncompatibleInterpreter: request.snapshotIncompatibleInterpreter
+          )
+    else { return nil }
+    return declaration
+}
+
+private func scriptStartingWithoutApproval(
+    for request: ApprovalRequest
+) -> BlessedScriptDeclaration? {
+    guard request.keys.isEmpty,
+          let declaration = scriptExecutionDeclaration(for: request),
+          declaration.manifest.capabilities.isEmpty,
+          declaration.snapshotIncompatibleInterpreter == nil
+    else { return nil }
+    return declaration
+}
+
 private final class ApprovalPanel: NSPanel {
     private var allowsKey = false
 
@@ -13640,6 +13735,41 @@ private func runApprovalSelfCheck() -> Int32 {
         return 1
     }
 
+    func scriptRequest(_ source: String, keys: [String] = []) -> ApprovalRequest {
+        ApprovalRequest(
+            op: "inject",
+            keys: keys,
+            target: "/usr/bin/python3",
+            args: ["/tmp/script"],
+            cwd: "/tmp",
+            replaceExistingEnv: false,
+            allowMissingKeys: false,
+            envConflicts: [],
+            shebangScript: "/tmp/script",
+            scriptData: Data(source.utf8),
+            tool: nil,
+            title: nil,
+            detail: nil
+        )
+    }
+    let inheritedScript = scriptStartingWithoutApproval(for: scriptRequest(
+        "#!/usr/local/bin/av inject -- /usr/bin/python3\nprint('ok')\n"
+    ))
+    let emptyCeilingScript = scriptStartingWithoutApproval(for: scriptRequest("""
+    #!/usr/local/bin/av inject -- /usr/bin/python3
+    # --- automic-vault
+    # capabilities: {}
+    # ---
+    print("ok")
+    """))
+    guard inheritedScript?.manifest.inheritsCapabilities == true,
+          emptyCeilingScript?.manifest.hasEmptyCapabilityCeiling == true,
+          scriptStartingWithoutApproval(for: scriptRequest(
+              "#!/usr/local/bin/av inject +TOKEN -- /usr/bin/python3\nprint('ok')\n",
+              keys: ["TOKEN"]
+          )) == nil
+    else { return 1 }
+
     let avSigning = SigningInfo(identifier: "com.automicvault.av", teamIdentifier: "TEAM")
     func awsRequest(
         keys: [String] = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
@@ -13713,6 +13843,17 @@ private func runApprovalSelfCheck() -> Int32 {
         capabilities: blessedScript.capabilities,
         launchers: []
     )
+    let inheritingScript = BlessedScript(
+        path: blessedScript.path,
+        checksum: blessedScript.checksum,
+        keys: blessedScript.keys,
+        target: blessedScript.target,
+        replaceExistingEnv: blessedScript.replaceExistingEnv,
+        allowMissingKeys: blessedScript.allowMissingKeys,
+        inheritsCapabilities: true,
+        capabilities: [:],
+        launchers: []
+    )
     guard blessedScriptCanAutoApprove(
         blessedScript,
         request: readOnlyAws,
@@ -13761,7 +13902,19 @@ private func runApprovalSelfCheck() -> Int32 {
         lostBlessingExplanation(
             for: ScriptApproval(path: "/tmp/script", checksum: "checksum"),
             blessedScripts: [blessedScript]
-        ) == nil
+        ) == nil,
+        ActiveScriptAuthority(
+            blessings: [inheritingScript],
+            hasEmptyCapabilityCeiling: false
+        ).inheritsLauncherPolicy,
+        !ActiveScriptAuthority(
+            blessings: [inheritingScript],
+            hasEmptyCapabilityCeiling: true
+        ).allowsAutomaticAuthority,
+        !ActiveScriptAuthority(
+            blessings: [inheritingScript, blessedScript],
+            hasEmptyCapabilityCeiling: false
+        ).inheritsLauncherPolicy
     else { return 1 }
 
     guard matchingSecretGate(request: readOnlyAws, signing: avSigning, descriptors: [awsDescriptor])?.id == "aws",

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -325,6 +325,20 @@ public struct BlessedScriptDeclaration: Equatable, Sendable {
     public let allowMissingKeys: Bool
     public let snapshotIncompatibleInterpreter: String?
     public let manifest: BlessedScriptManifest
+
+    public func matchesExecution(
+        keys: [String],
+        target: String,
+        replaceExistingEnv: Bool,
+        allowMissingKeys: Bool,
+        snapshotIncompatibleInterpreter: String?
+    ) -> Bool {
+        self.keys == keys.sorted()
+            && self.target == target
+            && self.replaceExistingEnv == replaceExistingEnv
+            && self.allowMissingKeys == allowMissingKeys
+            && self.snapshotIncompatibleInterpreter == snapshotIncompatibleInterpreter
+    }
 }
 
 public func blessedScriptDeclaration(data: Data) throws -> BlessedScriptDeclaration {

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -125,7 +125,7 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
     public let reviewedContents: Data?
 
     public var id: String { path }
-    public var usesCapabilityInheritance: Bool { inheritsCapabilities == true }
+    public var usesCapabilityInheritance: Bool { inheritsCapabilities ?? true }
 
     public var verifiedReviewedContents: Data? {
         guard let reviewedContents,

--- a/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/BlessedScripts.swift
@@ -74,9 +74,17 @@ public func readBlessedScript(path: String) throws -> Data {
 
 public struct BlessedScriptManifest: Equatable, Sendable {
     public let capabilities: [String: SecretGateProtection]
+    public let inheritsCapabilities: Bool
+    public let hasEmptyCapabilityCeiling: Bool
 
-    public init(capabilities: [String: SecretGateProtection]) {
+    public init(
+        capabilities: [String: SecretGateProtection],
+        inheritsCapabilities: Bool = false,
+        hasEmptyCapabilityCeiling: Bool = false
+    ) {
         self.capabilities = capabilities
+        self.inheritsCapabilities = inheritsCapabilities
+        self.hasEmptyCapabilityCeiling = hasEmptyCapabilityCeiling
     }
 }
 
@@ -110,12 +118,14 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
     public let replaceExistingEnv: Bool
     public let allowMissingKeys: Bool
     public let allowsCanonicalPathExecution: Bool?
+    public let inheritsCapabilities: Bool?
     public let capabilities: [String: SecretGateProtection]
     public let launchers: [BlessedScriptLauncher]
     public let blessedAt: Date
     public let reviewedContents: Data?
 
     public var id: String { path }
+    public var usesCapabilityInheritance: Bool { inheritsCapabilities == true }
 
     public var verifiedReviewedContents: Data? {
         guard let reviewedContents,
@@ -176,6 +186,7 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
         replaceExistingEnv: Bool,
         allowMissingKeys: Bool,
         allowsCanonicalPathExecution: Bool = false,
+        inheritsCapabilities: Bool = false,
         capabilities: [String: SecretGateProtection],
         launchers: [BlessedScriptLauncher],
         blessedAt: Date = Date(),
@@ -188,6 +199,7 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
         self.replaceExistingEnv = replaceExistingEnv
         self.allowMissingKeys = allowMissingKeys
         self.allowsCanonicalPathExecution = allowsCanonicalPathExecution
+        self.inheritsCapabilities = inheritsCapabilities
         self.capabilities = capabilities
         self.launchers = launchers
         self.blessedAt = blessedAt
@@ -218,6 +230,7 @@ public struct BlessedScript: Codable, Equatable, Identifiable, Sendable {
         replaceExistingEnv = script.replaceExistingEnv
         allowMissingKeys = script.allowMissingKeys
         allowsCanonicalPathExecution = script.allowsCanonicalPathExecution
+        inheritsCapabilities = script.inheritsCapabilities
         capabilities = script.capabilities
         self.launchers = launchers
         blessedAt = script.blessedAt
@@ -406,13 +419,28 @@ private func validBlessedSecretKey(_ key: String) -> Bool {
 
 private func parseBlessedScriptManifest(lines: [String]) throws -> BlessedScriptManifest {
     guard lines.count > 1, lines[1] == "# --- automic-vault" else {
-        return BlessedScriptManifest(capabilities: [:])
+        return BlessedScriptManifest(capabilities: [:], inheritsCapabilities: true)
     }
-    var capabilities: [String: SecretGateProtection] = [:]
     var index = 2
-    guard index < lines.count, lines[index] == "# capabilities:" else {
+    guard index < lines.count else {
         throw BlessedScriptManifestError.malformedManifest("expected `capabilities:`")
     }
+    if lines[index] == "# capabilities: {}" || lines[index] == "# capabilities: { inherit: true }" {
+        let inheritsCapabilities = lines[index] == "# capabilities: { inherit: true }"
+        index += 1
+        guard index < lines.count, lines[index] == "# ---" else {
+            throw BlessedScriptManifestError.malformedManifest("missing closing marker")
+        }
+        return BlessedScriptManifest(
+            capabilities: [:],
+            inheritsCapabilities: inheritsCapabilities,
+            hasEmptyCapabilityCeiling: !inheritsCapabilities
+        )
+    }
+    guard lines[index] == "# capabilities:" else {
+        throw BlessedScriptManifestError.malformedManifest("expected `capabilities:`")
+    }
+    var capabilities: [String: SecretGateProtection] = [:]
     index += 1
     while index < lines.count, lines[index] != "# ---" {
         let line = lines[index]

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -25,6 +25,8 @@ import Testing
         "aws": .fullExceptSecretDumps,
         "stripe": .fullExceptSecretDumps,
     ])
+    #expect(!declaration.manifest.inheritsCapabilities)
+    #expect(!declaration.manifest.hasEmptyCapabilityCeiling)
     #expect(declaration.checksum.count == 64)
 }
 
@@ -38,7 +40,31 @@ import Testing
 
     #expect(declaration.keys == ["TOKEN"])
     #expect(declaration.manifest.capabilities.isEmpty)
+    #expect(declaration.manifest.inheritsCapabilities)
+    #expect(!declaration.manifest.hasEmptyCapabilityCeiling)
     #expect(declaration.snapshotIncompatibleInterpreter == nil)
+}
+
+@Test(arguments: [
+    ("# capabilities: { inherit: true }", true, false),
+    ("# capabilities: {}", false, true),
+])
+func blessedScriptManifestParsesInlineCapabilityModes(
+    line: String,
+    inheritsCapabilities: Bool,
+    hasEmptyCapabilityCeiling: Bool
+) throws {
+    let declaration = try blessedScriptDeclaration(data: Data("""
+    #!/usr/local/bin/av inject -- /usr/bin/python3
+    # --- automic-vault
+    \(line)
+    # ---
+    print("ok")
+    """.utf8))
+
+    #expect(declaration.manifest.capabilities.isEmpty)
+    #expect(declaration.manifest.inheritsCapabilities == inheritsCapabilities)
+    #expect(declaration.manifest.hasEmptyCapabilityCeiling == hasEmptyCapabilityCeiling)
 }
 
 @Test func blessedScriptDetectsSnapshotIncompatibleInterpreterChains() throws {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -215,14 +215,14 @@ func blessedScriptManifestParsesInlineCapabilityModes(
     #expect(overridden.allowsExecution(snapshotIncompatibleInterpreter: "uv"))
 }
 
-@Test func existingBlessingsDoNotImplicitlyAllowCanonicalPathExecution() throws {
+@Test func existingBlessingsRetainCapabilityInheritanceWithoutCanonicalPathExecution() throws {
     let data = Data(#"{"path":"/tmp/script","checksum":"checksum","keys":[],"target":"/opt/homebrew/bin/uv","replaceExistingEnv":false,"allowMissingKeys":false,"capabilities":{},"launchers":[],"blessedAt":0}"#.utf8)
 
     let script = try JSONDecoder().decode(BlessedScript.self, from: data)
 
     #expect(!script.allowsExecution(snapshotIncompatibleInterpreter: "uv"))
     #expect(script.reviewedContents == nil)
-    #expect(!script.usesCapabilityInheritance)
+    #expect(script.usesCapabilityInheritance)
 }
 
 @Test func storedBlessingsPreserveExplicitCapabilityInheritance() throws {
@@ -231,6 +231,14 @@ func blessedScriptManifestParsesInlineCapabilityModes(
     let script = try JSONDecoder().decode(BlessedScript.self, from: data)
 
     #expect(script.usesCapabilityInheritance)
+}
+
+@Test func storedBlessingsPreserveExplicitlyDisabledCapabilityInheritance() throws {
+    let data = Data(#"{"path":"/tmp/script","checksum":"checksum","keys":[],"target":"/bin/sh","replaceExistingEnv":false,"allowMissingKeys":false,"inheritsCapabilities":false,"capabilities":{},"launchers":[],"blessedAt":0}"#.utf8)
+
+    let script = try JSONDecoder().decode(BlessedScript.self, from: data)
+
+    #expect(!script.usesCapabilityInheritance)
 }
 
 @Test func reviewedBlessingContentsMustMatchTheBlessedChecksum() throws {

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/BlessedScriptsTests.swift
@@ -65,6 +65,20 @@ func blessedScriptManifestParsesInlineCapabilityModes(
     #expect(declaration.manifest.capabilities.isEmpty)
     #expect(declaration.manifest.inheritsCapabilities == inheritsCapabilities)
     #expect(declaration.manifest.hasEmptyCapabilityCeiling == hasEmptyCapabilityCeiling)
+    #expect(declaration.matchesExecution(
+        keys: [],
+        target: "/usr/bin/python3",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        snapshotIncompatibleInterpreter: nil
+    ))
+    #expect(!declaration.matchesExecution(
+        keys: ["TOKEN"],
+        target: "/usr/bin/python3",
+        replaceExistingEnv: false,
+        allowMissingKeys: false,
+        snapshotIncompatibleInterpreter: nil
+    ))
 }
 
 @Test func blessedScriptDetectsSnapshotIncompatibleInterpreterChains() throws {
@@ -208,6 +222,15 @@ func blessedScriptManifestParsesInlineCapabilityModes(
 
     #expect(!script.allowsExecution(snapshotIncompatibleInterpreter: "uv"))
     #expect(script.reviewedContents == nil)
+    #expect(!script.usesCapabilityInheritance)
+}
+
+@Test func storedBlessingsPreserveExplicitCapabilityInheritance() throws {
+    let data = Data(#"{"path":"/tmp/script","checksum":"checksum","keys":[],"target":"/bin/sh","replaceExistingEnv":false,"allowMissingKeys":false,"inheritsCapabilities":true,"capabilities":{},"launchers":[],"blessedAt":0}"#.utf8)
+
+    let script = try JSONDecoder().decode(BlessedScript.self, from: data)
+
+    #expect(script.usesCapabilityInheritance)
 }
 
 @Test func reviewedBlessingContentsMustMatchTheBlessedChecksum() throws {
@@ -371,6 +394,12 @@ func blessedScriptManifestParsesInlineCapabilityModes(
     # --- automic-vault
     # capabilities:
     #   gh: read-only
+    # ---
+    """,
+    """
+    #!/usr/local/bin/av inject -- /bin/sh
+    # --- automic-vault
+    # capabilities: { inherit: false }
     # ---
     """,
 ])


### PR DESCRIPTION
## Summary

- preserve capability inheritance for scripts without a capabilities declaration
- support explicit `capabilities: { inherit: true }` and the empty ceiling `capabilities: {}`
- document the compatibility behavior, security boundary, and planned major-version corrections

## Security

The empty ceiling blocks automatic authority from ancestor Blessed Scripts, Launcher policy, Direct Access Rules, and Temporary Access Grants for the live script execution. Human Approval remains available. Legacy stored Blessings do not gain newly persisted inheritance authority.

The ceiling follows observable process ancestry and is memory-only. The documentation does not claim that it is an execution sandbox.

## Tests

- `swift test --package-path src/menu-helper --disable-automatic-resolution` (303 passed)
- `scripts/test-menu-helper-self-checks.sh` (28 passed)
- `cargo test --all-targets --all-features --locked` (passed; 1 ignored signed-release fixture)
