### PR TITLE
Explain Available While Locked in Secret errors

### DIFF
--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -10,13 +10,16 @@ public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable 
     case selectedValueInvalidUTF8(String)
     case selectedValueEmpty(String)
 
+    private static let availabilityGuidance = "Unlock the Mac and retry. You can allow Automic Vault to access the needed Secrets while locked: enable Available While Locked for them in the Automic Vault app. Authorization is still required. Login and credential changes may still require unlocking."
+
     public var errorDescription: String? {
         switch self {
         case .repairFailed(let status):
             "secret repair must complete before this request: \(status)"
-        case .inventoryUnavailable(let status) where status == errSecInteractionNotAllowed,
-             .selectedValueUnavailable(_, let status) where status == errSecInteractionNotAllowed:
-            "Secrets are unavailable from Keychain. Unlock the Mac and retry. To use Secrets while locked, enable Available While Locked for the needed Secrets in the Automic Vault app. Login and credential changes may still require unlocking. (\(status))"
+        case .inventoryUnavailable(let status) where status == errSecInteractionNotAllowed:
+            "Secrets are unavailable from Keychain. \(Self.availabilityGuidance) (\(status))"
+        case .selectedValueUnavailable(let name, let status) where status == errSecInteractionNotAllowed:
+            "Secret \(name) is unavailable from Keychain. \(Self.availabilityGuidance) (\(status))"
         case .inventoryUnavailable(let status):
             "failed to inspect stored Secrets: \(status)"
         case .secretMissing(let name):

--- a/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/SecretValueCustody.swift
@@ -14,8 +14,9 @@ public enum SecretValueCustodyError: Error, Equatable, LocalizedError, Sendable 
         switch self {
         case .repairFailed(let status):
             "secret repair must complete before this request: \(status)"
-        case .inventoryUnavailable(let status) where status == errSecInteractionNotAllowed:
-            "Stored Secrets are unavailable from Keychain. Unlock the Mac and retry. (\(status))"
+        case .inventoryUnavailable(let status) where status == errSecInteractionNotAllowed,
+             .selectedValueUnavailable(_, let status) where status == errSecInteractionNotAllowed:
+            "Secrets are unavailable from Keychain. Unlock the Mac and retry. To use Secrets while locked, enable Available While Locked for the needed Secrets in the Automic Vault app. Login and credential changes may still require unlocking. (\(status))"
         case .inventoryUnavailable(let status):
             "failed to inspect stored Secrets: \(status)"
         case .secretMissing(let name):

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
@@ -211,7 +211,12 @@ func unavailableSecretExplainsAvailabilitySetting(error: SecretValueCustodyError
     #expect(error.localizedDescription.contains("Unlock the Mac and retry"))
     #expect(error.localizedDescription.contains("enable Available While Locked"))
     #expect(error.localizedDescription.contains("Automic Vault app"))
+    #expect(error.localizedDescription.contains("allow Automic Vault to access"))
+    #expect(error.localizedDescription.contains("Authorization is still required"))
     #expect(error.localizedDescription.contains("Login and credential changes may still require unlocking"))
+    if case .selectedValueUnavailable(let name, _) = error {
+        #expect(error.localizedDescription.contains("Secret \(name) is unavailable"))
+    }
     #expect(!SecretValueCustodyError.inventoryUnavailable(errSecNotAvailable)
         .localizedDescription.contains("Available While Locked"))
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/SecretValueCustodyTests.swift
@@ -203,6 +203,19 @@ func lockedSecretIsUnavailableRatherThanMissing(hasOtherAvailableSecret: Bool) t
     }
 }
 
+@Test(arguments: [
+    SecretValueCustodyError.inventoryUnavailable(errSecInteractionNotAllowed),
+    .selectedValueUnavailable("GH_TOKEN_GITHUB_COM", errSecInteractionNotAllowed),
+])
+func unavailableSecretExplainsAvailabilitySetting(error: SecretValueCustodyError) {
+    #expect(error.localizedDescription.contains("Unlock the Mac and retry"))
+    #expect(error.localizedDescription.contains("enable Available While Locked"))
+    #expect(error.localizedDescription.contains("Automic Vault app"))
+    #expect(error.localizedDescription.contains("Login and credential changes may still require unlocking"))
+    #expect(!SecretValueCustodyError.inventoryUnavailable(errSecNotAvailable)
+        .localizedDescription.contains("Available While Locked"))
+}
+
 @Test func availableWhileLockedSecretRemainsUsable() throws {
     let cwd = try canonicalProjectDirectory(FileManager.default.temporaryDirectory.path)
     let secret = StoredSecret(account: "GH_TOKEN_GITHUB_COM", accessibility: .afterFirstUnlock, values: [


### PR DESCRIPTION
When Keychain refuses Secret access with `errSecInteractionNotAllowed`, explain that users can enable **Available While Locked** for the needed Secrets in the Automic Vault app. Keep the immediate unlock-and-retry advice and clarify that login and credential changes may still require unlocking.

Apply the same diagnostic to inventory and selected-value failures. Other Keychain statuses retain their existing errors; authorization and availability behavior are unchanged. [The companion gh Isotope change](https://github.com/automic-vault/gh-cli/pull/6) prints this diagnostic even when upstream token lookups discard the error.

Addresses #308.

Validation: all 323 Swift tests pass, including both availability-error variants and existing locked-inventory/Secret-use tests. Tests use fixtures without accessing real Secrets.
