### PR TITLE
Reduce avoidable CPU work during authorization and script startup

### DIFF
--- a/docs/cpu-profile-2026-09-09.md
+++ b/docs/cpu-profile-2026-09-09.md
@@ -1,0 +1,106 @@
+# CPU investigation, 9 September 2026
+
+The midnight session reduced Authorization History decoding and eliminated
+Launcher discovery for no-Secret scripts with an empty capability ceiling.
+Signature validation remains the main observed CPU cost during repeated
+requests. The measurements below do not establish a reduction in
+total CPU for Secret exchange with Isotopes.
+
+This report uses the definitions in [domain language](domain-language.md),
+[architecture](architecture.md), and [positioning](positioning.md).
+
+Branch: `codex/overnight-cpu-20260909`, in `/Users/mxcl/src/av-cpu-20260909`.
+Implementation commits:
+
+- `75d6e390`: verify persisted history without decoding it twice.
+- `3ab7b54d`: skip catalog reads for ineligible helper candidates.
+- `ec616c8a`: defer Launcher discovery for empty-capability script starts.
+
+## Changes
+
+- Verify the complete persisted Authorization History bytes after each append,
+  instead of decoding all 50 records again and comparing only the newest UUID.
+  The app still persists and verifies the Authorization Record before releasing
+  Secrets. The lock, storage destination, and Keychain accessibility are unchanged.
+- Reject non-Developer-ID and non-app helper candidates before reading the
+  Launcher helper catalog. Eligible helpers still undergo the same catalog,
+  signature, runtime, and resource-seal checks.
+- Defer ordinary Launcher discovery until after the existing no-Secret script
+  path for an explicit empty capability ceiling. Gate Client verification and
+  Launcher Bundle integrity checks still precede dispatch. Request normalization,
+  credential binding, and ceiling registration retain their existing order.
+  GPG still discovers Launchers before selecting its credential; SSH still uses
+  its verified peer Launchers. Requests that need authorization still discover
+  Launchers before evaluating policy.
+
+## Measurements
+
+Release builds on macOS 26.6.2 (25G83), Xcode 26.6 (17F113). The branch starts at
+`bc3ccf5c`; paired comparisons isolate each change. Fixtures contain synthetic
+metadata and request no real Secrets.
+CPU means process user plus system CPU time; paired runs alternate before/after.
+
+| Workload | Before median CPU | After median CPU | Result |
+| --- | ---: | ---: | --- |
+| History fixture, 50 warm-up + 500 appends, seven pairs | 448 ms | 318 ms | 29% lower |
+| Launcher ancestry, 30 scans, five pairs | 9.442 s | 9.424 s | Within measurement noise |
+| Empty-ceiling inject handler, 30 calls, five pairs | 9.594 s | 0.020 s | Launcher discovery eliminated |
+
+History fixture wall time fell from 500 ms to 357 ms. These figures include
+standalone executable startup and use the existing UserDefaults test seam.
+They measure serialization and persistence verification overhead, not production
+Data Protection Keychain latency. An isolated signed Keychain fixture could not
+run because it lacked the required entitlement (`-34018`).
+
+The empty-ceiling fixture invokes `handleInject` with a synthetic script and
+asserts that each call returns success with an empty Secret payload and registers
+the live execution's empty capability ceiling. Median wall time fell from
+10.240 s to 0.096 s, including executable startup. The timed handler loop itself
+took about 3–4 ms after the change. The fixture omits the earlier XPC peer and
+Gate Client checks and the later target launch, so this is a handler measurement,
+not an end-to-end `av inject` measurement. Temporary instrumentation existed only
+in separately signed probe binaries and has been removed from the final source.
+
+A live baseline ran 40 no-Secret `av inject` script executions with
+`capabilities: {}`: median latency 402 ms, 17.15 s total wall time. The installed
+app consumed 15.19 s CPU during that interval, but it also handled other automatic
+operations. That CPU total cannot be attributed solely to the fixture. A
+10-second `sample` capture repeatedly showed
+`verifiedLauncherHelperAppSigningInfo` → `validateAppBundleResource` →
+`SecStaticCodeCheckValidityWithErrors` on active request stacks.
+
+## Verification
+
+- Release Swift suite passed (322 tests reported; 32 entitlement-gated skips).
+- CLI injection tests: eight passed. Secret custody boundary tests: three passed.
+- Menu helper self-checks: 29 passed.
+- New corruption regression rejects altered persisted content even when its UUID
+  matches the expected record. It fails against the original implementation.
+- Empty-ceiling checks cover inherited capabilities, requested Secrets,
+  incompatible script execution, and a non-inject operation.
+- Independent Standards and Spec/security reviews found no concrete issues in
+  the final changes. The committed script checks verify branch eligibility;
+  the temporary handler probe supplies the performance comparison.
+
+Run the committed history benchmark alone to avoid CPU contamination:
+
+```sh
+AV_BENCHMARK_AUTHORIZATION=1 swift test --package-path src/menu-helper \
+  -c release --disable-automatic-resolution --filter authorizationHistoryPerformance
+cargo test --test inject_cli --test secret_custody_boundary
+scripts/test-menu-helper-self-checks.sh src/menu-helper/.build/release/AutomicVaultMenubar
+```
+
+## Remaining work
+
+Measure representative Secret-bearing requests with an isolated, properly
+entitled app and synthetic Secrets. This session did not measure production
+Keychain persistence or full Secret exchange before and after the changes.
+
+Signature verification remains expensive. This session retains strict
+all-architecture validation and exact helper resource validation; it adds no
+cross-request identity cache. Further work must preserve the bounds in
+[ADR 0033](adr/0033-targeted-app-launcher-validation.md).
+
+Local raw measurements and temporary probes are in `/tmp/av-cpu-20260909`.
+The installed app, production Secrets, and Authorization Policies were unchanged.

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3906,10 +3906,15 @@ private final class ApprovalServer: @unchecked Sendable {
             return
         }
         let originIdentity = parsedRequest.sshPeer?.identity ?? identity
-        var launchers = parsedRequest.sshPeer?.launchers ?? launcherIdentities(for: identity)
-        if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {
-            launchers.append(launcher)
+        func requestLaunchers() -> [LauncherIdentity] {
+            var launchers = parsedRequest.sshPeer?.launchers ?? launcherIdentities(for: identity)
+            if launchers.isEmpty, let launcher = launcherIdentity(pid: pid, identity: identity) {
+                launchers.append(launcher)
+            }
+            return launchers
         }
+        // GPG needs Launchers for credential selection; other requests need them for authorization.
+        var launchers = parsedRequest.op == "gpg-sign" ? requestLaunchers() : []
         if parsedRequest.op == "gpg-sign" {
             let migrationStatus = migrateLegacyGPGSigningSecrets()
             guard migrationStatus == errSecSuccess else {
@@ -4089,6 +4094,9 @@ private final class ApprovalServer: @unchecked Sendable {
             }
             reply(peer, to: message, ok: true, error: nil, secrets: [:])
             return
+        }
+        if request.op != "gpg-sign" {
+            launchers = requestLaunchers()
         }
         let processChains = request.sshPeer == nil ? retainedProcessChains(for: identity) : []
         let keepsDetachedProcessAccess = UserDefaults.standard.bool(
@@ -14381,9 +14389,14 @@ private func runApprovalSelfCheck() -> Int32 {
         return 1
     }
 
-    func scriptRequest(_ source: String, keys: [String] = []) -> ApprovalRequest {
+    func scriptRequest(
+        _ source: String,
+        keys: [String] = [],
+        op: String = "inject",
+        snapshotIncompatibleInterpreter: String? = nil
+    ) -> ApprovalRequest {
         ApprovalRequest(
-            op: "inject",
+            op: op,
             keys: keys,
             target: "/usr/bin/python3",
             args: ["/tmp/script"],
@@ -14393,6 +14406,7 @@ private func runApprovalSelfCheck() -> Int32 {
             envConflicts: [],
             shebangScript: "/tmp/script",
             scriptData: Data(source.utf8),
+            snapshotIncompatibleInterpreter: snapshotIncompatibleInterpreter,
             tool: nil,
             title: nil,
             detail: nil
@@ -14408,18 +14422,23 @@ private func runApprovalSelfCheck() -> Int32 {
     # ---
     print("ok")
     """))
-    let emptyCeilingScript = scriptStartingWithoutApproval(for: scriptRequest("""
+    let emptyCeilingSource = """
     #!/usr/local/bin/av inject -- /usr/bin/python3
     # --- automic-vault
     # capabilities: {}
     # ---
     print("ok")
-    """))
+    """
+    let emptyCeilingScript = scriptStartingWithoutApproval(for: scriptRequest(emptyCeilingSource))
     guard inheritedScript == nil,
           explicitlyInheritedScript == nil,
           emptyCeilingScript?.manifest.hasEmptyCapabilityCeiling == true,
+          scriptStartingWithoutApproval(for: scriptRequest(emptyCeilingSource, op: "authorize")) == nil,
           scriptStartingWithoutApproval(for: scriptRequest(
-              "#!/usr/local/bin/av inject +TOKEN -- /usr/bin/python3\nprint('ok')\n",
+              emptyCeilingSource, snapshotIncompatibleInterpreter: "/usr/bin/python3"
+          )) == nil,
+          scriptStartingWithoutApproval(for: scriptRequest(
+              emptyCeilingSource.replacingOccurrences(of: "inject --", with: "inject +TOKEN --"),
               keys: ["TOKEN"]
           )) == nil
     else { return 1 }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -11476,14 +11476,15 @@ private func verifiedLauncherHelperAssociation(
     configuration: VerifiedLauncherHelperConfiguration? = nil,
     bundleIdentifier: (URL) -> String? = { Bundle(url: $0)?.bundleIdentifier }
 ) -> VerifiedLauncherHelperAssociation? {
-    let configuration = configuration ?? loadVerifiedLauncherHelperConfiguration()
-    let helpers = helpers ?? configuration.helpers
     guard signing.isDeveloperID else { return nil }
     let executablePath = signing.mainExecutable.isEmpty ? path : signing.mainExecutable
     let executableURL = URL(fileURLWithPath: executablePath)
         .standardizedFileURL
         .resolvingSymlinksInPath()
     let appURLs = containingAppURLs ?? appBundleURLs(containing: executableURL.path)
+    guard !appURLs.isEmpty else { return nil }
+    let configuration = configuration ?? loadVerifiedLauncherHelperConfiguration()
+    let helpers = helpers ?? configuration.helpers
     for helper in helpers where configuration.isEnabled(helper)
         && helper.helperSigningIdentifier == signing.identifier
         && helper.helperTeamIdentifier == signing.teamIdentifier

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1592,6 +1592,7 @@ public func appendAccessRequestRecord(
     if let defaults {
         defaults.set(data, forKey: key)
         guard defaults.synchronize() else { return false }
+        return defaults.data(forKey: key) == data
     } else {
         guard saveKeychainData(
             data,
@@ -1601,8 +1602,11 @@ public func appendAccessRequestRecord(
         ) == errSecSuccess else {
             return false
         }
+        // Verify the complete persisted bytes without decoding the history a second time.
+        guard case .success(let persisted) = loadKeychainDataResult(service: service, account: key)
+        else { return false }
+        return persisted == data
     }
-    return loadAccessRequestRecords(defaults: defaults, key: key, service: service).first?.id == record.id
 }
 
 private let projectValueAccountPrefix = "AVProjectValueV1:"

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationPerformanceTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/AuthorizationPerformanceTests.swift
@@ -1,0 +1,35 @@
+import Darwin
+import Foundation
+import Testing
+@testable import MenubarHelperCore
+
+// Opt in and filter to this test so other tests do not contaminate process CPU time.
+@Test(.enabled(if: ProcessInfo.processInfo.environment["AV_BENCHMARK_AUTHORIZATION"] == "1"))
+func authorizationHistoryPerformance() throws {
+    let suite = "com.automicvault.benchmark.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+    func record(_ index: Int) -> AccessRequestRecord {
+        AccessRequestRecord(
+            date: Date(timeIntervalSince1970: Double(index)), tool: "fixture",
+            command: "fixture list --project synthetic-\(index)", decision: "Approved",
+            approvalSource: "Auto", reason: "Read Only", launcher: "Fixture Launcher",
+            callerPath: "/fixture/av", target: "/fixture/tool", cwd: "/fixture",
+            keys: ["SYNTHETIC_TOKEN"], detail: nil
+        )
+    }
+    for index in 0..<50 {
+        try #require(appendAccessRequestRecord(record(index), defaults: defaults))
+    }
+    let start = ContinuousClock.now
+    let cpuStart = clock()
+    for index in 50..<550 {
+        try #require(appendAccessRequestRecord(record(index), defaults: defaults))
+    }
+    let cpu = Double(clock() - cpuStart) / Double(CLOCKS_PER_SEC)
+    print("Authorization History: 500 appends, wall=\(start.duration(to: .now)), CPU=\(cpu)s")
+    let records = loadAccessRequestRecords(defaults: defaults)
+    #expect(records.count == 50)
+    #expect(records.first?.command == record(549).command)
+    #expect(records.last?.command == record(500).command)
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -1608,3 +1608,29 @@ func keychainAccessibility(account: String, service: String) -> String? {
     else { return nil }
     return attributes[kSecAttrAccessible as String] as? String
 }
+
+// A matching UUID is insufficient evidence that the complete record was persisted.
+private final class AlteredAccessLogDefaults: UserDefaults, @unchecked Sendable {
+    private var stored: Data?
+
+    override func data(forKey defaultName: String) -> Data? { stored }
+    override func synchronize() -> Bool { true }
+    override func set(_ value: Any?, forKey defaultName: String) {
+        guard let data = value as? Data,
+              var records = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              !records.isEmpty
+        else { stored = nil; return }
+        records[0]["target"] = "/altered-target"
+        stored = try? JSONSerialization.data(withJSONObject: records)
+    }
+}
+
+@Test func accessRequestLogRejectsAlteredRecordWithMatchingID() {
+    let record = AccessRequestRecord(
+        date: Date(timeIntervalSince1970: 0), tool: "fixture", command: "fixture list",
+        decision: "Approved", approvalSource: "Auto", reason: "Read Only",
+        launcher: "Fixture", callerPath: "/fixture/av", target: "/fixture/tool",
+        cwd: "/fixture", keys: ["SYNTHETIC_TOKEN"], detail: nil
+    )
+    #expect(!appendAccessRequestRecord(record, defaults: AlteredAccessLogDefaults()))
+}


### PR DESCRIPTION
Repeated authorization requests decode the full Authorization History twice, and no-Secret scripts with an explicit empty capability ceiling discover Launchers before taking an existing path that does not use them. This change verifies the complete persisted history bytes, defers Launcher discovery for that script path, and skips helper-catalog reads for ineligible candidates.

Gate Client verification, Launcher Bundle integrity checks, capability-ceiling registration, and record-before-release ordering remain intact. GPG still discovers Launchers before credential selection, and SSH retains its verified peer Launchers.

Measurements from paired release fixtures:

- History append fixture: 29% lower CPU (448 ms → 318 ms).
- Empty-capability, no-Secret inject handler: 9.594 s → 0.020 s CPU for 30 calls. This excludes XPC verification and target launch.
- Helper-catalog guard: no measurable overall gain. Signature validation remains the main observed CPU cost; full Secret-exchange gains remain unverified.

Validation: release Swift suite passed (322 tests reported, 32 entitlement-gated skips), 11 Rust injection/custody tests passed, and 29 menu-helper self-checks passed. The new corruption regression fails against the original implementation. Independent Standards and security reviews found no concrete issues.

See [the investigation report](docs/cpu-profile-2026-09-09.md) for methodology and limitations. The installed app and production Authorization Policies were unchanged during the investigation.
