### PR TITLE
Add gated CLI Authorization History access

### DIFF
--- a/docs/adr/0046-cli-authorization-history-access.md
+++ b/docs/adr/0046-cli-authorization-history-access.md
@@ -13,7 +13,8 @@ historical activity.
 
 `av history` uses the signed `av` Gate Client and the same live Verified Launcher
 verification and Approval flow as `av list`. It returns a table by default and
-JSON with `--json`.
+JSON with `--json`. Both formats receive the display-safe command; the exact
+command retained for authorization integrity never leaves the menu bar app.
 
 Automic authorization uses a separate, Data Protection Keychain-backed
 Authorization History Access list. Adding a Verified Launcher requires Approval;

--- a/docs/adr/0046-cli-authorization-history-access.md
+++ b/docs/adr/0046-cli-authorization-history-access.md
@@ -1,0 +1,33 @@
+# ADR 0046: CLI Authorization History Access
+
+Status: accepted
+
+## Context
+
+Authorization History contains cumulative Secret Names and request metadata.
+Although `av list` already gates disclosure of saved Secret Names, its Secret
+Name Access grant does not describe or authorize disclosure of other Launchers'
+historical activity.
+
+## Decision
+
+`av history` uses the signed `av` Gate Client and the same live Verified Launcher
+verification and Approval flow as `av list`. It returns a table by default and
+JSON with `--json`.
+
+Automic authorization uses a separate, Data Protection Keychain-backed
+Authorization History Access list. Adding a Verified Launcher requires Approval;
+removal is immediate. Secret Name Access and Authorization History Access do not
+imply one another.
+
+The history read is classified as Secret Disclosure for Approval presentation.
+An allowed read must append its own Authorization Record before any records are
+returned. Failure to record denies the disclosure. The menu bar app must be
+running because the CLI has no direct access to the history store.
+
+## Consequences
+
+- Existing `av list` grants gain no authority.
+- Scripts can use `av history --json` only after per-request Approval or an
+  explicit Verified Launcher grant.
+- The returned bounded history includes the record for the current read.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,13 @@ authorization policy.
 
 Authorization Gates verify the Launcher, bind the Gate Client and Target, classify the complete operation, apply the gate's Authorization Policy, request Approval when policy cannot allow it, and enforce the Authorization Decision.
 
+`av history` exposes the bounded local Authorization History through the signed
+`av` Gate Client. The service verifies the live Launcher and requires Approval
+unless that exact Verified Launcher has a separate Authorization History Access
+grant in the Data Protection Keychain. Secret Name Access never satisfies this
+grant. The service records the history read before returning the records, and a
+recording failure denies disclosure. See [ADR 0046](adr/0046-cli-authorization-history-access.md).
+
 The Direct Secret Gate handles direct `av inject` requests that do not match a
 Tool-specific gate. It defaults to Approval Required. A user may add a Direct
 Access Rule for one exact Secret Name and Verified Launcher, knowingly allowing

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -656,6 +656,15 @@ Permission for one Verified Launcher to execute an exact Blessing with automic a
 
 ## Authorization History
 
+### Authorization History Access
+
+A durable, Keychain-protected grant allowing one exact Verified Launcher to read
+the bounded local Authorization History without Approval. It is distinct from
+Secret Name Access: granting `av list` does not grant `av history`, and granting
+`av history` does not grant `av list`. Without a matching grant, each history
+read requires Approval. Every read is itself recorded before the history is
+returned.
+
 ### Authorization Record
 
 A local record of an Authorization Request and its Authorization Decision. It includes the decision source, Launcher, Gate Client, Target, Secret Names, and operation. For an automically authorized Secret Use, it also records the Target's available Hardened Runtime posture at authorization time. This posture is diagnostic metadata, not Target identity evidence or an authorization input.

--- a/scripts/test-menu-helper-self-checks.sh
+++ b/scripts/test-menu-helper-self-checks.sh
@@ -48,6 +48,7 @@ checks=(
   --self-check-approval-process-execution
   --self-check-standalone-launchers
   --self-check-secret-mutations
+  --self-check-metadata-disclosure
   --self-check-gh-read-only
   --self-check-docker-credentials
   --self-check-terraform-credentials

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -1,0 +1,160 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::io::Write;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HistoryRecord {
+    id: String,
+    date: String,
+    tool: String,
+    command: String,
+    display_command: Option<String>,
+    decision: String,
+    approval_source: Option<String>,
+    reason: String,
+    launcher: Option<String>,
+    launcher_icon_path: Option<String>,
+    caller_path: String,
+    target: String,
+    target_runtime_protection: Option<String>,
+    cwd: String,
+    keys: Vec<String>,
+    detail: Option<String>,
+    secret_value_sources: Option<BTreeMap<String, String>>,
+}
+
+pub(super) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    let json = match args.as_slice() {
+        [] => false,
+        [arg] if arg == "--json" => true,
+        _ => {
+            let _ = writeln!(stderr, "usage: av history [--json]");
+            return 2;
+        }
+    };
+    match crate::secrets::authorization_history().and_then(|value| {
+        serde_json::from_str::<Vec<HistoryRecord>>(&value)
+            .map_err(|error| format!("invalid Authorization History response: {error}"))
+    }) {
+        Ok(records) => {
+            let result = if json {
+                serde_json::to_writer_pretty(&mut *stdout, &records)
+                    .map_err(|error| error.to_string())
+                    .and_then(|()| writeln!(stdout).map_err(|error| error.to_string()))
+            } else {
+                write_table(stdout, &records)
+            };
+            if let Err(error) = result {
+                let _ = writeln!(stderr, "av history: {error}");
+                return 1;
+            }
+            0
+        }
+        Err(error) => {
+            let _ = writeln!(stderr, "av history: {error}");
+            1
+        }
+    }
+}
+
+fn write_table(output: &mut dyn Write, records: &[HistoryRecord]) -> Result<(), String> {
+    let mut rows = vec![[
+        "DATE".into(),
+        "DECISION".into(),
+        "SOURCE".into(),
+        "LAUNCHER".into(),
+        "COMMAND".into(),
+        "SECRET NAMES".into(),
+        "REASON".into(),
+        "TARGET".into(),
+    ]];
+    rows.extend(records.iter().map(|record| {
+        let command = record
+            .display_command
+            .clone()
+            .unwrap_or_else(|| format!("{} <arguments hidden>", record.tool));
+        [
+            safe_cell(&record.date),
+            safe_cell(&record.decision),
+            safe_cell(&record.source_label()),
+            safe_cell(record.launcher.as_deref().unwrap_or(&record.caller_path)),
+            safe_cell(&command),
+            safe_cell(&record.keys.join(", ")),
+            safe_cell(&record.reason),
+            safe_cell(&record.target),
+        ]
+    }));
+    let widths: [usize; 8] = std::array::from_fn(|column| {
+        rows.iter()
+            .map(|row| row[column].chars().count())
+            .max()
+            .unwrap_or(0)
+    });
+    for row in rows {
+        for (column, cell) in row.iter().enumerate() {
+            write!(output, "{cell:width$}", width = widths[column])
+                .map_err(|error| error.to_string())?;
+            if column + 1 < row.len() {
+                write!(output, "  ").map_err(|error| error.to_string())?;
+            }
+        }
+        writeln!(output).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn safe_cell(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| {
+            if character.is_control() {
+                character.escape_default().collect::<Vec<_>>()
+            } else {
+                vec![character]
+            }
+        })
+        .collect()
+}
+
+impl HistoryRecord {
+    fn source_label(&self) -> String {
+        match self
+            .approval_source
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("auto" | "automatic" | "policy") => "Policy".into(),
+            Some("manual" | "human") => "Human".into(),
+            Some(source) if !source.is_empty() => source.into(),
+            _ if self.reason.to_ascii_lowercase().contains("auto")
+                || self.reason.to_ascii_lowercase().contains("reused") =>
+            {
+                "Policy".into()
+            }
+            _ if self.reason.to_ascii_lowercase().contains("prompt") => "Human".into(),
+            _ => "Unknown".into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_labels_sources_and_escapes_terminal_controls() {
+        let records: Vec<HistoryRecord> = serde_json::from_str(
+            r#"[{"id":"1","date":"2026-09-12T12:00:00Z","tool":"av","command":"history","displayCommand":null,"decision":"Approved","approvalSource":"Auto","reason":"Always allowed\nin Settings","launcher":"Terminal","launcherIconPath":null,"callerPath":"/usr/local/bin/av","target":"av\u001b[31m","targetRuntimeProtection":null,"cwd":"","keys":[],"detail":null,"secretValueSources":null}]"#,
+        ).unwrap();
+        let mut output = Vec::new();
+        write_table(&mut output, &records).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Policy"));
+        assert!(output.contains(r"Always allowed\nin Settings"));
+        assert!(output.contains(r"av\u{1b}[31m"));
+        assert!(!output.contains('\u{1b}'));
+    }
+}

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -34,28 +34,25 @@ pub(super) fn run(args: Vec<OsString>, stdout: &mut dyn Write, stderr: &mut dyn 
             return 2;
         }
     };
-    match crate::secrets::authorization_history().and_then(|value| {
-        serde_json::from_str::<Vec<HistoryRecord>>(&value)
-            .map_err(|error| format!("invalid Authorization History response: {error}"))
-    }) {
-        Ok(records) => {
-            let result = if json {
-                serde_json::to_writer_pretty(&mut *stdout, &records)
-                    .map_err(|error| error.to_string())
-                    .and_then(|()| writeln!(stdout).map_err(|error| error.to_string()))
-            } else {
-                write_table(stdout, &records)
-            };
-            if let Err(error) = result {
-                let _ = writeln!(stderr, "av history: {error}");
-                return 1;
-            }
-            0
-        }
+    match crate::secrets::authorization_history()
+        .and_then(|value| write_response(stdout, &value, json))
+    {
+        Ok(()) => 0,
         Err(error) => {
             let _ = writeln!(stderr, "av history: {error}");
             1
         }
+    }
+}
+
+fn write_response(output: &mut dyn Write, value: &str, json: bool) -> Result<(), String> {
+    let records = serde_json::from_str::<Vec<HistoryRecord>>(value)
+        .map_err(|error| format!("invalid Authorization History response: {error}"))?;
+    if json {
+        serde_json::to_writer_pretty(&mut *output, &records).map_err(|error| error.to_string())?;
+        writeln!(output).map_err(|error| error.to_string())
+    } else {
+        write_table(output, &records)
     }
 }
 
@@ -144,17 +141,30 @@ impl HistoryRecord {
 mod tests {
     use super::*;
 
+    const RESPONSE: &str = r#"[{"id":"1","date":"2026-09-12T12:00:00Z","tool":"av","command":"av history --token <redacted>","displayCommand":"av history --token <redacted>","decision":"Approved","approvalSource":"Auto","reason":"Always allowed\nin Settings","launcher":"Terminal","launcherIconPath":null,"callerPath":"/usr/local/bin/av","target":"av\u001b[31m","targetRuntimeProtection":null,"cwd":"","keys":[],"detail":null,"secretValueSources":null}]"#;
+
     #[test]
     fn table_labels_sources_and_escapes_terminal_controls() {
-        let records: Vec<HistoryRecord> = serde_json::from_str(
-            r#"[{"id":"1","date":"2026-09-12T12:00:00Z","tool":"av","command":"history","displayCommand":null,"decision":"Approved","approvalSource":"Auto","reason":"Always allowed\nin Settings","launcher":"Terminal","launcherIconPath":null,"callerPath":"/usr/local/bin/av","target":"av\u001b[31m","targetRuntimeProtection":null,"cwd":"","keys":[],"detail":null,"secretValueSources":null}]"#,
-        ).unwrap();
         let mut output = Vec::new();
-        write_table(&mut output, &records).unwrap();
+        write_response(&mut output, RESPONSE, false).unwrap();
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains("Policy"));
+        assert!(output.contains("av history --token <redacted>"));
         assert!(output.contains(r"Always allowed\nin Settings"));
         assert!(output.contains(r"av\u{1b}[31m"));
         assert!(!output.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn json_decodes_wire_response_and_writes_camel_case_document() {
+        let mut output = Vec::new();
+        write_response(&mut output, RESPONSE, true).unwrap();
+        let document: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(document[0]["date"], "2026-09-12T12:00:00Z");
+        assert_eq!(
+            document[0]["displayCommand"],
+            "av history --token <redacted>"
+        );
+        assert!(document[0].get("display_command").is_none());
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod doctor;
 pub(crate) mod fastly_credential;
 pub(crate) mod goat_credential;
 mod gpg_sign;
+mod history;
 mod inject;
 pub(crate) mod kubectl_credential;
 mod launcher_bundle;
@@ -48,6 +49,7 @@ commands:
   $ av inject --mode=fd +KEY:FD -- <cmd>  # apply secrets through anonymous pipes
   $ av proxy +KEY... [--] <command>       # proxy secret references for a command
   $ av list                               # list saved secret names
+  $ av history [--json]                   # show Authorization History
   $ av save [options] KEY                 # store a global or Project Value
   $ av harden <tool> [-y|--yes]           # harden a tool; migrate credentials
   $ av unharden brew [-y|--yes]           # temporarily restore Homebrew for cask migration
@@ -61,7 +63,7 @@ modes:
 more:
   $ open https://www.automicvault.com/docs/";
 
-pub(crate) const INSTALL_REVISION: u32 = 52;
+pub(crate) const INSTALL_REVISION: u32 = 53;
 
 pub(crate) fn bash_shell_secret_insecurity_reasons() -> Result<Vec<String>, String> {
     shell_secrets::bash_reasons()
@@ -539,6 +541,7 @@ where
         Some("wakatime-credential") => wakatime_credential::run(rest, stdout, stderr),
         Some("rclone-password") => rclone_password::run(rest, stdout, stderr),
         Some("list" | "ls") => list::run(rest, stdout, stderr),
+        Some("history") => history::run(rest, stdout, stderr),
         Some("bless") => bless::run(rest, stderr),
         Some("open") => {
             let Some(secret_gate) = parse_open_args(&rest) else {

--- a/src/menu-helper/Resources/en.lproj/Localizable.strings
+++ b/src/menu-helper/Resources/en.lproj/Localizable.strings
@@ -404,3 +404,8 @@
 "macOS will authenticate you. Recovery disables iPhone Approval, cancels pending requests, rotates the iCloud key, and invalidates every iPhone and other Mac on this account." = "macOS will authenticate you. Recovery disables iPhone Approval, cancels pending requests, rotates the iCloud key, and invalidates every iPhone and other Mac on this account.";
 "via %@" = "via %@";
 "✓ Passed" = "✓ Passed";
+"Authorization History Access" = "Authorization History Access";
+"Manage Verified Launchers that may read Authorization History without Approval." = "Manage Verified Launchers that may read Authorization History without Approval.";
+"No Verified Launchers may read Authorization History without Approval." = "No Verified Launchers may read Authorization History without Approval.";
+"These Verified Launchers may run av history without Approval." = "These Verified Launchers may run av history without Approval.";
+"Verified Launchers allowed to run av history" = "Verified Launchers allowed to run av history";

--- a/src/menu-helper/Resources/en.lproj/Localizable.strings
+++ b/src/menu-helper/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "Allow JIT compilation" = "Allow JIT compilation";
 "Allow Signing" = "Allow Signing";
 "Allow Verified Launcher to List Secret Names" = "Allow Verified Launcher to List Secret Names";
+"Allow Verified Launcher to Read Authorization History" = "Allow Verified Launcher to Read Authorization History";
 "Allow Verified Launcher…" = "Allow Verified Launcher…";
 "Allow Write Access for 10 Minutes…" = "Allow Write Access for 10 Minutes…";
 "Allow an exact live process execution to retain gate-specific Launcher attribution after its parent chain exits." = "Allow an exact live process execution to retain gate-specific Launcher attribution after its parent chain exits.";

--- a/src/menu-helper/Resources/zh-Hans.lproj/Localizable.strings
+++ b/src/menu-helper/Resources/zh-Hans.lproj/Localizable.strings
@@ -404,3 +404,8 @@
 "macOS will authenticate you. Recovery disables iPhone Approval, cancels pending requests, rotates the iCloud key, and invalidates every iPhone and other Mac on this account." = "macOS 将验证你的身份。恢复操作会禁用 iPhone 批准、取消待处理的请求、轮换 iCloud 密钥，并使此账户下所有 iPhone 和其他 Mac 的登记失效。";
 "via %@" = "通过 %@";
 "✓ Passed" = "✓ 通过";
+"Authorization History Access" = "授权历史访问";
+"Manage Verified Launchers that may read Authorization History without Approval." = "管理无需批准即可读取授权历史的已验证启动器。";
+"No Verified Launchers may read Authorization History without Approval." = "没有已验证启动器可以无需批准读取授权历史。";
+"These Verified Launchers may run av history without Approval." = "这些已验证启动器可以运行 av history，无需批准。";
+"Verified Launchers allowed to run av history" = "允许运行 av history 的已验证启动器";

--- a/src/menu-helper/Resources/zh-Hans.lproj/Localizable.strings
+++ b/src/menu-helper/Resources/zh-Hans.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "Allow JIT compilation" = "允许 JIT 编译";
 "Allow Signing" = "允许签名";
 "Allow Verified Launcher to List Secret Names" = "允许已验证启动器列出 Secret 名称";
+"Allow Verified Launcher to Read Authorization History" = "允许已验证启动器读取授权历史";
 "Allow Verified Launcher…" = "允许已验证启动器…";
 "Allow Write Access for 10 Minutes…" = "允许写入 10 分钟…";
 "Allow an exact live process execution to retain gate-specific Launcher attribution after its parent chain exits." = "允许一次确定的存活进程执行在父进程链退出后，保留特定关卡的启动器归属。";

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -404,6 +404,12 @@ final class DashboardModel: ObservableObject {
                     detail: String(localized: "Manage Verified Launchers that may list saved Secret Names without Approval.")
                 ),
                 DashboardItem(
+                    id: String(localized: "authorization-history-access"),
+                    title: String(localized: "Authorization History Access"),
+                    subtitle: String(localized: "Verified Launchers allowed to run av history"),
+                    detail: String(localized: "Manage Verified Launchers that may read Authorization History without Approval.")
+                ),
+                DashboardItem(
                     id: String(localized: "about"),
                     title: String(localized: "About"),
                     subtitle: String(localized: "GUI environment details"),
@@ -692,6 +698,29 @@ final class DashboardModel: ObservableObject {
     func removeSecretNameAccessApp(_ app: BlessedScriptLauncher) {
         finishPolicyUpdate(
             removeSecretNameAccess(app),
+            error: "Could not remove \(app.bundleIdentifier)"
+        )
+    }
+
+    func addAuthorizationHistoryAccessApp() {
+        chooseLauncherApp { [weak self] launcher in
+            guard let self, let launcher else { return }
+            self.approveAuthorityChange(
+                action: "authorization-history-access",
+                "Allow \(launcher.bundleIdentifier) to read Authorization History",
+                detail: "The Verified Launcher may read the bounded local Authorization History, including Secret Names and request metadata, without future Approval."
+            ) {
+                self.finishPolicyUpdate(
+                    allowAuthorizationHistoryAccess(launcher),
+                    error: "Could not allow \(launcher.bundleIdentifier)"
+                )
+            }
+        }
+    }
+
+    func removeAuthorizationHistoryAccessApp(_ app: BlessedScriptLauncher) {
+        finishPolicyUpdate(
+            removeAuthorizationHistoryAccess(app),
             error: "Could not remove \(app.bundleIdentifier)"
         )
     }
@@ -2070,6 +2099,15 @@ struct DashboardRootView: View {
                         .labelStyle(.titleAndIcon)
                         .help("Allow Verified Launcher to List Secret Names")
                     }
+                    if model.selectedSection == .settings,
+                       model.selectedItem?.id == "authorization-history-access" {
+                        AuthorityApprovalButton(
+                            title: "Allow Verified Launcher to Read Authorization History",
+                            approval: model.authorityApproval, action: "authorization-history-access"
+                        ) { model.addAuthorizationHistoryAccessApp() }
+                        .labelStyle(.titleAndIcon)
+                        .help("Allow Verified Launcher to Read Authorization History")
+                    }
                     if model.isReloading {
                         ProgressView()
                             .controlSize(.small)
@@ -2318,6 +2356,12 @@ private struct DashboardDetailView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else if model.selectedItem?.id == "gpg-signing" {
                     GPGSigningSettingsView(onCredentialSaved: model.reload)
+                        .padding(.horizontal, 22)
+                        .padding(.top, 32)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else if model.selectedItem?.id == "authorization-history-access" {
+                    AuthorizationHistoryAccessSettingsView(model: model)
                         .padding(.horizontal, 22)
                         .padding(.top, 32)
                         .padding(.bottom, 28)
@@ -4071,6 +4115,32 @@ private struct SecretNameAccessSettingsView: View {
                 empty: "No Verified Launchers have Secret Name Access."
             ) {
                 model.removeSecretNameAccessApp($0)
+            }
+            if let error = model.errorMessage {
+                InfoBlock(title: "Error", text: error)
+            }
+        }
+    }
+}
+
+private struct AuthorizationHistoryAccessSettingsView: View {
+    @ObservedObject var model: DashboardModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Authorization History Access")
+                    .font(.system(size: 24, weight: .semibold))
+                Text("These Verified Launchers may run av history without Approval.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            launcherList(
+                model.snapshot.authorizationHistoryAccessApps,
+                title: "Verified Launchers",
+                empty: "No Verified Launchers may read Authorization History without Approval."
+            ) {
+                model.removeAuthorizationHistoryAccessApp($0)
             }
             if let error = model.errorMessage {
                 InfoBlock(title: "Error", text: error)

--- a/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
+++ b/src/menu-helper/Sources/MenubarHelper/MainWindow.swift
@@ -1905,6 +1905,7 @@ func runDashboardSearchSelfCheck() -> Int32 {
         "gpg-signing",
         "ssh-agent",
         "secret-name-access",
+        "authorization-history-access",
         "about",
     ],
           model.selectedItemID == "touch-id-approval",

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3436,6 +3436,43 @@ private struct ApprovedFulfillmentMaterial: Sendable {
 
 private let registryHelperProtocolVersion: UInt64 = 3
 
+private enum MetadataDisclosure {
+    case secretNames(globalOnly: Bool)
+    case authorizationHistory
+}
+
+private func metadataDisclosureHasAutomaticAccess(
+    _ kind: MetadataDisclosure,
+    launchers: [LauncherIdentity],
+    secretNameAccessApps: [BlessedScriptLauncher] = loadSecretNameAccessApps(),
+    authorizationHistoryAccessApps: [BlessedScriptLauncher] = loadAuthorizationHistoryAccessApps()
+) -> Bool {
+    let allowedApps = switch kind {
+    case .secretNames: secretNameAccessApps
+    case .authorizationHistory: authorizationHistoryAccessApps
+    }
+    return launchers.contains { candidate in
+        allowedApps.contains { $0.requirement == candidate.designatedRequirement }
+    }
+}
+
+private func authorizationHistoryDisclosureValue(
+    record: AccessRequestRecord,
+    records: () -> [AccessRequestRecord] = { loadAccessRequestRecords() },
+    onAccessRequest: (AccessRequestRecord) -> Bool
+) -> String? {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.sortedKeys]
+    let disclosedRecords = Array(([record] + records()).prefix(50))
+        .map(\.redactedForDisclosure)
+    guard let data = try? encoder.encode(disclosedRecords),
+          let value = String(data: data, encoding: .utf8),
+          onAccessRequest(record)
+    else { return nil }
+    return value
+}
+
 private final class ApprovalServer: @unchecked Sendable {
     private let serviceName: String
     private let teamIdentifier: String
@@ -3899,11 +3936,6 @@ private final class ApprovalServer: @unchecked Sendable {
         }
     }
 
-    private enum MetadataDisclosure {
-        case secretNames(globalOnly: Bool)
-        case authorizationHistory
-    }
-
     private func handleMetadataDisclosure(
         _ message: xpc_object_t,
         on peer: xpc_connection_t,
@@ -3921,13 +3953,7 @@ private final class ApprovalServer: @unchecked Sendable {
         if launchers.isEmpty, let caller = launcherIdentity(pid: pid, identity: identity) {
             launchers.append(caller)
         }
-        let allowedApps = switch kind {
-        case .secretNames: loadSecretNameAccessApps()
-        case .authorizationHistory: loadAuthorizationHistoryAccessApps()
-        }
-        let allowedLauncher = launchers.first {
-            candidate in allowedApps.contains { $0.requirement == candidate.designatedRequirement }
-        }
+        let hasAutomaticAccess = metadataDisclosureHasAutomaticAccess(kind, launchers: launchers)
         let launcher = executionOrigin(
             among: launchers,
             callerPID: pid,
@@ -3962,7 +3988,7 @@ private final class ApprovalServer: @unchecked Sendable {
             title: title,
             detail: detail
         )
-        if allowedLauncher != nil
+        if hasAutomaticAccess
         {
             discloseMetadata(
                 request: request,
@@ -4083,31 +4109,22 @@ private final class ApprovalServer: @unchecked Sendable {
             reason: reason,
             launcher: launcher
         )
-        var historyValue: String?
         if case .authorizationHistory = kind {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            encoder.outputFormatting = [.sortedKeys]
-            let records = Array(([record] + loadAccessRequestRecords()).prefix(50))
-                .map(\.redactedForDisclosure)
-            guard let data = try? encoder.encode(records),
-                  let value = String(data: data, encoding: .utf8)
-            else {
-                reply(peer, to: message, ok: false, error: "Authorization History could not be encoded")
+            guard let value = authorizationHistoryDisclosureValue(
+                record: record,
+                onAccessRequest: onAccessRequest
+            ) else {
+                reply(peer, to: message, ok: false, error: "Authorization History is unavailable")
                 return
             }
-            historyValue = value
+            reply(peer, to: message, ok: true, error: nil, value: value)
+            return
         }
         guard onAccessRequest(record) else {
             reply(peer, to: message, ok: false, error: "Authorization History is unavailable")
             return
         }
-        switch kind {
-        case .secretNames:
-            reply(peer, to: message, ok: true, error: nil, names: names)
-        case .authorizationHistory:
-            reply(peer, to: message, ok: true, error: nil, value: historyValue)
-        }
+        reply(peer, to: message, ok: true, error: nil, names: names)
     }
 
     private func handleInject(
@@ -13773,6 +13790,63 @@ private func runKeychainPersistenceSelfCheck() -> Int32 {
     return 0
 }
 
+private func runMetadataDisclosureSelfCheck() -> Int32 {
+    let requirement = #"identifier "com.apple.Terminal" and anchor apple"#
+    let launcher = LauncherIdentity(
+        pid: 42,
+        path: "/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+        identifier: "com.apple.Terminal",
+        teamIdentifier: "APPLE",
+        designatedRequirement: requirement,
+        runtimeProtection: .hardened
+    )
+    let grant = BlessedScriptLauncher(
+        bundleIdentifier: launcher.identifier,
+        requirement: requirement
+    )
+    guard metadataDisclosureHasAutomaticAccess(
+        .secretNames(globalOnly: false),
+        launchers: [launcher],
+        secretNameAccessApps: [grant],
+        authorizationHistoryAccessApps: []
+    ),
+        !metadataDisclosureHasAutomaticAccess(
+            .authorizationHistory,
+            launchers: [launcher],
+            secretNameAccessApps: [grant],
+            authorizationHistoryAccessApps: []
+        ),
+        metadataDisclosureHasAutomaticAccess(
+            .authorizationHistory,
+            launchers: [launcher],
+            secretNameAccessApps: [],
+            authorizationHistoryAccessApps: [grant]
+        )
+    else { return 1 }
+
+    let record = AccessRequestRecord(
+        date: Date(timeIntervalSince1970: 0),
+        tool: "av",
+        command: "av history",
+        displayCommand: "av history",
+        decision: "Approved",
+        approvalSource: "Manual",
+        reason: "Allowed once in prompt",
+        launcher: "Terminal",
+        callerPath: "/usr/local/bin/av",
+        target: "/usr/local/bin/av",
+        cwd: "/tmp",
+        keys: [],
+        detail: nil
+    )
+    guard authorizationHistoryDisclosureValue(
+        record: record,
+        records: { [] },
+        onAccessRequest: { _ in false }
+    ) == nil else { return 1 }
+    return 0
+}
+
 @MainActor
 private func fileDescriptorInjectionSelfCheck() -> Bool {
     let message = xpc_dictionary_create_empty()
@@ -17407,6 +17481,10 @@ if CommandLine.arguments.contains("--self-check-secret-mutations") {
 
 if CommandLine.arguments.contains("--self-check-keychain-persistence") {
     exit(runKeychainPersistenceSelfCheck())
+}
+
+if CommandLine.arguments.contains("--self-check-metadata-disclosure") {
+    exit(runMetadataDisclosureSelfCheck())
 }
 
 if CommandLine.arguments.contains("--self-check-gh-read-only") {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -13828,8 +13828,8 @@ private func runMetadataDisclosureSelfCheck() -> Int32 {
     let record = AccessRequestRecord(
         date: Date(timeIntervalSince1970: 0),
         tool: "av",
-        command: "av history",
-        displayCommand: "av history",
+        command: "av history --token plaintext-credential",
+        displayCommand: "av history --token <redacted>",
         decision: "Approved",
         approvalSource: "Manual",
         reason: "Allowed once in prompt",
@@ -13840,6 +13840,24 @@ private func runMetadataDisclosureSelfCheck() -> Int32 {
         keys: [],
         detail: nil
     )
+    var recordedSuccessfulDisclosure = false
+    guard let disclosure = authorizationHistoryDisclosureValue(
+        record: record,
+        records: { [] },
+        onAccessRequest: { _ in
+            recordedSuccessfulDisclosure = true
+            return true
+        }
+    ), recordedSuccessfulDisclosure,
+        let disclosureData = disclosure.data(using: .utf8)
+    else { return 1 }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    guard let disclosedRecords = try? decoder.decode([AccessRequestRecord].self, from: disclosureData),
+          disclosedRecords.first?.id == record.id,
+          disclosedRecords.first?.command == record.commandForDisplay,
+          disclosedRecords.first?.command != record.command
+    else { return 1 }
     guard authorizationHistoryDisclosureValue(
         record: record,
         records: { [] },

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3458,13 +3458,14 @@ private func metadataDisclosureHasAutomaticAccess(
 
 private func authorizationHistoryDisclosureValue(
     record: AccessRequestRecord,
-    records: () -> [AccessRequestRecord] = { loadAccessRequestRecords() },
+    records: () -> [AccessRequestRecord]? = { loadAccessRequestRecordsIfAvailable() },
     onAccessRequest: (AccessRequestRecord) -> Bool
 ) -> String? {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.sortedKeys]
-    let disclosedRecords = Array(([record] + records()).prefix(50))
+    guard let records = records() else { return nil }
+    let disclosedRecords = Array(([record] + records).prefix(50))
         .map(\.redactedForDisclosure)
     guard let data = try? encoder.encode(disclosedRecords),
           let value = String(data: data, encoding: .utf8),
@@ -13672,8 +13673,8 @@ private func runSecretMutationSelfCheck() async -> Int32 {
         launcher: nil,
         launcherFallbackPath: "/Applications/Terminal.app",
         canRequestHumanApproval: { true },
-        onAccessRequest: {
-            cancellationRecord = $0
+        onAccessRequest: { record in
+            cancellationRecord = record
             return true
         },
         decision: { _ in .canceled },
@@ -13844,6 +13845,15 @@ private func runMetadataDisclosureSelfCheck() -> Int32 {
         records: { [] },
         onAccessRequest: { _ in false }
     ) == nil else { return 1 }
+    var recordedUnavailableHistory = false
+    guard authorizationHistoryDisclosureValue(
+        record: record,
+        records: { nil },
+        onAccessRequest: { _ in
+            recordedUnavailableHistory = true
+            return true
+        }
+    ) == nil, !recordedUnavailableHistory else { return 1 }
     return 0
 }
 

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -4089,6 +4089,7 @@ private final class ApprovalServer: @unchecked Sendable {
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = [.sortedKeys]
             let records = Array(([record] + loadAccessRequestRecords()).prefix(50))
+                .map(\.redactedForDisclosure)
             guard let data = try? encoder.encode(records),
                   let value = String(data: data, encoding: .utf8)
             else {

--- a/src/menu-helper/Sources/MenubarHelper/main.swift
+++ b/src/menu-helper/Sources/MenubarHelper/main.swift
@@ -3835,14 +3835,26 @@ private final class ApprovalServer: @unchecked Sendable {
         case .terraformDelete where isTrustedAvCaller(path: callerPath, signing: signing):
             handleTerraformDelete(message, on: peer, cancellation: cancellation, caller: mutationCaller)
         case .list where isTrustedAvCaller(path: callerPath, signing: signing):
-            handleList(
+            handleMetadataDisclosure(
                 message,
                 on: peer,
                 cancellation: cancellation,
                 pid: pid,
                 identity: identity,
                 callerPath: callerPath,
-                signing: signing
+                signing: signing,
+                kind: .secretNames(globalOnly: xpc_dictionary_get_bool(message, "global_only"))
+            )
+        case .history where isTrustedAvCaller(path: callerPath, signing: signing):
+            handleMetadataDisclosure(
+                message,
+                on: peer,
+                cancellation: cancellation,
+                pid: pid,
+                identity: identity,
+                callerPath: callerPath,
+                signing: signing,
+                kind: .authorizationHistory
             )
         case .save where isTrustedAvCaller(path: callerPath, signing: signing):
             handleSave(message, on: peer, cancellation: cancellation, caller: mutationCaller)
@@ -3887,24 +3899,32 @@ private final class ApprovalServer: @unchecked Sendable {
         }
     }
 
-    private func handleList(
+    private enum MetadataDisclosure {
+        case secretNames(globalOnly: Bool)
+        case authorizationHistory
+    }
+
+    private func handleMetadataDisclosure(
         _ message: xpc_object_t,
         on peer: xpc_connection_t,
         cancellation: ApprovalCancellation,
         pid: pid_t,
         identity: AVProcessIdentity,
         callerPath: String,
-        signing: SigningInfo
+        signing: SigningInfo,
+        kind: MetadataDisclosure
     ) {
         let cwd = xpc_dictionary_get_string(message, "cwd")
             .map { String(cString: $0) } ?? ""
-        let globalOnly = xpc_dictionary_get_bool(message, "global_only")
         var launchers = launcherIdentities(for: identity)
         let ancestorFallbackPath = launcherFallbackPath(for: identity)
         if launchers.isEmpty, let caller = launcherIdentity(pid: pid, identity: identity) {
             launchers.append(caller)
         }
-        let allowedApps = loadSecretNameAccessApps()
+        let allowedApps = switch kind {
+        case .secretNames: loadSecretNameAccessApps()
+        case .authorizationHistory: loadAuthorizationHistoryAccessApps()
+        }
         let allowedLauncher = launchers.first {
             candidate in allowedApps.contains { $0.requirement == candidate.designatedRequirement }
         }
@@ -3913,11 +3933,25 @@ private final class ApprovalServer: @unchecked Sendable {
             callerPID: pid,
             ancestorFallbackPath: ancestorFallbackPath
         )
+        let (operation, title, detail) = switch kind {
+        case .secretNames(let globalOnly): (
+            "list",
+            "List saved secret names?",
+            globalOnly
+                ? "Secret values will remain hidden. av will receive every saved Global Value name."
+                : "Secret values will remain hidden. av will receive every saved Secret Name."
+        )
+        case .authorizationHistory: (
+            "history",
+            "Read Authorization History?",
+            "av will receive the bounded local Authorization History, including Secret Names and request metadata."
+        )
+        }
         let request = ApprovalRequest(
-            op: "list",
+            op: operation,
             keys: [],
             target: callerPath,
-            args: ["list"],
+            args: [operation],
             cwd: cwd,
             replaceExistingEnv: false,
             allowMissingKeys: false,
@@ -3925,14 +3959,12 @@ private final class ApprovalServer: @unchecked Sendable {
             shebangScript: nil,
             scriptData: nil,
             tool: "av",
-            title: "List saved secret names?",
-            detail: globalOnly
-                ? "Secret values will remain hidden. av will receive every saved Global Value name."
-                : "Secret values will remain hidden. av will receive every saved Secret Name."
+            title: title,
+            detail: detail
         )
         if allowedLauncher != nil
         {
-            discloseSecretNames(
+            discloseMetadata(
                 request: request,
                 callerPath: callerPath,
                 launcher: launcher,
@@ -3940,7 +3972,7 @@ private final class ApprovalServer: @unchecked Sendable {
                 reason: "Always allowed in Settings",
                 peer: peer,
                 message: message,
-                globalOnly: globalOnly
+                kind: kind
             )
             return
         }
@@ -3960,7 +3992,7 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: "User session is inactive",
                     launcher: launcher
                 ))
-                self.reply(peer, to: message, ok: false, error: "list denied while user session is inactive")
+                self.reply(peer, to: message, ok: false, error: "\(request.op) denied while user session is inactive")
                 return
             }
             let decision = await showApprovalAlert(
@@ -3996,10 +4028,10 @@ private final class ApprovalServer: @unchecked Sendable {
                     reason: "Denied in prompt",
                     launcher: launcher
                 ))
-                self.reply(peer, to: message, ok: false, error: "list denied")
+                self.reply(peer, to: message, ok: false, error: "\(request.op) denied")
                 return
             }
-            self.discloseSecretNames(
+            self.discloseMetadata(
                 request: request,
                 callerPath: callerPath,
                 launcher: launcher,
@@ -4007,12 +4039,12 @@ private final class ApprovalServer: @unchecked Sendable {
                 reason: "Allowed once in prompt",
                 peer: peer,
                 message: message,
-                globalOnly: globalOnly
+                kind: kind
             )
         }
     }
 
-    private func discloseSecretNames(
+    private func discloseMetadata(
         request: ApprovalRequest,
         callerPath: String,
         launcher: LauncherIdentity?,
@@ -4020,39 +4052,61 @@ private final class ApprovalServer: @unchecked Sendable {
         reason: String,
         peer: xpc_connection_t,
         message: xpc_object_t,
-        globalOnly: Bool
+        kind: MetadataDisclosure
     ) {
-        let names: [String]
-        switch loadStoredSecretsResult() {
-        case .success(let secrets):
-            names = secrets.compactMap { secret in
-                (!globalOnly || secret.values.contains { $0.source == .global })
-                    ? secret.account : nil
+        var names: [String]?
+        if case .secretNames(let globalOnly) = kind {
+            switch loadStoredSecretsResult() {
+            case .success(let secrets):
+                names = secrets.compactMap { secret in
+                    (!globalOnly || secret.values.contains { $0.source == .global })
+                        ? secret.account : nil
+                }
+            case .failure(let status):
+                _ = onAccessRequest(accessRequestRecord(
+                    request: request,
+                    callerPath: callerPath,
+                    decision: "Failed",
+                    approvalSource: approvalSource,
+                    reason: "Stored Secret names are unavailable: \(status)",
+                    launcher: launcher
+                ))
+                reply(peer, to: message, ok: false, error: "stored Secret names are unavailable: \(status)")
+                return
             }
-        case .failure(let status):
-            _ = onAccessRequest(accessRequestRecord(
-                request: request,
-                callerPath: callerPath,
-                decision: "Failed",
-                approvalSource: approvalSource,
-                reason: "Stored Secret names are unavailable: \(status)",
-                launcher: launcher
-            ))
-            reply(peer, to: message, ok: false, error: "stored Secret names are unavailable: \(status)")
-            return
         }
-        guard onAccessRequest(accessRequestRecord(
+        let record = accessRequestRecord(
             request: request,
             callerPath: callerPath,
             decision: "Approved",
             approvalSource: approvalSource,
             reason: reason,
             launcher: launcher
-        )) else {
+        )
+        var historyValue: String?
+        if case .authorizationHistory = kind {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.sortedKeys]
+            let records = Array(([record] + loadAccessRequestRecords()).prefix(50))
+            guard let data = try? encoder.encode(records),
+                  let value = String(data: data, encoding: .utf8)
+            else {
+                reply(peer, to: message, ok: false, error: "Authorization History could not be encoded")
+                return
+            }
+            historyValue = value
+        }
+        guard onAccessRequest(record) else {
             reply(peer, to: message, ok: false, error: "Authorization History is unavailable")
             return
         }
-        reply(peer, to: message, ok: true, error: nil, names: names)
+        switch kind {
+        case .secretNames:
+            reply(peer, to: message, ok: true, error: nil, names: names)
+        case .authorizationHistory:
+            reply(peer, to: message, ok: true, error: nil, value: historyValue)
+        }
     }
 
     private func handleInject(
@@ -12221,7 +12275,8 @@ private func phoneApprovalRisks(
     case .secretDump: return [.secretDisclosure]
     case .unknown: return [.unknown]
     case .readOnly, .localWrite, .update, .mutating: return [.routine]
-    case nil where request.op == "list": return [.secretDisclosure]
+    case nil where ApprovalServiceOperation(rawValue: request.op)?.disclosesProtectedMetadata == true:
+        return [.secretDisclosure]
     case nil where request.op == "inject" || request.op == "inject-fd": return [.unconstrainedSecretApplication]
     case nil: return [.securityWarning]
     }

--- a/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/ApprovalServiceOperation.swift
@@ -61,6 +61,7 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case terraformSave = "terraform-save"
     case terraformDelete = "terraform-delete"
     case list
+    case history
     case save
     case saveIfAbsentOrEqual = "save-if-absent"
     case bless
@@ -72,4 +73,8 @@ public enum ApprovalServiceOperation: String, CaseIterable, Sendable {
     case ghDelete = "gh-delete"
     case stripeSave = "stripe-save"
     case stripeDelete = "stripe-delete"
+
+    public var disclosesProtectedMetadata: Bool {
+        self == .list || self == .history
+    }
 }

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1658,11 +1658,19 @@ public func loadAccessRequestRecords(
     key: String = accessRequestLogDefaultsKey,
     service: String = accessRequestLogKeychainService
 ) -> [AccessRequestRecord] {
+    loadAccessRequestRecordsIfAvailable(defaults: defaults, key: key, service: service) ?? []
+}
+
+public func loadAccessRequestRecordsIfAvailable(
+    defaults: UserDefaults? = nil,
+    key: String = accessRequestLogDefaultsKey,
+    service: String = accessRequestLogKeychainService
+) -> [AccessRequestRecord]? {
     guard case .success(let records) = loadAccessRequestRecordsResult(
         defaults: defaults,
         key: key,
         service: service
-    ) else { return [] }
+    ) else { return nil }
     return records
 }
 

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -853,6 +853,28 @@ public struct AccessRequestRecord: Codable, Equatable, Identifiable, Sendable {
         displayCommand ?? "\(tool.isEmpty ? "tool" : tool) <arguments hidden>"
     }
 
+    public var redactedForDisclosure: AccessRequestRecord {
+        AccessRequestRecord(
+            id: id,
+            date: date,
+            tool: tool,
+            command: commandForDisplay,
+            displayCommand: displayCommand,
+            decision: decision,
+            approvalSource: approvalSource,
+            reason: reason,
+            launcher: launcher,
+            launcherIconPath: launcherIconPath,
+            callerPath: callerPath,
+            target: target,
+            targetRuntimeProtection: targetRuntimeProtection,
+            cwd: cwd,
+            keys: keys,
+            detail: detail,
+            secretValueSources: secretValueSources
+        )
+    }
+
     public var approvalSourceLabel: String {
         if let approvalSource, !approvalSource.isEmpty {
             return switch approvalSource.lowercased() {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1524,26 +1524,38 @@ public func removeAuthorizationHistoryAccess(
 }
 
 @discardableResult
+public func removeAuthorizationHistoryAccess(
+    forLauncherRequirement requirement: String,
+    service: String = authorizationHistoryAccessKeychainService,
+    account: String = authorizationHistoryAccessKeychainAccount
+) -> OSStatus {
+    removeLauncherAccess(
+        forRequirement: requirement,
+        service: service,
+        account: account
+    )
+}
+
+@discardableResult
 public func removeSecretNameAccess(
     forLauncherRequirement requirement: String,
     service: String = secretNameAccessKeychainService,
     account: String = secretNameAccessKeychainAccount
 ) -> OSStatus {
-    let apps: [BlessedScriptLauncher]
-    switch loadSecretNameAccessAppsResult(service: service, account: account) {
-    case .success(let loaded): apps = loaded.filter { $0.requirement != requirement }
-    case .failure(let status): return status
-    }
-    return saveSecretNameAccessApps(apps, service: service, account: account)
+    removeLauncherAccess(
+        forRequirement: requirement,
+        service: service,
+        account: account
+    )
 }
 
-private enum SecretNameAccessAppsLoad {
+private enum LauncherAccessAppsLoad {
     case success([BlessedScriptLauncher])
     case failure(OSStatus)
 }
 
 private func loadLauncherAccessApps(service: String, account: String) -> [BlessedScriptLauncher] {
-    guard case .success(let apps) = loadSecretNameAccessAppsResult(service: service, account: account)
+    guard case .success(let apps) = loadLauncherAccessAppsResult(service: service, account: account)
     else { return [] }
     return apps.sorted { $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending }
 }
@@ -1554,13 +1566,13 @@ private func allowLauncherAccess(
     account: String
 ) -> OSStatus {
     var apps: [BlessedScriptLauncher]
-    switch loadSecretNameAccessAppsResult(service: service, account: account) {
+    switch loadLauncherAccessAppsResult(service: service, account: account) {
     case .success(let loaded): apps = loaded
     case .failure(let status): return status
     }
     apps.removeAll { $0.requirement == app.requirement }
     apps.append(app)
-    return saveSecretNameAccessApps(apps, service: service, account: account)
+    return saveLauncherAccessApps(apps, service: service, account: account)
 }
 
 private func removeLauncherAccess(
@@ -1569,21 +1581,34 @@ private func removeLauncherAccess(
     account: String
 ) -> OSStatus {
     let apps: [BlessedScriptLauncher]
-    switch loadSecretNameAccessAppsResult(service: service, account: account) {
+    switch loadLauncherAccessAppsResult(service: service, account: account) {
     case .success(let loaded): apps = loaded
     case .failure(let status): return status
     }
-    return saveSecretNameAccessApps(
+    return saveLauncherAccessApps(
         apps.filter { $0.requirement != app.requirement },
         service: service,
         account: account
     )
 }
 
-private func loadSecretNameAccessAppsResult(
+private func removeLauncherAccess(
+    forRequirement requirement: String,
     service: String,
     account: String
-) -> SecretNameAccessAppsLoad {
+) -> OSStatus {
+    let apps: [BlessedScriptLauncher]
+    switch loadLauncherAccessAppsResult(service: service, account: account) {
+    case .success(let loaded): apps = loaded.filter { $0.requirement != requirement }
+    case .failure(let status): return status
+    }
+    return saveLauncherAccessApps(apps, service: service, account: account)
+}
+
+private func loadLauncherAccessAppsResult(
+    service: String,
+    account: String
+) -> LauncherAccessAppsLoad {
     switch loadKeychainDataResult(service: service, account: account) {
     case .notFound:
         return .success([])
@@ -1596,7 +1621,7 @@ private func loadSecretNameAccessAppsResult(
     }
 }
 
-private func saveSecretNameAccessApps(
+private func saveLauncherAccessApps(
     _ apps: [BlessedScriptLauncher],
     service: String,
     account: String

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -8,6 +8,8 @@ public let secretGatePoliciesKeychainService = "com.automicvault.gate-policies"
 public let secretGatePoliciesKeychainAccount = "SecretGatePoliciesV2"
 public let secretNameAccessKeychainService = "com.automicvault.secret-name-access"
 public let secretNameAccessKeychainAccount = "SecretNameAccessV1"
+public let authorizationHistoryAccessKeychainService = "com.automicvault.authorization-history-access"
+public let authorizationHistoryAccessKeychainAccount = "AuthorizationHistoryAccessV1"
 public let directAccessKeychainService = "com.automicvault.direct-secret-access"
 public let directAccessKeychainAccount = "DirectAccessRulesV1"
 public let touchIDApprovalKeychainService = "com.automicvault.touch-id-approval"
@@ -28,6 +30,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
     public var secretGates: [SecretGate]
     public var blessedScripts: [BlessedScript]
     public var secretNameAccessApps: [BlessedScriptLauncher]
+    public var authorizationHistoryAccessApps: [BlessedScriptLauncher]
     public var secrets: [StoredSecret]
     public var accessRequests: [AccessRequestRecord]
     public var doctorIssues: [DoctorIssue]
@@ -40,6 +43,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         secretGates: [SecretGate],
         blessedScripts: [BlessedScript] = [],
         secretNameAccessApps: [BlessedScriptLauncher] = [],
+        authorizationHistoryAccessApps: [BlessedScriptLauncher] = [],
         secrets: [StoredSecret],
         accessRequests: [AccessRequestRecord] = [],
         doctorIssues: [DoctorIssue] = []
@@ -51,6 +55,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         self.secretGates = secretGates
         self.blessedScripts = blessedScripts
         self.secretNameAccessApps = secretNameAccessApps
+        self.authorizationHistoryAccessApps = authorizationHistoryAccessApps
         self.secrets = secrets
         self.accessRequests = accessRequests
         self.doctorIssues = doctorIssues
@@ -64,6 +69,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
         secretGates: [],
         blessedScripts: [],
         secretNameAccessApps: [],
+        authorizationHistoryAccessApps: [],
         secrets: [],
         accessRequests: [],
         doctorIssues: []
@@ -106,6 +112,7 @@ public struct DashboardSnapshot: Equatable, Sendable {
             secretGates: loadSecretGates(descriptors: gateDescriptors, service: policyService),
             blessedScripts: loadBlessedScripts(),
             secretNameAccessApps: loadSecretNameAccessApps(),
+            authorizationHistoryAccessApps: loadAuthorizationHistoryAccessApps(),
             secrets: secrets,
             accessRequests: loadAccessRequestRecords(),
             doctorIssues: hardening.doctorIssues
@@ -1179,12 +1186,14 @@ public func reloadDashboardAuthorizationState(
     from snapshot: DashboardSnapshot,
     blessedScripts: [BlessedScript] = loadBlessedScripts(),
     secretNameAccessApps: [BlessedScriptLauncher] = loadSecretNameAccessApps(),
+    authorizationHistoryAccessApps: [BlessedScriptLauncher] = loadAuthorizationHistoryAccessApps(),
     secrets: [StoredSecret]? = nil,
     reloadGatePolicy: (SecretGate) -> SecretGate = { reloadSecretGatePolicy(for: $0) }
 ) -> DashboardSnapshot {
     var refreshed = snapshot
     refreshed.blessedScripts = blessedScripts
     refreshed.secretNameAccessApps = secretNameAccessApps
+    refreshed.authorizationHistoryAccessApps = authorizationHistoryAccessApps
     refreshed.secrets = secrets ?? loadStoredSecrets(directAccessRules: loadDirectAccessRules())
     refreshed.secretGates = snapshot.secretGates.map(reloadGatePolicy)
     return refreshed
@@ -1450,9 +1459,7 @@ public func loadSecretNameAccessApps(
     service: String = secretNameAccessKeychainService,
     account: String = secretNameAccessKeychainAccount
 ) -> [BlessedScriptLauncher] {
-    guard case .success(let apps) = loadSecretNameAccessAppsResult(service: service, account: account)
-    else { return [] }
-    return apps.sorted { $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending }
+    loadLauncherAccessApps(service: service, account: account)
 }
 
 public func allowSecretNameAccess(
@@ -1460,14 +1467,7 @@ public func allowSecretNameAccess(
     service: String = secretNameAccessKeychainService,
     account: String = secretNameAccessKeychainAccount
 ) -> OSStatus {
-    var apps: [BlessedScriptLauncher]
-    switch loadSecretNameAccessAppsResult(service: service, account: account) {
-    case .success(let loaded): apps = loaded
-    case .failure(let status): return status
-    }
-    apps.removeAll { $0.requirement == app.requirement }
-    apps.append(app)
-    return saveSecretNameAccessApps(apps, service: service, account: account)
+    allowLauncherAccess(app, service: service, account: account)
 }
 
 public func removeSecretNameAccess(
@@ -1475,16 +1475,30 @@ public func removeSecretNameAccess(
     service: String = secretNameAccessKeychainService,
     account: String = secretNameAccessKeychainAccount
 ) -> OSStatus {
-    let apps: [BlessedScriptLauncher]
-    switch loadSecretNameAccessAppsResult(service: service, account: account) {
-    case .success(let loaded): apps = loaded
-    case .failure(let status): return status
-    }
-    return saveSecretNameAccessApps(
-        apps.filter { $0.requirement != app.requirement },
-        service: service,
-        account: account
-    )
+    removeLauncherAccess(app, service: service, account: account)
+}
+
+public func loadAuthorizationHistoryAccessApps(
+    service: String = authorizationHistoryAccessKeychainService,
+    account: String = authorizationHistoryAccessKeychainAccount
+) -> [BlessedScriptLauncher] {
+    loadLauncherAccessApps(service: service, account: account)
+}
+
+public func allowAuthorizationHistoryAccess(
+    _ app: BlessedScriptLauncher,
+    service: String = authorizationHistoryAccessKeychainService,
+    account: String = authorizationHistoryAccessKeychainAccount
+) -> OSStatus {
+    allowLauncherAccess(app, service: service, account: account)
+}
+
+public func removeAuthorizationHistoryAccess(
+    _ app: BlessedScriptLauncher,
+    service: String = authorizationHistoryAccessKeychainService,
+    account: String = authorizationHistoryAccessKeychainAccount
+) -> OSStatus {
+    removeLauncherAccess(app, service: service, account: account)
 }
 
 @discardableResult
@@ -1504,6 +1518,44 @@ public func removeSecretNameAccess(
 private enum SecretNameAccessAppsLoad {
     case success([BlessedScriptLauncher])
     case failure(OSStatus)
+}
+
+private func loadLauncherAccessApps(service: String, account: String) -> [BlessedScriptLauncher] {
+    guard case .success(let apps) = loadSecretNameAccessAppsResult(service: service, account: account)
+    else { return [] }
+    return apps.sorted { $0.bundleIdentifier.localizedStandardCompare($1.bundleIdentifier) == .orderedAscending }
+}
+
+private func allowLauncherAccess(
+    _ app: BlessedScriptLauncher,
+    service: String,
+    account: String
+) -> OSStatus {
+    var apps: [BlessedScriptLauncher]
+    switch loadSecretNameAccessAppsResult(service: service, account: account) {
+    case .success(let loaded): apps = loaded
+    case .failure(let status): return status
+    }
+    apps.removeAll { $0.requirement == app.requirement }
+    apps.append(app)
+    return saveSecretNameAccessApps(apps, service: service, account: account)
+}
+
+private func removeLauncherAccess(
+    _ app: BlessedScriptLauncher,
+    service: String,
+    account: String
+) -> OSStatus {
+    let apps: [BlessedScriptLauncher]
+    switch loadSecretNameAccessAppsResult(service: service, account: account) {
+    case .success(let loaded): apps = loaded
+    case .failure(let status): return status
+    }
+    return saveSecretNameAccessApps(
+        apps.filter { $0.requirement != app.requirement },
+        service: service,
+        account: account
+    )
 }
 
 private func loadSecretNameAccessAppsResult(
@@ -2423,6 +2475,8 @@ public func migrateBackgroundKeychainItems(
     accessLogAccount: String = accessRequestLogDefaultsKey,
     secretNameAccessService: String = secretNameAccessKeychainService,
     secretNameAccessAccount: String = secretNameAccessKeychainAccount,
+    authorizationHistoryAccessService: String = authorizationHistoryAccessKeychainService,
+    authorizationHistoryAccessAccount: String = authorizationHistoryAccessKeychainAccount,
     directAccessService: String = directAccessKeychainService,
     directAccessAccount: String = directAccessKeychainAccount,
     gpgSigningService: String = gpgSigningConfigurationService,
@@ -2432,6 +2486,7 @@ public func migrateBackgroundKeychainItems(
         (policyService, policyAccount),
         (accessLogService, accessLogAccount),
         (secretNameAccessService, secretNameAccessAccount),
+        (authorizationHistoryAccessService, authorizationHistoryAccessAccount),
         (directAccessService, directAccessAccount),
         (gpgSigningService, gpgSigningAccount),
     ] {

--- a/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/DashboardSnapshot.swift
@@ -1616,21 +1616,28 @@ private func saveSecretNameAccessApps(
     )
 }
 
-public func loadAccessRequestRecords(
+private enum AccessRequestRecordsLoad {
+    case success([AccessRequestRecord])
+    case failure(OSStatus)
+}
+
+private func loadAccessRequestRecordsResult(
     defaults: UserDefaults? = nil,
     key: String = accessRequestLogDefaultsKey,
     service: String = accessRequestLogKeychainService
-) -> [AccessRequestRecord] {
+) -> AccessRequestRecordsLoad {
     if let defaults {
         return decodeAccessRequestRecords(defaults.data(forKey: key))
     }
     switch loadKeychainDataResult(service: service, account: key) {
     case .success(let data):
         return decodeAccessRequestRecords(data)
-    case .failure:
-        return []
+    case .failure(let status):
+        return .failure(status)
     case .notFound:
-        let legacy = decodeAccessRequestRecords(UserDefaults.standard.data(forKey: key))
+        guard case .success(let legacy) = decodeAccessRequestRecords(
+            UserDefaults.standard.data(forKey: key)
+        ) else { return .failure(errSecDecode) }
         guard !legacy.isEmpty,
               let data = try? JSONEncoder().encode(legacy),
               saveKeychainData(
@@ -1639,20 +1646,31 @@ public func loadAccessRequestRecords(
                   account: key,
                   accessibility: .afterFirstUnlock
               ) == errSecSuccess
-        else { return legacy }
+        else { return .success(legacy) }
         UserDefaults.standard.removeObject(forKey: key)
         _ = UserDefaults.standard.synchronize()
-        return legacy
+        return .success(legacy)
     }
 }
 
-private func decodeAccessRequestRecords(_ data: Data?) -> [AccessRequestRecord] {
-    guard let data,
-          let records = try? JSONDecoder().decode([AccessRequestRecord].self, from: data)
-    else {
-        return []
-    }
-    return Array(records.prefix(50))
+public func loadAccessRequestRecords(
+    defaults: UserDefaults? = nil,
+    key: String = accessRequestLogDefaultsKey,
+    service: String = accessRequestLogKeychainService
+) -> [AccessRequestRecord] {
+    guard case .success(let records) = loadAccessRequestRecordsResult(
+        defaults: defaults,
+        key: key,
+        service: service
+    ) else { return [] }
+    return records
+}
+
+private func decodeAccessRequestRecords(_ data: Data?) -> AccessRequestRecordsLoad {
+    guard let data else { return .success([]) }
+    guard let records = try? JSONDecoder().decode([AccessRequestRecord].self, from: data)
+    else { return .failure(errSecDecode) }
+    return .success(Array(records.prefix(50)))
 }
 
 @discardableResult
@@ -1664,9 +1682,12 @@ public func appendAccessRequestRecord(
 ) -> Bool {
     accessRequestLogLock.lock()
     defer { accessRequestLogLock.unlock() }
-    let records = Array(
-        ([record] + loadAccessRequestRecords(defaults: defaults, key: key, service: service)).prefix(50)
-    )
+    guard case .success(let existing) = loadAccessRequestRecordsResult(
+        defaults: defaults,
+        key: key,
+        service: service
+    ) else { return false }
+    let records = Array(([record] + existing).prefix(50))
     guard let data = try? JSONEncoder().encode(records) else { return false }
     if let defaults {
         defaults.set(data, forKey: key)

--- a/src/menu-helper/Sources/MenubarHelperCore/LauncherBundles.swift
+++ b/src/menu-helper/Sources/MenubarHelperCore/LauncherBundles.swift
@@ -195,6 +195,8 @@ public func removeLauncherBundleAuthorization(
     guard gateStatus == errSecSuccess else { return gateStatus }
     let namesStatus = removeSecretNameAccess(forLauncherRequirement: requirement)
     guard namesStatus == errSecSuccess else { return namesStatus }
+    let historyStatus = removeAuthorizationHistoryAccess(forLauncherRequirement: requirement)
+    guard historyStatus == errSecSuccess else { return historyStatus }
     let directStatus = removeDirectAccess(forLauncherRequirement: requirement)
     guard directStatus == errSecSuccess else { return directStatus }
     return removeLauncherFromBlessedScripts(requirement: requirement)

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/ApprovalServiceOperationTests.swift
@@ -13,6 +13,13 @@ import Testing
     #expect(ApprovalServiceOperation.varlock.rawValue == "varlock")
 }
 
+@Test func authorizationHistoryHasADedicatedWireOperation() {
+    #expect(ApprovalServiceOperation.history.rawValue == "history")
+    #expect(ApprovalServiceOperation.history.disclosesProtectedMetadata)
+    #expect(ApprovalServiceOperation.list.disclosesProtectedMetadata)
+    #expect(!ApprovalServiceOperation.inject.disclosesProtectedMetadata)
+}
+
 @Test func terraformCredentialGetHasADedicatedWireOperation() {
     #expect(ApprovalServiceOperation.terraformGet.rawValue == "terraform-get")
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -672,6 +672,27 @@ func malformedSecretNameAccessPolicyFailsClosedAndIsNotReplaced() throws {
     #expect(loadStoredSecret(account: account, service: service) == "not json")
 }
 
+@Test(.enabled(if: dataProtectionKeychainAvailable(), "requires an entitled Keychain test host"))
+func authorizationHistoryAccessIsSeparatePersistedAuthority() throws {
+    let secretNamesService = "com.automicvault.tests.\(UUID().uuidString)"
+    let historyService = "com.automicvault.tests.\(UUID().uuidString)"
+    let account = "launcher-access.\(UUID().uuidString)"
+    defer {
+        _ = deleteStoredSecret(account: account, service: secretNamesService)
+        _ = deleteStoredSecret(account: account, service: historyService)
+    }
+    let terminal = BlessedScriptLauncher(bundleIdentifier: "com.apple.Terminal", requirement: "terminal")
+
+    #expect(allowSecretNameAccess(terminal, service: secretNamesService, account: account) == errSecSuccess)
+    #expect(loadAuthorizationHistoryAccessApps(service: historyService, account: account).isEmpty)
+    #expect(allowAuthorizationHistoryAccess(terminal, service: historyService, account: account) == errSecSuccess)
+    #expect(loadAuthorizationHistoryAccessApps(service: historyService, account: account) == [terminal])
+    #expect(keychainAccessibility(account: account, service: historyService) == kSecAttrAccessibleAfterFirstUnlock as String)
+    #expect(removeAuthorizationHistoryAccess(terminal, service: historyService, account: account) == errSecSuccess)
+    #expect(loadAuthorizationHistoryAccessApps(service: historyService, account: account).isEmpty)
+    #expect(loadSecretNameAccessApps(service: secretNamesService, account: account) == [terminal])
+}
+
 @Test func directAccessRequiresEveryExactSecretAndHardenedRuntime() {
     let launcher = BlessedScriptLauncher(
         bundleIdentifier: "com.example.launcher",

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -688,7 +688,11 @@ func authorizationHistoryAccessIsSeparatePersistedAuthority() throws {
     #expect(allowAuthorizationHistoryAccess(terminal, service: historyService, account: account) == errSecSuccess)
     #expect(loadAuthorizationHistoryAccessApps(service: historyService, account: account) == [terminal])
     #expect(keychainAccessibility(account: account, service: historyService) == kSecAttrAccessibleAfterFirstUnlock as String)
-    #expect(removeAuthorizationHistoryAccess(terminal, service: historyService, account: account) == errSecSuccess)
+    #expect(removeAuthorizationHistoryAccess(
+        forLauncherRequirement: terminal.requirement,
+        service: historyService,
+        account: account
+    ) == errSecSuccess)
     #expect(loadAuthorizationHistoryAccessApps(service: historyService, account: account).isEmpty)
     #expect(loadSecretNameAccessApps(service: secretNamesService, account: account) == [terminal])
 }

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -1677,3 +1677,21 @@ private final class AlteredAccessLogDefaults: UserDefaults, @unchecked Sendable 
     )
     #expect(!appendAccessRequestRecord(record, defaults: AlteredAccessLogDefaults()))
 }
+
+@Test func accessRequestLogDoesNotReplaceMalformedHistory() throws {
+    let defaultsName = "com.automicvault.tests.defaults.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: defaultsName))
+    defer { defaults.removePersistentDomain(forName: defaultsName) }
+    let key = "malformed-access-history"
+    let malformed = Data("not json".utf8)
+    defaults.set(malformed, forKey: key)
+
+    let record = AccessRequestRecord(
+        date: Date(timeIntervalSince1970: 0), tool: "fixture", command: "fixture list",
+        decision: "Approved", approvalSource: "Auto", reason: "Read Only",
+        launcher: "Fixture", callerPath: "/fixture/av", target: "/fixture/tool",
+        cwd: "/fixture", keys: ["SYNTHETIC_TOKEN"], detail: nil
+    )
+    #expect(!appendAccessRequestRecord(record, defaults: defaults, key: key))
+    #expect(defaults.data(forKey: key) == malformed)
+}

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -693,6 +693,27 @@ func authorizationHistoryAccessIsSeparatePersistedAuthority() throws {
     #expect(loadSecretNameAccessApps(service: secretNamesService, account: account) == [terminal])
 }
 
+@Test
+func authorizationHistoryDisclosureOmitsExactCommand() {
+    let record = AccessRequestRecord(
+        date: Date(timeIntervalSince1970: 0),
+        tool: "curl",
+        command: "curl --api-key plaintext-credential",
+        displayCommand: "curl --api-key <redacted>",
+        decision: "Approved",
+        reason: "Allowed",
+        launcher: "Terminal",
+        callerPath: "/usr/bin/curl",
+        target: "/usr/bin/curl",
+        cwd: "/tmp",
+        keys: ["API_KEY"],
+        detail: nil
+    )
+
+    #expect(record.redactedForDisclosure.command == "curl --api-key <redacted>")
+    #expect(record.command == "curl --api-key plaintext-credential")
+}
+
 @Test func directAccessRequiresEveryExactSecretAndHardenedRuntime() {
     let launcher = BlessedScriptLauncher(
         bundleIdentifier: "com.example.launcher",

--- a/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
+++ b/src/menu-helper/Tests/MenubarHelperCoreTests/DashboardSnapshotTests.swift
@@ -539,6 +539,8 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     }
     let oldLauncher = BlessedScriptLauncher(bundleIdentifier: "old", requirement: "old")
     let newLauncher = BlessedScriptLauncher(bundleIdentifier: "new", requirement: "new")
+    let oldHistoryLauncher = BlessedScriptLauncher(bundleIdentifier: "old-history", requirement: "old-history")
+    let newHistoryLauncher = BlessedScriptLauncher(bundleIdentifier: "new-history", requirement: "new-history")
     let newScript = script("/new")
     let oldGate = SecretGate(
         id: "test",
@@ -554,6 +556,7 @@ private func secretlessGateMetadata() -> HardenerMetadata {
         secretGates: [oldGate],
         blessedScripts: [script("/old")],
         secretNameAccessApps: [oldLauncher],
+        authorizationHistoryAccessApps: [oldHistoryLauncher],
         secrets: [StoredSecret(account: "OLD")],
         doctorIssues: [DoctorIssue(
             hardener: "tool",
@@ -570,6 +573,7 @@ private func secretlessGateMetadata() -> HardenerMetadata {
         from: snapshot,
         blessedScripts: [newScript],
         secretNameAccessApps: [newLauncher],
+        authorizationHistoryAccessApps: [newHistoryLauncher],
         secrets: [newSecret]
     ) { gate in
         SecretGate(
@@ -586,6 +590,7 @@ private func secretlessGateMetadata() -> HardenerMetadata {
     #expect(refreshed.doctorIssues == snapshot.doctorIssues)
     #expect(refreshed.blessedScripts == [newScript])
     #expect(refreshed.secretNameAccessApps == [newLauncher])
+    #expect(refreshed.authorizationHistoryAccessApps == [newHistoryLauncher])
     #expect(refreshed.secrets == [newSecret])
     #expect(refreshed.secretGates[0].defaultProtection == .noAccess)
 }
@@ -1482,18 +1487,22 @@ func malformedProjectValueAccountsFailClosed() {
 func backgroundMetadataMigratesWithoutChangingSecretAccessibility() throws {
     let policyService = "com.automicvault.tests.policy.\(UUID().uuidString)"
     let accessLogService = "com.automicvault.tests.log.\(UUID().uuidString)"
+    let historyAccessService = "com.automicvault.tests.history-access.\(UUID().uuidString)"
     let secretService = "com.automicvault.tests.secret.\(UUID().uuidString)"
     let gpgSigningService = "com.automicvault.tests.gpg-config.\(UUID().uuidString)"
     let policyAccount = "policies"
     let accessLogAccount = "access-log"
+    let historyAccessAccount = "history-access"
     let gpgSigningAccount = "configuration"
     defer { _ = deleteStoredSecret(account: policyAccount, service: policyService) }
     defer { _ = deleteStoredSecret(account: accessLogAccount, service: accessLogService) }
+    defer { _ = deleteStoredSecret(account: historyAccessAccount, service: historyAccessService) }
     defer { _ = deleteStoredSecret(account: "API_TOKEN", service: secretService) }
     defer { _ = deleteStoredSecret(account: gpgSigningAccount, service: gpgSigningService) }
 
     #expect(saveStoredSecret(account: policyAccount, value: "[]", service: policyService) == errSecSuccess)
     #expect(saveStoredSecret(account: accessLogAccount, value: "[]", service: accessLogService) == errSecSuccess)
+    #expect(saveStoredSecret(account: historyAccessAccount, value: "[]", service: historyAccessService) == errSecSuccess)
     #expect(saveStoredSecret(account: "API_TOKEN", value: "secret", service: secretService) == errSecSuccess)
     #expect(saveStoredSecret(
         account: gpgSigningAccount,
@@ -1506,11 +1515,14 @@ func backgroundMetadataMigratesWithoutChangingSecretAccessibility() throws {
         policyAccount: policyAccount,
         accessLogService: accessLogService,
         accessLogAccount: accessLogAccount,
+        authorizationHistoryAccessService: historyAccessService,
+        authorizationHistoryAccessAccount: historyAccessAccount,
         gpgSigningService: gpgSigningService,
         gpgSigningAccount: gpgSigningAccount
     ) == errSecSuccess)
     #expect(keychainAccessibility(account: policyAccount, service: policyService) == kSecAttrAccessibleAfterFirstUnlock as String)
     #expect(keychainAccessibility(account: accessLogAccount, service: accessLogService) == kSecAttrAccessibleAfterFirstUnlock as String)
+    #expect(keychainAccessibility(account: historyAccessAccount, service: historyAccessService) == kSecAttrAccessibleAfterFirstUnlock as String)
     #expect(keychainAccessibility(account: gpgSigningAccount, service: gpgSigningService) == kSecAttrAccessibleAfterFirstUnlock as String)
     #expect(keychainAccessibility(account: "API_TOKEN", service: secretService) == kSecAttrAccessibleWhenUnlocked as String)
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -161,6 +161,12 @@ pub(crate) fn list_global_secret_names() -> Result<Vec<String>, String> {
     list_secret_names_filtered(true)
 }
 
+pub(crate) fn authorization_history() -> Result<String, String> {
+    xpc_request("history", None, None, None, None)?
+        .value
+        .ok_or_else(|| "the approval service returned no Authorization History".into())
+}
+
 fn list_secret_names_filtered(global_only: bool) -> Result<Vec<String>, String> {
     if let Some(dir) = crate::test_keychain_dir() {
         let entries = match std::fs::read_dir(dir) {


### PR DESCRIPTION
## Summary

- add av history with table and JSON output
- gate history reads behind the existing Verified Launcher approval flow
- keep automatic access in a separate Keychain-backed Settings row from Secret Name Access
- record each allowed history read before returning records
- document the boundary in ADR 0046

## Security

- treats Authorization History as Secret Disclosure
- existing av list grants gain no new authority
- malformed or missing policy and recording failures fail closed
- returns only display-safe commands; exact authorization commands remain in the menu bar app
- escapes terminal control characters in table output

## Tests

- cargo test --all-targets --all-features --locked
- cargo test --profile test-release --all-targets --all-features --locked
- swift test in src/menu-helper
- scripts/test-menu-helper-self-checks.sh
- localization validation

Closes #337
