### PR TITLE
Refresh detectors when non-file state changes

### DIFF
--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -74,6 +74,7 @@ fn json_detectors(home: &Path) -> Vec<serde_json::Value> {
                 "homepage": detector.homepage,
                 "docs_url": detector.docs_url,
                 "documentation": detector.documentation,
+                "requires_periodic_scan": detector.requires_periodic_scan,
                 "watch_scopes": detector.watch_scopes.into_iter().map(|scope| serde_json::json!({
                     "path": scope.path,
                     "recursive": scope.recursive,
@@ -601,6 +602,30 @@ mod tests {
         assert!(output.contains(r#""name":"git-credentials-file""#));
         assert!(output.contains(r##""documentation":"# git-credential-fill Detector"##));
         assert!(output.contains(r#""watch_scopes":[{"path":"#));
+    }
+
+    #[test]
+    fn detectors_with_non_file_state_require_periodic_scans_even_when_clean() {
+        // Metadata, not last-scan findings, must opt in: the first exposure has
+        // no affected path to watch either.
+        let detectors = json_detectors(Path::new("/Users/fixture"));
+        let periodic = detectors
+            .iter()
+            .filter(|detector| detector["requires_periodic_scan"] == true)
+            .map(|detector| detector["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            periodic,
+            [
+                "cloudflare-wrangler",
+                "gh-cli-keychain-access",
+                "git-credential-fill",
+                "macOS",
+                "sip",
+                "stripe-cli",
+                "sudo",
+            ]
+        );
     }
 
     #[test]

--- a/src/isotopes/detectors/mod.rs
+++ b/src/isotopes/detectors/mod.rs
@@ -164,6 +164,7 @@ pub(crate) struct DetectorMetadata {
     pub(crate) docs_url: String,
     pub(crate) documentation: &'static str,
     pub(crate) watch_scopes: Vec<DetectorWatchScope>,
+    pub(crate) requires_periodic_scan: bool,
 }
 
 pub(crate) struct DetectorWatchScope {
@@ -558,6 +559,19 @@ pub(crate) fn metadata(home: &Path) -> Vec<DetectorMetadata> {
                 documentation: detector.documentation,
                 homepage: detector.docs_url.to_string(),
                 docs_url: detector.docs_url.to_string(),
+                // Keychain metadata, launchd environment, and system state can
+                // change without writing any declared watch scope. Opt in even
+                // while clean, so the first exposure is discovered too.
+                requires_periodic_scan: matches!(
+                    name.as_str(),
+                    "cloudflare-wrangler"
+                        | "gh-cli-keychain-access"
+                        | "git-credential-fill"
+                        | "macOS"
+                        | "sip"
+                        | "stripe-cli"
+                        | "sudo"
+                ),
                 name,
                 watch_scopes: sensitive_file_scopes(detector.documentation, home),
             }

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -294,6 +294,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func startServices() {
+        servicesStopped = false
         if isStartingUp {
             isStartingUp = false
             updateMenuVisibility(
@@ -860,6 +861,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func scheduleScan(detectors: Set<String>? = nil, after delay: TimeInterval) {
+        guard !servicesStopped else { return }
         if let detectors, !pendingFullScan {
             pendingScanDetectors.formUnion(scanDetectorGroup(detectors))
         } else if detectors == nil {
@@ -16974,9 +16976,15 @@ extension AppDelegate {
         applyScanResult(.success([], nil))
         guard !fullScanFailed, scanStatusItem.title == "No Vulnerabilities Detected" else { return false }
         stopServices()
+        // A timer or watcher callback already enqueued before cancellation
+        // must not leave scan work behind while services are stopped.
+        schedulePeriodicDetectorScan()
+        scheduleScan(detectors: ["npm"], after: 0)
+        scheduleScan(after: 0)
         applyScanResult(.success([], nil))
         startDetectorWatchers()
         return periodicDetectorPoller == nil && missingFilePoller == nil
+            && scanWorkItem == nil && !pendingFullScan && pendingScanDetectors.isEmpty
     }
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -19,6 +19,7 @@ private let pendingSecretGateKey = "pendingSecretGate"
 private let varlockProtocolVersion: UInt64 = 1
 let secCodeSignatureAdHoc: UInt32 = 0x2
 private let scanMaximumDelay: TimeInterval = 5
+private let periodicDetectorScanInterval: TimeInterval = 5 * 60
 private let scanQueue = DispatchQueue(label: "com.automicvault.av2.scan")
 private let temporaryAccessGrantCollapseDelay: TimeInterval = 5
 private let updateCheckInterval: Duration = .seconds(24 * 60 * 60)
@@ -87,7 +88,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var scanBurstStartedAt: TimeInterval?
     private var pendingFullScan = false
     private var pendingScanDetectors = Set<String>()
+    private var servicesStopped = false
     private var isScanRunning = false
+    private var failedScanDetectors = Set<String>()
+    private var fullScanFailed = false
     private var latestDetectorFindings: [DetectorFinding] = []
     private var detectorMetadata: [DetectorMetadata] = []
     private var eventStream: FSEventStreamRef?
@@ -95,6 +99,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var fileWatchSources: [DispatchSourceFileSystemObject] = []
     private var missingFileWatchDetectors: [String: Set<String>] = [:]
     private var missingFilePoller: DispatchSourceTimer?
+    private var periodicDetectorPoller: DispatchSourceTimer?
     private var mainWindow: NSWindow?
     private var isUserSessionActive = true
     private var areScreensAwake = true
@@ -382,6 +387,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func stopServices() {
+        servicesStopped = true
         sshAgent.stop()
         temporaryAccessGrants.cancelAll()
         refreshTemporaryAccessGrants()
@@ -401,6 +407,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         scanWorkItem = nil
         scanBurstStartedAt = nil
         stopDetectorWatchers()
+        periodicDetectorPoller?.cancel()
+        periodicDetectorPoller = nil
         approval?.stop()
         approval = nil
     }
@@ -679,6 +687,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func startDetectorWatchers() {
+        guard !servicesStopped else { return }
         stopDetectorWatchers()
         let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
         var exact = [String: Set<String>]()
@@ -738,6 +747,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         recursiveWatchDetectors = recursive
         startRecursiveWatcher(paths: Array(recursive.keys))
         startMissingFilePoller()
+        startPeriodicDetectorPoller()
     }
 
     private func startRecursiveWatcher(paths: [String]) {
@@ -786,6 +796,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if !detectors.isEmpty {
             scheduleScan(detectors: detectors, after: 1)
         }
+    }
+
+    private func startPeriodicDetectorPoller() {
+        // Watchers are rebuilt after every scan. Keep this independent so
+        // unrelated file activity cannot postpone a non-file state refresh.
+        guard periodicDetectorPoller == nil,
+              detectorMetadata.contains(where: \.requiresPeriodicScan) else { return }
+        let poller = DispatchSource.makeTimerSource(queue: .main)
+        poller.schedule(
+            deadline: .now() + periodicDetectorScanInterval,
+            repeating: periodicDetectorScanInterval,
+            leeway: .seconds(15)
+        )
+        poller.setEventHandler { [weak self] in
+            self?.schedulePeriodicDetectorScan()
+        }
+        poller.resume()
+        periodicDetectorPoller = poller
+    }
+
+    private func schedulePeriodicDetectorScan() {
+        let detectors = Set(detectorMetadata.filter(\.requiresPeriodicScan).map(\.name))
+        guard !detectors.isEmpty else { return }
+        // Reuse the single-flight queue: timer and file events coalesce, with
+        // at most one pending refresh while a scan is already running.
+        scheduleScan(detectors: detectors, after: 0)
     }
 
     private func startMissingFilePoller() {
@@ -847,7 +883,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func runPendingScan() {
-        guard !isScanRunning, pendingFullScan || !pendingScanDetectors.isEmpty else { return }
+        guard !servicesStopped, !isScanRunning, pendingFullScan || !pendingScanDetectors.isEmpty else { return }
         let detectors = pendingFullScan ? nil : pendingScanDetectors
         pendingFullScan = false
         pendingScanDetectors.removeAll()
@@ -862,14 +898,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func applyScanResult(_ result: ScanResult) {
         isScanRunning = false
+        guard !servicesStopped else { return }
         switch result {
         case .success(let findings, let detectors):
             if let detectors {
+                failedScanDetectors.subtract(detectors)
                 latestDetectorFindings.removeAll {
                     !Set($0.detectors).isDisjoint(with: detectors)
                 }
                 latestDetectorFindings.append(contentsOf: findings)
             } else {
+                failedScanDetectors.removeAll()
+                fullScanFailed = false
                 latestDetectorFindings = findings
             }
             if !detectorMetadata.isEmpty {
@@ -904,7 +944,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     image: shieldImage(color: level.color)
                 )
             }
-        case .failed:
+        case .failed(let detectors):
+            if let detectors {
+                failedScanDetectors.formUnion(detectors)
+            } else {
+                fullScanFailed = true
+            }
+        }
+        // A successful unrelated partial scan cannot certify a failed check.
+        if fullScanFailed || !failedScanDetectors.isEmpty {
             setBaseStatusImage(brandImage(color: .systemRed))
             setScanStatus("Scan failed", image: shieldImage(color: .systemRed))
         }
@@ -1883,7 +1931,7 @@ private func resolvedShebangScriptPath(_ request: ApprovalRequest) -> String? {
 
 private enum ScanResult {
     case success([DetectorFinding], Set<String>?)
-    case failed
+    case failed(Set<String>?)
 }
 
 private func boundedScanDelay(
@@ -1937,7 +1985,7 @@ private func scanResult(detectors: Set<String>?) -> ScanResult {
     do {
         try process.run()
     } catch {
-        return .failed
+        return .failed(detectors)
     }
 
     let data = output.fileHandleForReading.readDataToEndOfFile()
@@ -1945,7 +1993,7 @@ private func scanResult(detectors: Set<String>?) -> ScanResult {
     guard process.terminationStatus == 0,
           let findings = try? detectorFindings(from: data)
     else {
-        return .failed
+        return .failed(detectors)
     }
     return .success(findings, detectors)
 }
@@ -16847,6 +16895,7 @@ private func runMenuStatusSelfCheck() -> Int32 {
     return 0
 }
 
+@MainActor
 private func runScanSchedulingSelfCheck() -> Int32 {
     var burstStartedAt: TimeInterval?
     guard boundedScanDelay(
@@ -16868,11 +16917,67 @@ private func runScanSchedulingSelfCheck() -> Int32 {
         maximumDelay: 5
     ) == 0,
     scanDetectorGroup(["npm"]) == ["npm"],
-    scanDetectorGroup(["bash"]) == ["bash", "zsh"]
+    scanDetectorGroup(["bash"]) == ["bash", "zsh"],
+    AppDelegate().checkPeriodicDetectorRefresh()
     else {
         return 1
     }
     return 0
+}
+
+extension AppDelegate {
+    fileprivate func checkPeriodicDetectorRefresh() -> Bool {
+        detectorMetadata = [
+            DetectorMetadata(name: "git-credential-fill", homepage: "", docsURL: "", requiresPeriodicScan: true),
+            DetectorMetadata(name: "npm", homepage: "", docsURL: ""),
+        ]
+        defer { stopServices() }
+        startDetectorWatchers()
+        guard let poller = periodicDetectorPoller else { return false }
+        let timerIdentity = ObjectIdentifier(poller as AnyObject)
+
+        // Start clean, change only non-file state, and invoke the timer's real
+        // callback. No filesystem event, credential probe, or real CLI runs.
+        isScanRunning = true
+        schedulePeriodicDetectorScan()
+        scheduleScan(detectors: ["npm"], after: 1)
+        schedulePeriodicDetectorScan()
+        runPendingScan()
+        guard !pendingFullScan,
+              pendingScanDetectors == ["git-credential-fill", "npm"],
+              isScanRunning else { return false }
+        scheduleScan(after: 0)
+        schedulePeriodicDetectorScan()
+        guard pendingFullScan, pendingScanDetectors.isEmpty else { return false }
+        scanWorkItem?.cancel()
+        scanWorkItem = nil
+        pendingFullScan = false
+
+        let json = Data(#"{"findings":[{"source":"git-credential-fill","severity":"high","affected":[]},{"source":"npm","severity":"high","affected":[]}]}"#.utf8)
+        guard let findings = try? detectorFindings(from: json) else { return false }
+        applyScanResult(.success(findings, nil))
+        guard latestDetectorFindings.count == 2,
+              let retainedPoller = periodicDetectorPoller,
+              ObjectIdentifier(retainedPoller as AnyObject) == timerIdentity else { return false }
+        applyScanResult(.failed(["git-credential-fill"]))
+        guard latestDetectorFindings.count == 2, scanStatusItem.title == "Scan failed" else { return false }
+        applyScanResult(.success([findings[1]], ["npm"]))
+        guard scanStatusItem.title == "Scan failed" else { return false }
+        // Remediation clears just the refreshed detector; unrelated findings
+        // and the timer's original deadline survive the partial result.
+        applyScanResult(.success([], ["git-credential-fill"]))
+        guard latestDetectorFindings.map(\.source) == ["npm"],
+              failedScanDetectors.isEmpty, scanStatusItem.title != "Scan failed" else { return false }
+        applyScanResult(.failed(nil))
+        applyScanResult(.success([], ["git-credential-fill"]))
+        guard scanStatusItem.title == "Scan failed" else { return false }
+        applyScanResult(.success([], nil))
+        guard !fullScanFailed, scanStatusItem.title == "No Vulnerabilities Detected" else { return false }
+        stopServices()
+        applyScanResult(.success([], nil))
+        startDetectorWatchers()
+        return periodicDetectorPoller == nil && missingFilePoller == nil
+    }
 }
 
 @MainActor

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -156,6 +156,7 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
     public let docsURL: String
     public let documentation: String
     public let watchScopes: [DetectorWatchScope]
+    public let requiresPeriodicScan: Bool
 
     public var displayName: DetectorDisplayName {
         detectorDisplayName(name)
@@ -166,13 +167,15 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
         homepage: String,
         docsURL: String,
         documentation: String = "",
-        watchScopes: [DetectorWatchScope] = []
+        watchScopes: [DetectorWatchScope] = [],
+        requiresPeriodicScan: Bool = false
     ) {
         self.name = name
         self.homepage = homepage
         self.docsURL = docsURL
         self.documentation = documentation
         self.watchScopes = watchScopes
+        self.requiresPeriodicScan = requiresPeriodicScan
     }
 
     public init(from decoder: Decoder) throws {
@@ -182,6 +185,7 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
         self.docsURL = try container.decode(String.self, forKey: .docsURL)
         self.documentation = try container.decodeIfPresent(String.self, forKey: .documentation) ?? ""
         self.watchScopes = try container.decodeIfPresent([DetectorWatchScope].self, forKey: .watchScopes) ?? []
+        self.requiresPeriodicScan = try container.decodeIfPresent(Bool.self, forKey: .requiresPeriodicScan) ?? false
     }
 
     enum CodingKeys: String, CodingKey {
@@ -190,6 +194,7 @@ public struct DetectorMetadata: Codable, Equatable, Sendable {
         case docsURL = "docs_url"
         case documentation
         case watchScopes = "watch_scopes"
+        case requiresPeriodicScan = "requires_periodic_scan"
     }
 }
 

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -59,7 +59,7 @@ import Testing
 
 @Test func detectorMetadataDecodesAllDetectors() throws {
     let data = Data("""
-    {"detectors":[{"name":"git","homepage":"https://git-scm.com/","docs_url":"https://example.test/git","documentation":"# git Detector","watch_scopes":[{"path":"/Users/tester/.gitconfig","recursive":false}]}]}
+    {"detectors":[{"name":"git","homepage":"https://git-scm.com/","docs_url":"https://example.test/git","documentation":"# git Detector","requires_periodic_scan":true,"watch_scopes":[{"path":"/Users/tester/.gitconfig","recursive":false}]}]}
     """.utf8)
 
     #expect(try detectorMetadata(from: data) == [
@@ -68,7 +68,8 @@ import Testing
             homepage: "https://git-scm.com/",
             docsURL: "https://example.test/git",
             documentation: "# git Detector",
-            watchScopes: [DetectorWatchScope(path: "/Users/tester/.gitconfig", recursive: false)]
+            watchScopes: [DetectorWatchScope(path: "/Users/tester/.gitconfig", recursive: false)],
+            requiresPeriodicScan: true
         )
     ])
 }


### PR DESCRIPTION
The dashboard can remain clean after a Keychain credential appears, or flagged after it is removed, because neither change produces an event in the detector’s file watch scopes.

Add explicit detector metadata for periodic refresh of Git/gh/Stripe/Wrangler Keychain checks, launchd PATH, SIP, and sudo biometric state. The menu app schedules only these seven detectors every five minutes, including when their last result was clean. It reuses the existing single-flight scan queue and coalesces file events and full scans. Watcher rebuilds retain the timer’s deadline; shutdown cancels it and ignores late completions.

Failed checks retain their previous findings and the red “Scan failed” status until those checks succeed. An unrelated successful partial scan cannot erase that failure. A failed full scan requires a successful full scan; the existing toolbar refresh provides that retry.

Validation:
- Metadata regression failed before the fix and passes after it.
- Executable scheduling self-check fails with watcher-only startup and passes with the timer. Fixtures cover clean-to-flagged-to-remediated state, partial/full coalescing, no concurrent scan, timer retention, failure retention/recovery, and shutdown.
- `cargo test --all-targets --all-features --locked`: 1,160 passed, 1 ignored.
- `swift test --package-path src/menu-helper --disable-automatic-resolution`: 322 passed.
- `scripts/test-menu-helper-self-checks.sh src/menu-helper/.build/debug/AutomicVaultMenubar`: all 29 executable self-checks pass.
- `cargo fmt --all -- --check` and `git diff --check` pass.

Security and limits: existing passive detector behavior is unchanged; no configured credential helpers or Secret Use are introduced. Validation used fixtures, not real credential probes. Non-file changes are eventually refreshed while the app runs: roughly five minutes plus up to 15 seconds of timer leeway and existing scan queue/runtime delay, with no sleep-time guarantee. File-driven detectors continue to use file events; no periodic full scan was added.

Fixes #231.
