### PR TITLE
Fix Homebrew ten-minute access grants across the setuid boundary

### DIFF
--- a/docs/adr/0016-agent-scoped-temporary-access-grants.md
+++ b/docs/adr/0016-agent-scoped-temporary-access-grants.md
@@ -1,6 +1,7 @@
 # ADR 0016: Agent-scoped Temporary Access Grants
 
-Status: accepted
+Status: accepted; Homebrew context transport amended by
+[ADR 0045](0045-homebrew-agent-task-context.md).
 
 ## Context
 

--- a/docs/adr/0045-homebrew-agent-task-context.md
+++ b/docs/adr/0045-homebrew-agent-task-context.md
@@ -22,8 +22,10 @@ The signed brew stub reads its own environment before submitting its single
 Authorization Request and may send `brew_CODEX_THREAD_ID` or
 `brew_CLAUDE_CODE_SESSION_ID` over its existing authenticated XPC connection.
 It sends no context when multiple recognized variables (including duplicate
-entries) are present, or when the selected value is not UTF-8 or exceeds 36
-bytes. These fields are never command-line inputs or Launcher identity claims.
+entries) are present, or when the selected value is not a canonical 36-byte
+UUID: hexadecimal digits with hyphens at the UUID positions. Uppercase and
+lowercase hex are accepted, matching the service's validation. These fields
+are never command-line inputs or Launcher identity claims.
 
 The approval service accepts these fields only from the verified brew stub for
 an `authorize` request with no Secret Names, the `brew` Tool, and the matched

--- a/docs/adr/0045-homebrew-agent-task-context.md
+++ b/docs/adr/0045-homebrew-agent-task-context.md
@@ -1,0 +1,54 @@
+# ADR 0045: Transport Homebrew Agent Task Context through the signed stub
+
+Status: accepted
+
+## Context
+
+The Homebrew Gate Client runs setuid as the dedicated `automic` user. macOS
+withholds its process environment from the approval service's `KERN_PROCARGS2`
+query. Consequently a recognized agent's write request cannot offer or match a
+Temporary Access Grant, even when its Verified Launcher is eligible. A
+byte-identical signed stub running as the invoking user exposes the same task
+variable successfully.
+
+Reading a parent's environment is not equivalent: an agent may set a task UUID
+only for a particular child execution. Removing setuid would break Homebrew's
+protected ownership model. Neither is an appropriate fix.
+
+## Decision
+
+Amend ADR 0016 with one transport exception for the Homebrew Execution Gate.
+The signed brew stub reads its own environment before submitting its single
+Authorization Request and may send `brew_CODEX_THREAD_ID` or
+`brew_CLAUDE_CODE_SESSION_ID` over its existing authenticated XPC connection.
+It sends no context when multiple recognized variables (including duplicate
+entries) are present, or when the selected value is not UTF-8 or exceeds 36
+bytes. These fields are never command-line inputs or Launcher identity claims.
+
+The approval service accepts these fields only from the verified brew stub for
+an `authorize` request with no Secret Names, the `brew` Tool, and the matched
+Homebrew Execution Gate. Each present field must be a 36-byte XPC string; the
+existing Agent Task Context parser requires exactly one provider with a
+canonical UUID. Missing, malformed, oversized or ambiguous context leaves the
+ten-minute option and grant matching unavailable. Other gates continue to use
+live process-environment inspection; SSH remains excluded.
+
+The immutable context belongs to that one request and its live Gate Client.
+Initial matching, queued matching and grant activation use the same resolver.
+The ordinary live process, signature, Verified Launcher, runtime posture,
+operation, empty capability ceiling, expiry and Authorization Record checks
+remain mandatory before allowing execution. No context is inferred from a
+parent or persisted in Authorization History or telemetry.
+
+## Consequences
+
+A task label remains forgeable by same-user software and grants no authority by
+itself. The user still explicitly grants Write Access scoped to a Verified
+Launcher, runtime posture, Homebrew gate and exact task label. The exception
+changes transport, not the identity boundary or allowed operation classes.
+
+The stub version advances so doctor detects older installations for refresh.
+An old stub omits these fields and continues to require ordinary Approval when
+policy does not authorize the request. An old app ignores the new fields and
+continues to withhold temporary grants. Both the updated app and stub are
+required to restore the feature.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,9 +108,19 @@ broader Direct Secret Gate because a diagnostic check is unavailable.
 For recognized agent Launchers, the service may read `CODEX_THREAD_ID` or
 `CLAUDE_CODE_SESSION_ID` directly from the live XPC peer with a bounded
 `KERN_PROCARGS2` query. It accepts only one canonical UUID from exactly one
-provider and adds no client-controlled identity field to XPC. This label is an
-Agent Task Context: same-user software can forge it, so the live Verified
-Launcher remains the identity boundary.
+provider. This label is an Agent Task Context: same-user software can forge it,
+so the live Verified Launcher remains the identity boundary.
+
+The setuid Homebrew Gate Client is the sole transport exception: macOS withholds
+its environment from the approval service. The signed, single-request brew stub
+sends its own bounded provider variable over authenticated XPC. Only a verified
+brew stub making a Secret-free `authorize` request at the Homebrew Execution
+Gate may supply that context. The service applies the same canonical UUID and
+single-provider validation, and uses that request's immutable context for grant
+creation and matching, including queued requests. Live Gate Client, Launcher,
+runtime, capability-ceiling, recording and release checks still apply. Missing
+or invalid context disables Temporary Access Grants without changing ordinary
+Approval. See [ADR 0045](adr/0045-homebrew-agent-task-context.md).
 
 An eligible live write-request Approval can create a Temporary Access Grant
 with an initial ten minutes of active countdown time through an explicit prompt

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -207,6 +207,11 @@ providers are a Codex task identified by a canonical UUID in
 `CODEX_THREAD_ID` and a Claude Code session identified by a canonical UUID in
 `CLAUDE_CODE_SESSION_ID`. Automic Vault accepts a context only when exactly one
 recognized provider variable is present in the live process environment.
+For the setuid Homebrew Gate Client, macOS prevents the approval service from
+inspecting that environment. The signed brew stub transports its own bounded
+provider variable with its single Authorization Request instead. This exception
+applies only at the Homebrew Execution Gate; it supplies no Launcher identity.
+See [ADR 0045](adr/0045-homebrew-agent-task-context.md).
 
 An Agent Task Context is forgeable by software running as the user. It is not
 identity, authentication, or a security boundary and grants no authority by

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -6,7 +6,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V20";
+const MARKER: &str = "AUTOMIC_VAULT_BREW_STUB_V21";
 const TARGET: &str = "/opt/homebrew/bin/brew";
 const PREFIX: &str = "/opt/homebrew";
 const SHELLENV_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
@@ -383,6 +383,28 @@ fn authorization_request(args: &[OsString], cwd: &Path) -> Result<AuthorizationR
     })
 }
 
+// Only a narrowing label; the approval service still verifies the live Launcher.
+// Preserve ambiguity by sending no context if more than one provider is present.
+fn agent_task_environment<I>(source: I) -> Option<(&'static [u8], String)>
+where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    let mut values = source.into_iter().filter_map(|(key, value)| {
+        let field: &'static [u8] = match key.to_str()? {
+            "CODEX_THREAD_ID" => b"brew_CODEX_THREAD_ID\0",
+            "CLAUDE_CODE_SESSION_ID" => b"brew_CLAUDE_CODE_SESSION_ID\0",
+            _ => return None,
+        };
+        Some((field, value))
+    });
+    let (field, value) = values.next()?;
+    if values.next().is_some() {
+        return None;
+    }
+    let value = value.into_string().ok()?;
+    (value.len() <= 36).then_some((field, value))
+}
+
 #[cfg(target_os = "macos")]
 fn xpc_authorize(request: &AuthorizationRequest) -> Result<(), String> {
     use std::os::raw::{c_char, c_int, c_void};
@@ -482,6 +504,9 @@ fn xpc_authorize(request: &AuthorizationRequest) -> Result<(), String> {
         set_string(message, b"target\0", &request.target)?;
         set_string(message, b"cwd\0", &request.cwd)?;
         set_string(message, b"tool\0", "brew")?;
+        if let Some((field, value)) = agent_task_environment(std::env::vars_os()) {
+            set_string(message, field, &value)?;
+        }
         xpc_dictionary_set_bool(message, b"replace_existing_env\0".as_ptr().cast(), false);
         xpc_dictionary_set_bool(message, b"allow_missing_keys\0".as_ptr().cast(), false);
         xpc_dictionary_set_value(message, b"keys\0".as_ptr().cast(), empty);
@@ -582,6 +607,42 @@ where
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn agent_context_transport_is_bounded_and_unambiguous() {
+        use std::os::unix::ffi::OsStringExt;
+        let uuid = "11111111-2222-3333-4444-555555555555";
+        for (variable, field) in [
+            ("CODEX_THREAD_ID", b"brew_CODEX_THREAD_ID\0".as_slice()),
+            (
+                "CLAUDE_CODE_SESSION_ID",
+                b"brew_CLAUDE_CODE_SESSION_ID\0".as_slice(),
+            ),
+        ] {
+            assert_eq!(
+                agent_task_environment([
+                    ("UNRELATED".into(), "ignored".into()),
+                    (variable.into(), uuid.into()),
+                ]),
+                Some((field, uuid.into()))
+            );
+        }
+        for environment in [
+            vec![],
+            vec![("CODEX_THREAD_ID".into(), "x".repeat(37).into())],
+            vec![("CODEX_THREAD_ID".into(), OsString::from_vec(vec![0xff]))],
+            vec![
+                ("CODEX_THREAD_ID".into(), uuid.into()),
+                ("CLAUDE_CODE_SESSION_ID".into(), "malformed".into()),
+            ],
+            vec![
+                ("CODEX_THREAD_ID".into(), uuid.into()),
+                ("CODEX_THREAD_ID".into(), uuid.into()),
+            ],
+        ] {
+            assert_eq!(agent_task_environment(environment), None);
+        }
+    }
 
     #[test]
     fn authorization_request_keeps_exact_args_and_cwd() {

--- a/src/brew_stub/main.rs
+++ b/src/brew_stub/main.rs
@@ -402,7 +402,15 @@ where
         return None;
     }
     let value = value.into_string().ok()?;
-    (value.len() <= 36).then_some((field, value))
+    let canonical = value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        });
+    canonical.then_some((field, value))
 }
 
 #[cfg(target_os = "macos")]
@@ -625,6 +633,28 @@ mod tests {
                     (variable.into(), uuid.into()),
                 ]),
                 Some((field, uuid.into()))
+            );
+        }
+        for invalid in [
+            "",
+            "short",
+            "g1111111-2222-3333-4444-555555555555",
+            "1111111-12222-3333-4444-555555555555",
+            "11111111222223333-4444-555555555555",
+        ] {
+            assert_eq!(
+                agent_task_environment([("CODEX_THREAD_ID".into(), invalid.into())]),
+                None,
+                "forwarded invalid task label: {invalid}"
+            );
+        }
+        for valid in [
+            "abcdefab-cdef-abcd-efab-cdefabcdefab",
+            "ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB",
+        ] {
+            assert_eq!(
+                agent_task_environment([("CODEX_THREAD_ID".into(), valid.into())]),
+                Some((b"brew_CODEX_THREAD_ID\0".as_slice(), valid.into()))
             );
         }
         for environment in [

--- a/src/isotopes/hardeners/homebrew.rs
+++ b/src/isotopes/hardeners/homebrew.rs
@@ -24,8 +24,8 @@ const BREW_USER_UID_FILE: &str = "var/automic/user-uid";
 const LEGACY_CASK_USER_UID_FILE: &str = "var/automic/cask-user-uid";
 const STUB_MARKER_PREFIX: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V";
 #[cfg(test)]
-const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V20";
-const STUB_VERSION: u32 = 20;
+const STUB_MARKER: &[u8] = b"AUTOMIC_VAULT_BREW_STUB_V21";
+const STUB_VERSION: u32 = 21;
 const ID_RANGE: std::ops::RangeInclusive<u32> = 550..=599;
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3055,6 +3055,125 @@ private func agentTaskContext(pid: pid_t) -> AgentTaskContext? {
     return AgentTaskContext(environment: environment)
 }
 
+// Resolve task context only after ordinary Gate Client and gate verification.
+private func agentTaskContext(
+    for request: ApprovalRequest,
+    identity: AVProcessIdentity,
+    gateID: String?,
+    callerPath: String,
+    signing: SigningInfo,
+    message: xpc_object_t
+) -> AgentTaskContext? {
+    var current = AVProcessIdentity()
+    guard request.sshPeer == nil,
+          av_process_identity(identity.pid, &current), sameProcessIdentity(identity, current),
+          pathString(identity) == pathString(current)
+    else { return nil }
+    guard gateID == "brew", request.op == "authorize", request.tool == "brew",
+          request.keys.isEmpty, isTrustedBrewStubCaller(path: callerPath, signing: signing)
+    else { return agentTaskContext(pid: identity.pid) }
+
+    // macOS withholds the setuid stub's environment. Its signed, single-request
+    // Gate Client supplies only this forgeable narrowing label (ADR 0045).
+    var environment: [String: String] = [:]
+    for provider in AgentProvider.allCases {
+        let field = "brew_\(provider.environmentVariable)"
+        guard let value = xpc_dictionary_get_value(message, field) else { continue }
+        guard xpc_get_type(value) == XPC_TYPE_STRING,
+              xpc_string_get_length(value) == 36,
+              let pointer = xpc_string_get_string_ptr(value),
+              let string = String(validatingCString: pointer)
+        else { return nil }
+        environment[provider.environmentVariable] = string
+    }
+    return AgentTaskContext(environment: environment)
+}
+
+private func brewAgentTaskContextSelfCheck() -> Bool {
+    // No readable task environment: exercise the transported context with a live peer.
+    let process = Process()
+    guard let executable = Bundle.main.executableURL else { return false }
+    process.executableURL = executable
+    process.arguments = ["--self-check-sleep"]
+    process.environment = [:]
+    do { try process.run() } catch { return false }
+    defer {
+        if process.isRunning { process.terminate() }
+        process.waitUntilExit()
+    }
+    var identity = AVProcessIdentity()
+    guard av_process_identity(process.processIdentifier, &identity) else { return false }
+    let message = xpc_dictionary_create_empty()
+    let uuid = "11111111-2222-3333-4444-555555555555"
+    uuid.withCString { xpc_dictionary_set_string(message, "brew_CODEX_THREAD_ID", $0) }
+    let request = ApprovalRequest(
+        op: "authorize", keys: [], target: "/opt/homebrew/bin/brew",
+        args: ["install", "--formula", "tree"], cwd: "/tmp",
+        replaceExistingEnv: false, allowMissingKeys: false, envConflicts: [],
+        shebangScript: nil, scriptData: nil, tool: "brew", title: nil, detail: nil
+    )
+    func context(
+        gateID: String? = "brew",
+        callerPath: String = "/usr/local/bin/brew",
+        identifier: String = "com.automicvault.av-brew-stub",
+        identity: AVProcessIdentity = identity,
+        request: ApprovalRequest = request
+    ) -> AgentTaskContext? {
+        agentTaskContext(
+            for: request, identity: identity, gateID: gateID, callerPath: callerPath,
+            signing: SigningInfo(identifier: identifier, teamIdentifier: "ZU76A67LGU"),
+            message: message
+        )
+    }
+    let expected = AgentTaskContext(provider: .codex, id: UUID(uuidString: uuid)!)
+    guard context() == expected else {
+        print("brew task context unavailable when the peer environment cannot be read")
+        return false
+    }
+    let launcher = LauncherIdentity(
+        pid: 41, path: "/Applications/Codex.app/Contents/MacOS/Codex",
+        identifier: "com.openai.codex", teamIdentifier: "TEAM",
+        designatedRequirement: "identifier com.openai.codex", runtimeProtection: .hardened
+    )
+    let gate = SecretGate(id: "brew", keyPatterns: [], routes: [], defaultProtection: .noAccess, appPolicies: [])
+    guard let candidate = temporaryAccessGrantCandidate(
+        gate: gate, classification: brewRequestClassification(request.args),
+        launcher: launcher, agentTaskContext: context()
+    ), candidate.scope.agentTaskContext == expected,
+       candidate.scope.matches(
+           authorizationGateID: "brew", launcherDesignatedRequirement: launcher.designatedRequirement,
+           launcherRuntimeProtection: .hardened, agentTaskContext: expected,
+           classification: brewRequestClassification(["upgrade", "--formula", "tree"])
+       ),
+       context(gateID: "gh") == nil,
+       context(gateID: nil) == nil,
+       context(identifier: "com.automicvault.av") == nil,
+       context(callerPath: "/usr/local/bin/unrelated") == nil,
+       context(request: request.requesting(keys: ["SECRET"], title: "", detail: "")) == nil
+    else { return false }
+
+    // Both providers, malformed UUIDs, oversized strings and wrong XPC types fail closed.
+    uuid.withCString { xpc_dictionary_set_string(message, "brew_CLAUDE_CODE_SESSION_ID", $0) }
+    guard context() == nil else { return false }
+    xpc_dictionary_set_value(message, "brew_CODEX_THREAD_ID", nil)
+    guard context() == AgentTaskContext(provider: .claudeCode, id: expected.id) else { return false }
+    for invalid in ["", String(repeating: "x", count: 36), uuid + "x"] {
+        invalid.withCString { xpc_dictionary_set_string(message, "brew_CLAUDE_CODE_SESSION_ID", $0) }
+        guard context() == nil else { return false }
+    }
+    xpc_dictionary_set_int64(message, "brew_CLAUDE_CODE_SESSION_ID", 1)
+    guard context() == nil else { return false }
+    xpc_dictionary_set_value(message, "brew_CLAUDE_CODE_SESSION_ID", nil)
+    guard context() == nil else { return false }
+    uuid.withCString { xpc_dictionary_set_string(message, "brew_CODEX_THREAD_ID", $0) }
+    var changedIdentity = identity
+    changedIdentity.start_usec &+= 1
+    guard context(identity: changedIdentity) == nil, context() == expected else { return false }
+    process.terminate()
+    process.waitUntilExit()
+    return context() == nil
+}
+
 private func processEnvironmentValueSelfCheck() -> Bool {
     let expected = "11111111-2222-3333-4444-555555555555"
     let process = Process()
@@ -4271,7 +4390,10 @@ private final class ApprovalServer: @unchecked Sendable {
         let classification = configuredGate.map {
             classifySecretGateRequest(gateID: $0.id, request: request)
         }
-        let currentAgentTaskContext = request.sshPeer == nil ? agentTaskContext(pid: pid) : nil
+        let currentAgentTaskContext = agentTaskContext(
+            for: request, identity: identity, gateID: configuredGate?.id,
+            callerPath: callerPath, signing: signing, message: message
+        )
         let retainedProcessExplanation: String?
         if !keepsDetachedProcessAccess,
            retainedBlessingMatch != nil,
@@ -4594,7 +4716,10 @@ private final class ApprovalServer: @unchecked Sendable {
                        let configuredGate,
                        let classification,
                        request.sshPeer == nil,
-                       let currentAgentTaskContext = agentTaskContext(pid: pid),
+                       let currentAgentTaskContext = agentTaskContext(
+                           for: request, identity: identity, gateID: configuredGate.id,
+                           callerPath: currentCallerPath, signing: currentSigning, message: message
+                       ),
                        self.handleTemporaryAccessGrant(
                            request: request,
                            gate: configuredGate,
@@ -4763,7 +4888,10 @@ private final class ApprovalServer: @unchecked Sendable {
                           gate: configuredGate,
                           classification: classification,
                           launcher: liveLauncher,
-                          agentTaskContext: agentTaskContext(pid: pid)
+                          agentTaskContext: agentTaskContext(
+                              for: request, identity: identity, gateID: configuredGate?.id,
+                              callerPath: callerPath, signing: signing, message: message
+                          )
                       ),
                       refreshedCandidate.scope == originalCandidate.scope
                 else {
@@ -13646,6 +13774,7 @@ private func runApprovalSelfCheck() -> Int32 {
         print("SSH command and npm invocation presentation self-check failed")
         return 1
     }
+    guard brewAgentTaskContextSelfCheck() else { return 1 }
     guard processEnvironmentValueSelfCheck() else {
         print("bounded peer environment self-check failed")
         return 2


### PR DESCRIPTION
Homebrew's setuid brew stub makes its process environment unreadable to the approval service, so eligible agent write requests cannot offer or match ten-minute Temporary Access Grants.

The signed stub now transports its bounded task/session label through the existing authenticated XPC request. The service accepts it only for Secret-free Homebrew authorization requests from the verified brew stub, validates one canonical provider UUID, and checks the originating process before initial matching, queued matching, and activation. Existing Launcher, runtime, capability-ceiling, and recording requirements remain in force. ADR 0045 records this transport exception; stub version 21 makes older installations detectable for refresh. Both the updated app and refreshed stub are needed to activate the fix.

Validation:
- Reproduced the eligibility failure before the fix, then passed the regression check.
- Covered both providers, malformed/ambiguous/oversized labels, wrong callers/gates, and exited or identity-changed clients.
- 35 focused Rust tests, 322 Swift tests, and all 29 menu-helper self-checks passed.
- Formatting and diff checks passed.
