### PR TITLE
Explain Launcher path collisions in the Hardener failure

### DIFF
--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -8071,8 +8071,18 @@ fn find_target(stub: &StubSpec) -> Result<PathBuf, String> {
     {
         return Ok(target);
     }
-    find_target_on_path(stub.command)
-        .ok_or_else(|| format!("{} is not installed on PATH", stub.command))
+    find_target_on_path(stub.command).ok_or_else(|| {
+        if super::executable(&launcher) && !is_managed_stub(&launcher, stub) {
+            format!(
+                "cannot harden {}: {} occupies the reserved Automic Vault Launcher path, and no separate Target was found on PATH. Review and preserve this executable, then move or reinstall the Target elsewhere on PATH, leaving {} absent before retrying hardening.",
+                stub.command,
+                launcher.display(),
+                launcher.display()
+            )
+        } else {
+            format!("{} is not installed on PATH", stub.command)
+        }
+    })
 }
 
 fn find_target_on_path(command: &str) -> Option<PathBuf> {

--- a/src/isotopes/hardeners/env_wrapper.rs
+++ b/src/isotopes/hardeners/env_wrapper.rs
@@ -8074,7 +8074,7 @@ fn find_target(stub: &StubSpec) -> Result<PathBuf, String> {
     find_target_on_path(stub.command).ok_or_else(|| {
         if super::executable(&launcher) && !is_managed_stub(&launcher, stub) {
             format!(
-                "cannot harden {}: {} occupies the reserved Automic Vault Launcher path, and no separate Target was found on PATH. Review and preserve this executable, then move or reinstall the Target elsewhere on PATH, leaving {} absent before retrying hardening.",
+                "{}: {} occupies the reserved Automic Vault Launcher path, and no separate Target was found on PATH. Review and preserve this executable, then move or reinstall the Target elsewhere on PATH, leaving {} absent before retrying hardening.",
                 stub.command,
                 launcher.display(),
                 launcher.display()

--- a/tests/harden_cli.rs
+++ b/tests/harden_cli.rs
@@ -5,6 +5,61 @@ use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
+fn harden_explains_launcher_collisions_without_changing_files() {
+    for command in ["sentry-cli", "doctl"] {
+        let root = fixture(command);
+        prepare(&root, command);
+        let launcher = root.join("stubs").join(command);
+        let target = root.join("targets").join(command);
+        // An executable in the working directory is not a Target unless on PATH.
+        fs::rename(&target, root.join(command)).unwrap();
+        let config = root.join("doctl.yaml");
+        let credentials = "access-token: do_secret\ncontext: default\n";
+        fs::write(&config, credentials).unwrap();
+
+        let mut harden = av(&root, command);
+        harden
+            .env_remove("AUTOMIC_VAULT_TEST_ENV_WRAPPER_TARGET_DIR")
+            .env("PATH", root.join("stubs"))
+            .env("DIGITALOCEAN_CONFIG", &config)
+            .current_dir(&root);
+
+        let missing = harden.output().unwrap();
+        assert!(!missing.status.success());
+        assert!(stderr(&missing).contains(&format!("{command} is not installed on PATH")));
+
+        fs::copy(root.join(command), &launcher).unwrap();
+        let original = fs::read(&launcher).unwrap();
+        let collision = harden.output().unwrap();
+        assert!(!collision.status.success());
+        let error = stderr(&collision);
+        assert!(error.contains(&format!("cannot harden {command}: {}", launcher.display())));
+        assert!(error.contains("reserved Automic Vault Launcher path"));
+        assert!(error.contains("no separate Target was found on PATH"));
+        assert!(error.contains("Review and preserve this executable"));
+        assert!(error.contains("leaving"));
+        assert!(stdout(&collision).is_empty());
+        assert_eq!(fs::read(&launcher).unwrap(), original);
+        assert_eq!(fs::read_to_string(&config).unwrap(), credentials);
+        assert!(!root.join("keychain").exists());
+
+        // A separate Target still cannot authorize overwriting the occupant.
+        fs::copy(root.join(command), &target).unwrap();
+        harden.env(
+            "PATH",
+            std::env::join_paths([root.join("stubs"), root.join("targets")]).unwrap(),
+        );
+        let occupied = harden.output().unwrap();
+        assert!(!occupied.status.success());
+        assert!(stderr(&occupied).contains("is not an Automic Vault env-wrapper stub"));
+        assert_eq!(fs::read(&launcher).unwrap(), original);
+        assert_eq!(fs::read_to_string(&config).unwrap(), credentials);
+        assert!(!root.join("keychain").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+}
+
+#[test]
 fn harden_installs_stub_then_migrates_direct_token() {
     let root = fixture("direct");
     let config = root.join("doctl.yaml");

--- a/tests/harden_cli.rs
+++ b/tests/harden_cli.rs
@@ -33,7 +33,7 @@ fn harden_explains_launcher_collisions_without_changing_files() {
         let collision = harden.output().unwrap();
         assert!(!collision.status.success());
         let error = stderr(&collision);
-        assert!(error.contains(&format!("cannot harden {command}: {}", launcher.display())));
+        assert!(error.starts_with(&format!("av harden: {command}: {}", launcher.display())));
         assert!(error.contains("reserved Automic Vault Launcher path"));
         assert!(error.contains("no separate Target was found on PATH"));
         assert!(error.contains("Review and preserve this executable"));


### PR DESCRIPTION
When an executable occupies `/usr/local/bin/sentry-cli` and no separate Target exists on PATH, `av harden sentry-cli` already aborts but misleadingly says the command is not installed. The shared environment-wrapper Hardener now identifies the reserved Launcher path and tells the user to review and preserve the executable, then move or reinstall the Target elsewhere on PATH before retrying.

The change only selects a clearer error after Target discovery has failed. Existing managed Launchers keep the missing-Target error. Hardening still aborts before installation or credential migration, and still refuses to overwrite an unmanaged occupant when another Target exists. Doctor, Secret routing, and authorization policy are unchanged.

Replaces #241, following the decision to explain this failure directly in the Hardener.

Validation:
- `cargo fmt --all -- --check`
- `cargo test --locked --test harden_cli` — 6 passed
- `cargo test --locked --lib isotopes::hardeners::env_wrapper::tests` — 56 passed
- `git diff --check`

The CLI regression covers sentry-cli and doctl, missing installations, executables in a working directory outside PATH, collisions with and without a separate Target, and preservation of the occupant and credentials.
